### PR TITLE
Fix Warp DeprecationWarning for warp.vec symbol

### DIFF
--- a/nvalchemiops/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/interactions/dispersion/_dftd3.py
@@ -651,10 +651,10 @@ def _unit_shift_to_cartesian(
     cell_mat: Any,
 ) -> Any:
     """Convert integer unit cell shift to Cartesian coordinates."""
-    unit_shift_float = wp.vec(
-        cell_mat[0].dtype(unit_shift[0]),
-        cell_mat[0].dtype(unit_shift[1]),
-        cell_mat[0].dtype(unit_shift[2]),
+    unit_shift_float = type(cell_mat[0])(
+        type(cell_mat[0, 0])(unit_shift[0]),
+        type(cell_mat[0, 0])(unit_shift[1]),
+        type(cell_mat[0, 0])(unit_shift[2]),
     )
     return unit_shift_float * cell_mat
 

--- a/nvalchemiops/math/gto.py
+++ b/nvalchemiops/math/gto.py
@@ -133,6 +133,10 @@ SQRT_4PI = wp.constant(wp.float64(math.sqrt(4.0 * math.pi)))  # sqrt(4*pi)
 # Small value for numerical stability
 EPSILON = wp.constant(wp.float64(1e-30))
 
+# Vector type aliases
+vec5d = wp.types.vector(length=5, dtype=wp.float64)
+vec9d = wp.types.vector(length=9, dtype=wp.float64)
+
 
 @wp.func
 def rsqrt(x: wp.float64) -> wp.float64:
@@ -264,9 +268,7 @@ def gto_density_l1(r: wp.vec3d, sigma: wp.float64) -> wp.vec3d:
 
 
 @wp.func
-def gto_density_l2(r: wp.vec3d, sigma: wp.float64) -> wp.vec(
-    length=5, dtype=wp.float64
-):
+def gto_density_l2(r: wp.vec3d, sigma: wp.float64) -> vec5d:
     r"""Compute GTO density for L=2 (quadrupole/d-orbital).
 
     Returns the five L=2 components:
@@ -281,7 +283,7 @@ def gto_density_l2(r: wp.vec3d, sigma: wp.float64) -> wp.vec(
 
     Returns
     -------
-    wp.vec(5)
+    vec5d
         The five L=2 GTO density values.
     """
     r2 = wp.dot(r, r)
@@ -292,13 +294,12 @@ def gto_density_l2(r: wp.vec3d, sigma: wp.float64) -> wp.vec(
     y_l2 = eval_spherical_harmonics_l2(r)
 
     prefactor = norm * gauss
-    return wp.vec(
+    return vec5d(
         prefactor * y_l2[0],
         prefactor * y_l2[1],
         prefactor * y_l2[2],
         prefactor * y_l2[3],
         prefactor * y_l2[4],
-        dtype=wp.float64,
     )
 
 
@@ -407,9 +408,7 @@ def gto_fourier_l1_imag(k: wp.vec3d, sigma: wp.float64) -> wp.vec3d:
 
 
 @wp.func
-def gto_fourier_l2_real(k: wp.vec3d, sigma: wp.float64) -> wp.vec(
-    length=5, dtype=wp.float64
-):
+def gto_fourier_l2_real(k: wp.vec3d, sigma: wp.float64) -> vec5d:
     r"""Compute real part of Fourier transform of L=2 GTO.
 
     .. math::
@@ -430,7 +429,7 @@ def gto_fourier_l2_real(k: wp.vec3d, sigma: wp.float64) -> wp.vec(
 
     Returns
     -------
-    wp.vec(5)
+    vec5d
         Real parts of the five L=2 Fourier coefficients.
     """
     k2 = wp.dot(k, k)
@@ -443,13 +442,12 @@ def gto_fourier_l2_real(k: wp.vec3d, sigma: wp.float64) -> wp.vec(
     # Coefficient: (-1/4) * sqrt(4*pi) * Y * exp(...)
     prefactor = wp.float64(-0.25) * SQRT_4PI * gauss
 
-    return wp.vec(
+    return vec5d(
         prefactor * y_l2[0],
         prefactor * y_l2[1],
         prefactor * y_l2[2],
         prefactor * y_l2[3],
         prefactor * y_l2[4],
-        dtype=wp.float64,
     )
 
 
@@ -535,9 +533,7 @@ def gto_self_overlap(L: int, sigma: wp.float64) -> wp.float64:
 
 
 @wp.func
-def gto_density_all(r: wp.vec3d, sigma: wp.float64) -> wp.vec(
-    length=9, dtype=wp.float64
-):
+def gto_density_all(r: wp.vec3d, sigma: wp.float64) -> vec9d:
     r"""Compute GTO density for all L=0,1,2 components.
 
     Returns all 9 components (1 + 3 + 5) in order:
@@ -552,7 +548,7 @@ def gto_density_all(r: wp.vec3d, sigma: wp.float64) -> wp.vec(
 
     Returns
     -------
-    wp.vec(9)
+    vec9d
         All 9 GTO density values.
     """
     r2 = wp.dot(r, r)
@@ -568,7 +564,7 @@ def gto_density_all(r: wp.vec3d, sigma: wp.float64) -> wp.vec(
     x, y, z = r[0], r[1], r[2]
     x2, y2, z2 = x * x, y * y, z * z
 
-    return wp.vec(
+    return vec9d(
         # L=0
         prefactor * Y00_COEFF,
         # L=1
@@ -581,7 +577,6 @@ def gto_density_all(r: wp.vec3d, sigma: wp.float64) -> wp.vec(
         prefactor * Y2_0_COEFF * (wp.float64(3.0) * z2 - r2_safe) * r2_inv,
         prefactor * Y2_P1_COEFF * x * z * r2_inv,
         prefactor * Y2_P2_COEFF * (x2 - y2) * r2_inv,
-        dtype=wp.float64,
     )
 
 

--- a/nvalchemiops/math/spherical_harmonics.py
+++ b/nvalchemiops/math/spherical_harmonics.py
@@ -129,6 +129,10 @@ Y2_P2_COEFF = wp.constant(wp.float64(0.5462742152960396))  # sqrt(15/(16pi))
 # Small value for safe division
 EPSILON = wp.constant(wp.float64(1e-30))
 
+# Vector type aliases (replacing deprecated wp.vec(...) factory)
+vec5d = wp.types.vector(length=5, dtype=wp.float64)
+vec9d = wp.types.vector(length=9, dtype=wp.float64)
+
 
 # =============================================================================
 # L = 0 (Monopole) - 1 component
@@ -617,12 +621,12 @@ def eval_spherical_harmonics_l1(r: wp.vec3d) -> wp.vec3d:
 
 
 @wp.func
-def eval_spherical_harmonics_l2(r: wp.vec3d) -> wp.vec(length=5, dtype=wp.float64):
+def eval_spherical_harmonics_l2(r: wp.vec3d) -> vec5d:
     """Evaluate all L=2 harmonics.
 
     Returns
     -------
-    wp.vec(5)
+    vec5d
         (Y_2^{-2}, Y_2^{-1}, Y_2^0, Y_2^{+1}, Y_2^{+2}) values.
     """
     r2 = wp.dot(r, r)
@@ -631,23 +635,22 @@ def eval_spherical_harmonics_l2(r: wp.vec3d) -> wp.vec(length=5, dtype=wp.float6
     x, y, z = r[0], r[1], r[2]
     x2, y2, z2 = x * x, y * y, z * z
 
-    return wp.vec(
+    return vec5d(
         Y2_M2_COEFF * x * y * r2_inv,  # Y_2^{-2}
         Y2_M1_COEFF * y * z * r2_inv,  # Y_2^{-1}
         Y2_0_COEFF * (wp.float64(3.0) * z2 - r2) * r2_inv,  # Y_2^0
         Y2_P1_COEFF * x * z * r2_inv,  # Y_2^{+1}
         Y2_P2_COEFF * (x2 - y2) * r2_inv,  # Y_2^{+2}
-        dtype=wp.float64,
     )
 
 
 @wp.func
-def eval_all_spherical_harmonics(r: wp.vec3d) -> wp.vec(length=9, dtype=wp.float64):
+def eval_all_spherical_harmonics(r: wp.vec3d) -> vec9d:
     """Evaluate all spherical harmonics up to L=2.
 
     Returns
     -------
-    wp.vec(9)
+    vec9d
         All harmonics in order:
         [Y_0^0, Y_1^{-1}, Y_1^0, Y_1^{+1}, Y_2^{-2}, Y_2^{-1}, Y_2^0, Y_2^{+1}, Y_2^{+2}]
     """
@@ -659,7 +662,7 @@ def eval_all_spherical_harmonics(r: wp.vec3d) -> wp.vec(length=9, dtype=wp.float
     x, y, z = r[0], r[1], r[2]
     x2, y2, z2 = x * x, y * y, z * z
 
-    return wp.vec(
+    return vec9d(
         # L=0
         Y00_COEFF,  # Y_0^0
         # L=1
@@ -672,7 +675,6 @@ def eval_all_spherical_harmonics(r: wp.vec3d) -> wp.vec(length=9, dtype=wp.float
         Y2_0_COEFF * (wp.float64(3.0) * z2 - r2_safe) * r2_inv,  # Y_2^0
         Y2_P1_COEFF * x * z * r2_inv,  # Y_2^{+1}
         Y2_P2_COEFF * (x2 - y2) * r2_inv,  # Y_2^{+2}
-        dtype=wp.float64,
     )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
## Description

Fix Warp `DeprecationWarning` for the `warp.vec` symbol. Warp 1.11.0 deprecates `wp.vec(...)` in favor of `wp.types.vector(...)`. The warning triggers at import time when loading `nvalchemiops.neighborlist` via the `spherical_harmonics` module's `@wp.func` type annotations.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- `nvalchemiops/math/spherical_harmonics.py`: Define `vec5d` / `vec9d` module-level type aliases via `wp.types.vector()`, replace `wp.vec(length=..., dtype=...)` annotations and `wp.vec(...)` constructors with the aliases.
- `nvalchemiops/math/gto.py`: Same approach with `vec5d` / `vec9d` aliases.
- `nvalchemiops/interactions/dispersion/dftd3.py`: Replace generic `wp.vec(...)` constructor with the `type()` pattern for type-generic vector construction.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

All 127 directly related tests pass (spherical harmonics, GTO, DFT-D3). Full suite (1034 tests) unaffected. Zero `warp.vec` deprecation warnings on import.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

No new tests needed -- this is a mechanical replacement of deprecated API calls. The `type()` pattern used in `dftd3.py` was verified to work correctly with both `mat33f` and `mat33d` type-generic dispatch.

Made with [Cursor](https://cursor.com)