### PR TITLE
feat: expose compute_charge_gradients in ewald_summation

### DIFF
--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -2938,6 +2938,7 @@ def ewald_summation(
     neighbor_matrix_shifts: torch.Tensor | None = None,
     mask_value: int | None = None,
     compute_forces: bool = False,
+    compute_charge_gradients: bool = False,
     compute_virial: bool = False,
     accuracy: float = 1e-6,
 ) -> tuple[torch.Tensor, ...] | torch.Tensor:
@@ -2976,6 +2977,8 @@ def ewald_summation(
         Value indicating invalid entries. Defaults to N.
     compute_forces : bool, default=False
         Whether to compute explicit forces.
+    compute_charge_gradients : bool, default=False
+        Whether to compute charge gradients dE/dq_i.
     compute_virial : bool, default=False
         Whether to compute the virial tensor W = -dE/d(epsilon).
         Stress = virial / volume.
@@ -2988,13 +2991,15 @@ def ewald_summation(
         Per-atom total Ewald energy.
     forces : torch.Tensor, shape (N, 3), optional
         Forces (if compute_forces=True).
+    charge_gradients : torch.Tensor, shape (N,), optional
+        Charge gradients (if compute_charge_gradients=True).
     virial : torch.Tensor, shape (1, 3, 3) or (B, 3, 3), optional
         Virial tensor (if compute_virial=True). Always last in the tuple.
 
     Note
     ----
     Energies are always float64 for numerical stability during accumulation.
-    Forces and virial match the input dtype (float32 or float64).
+    Forces, charge gradients, and virial match the input dtype (float32 or float64).
     """
     device = positions.device
     dtype = positions.dtype
@@ -3031,6 +3036,7 @@ def ewald_summation(
         mask_value=mask_value,
         batch_idx=batch_idx,
         compute_forces=compute_forces,
+        compute_charge_gradients=compute_charge_gradients,
         compute_virial=compute_virial,
     )
 
@@ -3043,6 +3049,7 @@ def ewald_summation(
         alpha=alpha_tensor,
         batch_idx=batch_idx,
         compute_forces=compute_forces,
+        compute_charge_gradients=compute_charge_gradients,
         compute_virial=compute_virial,
     )
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

The low-level ewald_real_space and ewald_reciprocal_space already support compute_charge_gradients, but the high-level ewald_summation did not pass it through — unlike particle_mesh_ewald which does.

This adds the parameter to ewald_summation() and forwards it to both component functions. The existing tuple-combination logic handles the extra return value automatically.

Tests added:
- charge_gradients only (no forces)
- forces + charge_gradients together
- charge_gradients vs torch.autograd reference
- batch system charge_gradients

Sphinx docs updates 

<!-- Provide a brief description of the changes in this PR -->

High-level Ewald API to support charge gradients (without splitting to real and reciprocal spaces)

<!-- Mark the relevant option with an "x" -->

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ x ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

- Add compute_charge_gradients: bool = False parameter to ewald_summation() and forward to ewald_real_space() / ewald_reciprocal_space()
- Update ewald_summation() docstring with parameter, return value, and note
- Add TestEwaldSummationChargeGradients test class (4 tests x CPU/CUDA = 8 total)
- Update 02_ewald_summation_example.py: add unified charge gradients cell, simplify autograd verification, fix numpy tensor warning, fix device print for Sphinx Gallery

## Testing
- [ x ] Unit tests pass locally (`make pytest`)
- [ x ] Linting passes (`make lint`)
- [ x ] New tests added for new functionality meets coverage expectations?

## Checklist

- [ x ] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ x ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [ x  ] I have performed a self-review of my code
- [ x ] I have added docstrings to new functions/classes
- [ x ] I have updated the documentation (if applicable)