### PR TITLE
fix: reduce per-system k_cutoff to shared max for batch Ewald Miller …

### DIFF
--- a/docs/userguide/components/electrostatics.md
+++ b/docs/userguide/components/electrostatics.md
@@ -1151,6 +1151,11 @@ energy_per_system = torch.zeros(3, device=positions.device)
 energy_per_system.scatter_add_(0, batch_idx.long(), energies)
 ```
 
+Batch mode uses one shared set of Miller indices for the reciprocal-space
+calculation. If `k_cutoff` is supplied per system, either directly or via
+`estimate_ewald_parameters`, `nvalchemiops` uses the maximum cutoff across the
+batch to build that shared set.
+
 :::
 
 :::{tab-item} JAX

--- a/nvalchemiops/jax/interactions/electrostatics/k_vectors.py
+++ b/nvalchemiops/jax/interactions/electrostatics/k_vectors.py
@@ -28,6 +28,17 @@ __all__ = [
 ]
 
 
+def _prepare_k_cutoff(
+    k_cutoff: float | jax.Array,
+    dtype: jax.typing.DTypeLike,
+) -> jax.Array:
+    """Normalize k_cutoff for shared batch Miller bounds."""
+    k_cutoff_array = jnp.asarray(k_cutoff, dtype=dtype)
+    if k_cutoff_array.ndim == 0 or k_cutoff_array.size == 1:
+        return jnp.reshape(k_cutoff_array, ())
+    return jnp.max(k_cutoff_array)
+
+
 def generate_miller_indices(
     cell: jax.Array,
     k_cutoff: float | jax.Array,
@@ -49,13 +60,15 @@ def generate_miller_indices(
 
     Notes
     -----
-    If cell represents a single system, returns max_h, max_k, max_l
-    computed by taking the maximum reciprocal cell_lengths over the entire batch of systems.
+    For batch mode, one shared set of Miller bounds is used for all systems.
+    If ``k_cutoff`` is provided per system, the maximum cutoff across the batch
+    is used to build those shared bounds.
     """
+    shared_k_cutoff = _prepare_k_cutoff(k_cutoff, cell.dtype)
     cell_lengths = (jnp.linalg.norm(cell, axis=-1).max(axis=0)) / (
         2 * jnp.pi
     )  # Length of each reciprocal vector
-    return jnp.ceil(k_cutoff * cell_lengths).astype(jnp.int32)
+    return jnp.ceil(shared_k_cutoff * cell_lengths).astype(jnp.int32)
 
 
 # Backwards-compatible alias
@@ -161,7 +174,9 @@ def generate_k_vectors_ewald_summation(
     -----
     - The k=0 vector is always excluded (causes division by zero in Green's function).
     - For batch mode, the same set of Miller indices is used for all systems but
-      transformed using each system's reciprocal cell.
+      transformed using each system's reciprocal cell. If ``k_cutoff`` is given
+      per system, the maximum cutoff across the batch determines the shared
+      Miller bounds.
     - The number of k-vectors K scales as O(k_cutoff³ · V) where V is the cell volume.
     - When using inside ``jax.jit``, you **must** provide ``miller_bounds``
       as a concrete ``tuple[int, int, int]``. The bounds determine array shapes

--- a/nvalchemiops/torch/interactions/electrostatics/k_vectors.py
+++ b/nvalchemiops/torch/interactions/electrostatics/k_vectors.py
@@ -21,6 +21,17 @@ PI = math.pi
 TWOPI = 2.0 * PI
 
 
+def _prepare_k_cutoff(
+    cell: torch.Tensor,
+    k_cutoff: float | torch.Tensor,
+) -> torch.Tensor:
+    """Normalize k_cutoff for shared batch Miller bounds."""
+    k_cutoff_tensor = torch.as_tensor(k_cutoff, device=cell.device, dtype=cell.dtype)
+    if k_cutoff_tensor.ndim == 0 or k_cutoff_tensor.numel() == 1:
+        return k_cutoff_tensor.reshape(())
+    return k_cutoff_tensor.max()
+
+
 def _generate_miller_indices(
     cell: torch.Tensor,
     k_cutoff: float | torch.Tensor,
@@ -36,13 +47,15 @@ def _generate_miller_indices(
 
     Notes
     -----
-    if cell represents a single system, return max_h, max_k, max_l
-    computed by taking the maximum reciprocal cell_lengths over the entire batch of systems.
+    For batch mode, one shared set of Miller bounds is used for all systems.
+    If ``k_cutoff`` is provided per system, the maximum cutoff across the batch
+    is used to build those shared bounds.
     """
+    shared_k_cutoff = _prepare_k_cutoff(cell, k_cutoff)
     cell_lengths = (torch.norm(cell, dim=-1).max(dim=0).values) / (
         2 * torch.pi
     )  # Length of each reciprocal vector
-    return torch.ceil(k_cutoff * cell_lengths).long()
+    return torch.ceil(shared_k_cutoff * cell_lengths).long()
 
 
 def generate_k_vectors_ewald_summation(
@@ -126,7 +139,9 @@ def generate_k_vectors_ewald_summation(
     -----
     - The k=0 vector is always excluded (causes division by zero in Green's function).
     - For batch mode, the same set of Miller indices is used for all systems but
-      transformed using each system's reciprocal cell.
+      transformed using each system's reciprocal cell. If ``k_cutoff`` is given
+      per system, the maximum cutoff across the batch determines the shared
+      Miller bounds.
     - The number of k-vectors K scales as O(k_cutoff³ · V) where V is the cell volume.
 
     See Also

--- a/test/interactions/electrostatics/bindings/jax/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/jax/test_ewald.py
@@ -1276,6 +1276,48 @@ class TestEdgeCases:
         assert jnp.all(jnp.isfinite(energies))
         assert energies.sum() < 0
 
+    def test_batch_auto_parameters(self, device):
+        """Test batched automatic parameter estimation uses a shared max cutoff."""
+        positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [3.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
+                [3.0, 0.0, 0.0],
+            ],
+            dtype=jnp.float64,
+        )
+        charges = jnp.array([1.0, -1.0, 1.0, -1.0], dtype=jnp.float64)
+        cell_single = cubic_cell_jax(10.0, dtype=jnp.float64)
+        cell = jnp.concatenate([cell_single, cell_single], axis=0)
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 2, 4], dtype=jnp.int32)
+
+        neighbor_matrix, num_neighbors, neighbor_matrix_shifts = batch_cell_list(
+            positions,
+            5.0,
+            cell,
+            jnp.array([[True, True, True], [True, True, True]]),
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=32,
+        )
+
+        energies = ewald_summation(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=None,
+            k_cutoff=None,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            batch_idx=batch_idx,
+            accuracy=1e-6,
+        )
+
+        assert energies.shape == (4,)
+        assert jnp.all(jnp.isfinite(energies))
+
 
 class TestEwaldJIT:
     """Smoke tests for Ewald summation compatibility with jax.jit."""

--- a/test/interactions/electrostatics/bindings/jax/test_kvectors.py
+++ b/test/interactions/electrostatics/bindings/jax/test_kvectors.py
@@ -69,6 +69,39 @@ class TestKVectorsEwald:
 
         assert k_vectors_large.shape[0] > k_vectors_small.shape[0]
 
+    def test_batch_tensor_cutoff_matches_max_reduction(self):
+        """Test batched k_cutoff tensors use the maximum shared cutoff."""
+        cell = jnp.stack(
+            [
+                jnp.eye(3, dtype=jnp.float64) * 10.0,
+                jnp.eye(3, dtype=jnp.float64) * 12.0,
+            ]
+        )
+        k_cutoff = jnp.array([5.0, 7.0], dtype=jnp.float64)
+
+        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff)
+        expected = generate_k_vectors_ewald_summation(cell, jnp.max(k_cutoff))
+
+        assert k_vectors.shape == expected.shape
+        assert jnp.allclose(k_vectors, expected)
+
+    def test_batch_tensor_cutoff_size_three_matches_max_reduction(self):
+        """Test B=3 does not silently use per-axis cutoffs."""
+        cell = jnp.stack(
+            [
+                jnp.eye(3, dtype=jnp.float64) * 10.0,
+                jnp.eye(3, dtype=jnp.float64) * 12.0,
+                jnp.eye(3, dtype=jnp.float64) * 14.0,
+            ]
+        )
+        k_cutoff = jnp.array([5.0, 6.0, 7.0], dtype=jnp.float64)
+
+        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff)
+        expected = generate_k_vectors_ewald_summation(cell, jnp.max(k_cutoff))
+
+        assert k_vectors.shape == expected.shape
+        assert jnp.allclose(k_vectors, expected)
+
     def test_halfspace_completeness(self):
         """Test that half-space enumeration produces exactly the right k-vectors.
 

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -4488,6 +4488,51 @@ class TestEwaldSummationAutoParameters:
         assert torch.isfinite(energies).all()
         assert torch.isfinite(forces).all()
 
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_batch_auto_estimate_alpha_and_k_cutoff(self, device):
+        """Test batch auto-estimation uses a shared maximum reciprocal cutoff."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions = torch.tensor(
+            [[2.0, 5.0, 5.0], [8.0, 5.0, 5.0], [3.0, 5.0, 5.0], [7.0, 5.0, 5.0]],
+            dtype=torch.float64,
+            device=device,
+        )
+        charges = torch.tensor(
+            [1.0, -1.0, 1.0, -1.0], dtype=torch.float64, device=device
+        )
+        cell = (
+            torch.eye(3, dtype=torch.float64, device=device)
+            .unsqueeze(0)
+            .expand(2, -1, -1)
+            .contiguous()
+            * 10.0
+        )
+        batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=device)
+        neighbor_list = torch.tensor(
+            [[0, 1, 2, 3], [1, 0, 3, 2]], dtype=torch.int32, device=device
+        )
+        neighbor_ptr = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32, device=device)
+        neighbor_shifts = torch.zeros((2, 3), dtype=torch.int32, device=device)
+
+        energies = ewald_summation(
+            positions,
+            charges,
+            cell,
+            neighbor_list=neighbor_list,
+            neighbor_ptr=neighbor_ptr,
+            neighbor_shifts=neighbor_shifts,
+            alpha=None,
+            k_cutoff=None,
+            batch_idx=batch_idx,
+            compute_forces=False,
+        )
+
+        assert energies.shape == (4,)
+        assert torch.isfinite(energies).all()
+
 
 class TestAutogradWithMatrixFormat:
     """Test autograd with neighbor matrix format for attach_for_backward coverage."""

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -4515,7 +4515,7 @@ class TestEwaldSummationAutoParameters:
             [[0, 1, 2, 3], [1, 0, 3, 2]], dtype=torch.int32, device=device
         )
         neighbor_ptr = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32, device=device)
-        neighbor_shifts = torch.zeros((2, 3), dtype=torch.int32, device=device)
+        neighbor_shifts = torch.zeros((4, 3), dtype=torch.int32, device=device)
 
         energies = ewald_summation(
             positions,

--- a/test/interactions/electrostatics/bindings/torch/test_kvectors.py
+++ b/test/interactions/electrostatics/bindings/torch/test_kvectors.py
@@ -118,6 +118,49 @@ class TestKVectorsEwald:
 
         assert k_vectors_large.shape[0] > k_vectors_small.shape[0]
 
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_batch_tensor_cutoff_matches_max_reduction(self, device):
+        """Test batched k_cutoff tensors use the maximum shared cutoff."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        cell = torch.stack(
+            [
+                torch.eye(3, dtype=torch.float64, device=device) * 10.0,
+                torch.eye(3, dtype=torch.float64, device=device) * 12.0,
+            ]
+        )
+        k_cutoff = torch.tensor([5.0, 7.0], dtype=torch.float64, device=device)
+
+        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff)
+        expected = generate_k_vectors_ewald_summation(cell, k_cutoff.max())
+
+        assert k_vectors.shape == expected.shape
+        assert torch.allclose(k_vectors, expected)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_batch_tensor_cutoff_size_three_matches_max_reduction(self, device):
+        """Test B=3 does not silently use per-axis cutoffs."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        cell = torch.stack(
+            [
+                torch.eye(3, dtype=torch.float64, device=device) * 10.0,
+                torch.eye(3, dtype=torch.float64, device=device) * 12.0,
+                torch.eye(3, dtype=torch.float64, device=device) * 14.0,
+            ]
+        )
+        k_cutoff = torch.tensor([5.0, 6.0, 7.0], dtype=torch.float64, device=device)
+
+        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff)
+        expected = generate_k_vectors_ewald_summation(cell, k_cutoff.max())
+
+        assert k_vectors.shape == expected.shape
+        assert torch.allclose(k_vectors, expected)
+
 
 ###########################################################################################
 ########################### PME K-Vector Tests ############################################


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
## Description

Fix incorrect broadcast of per-system `k_cutoff` tensor in batched Ewald summation. When `k_cutoff` is a 1-D tensor of shape `(B,)` and the batch size `B == 3`, element-wise multiplication against the 3-element reciprocal cell lengths silently produced per-axis cutoffs instead of a single shared scalar bound. This adds `_prepare_k_cutoff` to both Torch and JAX k-vector modules to reduce a per-system cutoff tensor to its maximum before computing Miller indices.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

## Changes Made

- Add `_prepare_k_cutoff` helper in `nvalchemiops/torch/interactions/electrostatics/k_vectors.py` that reduces a per-system `k_cutoff` tensor to its maximum scalar value before computing Miller bounds.
- Add matching `_prepare_k_cutoff` helper in `nvalchemiops/jax/interactions/electrostatics/k_vectors.py` with the same reduction logic.
- Update docstrings in `generate_miller_indices` / `_generate_miller_indices` and `generate_k_vectors_ewald_summation` to document the shared-max-cutoff behavior for batched inputs.
- Add tests for both Torch and JAX verifying that a per-system `k_cutoff` tensor produces the same k-vectors as passing the scalar maximum directly, including a `B=3` case that specifically catches the per-axis broadcast bug.
- Add batch auto-parameter Ewald tests for both bindings to verify end-to-end batched `alpha=None, k_cutoff=None` path.
- Add a note to the electrostatics user guide explaining how batch mode handles per-system `k_cutoff`.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

The root cause is the element-wise multiply `k_cutoff * cell_lengths` in `generate_miller_indices` / `_generate_miller_indices`. When `k_cutoff` has shape `(B,)` and `cell_lengths` has shape `(3,)`, the result is `(B, 3)` via broadcasting, which silently gives per-axis bounds instead of per-system ones. The bug is latent for `B != 3` (shape mismatch triggers a broadcast error) but goes undetected when `B == 3`.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
