### PR TITLE
fix: dynamics examples, benchmarks, docs, and deprecation warnings

### DIFF
--- a/benchmarks/dynamics/benchmark_fire_compare.py
+++ b/benchmarks/dynamics/benchmark_fire_compare.py
@@ -43,8 +43,7 @@ import torch
 
 from benchmarks.dynamics.shared_utils import (
     NvalchemiOpsBenchmark,
-    NvalchemiopsLJModel,
-    create_lj_system,
+    create_fcc_argon,
     get_gpu_sku,
     load_config,
 )
@@ -61,75 +60,45 @@ _DEFAULT_SEED = 42
 def _make_bench(num_atoms, perturbation=0.1, batch_size=1, seed=_DEFAULT_SEED):
     """Create a NvalchemiOpsBenchmark for a perturbed LJ system."""
     torch.manual_seed(seed)
-    positions, cell, masses, velocities = create_lj_system(
-        num_atoms=num_atoms,
-        lattice_constant=5.26,
-        temperature=300.0,
-        device="cuda",
-        dtype=torch.float64,
-    )
+    num_cells = int((num_atoms // 4 + 1) ** (1.0 / 3.0))
+    positions_np, cell_np = create_fcc_argon(num_unit_cells=num_cells, a=5.26)
+    positions = torch.as_tensor(positions_np, dtype=torch.float64, device="cuda")
+    cell = torch.as_tensor(cell_np, dtype=torch.float64, device="cuda")
     actual_atoms = positions.shape[0]
 
     if batch_size == 1:
         positions = positions + torch.randn_like(positions) * perturbation
         pbc = torch.tensor([True, True, True], device=positions.device)
 
-        lj_model = NvalchemiopsLJModel(
-            **_POTENTIAL,
-            cell=cell,
-            batch_idx=None,
-            device="cuda",
-            dtype=torch.float64,
-        )
         return NvalchemiOpsBenchmark(
             positions=positions,
             cell=cell,
-            masses=masses,
             pbc=pbc,
-            model=lj_model,
             skin=_SKIN,
             neighbor_rebuild_interval=_NEIGHBOR_REBUILD,
+            **_POTENTIAL,
         ), actual_atoms
     else:
-        # Batched system
-        pos_list, mass_list, cell_list = [], [], []
+        pos_list, cell_list = [], []
         for _ in range(batch_size):
             pos_list.append(positions + torch.randn_like(positions) * perturbation)
-            mass_list.append(masses)
             cell_list.append(cell)
         batch_positions = torch.cat(pos_list, dim=0)
-        batch_masses = torch.cat(mass_list, dim=0)
-        batch_cells = torch.cat(cell_list, dim=0)
+        batch_cells = torch.stack(cell_list, dim=0)
         batch_idx = torch.repeat_interleave(
             torch.arange(batch_size, device="cuda"),
             actual_atoms,
         ).to(torch.int32)
-        atom_ptr = torch.arange(
-            0,
-            (batch_size + 1) * actual_atoms,
-            actual_atoms,
-            device="cuda",
-            dtype=torch.int64,
-        )
         pbc = torch.tensor([True, True, True], device="cuda")
 
-        lj_model = NvalchemiopsLJModel(
-            **_POTENTIAL,
-            cell=batch_cells,
-            batch_idx=batch_idx,
-            device="cuda",
-            dtype=torch.float64,
-        )
         return NvalchemiOpsBenchmark(
             positions=batch_positions,
             cell=batch_cells,
-            masses=batch_masses,
             pbc=pbc,
-            model=lj_model,
             skin=_SKIN,
             neighbor_rebuild_interval=_NEIGHBOR_REBUILD,
             batch_idx=batch_idx,
-            atom_ptr=atom_ptr,
+            **_POTENTIAL,
         ), actual_atoms
 
 

--- a/benchmarks/dynamics/shared_utils.py
+++ b/benchmarks/dynamics/shared_utils.py
@@ -1785,8 +1785,7 @@ class NvalchemiOpsBenchmark:
     """Unified benchmark class for both single-system and batched simulations.
 
     This class consolidates MD and optimization benchmarks, automatically detecting
-    whether to use single-system or batched mode based on the presence of batch_idx
-    and atom_ptr parameters.
+    whether to use single-system or batched mode based on the presence of batch_idx.
 
     Parameters
     ----------
@@ -1794,36 +1793,35 @@ class NvalchemiOpsBenchmark:
         Atomic positions. Shape (N, 3) for single-system or (total_atoms, 3) for batched.
     cell : torch.Tensor
         Unit cell matrix. Shape (1, 3, 3) for single-system or (num_systems, 3, 3) for batched.
-    masses : torch.Tensor
-        Atomic masses. Shape (N,) for single-system or (total_atoms,) for batched.
     pbc : torch.Tensor
         Periodic boundary conditions, shape (3,).
-    model : NvalchemiopsModelInterface, optional
-        Model for force/energy computation. If None, uses LJ with epsilon/sigma/cutoff.
+    masses : torch.Tensor, optional
+        Atomic masses. Shape (N,) or (total_atoms,). Default: argon mass for all atoms.
     epsilon : float, optional
-        LJ epsilon parameter (eV). Used only if model is None.
+        LJ epsilon parameter (eV).
     sigma : float, optional
-        LJ sigma parameter (Å). Used only if model is None.
+        LJ sigma parameter (Å).
     cutoff : float, optional
-        LJ cutoff distance (Å). Used only if model is None.
+        LJ cutoff distance (Å).
     skin : float, optional
         Neighbor list skin distance (Å). Default 1.0.
+    switch_width : float, optional
+        Switching function width (Å). Default 0.0.
+    half_neighbor_list : bool, optional
+        Whether to use half neighbor lists. Default True.
     neighbor_rebuild_interval : int, optional
         Interval for rebuilding neighbor lists (0 = displacement-based). Default 10.
     velocities : torch.Tensor, optional
         Initial velocities. Required for MD, optional for optimization.
     batch_idx : torch.Tensor, optional
         Batch index for each atom (batched mode only). Shape (total_atoms,).
-    atom_ptr : torch.Tensor, optional
-        Pointer to start of each batch (batched mode only). Shape (num_systems+1,).
 
     Notes
     -----
-    - Batching is auto-detected: if batch_idx and atom_ptr are provided, batched mode is used.
+    - Batching is auto-detected: if batch_idx is provided, batched mode is used.
     - For batched mode, positions/velocities/masses should be concatenated across all systems.
     - Supports integrators: VelocityVerlet, Langevin, NoseHoover, NPT, NPH.
-    - Supports optimizer: FIRE.
-    - If model is None, automatically creates NvalchemiopsLJModel with epsilon/sigma/cutoff.
+    - Supports optimizers: FIRE, FIRE2.
     """
 
     def __init__(

--- a/benchmarks/dynamics/shared_utils.py
+++ b/benchmarks/dynamics/shared_utils.py
@@ -1221,6 +1221,7 @@ class MDSystem:
         self.num_atoms = len(positions)
         self.total_atoms = self.num_atoms
         self.num_systems = 1
+        self.wp_batch_idx = None
         self.epsilon = epsilon
         self.sigma = sigma
         self.cutoff = cutoff
@@ -1285,12 +1286,10 @@ class MDSystem:
 
     def _rebuild_neighbors(self) -> None:
         """Rebuild neighbor list from current positions."""
-        # Sync warp positions to torch
-        self.torch_positions = wp.to_torch(self.wp_positions)
-
-        # Sync warp cell to torch (cell may change for NPT/NPH)
-        self.torch_cell = wp.to_torch(self.wp_cell).squeeze(0)
-
+        self.positions = wp.to_torch(self.wp_positions).reshape(-1, 3)
+        self.cell = wp.to_torch(self.wp_cell).squeeze(0)
+        self.torch_positions = self.positions
+        self.torch_cell = self.cell
         self.neighbor_manager.build(
             positions=self.positions,
             cell=self.cell,
@@ -1406,7 +1405,7 @@ class MDSystem:
             New cell matrix.
         """
         wp.copy(self.wp_cell, cell)
-        compute_cell_inverse(self.wp_cell, self.wp_cell_inv, device=self.device)
+        compute_cell_inverse(self.wp_cell, self.wp_cell_inv, device=self.wp_device)
         # Update torch cell for neighbor list
         self.cell = wp.to_torch(self.wp_cell)
         # Force neighbor rebuild on next force computation
@@ -1414,24 +1413,24 @@ class MDSystem:
 
     def kinetic_energy(self) -> wp.array:
         """Compute kinetic energy on device (shape (1,), in eV)."""
-        ke = wp.zeros(1, dtype=self.wp_dtype, device=self.device)
+        ke = wp.zeros(1, dtype=self.wp_dtype, device=self.wp_device)
         compute_kinetic_energy(
             velocities=self.wp_velocities,
             masses=self.wp_masses,
             kinetic_energy=ke,
-            device=self.device,
+            device=self.wp_device,
         )
         return ke
 
     def temperature_kT(self) -> wp.array:
         """Compute instantaneous temperature on device (kB*T in eV, shape (1,))."""
         ke = self.kinetic_energy()
-        temp = wp.zeros(1, dtype=self.wp_dtype, device=self.device)
+        temp = wp.zeros(1, dtype=self.wp_dtype, device=self.wp_device)
         compute_temperature(
             kinetic_energy=ke,
             temperature=temp,
             num_atoms_per_system=wp.array(
-                [self.num_atoms], dtype=wp.int32, device=self.device
+                [self.num_atoms], dtype=wp.int32, device=self.wp_device
             ),
         )
         return temp
@@ -1447,12 +1446,12 @@ class MDSystem:
             Random seed for reproducibility.
         """
         kT = float(temperature) * KB_EV
-        wp_temperature = wp.array([kT], dtype=self.wp_dtype, device=self.device)
+        wp_temperature = wp.array([kT], dtype=self.wp_dtype, device=self.wp_device)
 
         # Scratch arrays for COM removal
-        wp_total_momentum = wp.zeros(1, dtype=self.wp_vec_dtype, device=self.device)
-        wp_total_mass = wp.zeros(1, dtype=self.wp_dtype, device=self.device)
-        wp_com_velocities = wp.zeros(1, dtype=self.wp_vec_dtype, device=self.device)
+        wp_total_momentum = wp.zeros(1, dtype=self.wp_vec_dtype, device=self.wp_device)
+        wp_total_mass = wp.zeros(1, dtype=self.wp_dtype, device=self.wp_device)
+        wp_com_velocities = wp.zeros(1, dtype=self.wp_vec_dtype, device=self.wp_device)
 
         initialize_velocities(
             velocities=self.wp_velocities,
@@ -1463,7 +1462,7 @@ class MDSystem:
             com_velocities=wp_com_velocities,
             random_seed=seed,
             remove_com=True,
-            device=self.device,
+            device=self.wp_device,
         )
 
         # One-time feedback: host read for user confidence
@@ -1554,6 +1553,10 @@ class BatchedMDSystem:
         self._rebuild_neighbors()
 
     def _rebuild_neighbors(self) -> None:
+        self.positions = wp.to_torch(self.wp_positions).reshape(-1, 3)
+        self.cell = wp.to_torch(self.wp_cell).reshape(-1, 3, 3)
+        self.torch_positions = self.positions
+        self.torch_cell = self.cell
         self.neighbor_manager.build(self.positions, self.cell, self.pbc)
 
     def initialize_temperature(self, temperatures_K: np.ndarray, seed: int = 0) -> None:
@@ -1713,7 +1716,7 @@ class BatchedMDSystem:
 
     def kinetic_energy_per_system(self) -> wp.array:
         """Compute kinetic energy per system (shape (B,), in eV)."""
-        ke = wp.zeros(self.num_systems, dtype=self.wp_dtype, device=self.device)
+        ke = wp.zeros(self.num_systems, dtype=self.wp_dtype, device=self.wp_device)
         compute_kinetic_energy(
             velocities=self.wp_velocities,
             masses=self.wp_masses,
@@ -1750,7 +1753,7 @@ class BatchedMDSystem:
         tensor_dtype = vec9f if self.wp_dtype == wp.float32 else vec9d
 
         # Pre-allocate scratch arrays
-        volumes = wp.empty(1, dtype=self.wp_dtype, device=self.device)
+        volumes = wp.empty(1, dtype=self.wp_dtype, device=self.wp_device)
         compute_cell_volume(self.wp_cell, volumes=volumes, device=self.wp_device)
 
         kinetic_tensors = wp.zeros((1, 9), dtype=self.wp_dtype, device=self.wp_device)
@@ -1840,7 +1843,6 @@ class NvalchemiOpsBenchmark:
         batch_idx: torch.Tensor | None = None,
     ):
         self.is_batched = batch_idx is not None
-        self.num_atoms = positions.shape[0] // cell.shape[0]
         if self.is_batched:
             self.system = BatchedMDSystem(
                 positions=positions,
@@ -1864,14 +1866,56 @@ class NvalchemiOpsBenchmark:
                 cell=cell,
                 masses=masses,
                 pbc=pbc,
+                epsilon=epsilon,
+                sigma=sigma,
+                cutoff=cutoff,
+                skin=skin,
+                switch_width=switch_width,
+                half_neighbor_list=half_neighbor_list,
                 device=positions.device,
                 dtype=positions.dtype,
             )
+
+        self.neighbor_rebuild_interval = neighbor_rebuild_interval
+        self._steps_since_rebuild = 0
 
         # Device and dtype setup (needed for model creation)
         self.device = positions.device
         self.dtype = positions.dtype
         self.wp_device = str(self.device)
+
+    def __getattr__(self, name: str):
+        """Delegate attribute lookups to the underlying system object."""
+        system = self.__dict__.get("system")
+        if system is not None:
+            try:
+                return getattr(system, name)
+            except AttributeError:
+                pass
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute {name!r}"
+        )
+
+    def _compute_forces(self, wp_positions, compute_virial=False):
+        """Update system positions and compute forces (and optionally virial).
+
+        Parameters
+        ----------
+        wp_positions : wp.array
+            Atomic positions.
+        compute_virial : bool
+            If True, compute and return virial tensor.
+
+        Returns
+        -------
+        tuple
+            (energies, forces, virial) if compute_virial, else (energies, forces).
+        """
+        self.system.wp_positions = wp_positions
+        if compute_virial:
+            return self.system.compute_forces_virial()
+        energies = self.system.compute_forces()
+        return energies, self.system.wp_forces
 
     def _run_warmup(
         self, run_step_fn, warmup_steps: int, log_message: str = "Warmup"
@@ -3343,11 +3387,8 @@ class NvalchemiOpsBenchmark:
             batch_idx=wp_bidx,
             device=self.wp_device,
         )
-        self.wp_cell = wp_cell
-        self.model.wp_cell = self.wp_cell
+        self.system.wp_cell = wp_cell
         wp.synchronize()
-        self.torch_positions = wp.to_torch(wp_positions).reshape(-1, 3)
-        self.torch_cell = wp.to_torch(wp_cell).reshape(M, 3, 3)
         self._rebuild_neighbors()
 
         # Extended batch_idx: atoms + 2 extra DOFs per system
@@ -3517,7 +3558,6 @@ class NvalchemiOpsBenchmark:
                 vv=wp_vv,
                 ff=wp_ff,
                 batch_idx=ext_bidx,
-                device=self.wp_device,
             )
 
             # Unpack extended positions → atom positions + cell
@@ -3530,8 +3570,7 @@ class NvalchemiOpsBenchmark:
             )
             wp_positions = wp_positions_scratch
             wp_cell = wp_cell_scratch
-            self.wp_cell = wp_cell
-            self.model.wp_cell = self.wp_cell
+            self.system.wp_cell = wp_cell
 
             # Wrap positions
             compute_cell_inverse(wp_cell, wp_cell_inv, device=self.wp_device)
@@ -3551,8 +3590,6 @@ class NvalchemiOpsBenchmark:
             )
 
             # Compute new forces + virial
-            self.torch_positions = wp.to_torch(wp_positions).reshape(-1, 3)
-            self.torch_cell = wp.to_torch(wp_cell).reshape(M, 3, 3)
             _, wp_forces, wp_virial = self._compute_forces(
                 wp_positions,
                 compute_virial=True,
@@ -3571,12 +3608,6 @@ class NvalchemiOpsBenchmark:
                 ext_forces,
                 device=self.wp_device,
             )
-
-            # Rebuild neighbors if needed
-            if self.neighbor_rebuild_interval > 0:
-                self._steps_since_rebuild += 1
-                if self._steps_since_rebuild >= self.neighbor_rebuild_interval:
-                    self._rebuild_neighbors()
 
         wp.synchronize()
         total_time = time.perf_counter() - start_time
@@ -3733,11 +3764,8 @@ class NvalchemiOpsBenchmark:
             batch_idx=wp_bidx,
             device=self.wp_device,
         )
-        self.wp_cell = wp_cell
-        self.model.wp_cell = self.wp_cell
+        self.system.wp_cell = wp_cell
         wp.synchronize()
-        self.torch_positions = wp.to_torch(wp_positions).reshape(-1, 3)
-        self.torch_cell = wp.to_torch(wp_cell).reshape(M, 3, 3)
         self._rebuild_neighbors()
 
         # Extended batch_idx: atoms + 2 extra DOFs per system
@@ -3868,8 +3896,7 @@ class NvalchemiOpsBenchmark:
             )
             wp_positions = wp_positions_scratch
             wp_cell = wp_cell_scratch
-            self.wp_cell = wp_cell
-            self.model.wp_cell = self.wp_cell
+            self.system.wp_cell = wp_cell
 
             # Wrap positions
             compute_cell_inverse(wp_cell, wp_cell_inv, device=self.wp_device)
@@ -3889,8 +3916,6 @@ class NvalchemiOpsBenchmark:
             )
 
             # Compute new forces + virial
-            self.torch_positions = wp.to_torch(wp_positions).reshape(-1, 3)
-            self.torch_cell = wp.to_torch(wp_cell).reshape(M, 3, 3)
             _, wp_forces, wp_virial = self._compute_forces(
                 wp_positions,
                 compute_virial=True,
@@ -3909,12 +3934,6 @@ class NvalchemiOpsBenchmark:
                 ext_forces,
                 device=self.wp_device,
             )
-
-            # Rebuild neighbors if needed
-            if self.neighbor_rebuild_interval > 0:
-                self._steps_since_rebuild += 1
-                if self._steps_since_rebuild >= self.neighbor_rebuild_interval:
-                    self._rebuild_neighbors()
 
         wp.synchronize()
         total_time = time.perf_counter() - start_time

--- a/docs/benchmarks/neighborlist.md
+++ b/docs/benchmarks/neighborlist.md
@@ -47,7 +47,8 @@ where we scale up the size of the system.
 :align: center
 :alt: Naive algorithm backend time comparison
 
-Median execution time comparison between backends. The $O(N^2)$ scaling becomes apparent for larger systems.
+Median execution time comparison between backends.
+The $O(N^2)$ scaling becomes apparent for larger systems.
 ```
 
 #### Throughput
@@ -167,7 +168,8 @@ where we scale up the size of the system.
 :align: center
 :alt: Cell list algorithm backend time comparison
 
-Median execution time comparison between backends. Shows near-linear $O(N)$ scaling for large systems.
+Median execution time comparison between backends.
+Shows near-linear $O(N)$ scaling for large systems.
 ```
 
 #### Throughput

--- a/docs/userguide/about/intro.md
+++ b/docs/userguide/about/intro.md
@@ -87,7 +87,7 @@ neighbor_matrix, num_neighbors, shifts = neighbor_list(
 )
 ```
 
-Dispatches to {func}`~nvalchemiops.torch.neighbors.unbatched.cell_list` — O(N) algorithm
+Dispatches to {func}`~nvalchemiops.torch.neighbors.cell_list.cell_list` — O(N) algorithm
 using spatial decomposition.
 :::
 
@@ -104,7 +104,7 @@ neighbor_matrix, num_neighbors, shifts = neighbor_list(
 )
 ```
 
-Dispatches to {func}`~nvalchemiops.torch.neighbors.unbatched.naive_neighbor_list` — O(N²)
+Dispatches to {func}`~nvalchemiops.torch.neighbors.naive.naive_neighbor_list` — O(N²)
 algorithm with lower overhead.
 :::
 
@@ -122,7 +122,7 @@ neighbor_matrix, num_neighbors, shifts = neighbor_list(
 )
 ```
 
-Dispatches to {func}`~nvalchemiops.torch.neighbors.batched.batch_cell_list` — O(N)
+Dispatches to {func}`~nvalchemiops.torch.neighbors.batch_cell_list.batch_cell_list` — O(N)
 algorithm for heterogeneous batches.
 :::
 
@@ -140,8 +140,9 @@ neighbor_matrix, num_neighbors, shifts = neighbor_list(
 )
 ```
 
-Dispatches to {func}`~nvalchemiops.torch.neighbors.batched.batch_naive_neighbor_list` —
-O(N²) algorithm for batched small systems.
+Dispatches to
+{func}`~nvalchemiops.torch.neighbors.batch_naive.batch_naive_neighbor_list`
+— O(N²) algorithm for batched small systems.
 :::
 
 ::::

--- a/docs/userguide/about/migration.md
+++ b/docs/userguide/about/migration.md
@@ -17,6 +17,7 @@ namespace. This guide provides a mapping of old import paths to new ones.
 | `from nvalchemiops.neighbors import neighbor_list` | `from nvalchemiops.torch.neighbors import neighbor_list` |
 | `from nvalchemiops.neighbors import estimate_max_neighbors` | `from nvalchemiops.torch.neighbors.neighbor_utils import estimate_max_neighbors` |
 | `from nvalchemiops.neighborlist import neighbor_list` | `from nvalchemiops.torch.neighbors import neighbor_list` |
+| `from nvalchemiops.neighborlist import cell_list` | `from nvalchemiops.torch.neighbors import cell_list` |
 
 ## Backwards Compatibility
 

--- a/docs/userguide/components/neighborlist.md
+++ b/docs/userguide/components/neighborlist.md
@@ -55,7 +55,7 @@ neighbor_matrix, num_neighbors, shifts = neighbor_list(
 )
 ```
 
-Dispatches to {func}`~nvalchemiops.torch.neighbors.unbatched.cell_list` --- \(O(N)\) algorithm
+Dispatches to {func}`~nvalchemiops.torch.neighbors.cell_list.cell_list` --- \(O(N)\) algorithm
 using spatial decomposition.
 :::
 
@@ -72,7 +72,7 @@ neighbor_matrix, num_neighbors, shifts = neighbor_list(
 )
 ```
 
-Dispatches to {func}`~nvalchemiops.torch.neighbors.unbatched.naive_neighbor_list` --- \(O(N^2)\)
+Dispatches to {func}`~nvalchemiops.torch.neighbors.naive.naive_neighbor_list` --- \(O(N^2)\)
 algorithm with lower overhead.
 :::
 
@@ -90,7 +90,7 @@ neighbor_matrix, num_neighbors, shifts = neighbor_list(
 )
 ```
 
-Dispatches to {func}`~nvalchemiops.torch.neighbors.batched.batch_cell_list` --- \(O(N)\)
+Dispatches to {func}`~nvalchemiops.torch.neighbors.batch_cell_list.batch_cell_list` --- \(O(N)\)
 algorithm for heterogeneous batches.
 :::
 
@@ -108,7 +108,7 @@ neighbor_matrix, num_neighbors, shifts = neighbor_list(
 )
 ```
 
-Dispatches to {func}`~nvalchemiops.torch.neighbors.batched.batch_naive_neighbor_list` ---
+Dispatches to {func}`~nvalchemiops.torch.neighbors.batch_naive.batch_naive_neighbor_list` ---
 \(O(N^2)\) algorithm for batched small systems.
 :::
 
@@ -239,7 +239,7 @@ $$
 
 ```python
 from nvalchemiops.neighbors.neighbor_utils import estimate_max_neighbors
-from nvalchemiops.torch.neighbors.unbatched import estimate_cell_list_sizes
+from nvalchemiops.torch.neighbors.cell_list import estimate_cell_list_sizes
 
 max_neighbors = estimate_max_neighbors(
     cutoff,
@@ -312,7 +312,7 @@ For cell list methods, you can also pre-allocate the spatial data structures:
 
 ```python
 from nvalchemiops.torch.neighbors import neighbor_list
-from nvalchemiops.torch.neighbors.unbatched import estimate_cell_list_sizes
+from nvalchemiops.torch.neighbors.cell_list import estimate_cell_list_sizes
 from nvalchemiops.torch.neighbors.neighbor_utils import allocate_cell_list
 
 max_total_cells, neighbor_search_radius = estimate_cell_list_sizes(cell, pbc, cutoff)
@@ -424,7 +424,7 @@ For molecular dynamics, separate building and querying allows caching the
 spatial data structure:
 
 ```python
-from nvalchemiops.torch.neighbors.unbatched import (
+from nvalchemiops.torch.neighbors.cell_list import (
     build_cell_list, query_cell_list, estimate_cell_list_sizes
 )
 from nvalchemiops.torch.neighbors.neighbor_utils import (
@@ -463,7 +463,7 @@ for step in range(num_steps):
 Avoid rebuilding neighbor lists every step by using a skin distance:
 
 ```python
-from nvalchemiops.torch.neighbors.unbatched import (
+from nvalchemiops.torch.neighbors.cell_list import (
     build_cell_list, query_cell_list, estimate_cell_list_sizes
 )
 from nvalchemiops.torch.neighbors.neighbor_utils import allocate_cell_list

--- a/examples/dynamics/06_fire_optimization.py
+++ b/examples/dynamics/06_fire_optimization.py
@@ -168,9 +168,6 @@ for step in range(max_steps):
         vf=vf_wp,
         vv=vv_wp,
         ff=ff_wp,
-        # Single system mode: no batch_idx, no atom_ptr
-        # No downhill check: energy, energy_last, positions_last, velocities_last not provided
-        device=device,
     )
 
     # Logging / stopping criteria (host read only at intervals)

--- a/examples/dynamics/07_fire_variable_cell.py
+++ b/examples/dynamics/07_fire_variable_cell.py
@@ -42,10 +42,10 @@ from __future__ import annotations
 import matplotlib.pyplot as plt
 import numpy as np
 import warp as wp
-from _langevin_utils import (
+from _dynamics_utils import (
     AMU_TO_EV_FS2_PER_A2 as AMU_TO_INTERNAL,
 )
-from _langevin_utils import (
+from _dynamics_utils import (
     EPSILON_AR,
     MASS_AR,
     SIGMA_AR,
@@ -308,7 +308,6 @@ for step in range(max_steps):
         vf=vf,
         vv=vv,
         ff=ff,
-        device=device,
     )
 
     # Check convergence and log only at intervals (avoid sync every step)

--- a/examples/dynamics/08_fire_batched.py
+++ b/examples/dynamics/08_fire_batched.py
@@ -241,7 +241,6 @@ for step in range(max_steps):
         vv=vv,
         ff=ff,
         batch_idx=batch_idx,
-        device=device,
     )
 
     # Check convergence at intervals
@@ -330,7 +329,6 @@ for step in range(max_steps):
         f_inc=f_inc_arr,
         uphill_flag=uphill_flag,
         atom_ptr=atom_ptr,  # Use atom_ptr instead of batch_idx
-        device=device,
     )
 
     # Check convergence at intervals

--- a/examples/dynamics/09_fire2_optimization.py
+++ b/examples/dynamics/09_fire2_optimization.py
@@ -145,7 +145,6 @@ for step in range(max_steps):
         v_sumsq=v_sumsq,
         f_sumsq=f_sumsq,
         max_norm=max_norm,
-        device=device,
     )
 
     # Logging / stopping criteria (host read only at intervals)

--- a/examples/dynamics/10_fire2_batched.py
+++ b/examples/dynamics/10_fire2_batched.py
@@ -182,7 +182,6 @@ for step in range(max_steps):
         v_sumsq=v_sumsq,
         f_sumsq=f_sumsq,
         max_norm=max_norm,
-        device=device,
     )
 
     # Check convergence at intervals

--- a/examples/dynamics/11_fire2_variable_cell.py
+++ b/examples/dynamics/11_fire2_variable_cell.py
@@ -263,7 +263,6 @@ for step in range(max_steps):
         v_sumsq=v_sumsq,
         f_sumsq=f_sumsq,
         max_norm=max_norm_buf,
-        device=device,
     )
 
     # Check convergence and log only at intervals

--- a/examples/dynamics/_dynamics_utils.py
+++ b/examples/dynamics/_dynamics_utils.py
@@ -852,6 +852,11 @@ class MDSystem:
             self.num_atoms, dtype=self.wp_vec_dtype, device=device
         )
         self.wp_masses = wp.array(masses, dtype=self.wp_dtype, device=device)
+        self.wp_num_atoms_per_system = wp.array(
+            [self.num_atoms], dtype=wp.int32, device=device
+        )
+        self._ke_buf = wp.zeros(1, dtype=self.wp_dtype, device=device)
+        self._temp_buf = wp.zeros(1, dtype=self.wp_dtype, device=device)
 
         # Cell matrix (shape (1,) for single system)
         cell_reshaped = cell.reshape(1, 3, 3).astype(dtype)
@@ -1011,26 +1016,25 @@ class MDSystem:
 
     def kinetic_energy(self) -> wp.array:
         """Compute kinetic energy on device (shape (1,), in eV)."""
-        ke = wp.zeros(1, dtype=self.wp_dtype, device=self.device)
+        self._ke_buf.zero_()
         compute_kinetic_energy(
             velocities=self.wp_velocities,
             masses=self.wp_masses,
-            kinetic_energy=ke,
+            kinetic_energy=self._ke_buf,
             device=self.device,
         )
-        return ke
+        return self._ke_buf
 
     def temperature_kT(self) -> wp.array:
         """Compute instantaneous temperature on device (kB*T in eV, shape (1,))."""
         ke = self.kinetic_energy()
-        temp = wp.zeros(1, dtype=self.wp_dtype, device=self.device)
+        self._temp_buf.zero_()
         compute_temperature(
             kinetic_energy=ke,
-            temperature=temp,
-            num_atoms=self.num_atoms,
-            device=self.device,
+            temperature=self._temp_buf,
+            num_atoms_per_system=self.wp_num_atoms_per_system,
         )
-        return temp
+        return self._temp_buf
 
     def initialize_temperature(self, temperature: float, seed: int = 42) -> None:
         """Initialize velocities to target temperature (single system).
@@ -1147,6 +1151,11 @@ class BatchedMDSystem:
         self.wp_batch_idx = wp.array(
             batch_idx.astype(np.int32), dtype=wp.int32, device=device
         )
+        self.wp_num_atoms_per_system = wp.array(
+            self.num_atoms_per_system.astype(np.int32), dtype=wp.int32, device=device
+        )
+        self._ke_buf = wp.zeros(self.num_systems, dtype=self.wp_dtype, device=device)
+        self._temp_buf = wp.zeros(self.num_systems, dtype=self.wp_dtype, device=device)
 
         self.neighbor_manager = BatchedNeighborListManager(
             total_atoms=self.total_atoms,
@@ -1236,45 +1245,27 @@ class BatchedMDSystem:
 
     def kinetic_energy_per_system(self) -> wp.array:
         """Compute kinetic energy per system (shape (B,), in eV)."""
-        B = self.num_systems
-        ke = wp.zeros(B, dtype=self.wp_dtype, device=self.device)
+        self._ke_buf.zero_()
         compute_kinetic_energy(
             velocities=self.wp_velocities,
             masses=self.wp_masses,
-            kinetic_energy=ke,
+            kinetic_energy=self._ke_buf,
             batch_idx=self.wp_batch_idx,
-            num_systems=B,
+            num_systems=self.num_systems,
             device=self.device,
         )
-        return ke
+        return self._ke_buf
 
     def temperature_kT_per_system(self) -> wp.array:
-        """Compute temperature per system (kB*T, shape (B,)).
-
-        Note
-        ----
-        :func:`nvalchemiops.dynamics.utils.compute_temperature` currently takes a
-        single `num_atoms` value (per system). For heterogeneous batches this is
-        ambiguous, so we require uniform system sizes here.
-        """
-        n = np.asarray(self.num_atoms_per_system, dtype=np.int64)
-        if not np.all(n == n[0]):
-            raise ValueError(
-                "temperature_kT_per_system requires uniform num_atoms per system; "
-                f"got {n}."
-            )
-        B = self.num_systems
+        """Compute temperature per system (kB*T, shape (B,))."""
         ke = self.kinetic_energy_per_system()
-        temp = wp.zeros(B, dtype=self.wp_dtype, device=self.device)
+        self._temp_buf.zero_()
         compute_temperature(
             kinetic_energy=ke,
-            temperature=temp,
-            num_atoms=int(n[0]),
-            batch_idx=self.wp_batch_idx,
-            num_systems=B,
-            device=self.device,
+            temperature=self._temp_buf,
+            num_atoms_per_system=self.wp_num_atoms_per_system,
         )
-        return temp
+        return self._temp_buf
 
 
 def run_langevin_baoab(

--- a/nvalchemiops/interactions/electrostatics/dsf.py
+++ b/nvalchemiops/interactions/electrostatics/dsf.py
@@ -108,9 +108,9 @@ References
 from __future__ import annotations
 
 import math
+from typing import Any
 
 import warp as wp
-from warp.types import Any
 
 from nvalchemiops.dynamics.utils.launch_helpers import (
     KernelFamily,

--- a/nvalchemiops/interactions/electrostatics/pme_kernels.py
+++ b/nvalchemiops/interactions/electrostatics/pme_kernels.py
@@ -94,9 +94,9 @@ REFERENCES
 """
 
 import math
+from typing import Any
 
 import warp as wp
-from warp.types import Any
 
 # Mathematical constants
 PI = math.pi

--- a/nvalchemiops/neighborlist/__init__.py
+++ b/nvalchemiops/neighborlist/__init__.py
@@ -142,7 +142,7 @@ def __getattr__(name: str):  # pragma: no cover
                 raise RuntimeError(
                     f"PyTorch is required to use the previous `{name}` API."
                     " Please install via `pip install 'nvalchemiops[torch]'`"
-                    f" and import from `nvalchemiops.torch.neighbors.{name}` instead."
+                    f" and use `from nvalchemiops.torch.neighbors import {name}` instead."
                 )
 
             return _missing

--- a/nvalchemiops/neighborlist/__init__.py
+++ b/nvalchemiops/neighborlist/__init__.py
@@ -112,7 +112,6 @@ sys.modules["nvalchemiops.neighborlist.rebuild_detection"] = (
 # Also expose submodules as attributes for `import nvalchemiops.neighborlist.naive` style
 naive = _neighbors.naive
 naive_dual_cutoff = _neighbors.naive_dual_cutoff
-cell_list = _neighbors.cell_list
 batch_cell_list = _neighbors.batch_cell_list
 batch_naive = _neighbors.batch_naive
 batch_naive_dual_cutoff = _neighbors.batch_naive_dual_cutoff
@@ -123,9 +122,10 @@ rebuild_detection = _neighbors.rebuild_detection
 def __getattr__(name: str):  # pragma: no cover
     """Lazy import for backward compatibility with the old API.
 
-    This handles the `neighbor_list` attribute which requires PyTorch.
+    This handles the `neighbor_list` and `cell_list` attributes which
+    require PyTorch.
     """
-    if name == "neighbor_list":
+    if name in ("neighbor_list", "cell_list"):
         import importlib.util
 
         if importlib.util.find_spec("torch") is None:
@@ -138,15 +138,14 @@ def __getattr__(name: str):  # pragma: no cover
                 stacklevel=2,
             )
 
-            def neighbor_list(*args, **kwargs):
-                """Raise a `RuntimeError` if we can't use the new API with torch."""
+            def _missing(*args, **kwargs):
                 raise RuntimeError(
-                    "PyTorch is required to use the previous `neighbor_list` API."
+                    f"PyTorch is required to use the previous `{name}` API."
                     " Please install via `pip install 'nvalchemiops[torch]'`"
-                    " and import from `nvalchemiops.torch.neighbors.neighbor_list` instead."
+                    f" and import from `nvalchemiops.torch.neighbors.{name}` instead."
                 )
 
-            return neighbor_list
+            return _missing
         else:
             warnings.warn(
                 "From version 0.3.0 onwards, PyTorch is now an optional dependency"
@@ -156,9 +155,9 @@ def __getattr__(name: str):  # pragma: no cover
                 category=DeprecationWarning,
                 stacklevel=2,
             )
-            from nvalchemiops.torch.neighbors import neighbor_list
+            import nvalchemiops.torch.neighbors as _torch_neighbors
 
-            return neighbor_list
+            return getattr(_torch_neighbors, name)
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/nvalchemiops/torch/neighbors/neighbor_utils.py
+++ b/nvalchemiops/torch/neighbors/neighbor_utils.py
@@ -150,8 +150,8 @@ def get_neighbor_list_from_neighbor_matrix(
 
     See Also
     --------
-    nvalchemiops.torch.neighbors.unbatched.naive_neighbor_list : Uses this for format conversion
-    nvalchemiops.torch.neighbors.unbatched.cell_list : Uses this for format conversion
+    nvalchemiops.torch.neighbors.naive.naive_neighbor_list : Uses this for format conversion
+    nvalchemiops.torch.neighbors.cell_list.cell_list : Uses this for format conversion
     """
     # Handle empty case
     if num_neighbors.shape[0] == 0:
@@ -247,8 +247,8 @@ def prepare_batch_idx_ptr(
 
     See Also
     --------
-    nvalchemiops.torch.neighbors.batched.batch_naive_neighbor_list : Uses this for batch setup
-    nvalchemiops.torch.neighbors.batched.batch_cell_list : Uses this for batch setup
+    nvalchemiops.torch.neighbors.batch_naive.batch_naive_neighbor_list : Uses this for batch setup
+    nvalchemiops.torch.neighbors.batch_cell_list.batch_cell_list : Uses this for batch setup
     """
     if batch_idx is None and batch_ptr is None:
         raise ValueError("Either batch_idx or batch_ptr must be provided.")
@@ -331,8 +331,8 @@ def allocate_cell_list(
     See Also
     --------
     nvalchemiops.neighbors.cell_list.build_cell_list : Warp launcher that uses these tensors
-    nvalchemiops.torch.neighbors.unbatched.build_cell_list : High-level PyTorch wrapper
-    nvalchemiops.torch.neighbors.batched.batch_build_cell_list : Batched version
+    nvalchemiops.torch.neighbors.cell_list.build_cell_list : High-level PyTorch wrapper
+    nvalchemiops.torch.neighbors.batch_cell_list.batch_build_cell_list : Batched version
     """
     # Detect number of systems from neighbor_search_radius shape
     is_batched = neighbor_search_radius.ndim == 2


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
## Description

Fix pre-existing bugs across dynamics examples, benchmarks, and documentation that prevented examples and benchmarks from running, along with deprecation warning cleanup and doc cross-reference corrections.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

### Examples (`examples/dynamics/`)
- Remove invalid `device=` kwarg from `fire_step()`/`fire2_step()` calls in 6 example files (these functions do not accept a `device` parameter)
- Fix broken import in `07_fire_variable_cell.py` (`_langevin_utils` -> `_dynamics_utils`)
- Pre-allocate KE/temperature scratch buffers in `MDSystem` and `BatchedMDSystem` to eliminate warp allocations in hot loops
- Fix `compute_temperature` call signature: `num_atoms=` -> `num_atoms_per_system=` to match actual API

### Benchmarks (`benchmarks/dynamics/`)
- Fix `benchmark_fire_compare.py`: replace non-existent `NvalchemiopsLJModel`/`create_lj_system` imports with `create_fcc_argon`; use `torch.stack` instead of `torch.cat` for batched cells (correct `(B, 3, 3)` shape)
- Fix `shared_utils.py` `NvalchemiOpsBenchmark`:
  - Add `__getattr__` delegation to `self.system` (replaces broken `self.model` references throughout variable-cell FIRE/FIRE2 methods)
  - Add `_compute_forces` bridge method (was called but never defined)
  - Forward LJ parameters (`epsilon`/`sigma`/`cutoff`/`skin`/`switch_width`/`half_neighbor_list`) to unbatched `MDSystem` (was already done for batched)
  - Fix `self.device` (torch.device) -> `self.wp_device` (string) for all warp API calls
  - Fix stale position/cell sync in `MDSystem._rebuild_neighbors` and `BatchedMDSystem._rebuild_neighbors`
  - Remove dead interval-based neighbor rebuild code (variables were never initialized, displacement-based check already handles rebuilds)
  - Add `self.wp_batch_idx = None` to `MDSystem.__init__` for uniform attribute access

### Library (`nvalchemiops/`)
- Fix `cell_list` import in `nvalchemiops.neighborlist` via `__getattr__` with `DeprecationWarning` (was resolving to the warp-kernel submodule instead of the torch function)
- Replace deprecated `warp.types.Any` with `typing.Any` in electrostatics kernels (`dsf.py`, `pme_kernels.py`)

### Documentation
- Update migration guide with `cell_list` deprecation mapping
- Fix Sphinx cross-references pointing to non-existent `~nvalchemiops.torch.neighbors.unbatched.*` and `~nvalchemiops.torch.neighbors.batched.*` modules (corrected to `cell_list`/`naive`/`batch_cell_list`/`batch_naive`)
- Fix markdownlint line-length violations in `docs/userguide/about/intro.md` and `docs/benchmarks/neighborlist.md`

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?
- [x] All pre-commit hooks pass
- [x] All dynamics examples run without errors (06-11)
- [x] All dynamics benchmarks run successfully (`benchmark_fire_compare`, `benchmark_opt_single`, `benchmark_opt_batch`)

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

All changes fix pre-existing bugs or address API signature mismatches. No new features or behavioral changes are introduced. The `NvalchemiopsLJModel` class and `create_lj_system` function referenced in `benchmark_fire_compare.py` were never defined in `shared_utils.py`, meaning the benchmark was broken from the start. The variable-cell FIRE/FIRE2 benchmark methods referenced `self.model` which also never existed. These are now properly routed through `self.system` via `__getattr__` delegation.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct pull request reviews. We encourage contributors to read and consider suggestions made by Greptile, but note that human maintainers will provide the necessary reviews for merging: Greptile's comments are **not** a qualitative judgement of your code, nor is it an indication that the PR will be accepted/rejected. We encourage the use of emoji reactions to Greptile comments, depending on their usefulness and accuracy.
