### PR TITLE
feat: Add hybrid forces mode for PME/Ewald

### DIFF
--- a/docs/userguide/components/electrostatics.md
+++ b/docs/userguide/components/electrostatics.md
@@ -1391,6 +1391,93 @@ charge_gradients = jax.grad(batch_energy_fn)(charges)
 
 ::::
 
+### Geometry-Dependent Charges (Hybrid Mode)
+
+When charges depend on atomic positions -- as in machine-learned interatomic
+potentials (MLIPs) with learned charge models (`q = q(R)`) -- computing total forces requires two contributions:
+
+- **Fixed-charge positional forces** `F = -dE/dR|_q`, computed analytically by
+  the Ewald/PME kernel (`compute_forces=True`)
+- **Charge chain-rule forces** `-(dE/dq)(dq/dR)`, computed via PyTorch autograd through the charge model
+
+The `hybrid_forces` parameter provides an efficient way to compute both
+contributions without redundancy.  In standard mode, `energy.backward()`
+already includes both position and charge terms, so adding explicit forces
+would **double-count** the positional contribution. `hybrid_forces=True`
+detaches positions and cell from the autograd graph and makes energy
+differentiable only through the charges via a straight-through estimator.
+
+```{important}
+Do not combine explicit forces (`compute_forces=True`) with full autograd
+forces (`-torch.autograd.grad(energy, positions)`) in standard mode -- this
+double-counts the positional term `dE/dR|_q`.  Use `hybrid_forces=True` when
+you need both explicit forces and autograd charge gradients.
+```
+
+::::{tab-set}
+
+:::{tab-item} PyTorch
+:sync: pytorch
+
+```python
+import torch
+from nvalchemiops.torch.interactions.electrostatics import particle_mesh_ewald
+
+positions.requires_grad_(True)
+
+# Uniform scaling tensor (identity) for computing the charge virial.
+# dE/d(scaling) through the charge path gives the charge contribution
+# to the virial, i.e. the energy derivative w.r.t. strain.
+scaling = torch.eye(3, dtype=positions.dtype, device=positions.device,
+                    requires_grad=True)
+positions_scaled = positions @ scaling
+cell_scaled = cell @ scaling
+
+# Geometry-dependent charges from scaled positions
+q = charge_model(positions_scaled, Z)
+
+# hybrid_forces=True: explicit forces + virial are analytical (forward-only),
+# energy is differentiable w.r.t. charges only (via straight-through trick)
+energies, direct_forces, direct_virial = particle_mesh_ewald(
+    positions_scaled, q, cell_scaled,
+    neighbor_list=nl, neighbor_ptr=nl_ptr, neighbor_shifts=shifts,
+    compute_forces=True, compute_virial=True,
+    hybrid_forces=True,
+)
+
+# Differentiate energy w.r.t. positions and scaling.
+# In hybrid mode only the charge pathway is in the autograd graph.
+dE_dpos, dE_dscaling = torch.autograd.grad(
+    energies.sum(), [positions, scaling],
+)
+
+total_forces = direct_forces - dE_dpos
+total_virial = direct_virial.squeeze(0) - dE_dscaling  # W = -dE/dε
+```
+
+:::
+
+::::
+
+```{note}
+**When not to use hybrid mode:** If the training loss involves forces or
+virial directly (e.g., `loss = ||F - F_ref||^2 + ||sigma - sigma_ref||^2`),
+use standard mode instead.  In hybrid mode, forces and virial are forward-only
+and do not propagate gradients back to model parameters.
+```
+
+```{note}
+**DSF comparison:** DSF (`dsf_coulomb`) always operates in hybrid mode --
+positions are never in the autograd graph, so explicit forces and autograd
+charge-chain-rule forces are always complementary without any extra flag.
+```
+
+```{note}
+**JAX:** Ewald/PME real-space kernels in JAX use forward-only differentiation
+and do not have this issue.  For PME reciprocal space, which uses differentiable
+spline/FFT ops, a similar `hybrid_forces` flag is planned.
+```
+
 ### Virial / Stress
 
 Both Ewald and PME provide explicit virial computation via `compute_virial=True`.

--- a/nvalchemiops/torch/interactions/electrostatics/_util.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_util.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared utilities for electrostatics PyTorch bindings."""
+
+from __future__ import annotations
+
+import torch
+
+__all__ = ["_InjectChargeGrad"]
+
+
+class _InjectChargeGrad(torch.autograd.Function):
+    """Inject analytical charge gradients into the autograd graph.
+
+    A no-op in the forward pass (returns ``energy`` unchanged).  On backward,
+    maps the per-system ``grad_energy`` to per-atom contributions using
+    ``batch_idx`` and multiplies by the kernel-computed ``charge_grad``
+    (dE/dq), so that ``energy.backward()`` propagates correct gradients
+    through the charge pathway without a Warp backward tape.
+
+    Parameters
+    ----------
+    energy : torch.Tensor
+        Per-system energies, shape ``(S,)``.
+    charges : torch.Tensor
+        Charges with ``requires_grad=True``, shape ``(N,)``.
+    charge_grad : torch.Tensor
+        Analytical per-atom dE/dq from the forward kernel, shape ``(N,)``.
+    batch_idx : torch.Tensor or None
+        Per-atom system index, shape ``(N,)``.  ``None`` for single-system.
+    """
+
+    @staticmethod
+    def forward(energy, charges, charge_grad, batch_idx):
+        """Return energy unchanged."""
+        return energy
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        """Save charge_grad and batch_idx for backward."""
+        _, _, charge_grad, batch_idx = inputs
+        ctx.save_for_backward(charge_grad)
+        ctx.batch_idx = batch_idx
+
+    @staticmethod
+    def backward(ctx, grad_energy):
+        """Compute gradients for energy and charges."""
+        (charge_grad,) = ctx.saved_tensors
+        if ctx.batch_idx is not None:
+            atom_grad = grad_energy.index_select(0, ctx.batch_idx)
+        else:
+            atom_grad = grad_energy.squeeze(0)
+        return grad_energy, charge_grad * atom_grad, None, None

--- a/nvalchemiops/torch/interactions/electrostatics/dsf.py
+++ b/nvalchemiops/torch/interactions/electrostatics/dsf.py
@@ -42,9 +42,9 @@ pattern used by the Coulomb bindings. This is intentional:
 - DSF does not require double backward (Hessian / gradients of forces w.r.t.
   positions). Forces and charge gradients are computed analytically in the
   forward Warp kernel, so there is no need for a Warp backward tape.
-- Charge gradients are propagated through PyTorch autograd via a
-  "straight-through trick": a zero-valued correction term whose gradient
-  equals the kernel-computed dE/dq is added to the energy tensor.
+- Charge gradients are propagated through PyTorch autograd via
+  a custom ``torch.autograd.Function`` that injects
+  the kernel-computed dE/dq into the energy's backward graph.
 - ``register_fake`` enables ``torch.compile`` compatibility.
 
 Examples
@@ -76,6 +76,7 @@ from nvalchemiops.interactions.electrostatics.dsf import (
 from nvalchemiops.interactions.electrostatics.dsf import (
     dsf_matrix as wp_dsf_matrix,
 )
+from nvalchemiops.torch.interactions.electrostatics._util import _InjectChargeGrad
 from nvalchemiops.torch.types import get_wp_dtype, get_wp_mat_dtype, get_wp_vec_dtype
 
 __all__ = [
@@ -567,27 +568,8 @@ def dsf_coulomb(
             device=device,
         )
 
-    # Charge gradient support via straight-through trick
-    # This makes energy differentiable w.r.t. charges without Warp tape.
-    # The correction term has value 0 but gradient dE/dq w.r.t. charges.
     if compute_charge_grad:
-        # Cast to float64 for numerical stability in the correction computation.
-        # charge_grad_out is in input precision (possibly float32).
-        cg_f64 = charge_grad_out.to(dtype=torch.float64)
-        charges_f64 = charges.to(dtype=torch.float64)
-        charges_detached_f64 = charges_f64.detach()
-        # correction[i] = dE_dq[i] * (q[i] - q_detached[i]) = dE_dq[i] * 0 = 0
-        # but d(correction)/d(q[i]) = dE_dq[i]
-        correction = cg_f64.detach() * (charges_f64 - charges_detached_f64)
-
-        if batch_idx is not None:
-            system_correction = torch.zeros_like(energy)
-            system_correction.scatter_add_(0, batch_idx.long(), correction)
-        else:
-            # Single system: sum all corrections
-            system_correction = correction.sum().unsqueeze(0)
-
-        energy = energy + system_correction
+        energy = _InjectChargeGrad.apply(energy, charges, charge_grad_out, batch_idx)
 
     # Build return tuple
     if not compute_forces:

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -105,6 +105,7 @@ from nvalchemiops.torch.autograd import (
     warp_custom_op,
     warp_from_torch,
 )
+from nvalchemiops.torch.interactions.electrostatics._util import _InjectChargeGrad
 from nvalchemiops.torch.interactions.electrostatics.k_vectors import (
     generate_k_vectors_ewald_summation,
 )
@@ -2508,6 +2509,7 @@ def ewald_real_space(
     compute_forces: bool = False,
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
+    hybrid_forces: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     """Compute real-space Ewald energy and optionally forces, charge gradients, and virial.
 
@@ -2546,6 +2548,14 @@ def ewald_real_space(
     compute_virial : bool, default=False
         Whether to compute the virial tensor W = -dE/d(epsilon).
         Stress = virial / volume.
+    hybrid_forces : bool, default=False
+        When True, positions and cell are detached from the autograd graph and
+        charge gradients are attached to the energy via a straight-through
+        trick.  Forces and virial are forward-only (not differentiable).
+        This is intended for efficient inference with geometry-dependent
+        charges ``q(R)``, where explicit forces provide ``dE/dR|_q`` and
+        autograd through the energy provides the charge chain-rule term
+        ``(dE/dq)(dq/dR)``.
 
     Returns
     -------
@@ -2598,6 +2608,81 @@ def ewald_real_space(
                 return energies, virial
             case _:
                 return energies
+
+    if hybrid_forces:
+        pos_d = positions.detach()
+        chg_d = charges.detach()
+        cell_d = cell.detach()
+        alpha_d = alpha.detach()
+        if neighbor_list is not None:
+            if neighbor_ptr is None:
+                raise ValueError(
+                    "neighbor_ptr is required when using neighbor_list format"
+                )
+            if is_batch:
+                energies, forces, charge_grads, virial = (
+                    _batch_ewald_real_space_energy_forces_charge_grad(
+                        pos_d,
+                        chg_d,
+                        cell_d,
+                        alpha_d,
+                        batch_idx,
+                        neighbor_list,
+                        neighbor_ptr,
+                        neighbor_shifts,
+                        compute_virial=compute_virial,
+                    )
+                )
+            else:
+                energies, forces, charge_grads, virial = (
+                    _ewald_real_space_energy_forces_charge_grad(
+                        pos_d,
+                        chg_d,
+                        cell_d,
+                        alpha_d,
+                        neighbor_list,
+                        neighbor_ptr,
+                        neighbor_shifts,
+                        compute_virial=compute_virial,
+                    )
+                )
+        elif neighbor_matrix is not None:
+            if is_batch:
+                energies, forces, charge_grads, virial = (
+                    _batch_ewald_real_space_energy_forces_charge_grad_matrix(
+                        pos_d,
+                        chg_d,
+                        cell_d,
+                        alpha_d,
+                        batch_idx,
+                        neighbor_matrix,
+                        neighbor_matrix_shifts,
+                        mask_value,
+                        compute_virial=compute_virial,
+                    )
+                )
+            else:
+                energies, forces, charge_grads, virial = (
+                    _ewald_real_space_energy_forces_charge_grad_matrix(
+                        pos_d,
+                        chg_d,
+                        cell_d,
+                        alpha_d,
+                        neighbor_matrix,
+                        neighbor_matrix_shifts,
+                        mask_value,
+                        compute_virial=compute_virial,
+                    )
+                )
+        else:
+            raise ValueError("Either neighbor_list or neighbor_matrix must be provided")
+
+        if charges.requires_grad:
+            energies = _InjectChargeGrad.apply(
+                energies, charges, charge_grads, batch_idx
+            )
+
+        return _build_result(energies, forces, charge_grads, virial)
 
     if compute_charge_gradients:
         if neighbor_list is not None:
@@ -2784,6 +2869,7 @@ def ewald_reciprocal_space(
     compute_forces: bool = False,
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
+    hybrid_forces: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     r"""Compute reciprocal-space Ewald energy and optionally forces, charge gradients, virial.
 
@@ -2811,6 +2897,11 @@ def ewald_reciprocal_space(
     compute_virial : bool, default=False
         Whether to compute the virial tensor W = -dE/d(epsilon).
         Stress = virial / volume.
+    hybrid_forces : bool, default=False
+        When True, positions and cell are detached from the autograd graph and
+        charge gradients are attached to the energy via a straight-through
+        trick.  Forces and virial are forward-only (not differentiable).
+        See :func:`ewald_real_space` for details.
 
     Returns
     -------
@@ -2860,6 +2951,42 @@ def ewald_reciprocal_space(
                 return energies, virial
             case _:
                 return energies
+
+    if hybrid_forces:
+        pos_d = positions.detach()
+        chg_d = charges.detach()
+        cell_d = cell.detach()
+        alpha_d = alpha.detach()
+        if is_batch:
+            energies, forces, charge_grads, virial = (
+                _batch_ewald_reciprocal_space_energy_forces_charge_grad(
+                    pos_d,
+                    chg_d,
+                    cell_d,
+                    k_vectors,
+                    alpha_d,
+                    batch_idx,
+                    compute_virial=compute_virial,
+                )
+            )
+        else:
+            energies, forces, charge_grads, virial = (
+                _ewald_reciprocal_space_energy_forces_charge_grad(
+                    pos_d,
+                    chg_d,
+                    cell_d,
+                    k_vectors,
+                    alpha_d,
+                    compute_virial=compute_virial,
+                )
+            )
+
+        if charges.requires_grad:
+            energies = _InjectChargeGrad.apply(
+                energies, charges, charge_grads, batch_idx
+            )
+
+        return _build_result(energies, forces, charge_grads, virial)
 
     if compute_charge_gradients:
         if is_batch:
@@ -2953,6 +3080,7 @@ def ewald_summation(
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
     accuracy: float = 1e-6,
+    hybrid_forces: bool = False,
 ) -> tuple[torch.Tensor, ...] | torch.Tensor:
     """Complete Ewald summation for long-range electrostatics.
 
@@ -2996,6 +3124,11 @@ def ewald_summation(
         Stress = virial / volume.
     accuracy : float, default=1e-6
         Target accuracy for parameter estimation.
+    hybrid_forces : bool, default=False
+        When True, positions and cell are detached from the autograd graph and
+        charge gradients are attached to the energy via a straight-through
+        trick.  Forces and virial are forward-only (not differentiable).
+        See :func:`ewald_real_space` for details.
 
     Returns
     -------
@@ -3050,6 +3183,7 @@ def ewald_summation(
         compute_forces=compute_forces,
         compute_charge_gradients=compute_charge_gradients,
         compute_virial=compute_virial,
+        hybrid_forces=hybrid_forces,
     )
 
     # Compute reciprocal-space
@@ -3063,6 +3197,7 @@ def ewald_summation(
         compute_forces=compute_forces,
         compute_charge_gradients=compute_charge_gradients,
         compute_virial=compute_virial,
+        hybrid_forces=hybrid_forces,
     )
 
     # Normalize return tuples for element-wise combination

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -179,7 +179,10 @@ from nvalchemiops.torch.autograd import (
     warp_custom_op,
     warp_from_torch,
 )
-from nvalchemiops.torch.interactions.electrostatics.ewald import ewald_real_space
+from nvalchemiops.torch.interactions.electrostatics._util import _InjectChargeGrad
+from nvalchemiops.torch.interactions.electrostatics.ewald import (
+    ewald_real_space,
+)
 from nvalchemiops.torch.interactions.electrostatics.k_vectors import (
     generate_k_vectors_pme,
 )
@@ -1547,6 +1550,7 @@ def _pme_reciprocal_space_impl(
     compute_virial: bool = False,
     k_vectors: torch.Tensor | None = None,
     k_squared: torch.Tensor | None = None,
+    hybrid_forces: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
     """Internal implementation of PME reciprocal space calculation.
 
@@ -1561,6 +1565,9 @@ def _pme_reciprocal_space_impl(
     num_atoms = positions.shape[0]
     is_batch = batch_idx is not None
     fft_dims = (1, 2, 3) if is_batch else (0, 1, 2)
+
+    if hybrid_forces:
+        compute_charge_gradients = True
 
     if num_atoms == 0:
         energies = torch.zeros(num_atoms, device=device, dtype=input_dtype)
@@ -1584,16 +1591,23 @@ def _pme_reciprocal_space_impl(
 
     mesh_nx, mesh_ny, mesh_nz = mesh_dimensions
 
+    # In hybrid mode, detach positions/charges/cell to sever autograd paths
+    # through the spline/FFT chain. Charge gradients are attached via
+    # straight-through trick after the forward pass.
+    pos_spline = positions.detach() if hybrid_forces else positions
+    chg_spline = charges.detach() if hybrid_forces else charges
+    cell_spline = cell.detach() if hybrid_forces else cell
+
     # Precompute cell inverse ONCE and derive what we need for all operations
-    cell_inv = torch.linalg.inv_ex(cell)[0]
+    cell_inv = torch.linalg.inv_ex(cell_spline)[0]
     cell_inv_t = cell_inv.transpose(-1, -2).contiguous()
     reciprocal_cell = TWOPI * cell_inv
 
     # Step 1: Charge assignment using unified spline_spread API
     mesh_grid = spline_spread(
-        positions,
-        charges,
-        cell,
+        pos_spline,
+        chg_spline,
+        cell_spline,
         mesh_dims=(mesh_nx, mesh_ny, mesh_nz),
         spline_order=spline_order,
         batch_idx=batch_idx,
@@ -1671,9 +1685,9 @@ def _pme_reciprocal_space_impl(
     # Step 6: Interpolate potential to atomic positions using unified spline_gather API
     # Note: raw_energies are already volume-normalized from Green's function
     raw_energies = spline_gather(
-        positions,
+        pos_spline,
         potential_mesh,
-        cell,
+        cell_spline,
         spline_order=spline_order,
         batch_idx=batch_idx,
         cell_inv_t=cell_inv_t,
@@ -1684,11 +1698,11 @@ def _pme_reciprocal_space_impl(
     charge_grads = None
     if compute_charge_gradients:
         reciprocal_energies, charge_grads = pme_energy_corrections_with_charge_grad(
-            raw_energies, charges, cell, alpha, batch_idx
+            raw_energies, chg_spline, cell_spline, alpha, batch_idx
         )
     else:
         reciprocal_energies = pme_energy_corrections(
-            raw_energies, charges, cell, alpha, batch_idx
+            raw_energies, chg_spline, cell_spline, alpha, batch_idx
         )
 
     # Step 8: Compute virial before forces to allow early release of mesh_fft_raw
@@ -1713,10 +1727,10 @@ def _pme_reciprocal_space_impl(
     if compute_forces:
         # Use unified spline_gather_vec3 API to interpolate electric field
         interpolated_field = spline_gather_vec3(
-            positions,
-            charges,
+            pos_spline,
+            chg_spline,
             electric_field_mesh,
-            cell,
+            cell_spline,
             spline_order=spline_order,
             batch_idx=batch_idx,
             cell_inv_t=cell_inv_t,
@@ -1726,6 +1740,11 @@ def _pme_reciprocal_space_impl(
             forces = _scale_force_field(interpolated_field)
         else:
             forces = 2.0 * interpolated_field
+
+    if hybrid_forces and charges.requires_grad:
+        reciprocal_energies = _InjectChargeGrad.apply(
+            reciprocal_energies, charges, charge_grads, batch_idx
+        )
 
     return reciprocal_energies, forces, charge_grads, virial
 
@@ -1744,6 +1763,7 @@ def pme_reciprocal_space(
     compute_forces: bool = False,
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
+    hybrid_forces: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     """Compute PME reciprocal-space energy and optionally forces and/or charge gradients.
 
@@ -1814,6 +1834,11 @@ def pme_reciprocal_space(
     compute_virial : bool, default=False
         Whether to compute the virial tensor W = -dE/d(epsilon).
         Stress = virial / volume.
+    hybrid_forces : bool, default=False
+        When True, positions and cell are detached from the autograd graph and
+        charge gradients are attached to the energy via a straight-through
+        trick.  Forces and virial are forward-only (not differentiable).
+        See :func:`ewald_real_space` for details.
 
     Returns
     -------
@@ -1914,6 +1939,7 @@ def pme_reciprocal_space(
         compute_virial=compute_virial,
         k_vectors=k_vectors,
         k_squared=k_squared,
+        hybrid_forces=hybrid_forces,
     )
 
     # Build return tuple based on flags
@@ -1962,6 +1988,7 @@ def particle_mesh_ewald(
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
     accuracy: float = 1e-6,
+    hybrid_forces: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     """Complete Particle Mesh Ewald (PME) calculation for long-range electrostatics.
 
@@ -2050,6 +2077,11 @@ def particle_mesh_ewald(
         Target relative accuracy for automatic parameter estimation (α, mesh dims).
         Only used when alpha or mesh_dimensions is None.
         Smaller values increase accuracy but also computational cost.
+    hybrid_forces : bool, default=False
+        When True, positions and cell are detached from the autograd graph and
+        charge gradients are attached to the energy via a straight-through
+        trick.  Forces and virial are forward-only (not differentiable).
+        See :func:`ewald_real_space` for details.
 
     Returns
     -------
@@ -2232,6 +2264,7 @@ def particle_mesh_ewald(
         compute_forces=compute_forces,
         compute_charge_gradients=compute_charge_gradients,
         compute_virial=compute_virial,
+        hybrid_forces=hybrid_forces,
     )
 
     # Compute reciprocal-space contribution
@@ -2248,6 +2281,7 @@ def particle_mesh_ewald(
         compute_virial=compute_virial,
         k_vectors=k_vectors,
         k_squared=k_squared,
+        hybrid_forces=hybrid_forces,
     )
 
     # Normalize return tuples for easy combination

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -1620,7 +1620,9 @@ def _pme_reciprocal_space_impl(
     # Use precomputed k_vectors/k_squared if provided, otherwise generate them
     if k_vectors is None or k_squared is None:
         k_vectors, k_squared = generate_k_vectors_pme(
-            cell_spline, mesh_dimensions=mesh_dimensions, reciprocal_cell=reciprocal_cell
+            cell_spline,
+            mesh_dimensions=mesh_dimensions,
+            reciprocal_cell=reciprocal_cell,
         )
 
     alpha_gsf = alpha.detach() if hybrid_forces else alpha

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -1620,14 +1620,15 @@ def _pme_reciprocal_space_impl(
     # Use precomputed k_vectors/k_squared if provided, otherwise generate them
     if k_vectors is None or k_squared is None:
         k_vectors, k_squared = generate_k_vectors_pme(
-            cell, mesh_dimensions=mesh_dimensions, reciprocal_cell=reciprocal_cell
+            cell_spline, mesh_dimensions=mesh_dimensions, reciprocal_cell=reciprocal_cell
         )
 
+    alpha_gsf = alpha.detach() if hybrid_forces else alpha
     green_function, structure_factor_sq = pme_green_structure_factor(
         k_squared,
         mesh_dimensions,
-        alpha,
-        cell,
+        alpha_gsf,
+        cell_spline,
         spline_order,
         batch_idx=batch_idx,
     )

--- a/test/interactions/electrostatics/bindings/torch/test_dsf.py
+++ b/test/interactions/electrostatics/bindings/torch/test_dsf.py
@@ -2116,6 +2116,46 @@ class TestTorchCompile:
         torch.testing.assert_close(energy_compiled, energy_eager, atol=1e-10, rtol=0.0)
         torch.testing.assert_close(forces_compiled, forces_eager, atol=1e-10, rtol=0.0)
 
+    def test_compile_csr_charge_grad(self, device):
+        """torch.compile should produce correct charge gradients (CSR)."""
+        positions = torch.tensor(
+            [[0.0, 0.0, 0.0], [3.0, 0.0, 0.0]], dtype=torch.float64, device=device
+        )
+        charges_base = torch.tensor([1.0, -1.0], dtype=torch.float64, device=device)
+        nl = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32, device=device)
+        ptr = torch.tensor([0, 1, 2], dtype=torch.int32, device=device)
+        cutoff = 10.0
+        alpha = 0.2
+
+        charges_eager = charges_base.clone().requires_grad_(True)
+        energy_eager, forces_eager = dsf_coulomb(
+            positions,
+            charges_eager,
+            cutoff=cutoff,
+            alpha=alpha,
+            neighbor_list=nl,
+            neighbor_ptr=ptr,
+        )
+        energy_eager.sum().backward()
+        cg_eager = charges_eager.grad.clone()
+
+        charges_compiled = charges_base.clone().requires_grad_(True)
+        dsf_compiled = torch.compile(dsf_coulomb)
+        energy_compiled, forces_compiled = dsf_compiled(
+            positions,
+            charges_compiled,
+            cutoff=cutoff,
+            alpha=alpha,
+            neighbor_list=nl,
+            neighbor_ptr=ptr,
+        )
+        energy_compiled.sum().backward()
+        cg_compiled = charges_compiled.grad.clone()
+
+        torch.testing.assert_close(energy_compiled, energy_eager, atol=1e-10, rtol=0.0)
+        torch.testing.assert_close(forces_compiled, forces_eager, atol=1e-10, rtol=0.0)
+        torch.testing.assert_close(cg_compiled, cg_eager, atol=1e-10, rtol=0.0)
+
 
 # ==============================================================================
 # Test Matrix PBC Virial

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -6457,5 +6457,444 @@ class TestEwaldTorchCompile:
         torch.testing.assert_close(dq_compiled, dq_eager, rtol=1e-3, atol=1e-3)
 
 
+###########################################################################################
+########################### Hybrid Forces Tests ###########################################
+###########################################################################################
+
+
+class TestHybridForces:
+    """Test hybrid_forces mode for Ewald summation.
+
+    hybrid_forces=True detaches positions/cell from the autograd graph and
+    attaches charge gradients via the straight-through trick.  Forces and
+    virial are forward-only.
+    """
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_energy_matches_standard(self, device):
+        """Forward energy values must be identical to standard mode."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell, nl, nl_ptr, nl_shifts = create_dipole_system(device)
+
+        e_std = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+        )
+        e_hyb = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            hybrid_forces=True,
+        )
+
+        torch.testing.assert_close(e_std, e_hyb, rtol=1e-12, atol=1e-14)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_forces_match_standard(self, device):
+        """Explicit forces must match non-hybrid mode."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell, nl, nl_ptr, nl_shifts = create_dipole_system(device)
+
+        _, f_std = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            compute_forces=True,
+        )
+        _, f_hyb = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+
+        torch.testing.assert_close(f_std, f_hyb, rtol=1e-12, atol=1e-14)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_positions_no_grad(self, device):
+        """Positions must not receive gradients in hybrid mode."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell, nl, nl_ptr, nl_shifts = create_dipole_system(device)
+        positions = positions.clone().requires_grad_(True)
+        charges = charges.clone().requires_grad_(True)
+
+        energies = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            hybrid_forces=True,
+        )
+        energies.sum().backward()
+
+        assert positions.grad is None or torch.all(positions.grad == 0)
+        assert charges.grad is not None
+        assert torch.isfinite(charges.grad).all()
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_charge_grad_matches_autograd(self, device):
+        """Charge gradients from straight-through must match standard autograd."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges_ref, cell, nl, nl_ptr, nl_shifts = create_dipole_system(
+            device
+        )
+
+        # Standard autograd path
+        charges_ad = charges_ref.clone().requires_grad_(True)
+        e_ad = ewald_summation(
+            positions,
+            charges_ad,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+        )
+        grad_std = torch.autograd.grad(e_ad.sum(), charges_ad)[0]
+
+        # Hybrid path
+        charges_hyb = charges_ref.clone().requires_grad_(True)
+        e_hyb = ewald_summation(
+            positions,
+            charges_hyb,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            hybrid_forces=True,
+        )
+        grad_hyb = torch.autograd.grad(e_hyb.sum(), charges_hyb)[0]
+
+        torch.testing.assert_close(grad_std, grad_hyb, rtol=1e-4, atol=1e-6)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_geometry_dependent_charges(self, device):
+        """End-to-end: q = f(R), total force = explicit + charge-chain-rule."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges_base, cell, nl, nl_ptr, nl_shifts = create_dipole_system(
+            device
+        )
+
+        weight = torch.tensor(
+            [[0.1, -0.05, 0.02], [-0.1, 0.05, -0.02]],
+            dtype=torch.float64,
+            device=device,
+        )
+        positions = positions.clone().requires_grad_(True)
+
+        q = charges_base + (positions * weight).sum(dim=1)
+        q = q - q.mean()
+
+        energies, forces = ewald_summation(
+            positions,
+            q,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+
+        charge_force = -torch.autograd.grad(
+            energies.sum(), positions, retain_graph=True
+        )[0]
+        total_force = forces + charge_force
+
+        assert torch.isfinite(total_force).all()
+        assert total_force.shape == (2, 3)
+
+        # Verify against finite differences on the full E(R) path
+        h = 1e-5
+        for atom in range(2):
+            for dim in range(3):
+                pos_p = positions.detach().clone()
+                pos_p[atom, dim] += h
+                q_p = charges_base + (pos_p * weight).sum(dim=1)
+                q_p = q_p - q_p.mean()
+                e_p = (
+                    ewald_summation(
+                        pos_p,
+                        q_p,
+                        cell,
+                        alpha=0.3,
+                        k_cutoff=8.0,
+                        neighbor_list=nl,
+                        neighbor_ptr=nl_ptr,
+                        neighbor_shifts=nl_shifts,
+                    )
+                    .sum()
+                    .item()
+                )
+
+                pos_m = positions.detach().clone()
+                pos_m[atom, dim] -= h
+                q_m = charges_base + (pos_m * weight).sum(dim=1)
+                q_m = q_m - q_m.mean()
+                e_m = (
+                    ewald_summation(
+                        pos_m,
+                        q_m,
+                        cell,
+                        alpha=0.3,
+                        k_cutoff=8.0,
+                        neighbor_list=nl,
+                        neighbor_ptr=nl_ptr,
+                        neighbor_shifts=nl_shifts,
+                    )
+                    .sum()
+                    .item()
+                )
+
+                fd_force = -(e_p - e_m) / (2 * h)
+                rel_err = abs(total_force[atom, dim].item() - fd_force) / (
+                    abs(fd_force) + 1e-30
+                )
+                assert rel_err < 0.01, (
+                    f"atom {atom}, dim {dim}: "
+                    f"hybrid={total_force[atom, dim].item():.8e}, "
+                    f"FD={fd_force:.8e}, rel={rel_err:.2e}"
+                )
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_virial_forward_only(self, device):
+        """Virial values must match standard mode and have no grad_fn."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell, nl, nl_ptr, nl_shifts = create_dipole_system(device)
+
+        _, _, v_std = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            compute_forces=True,
+            compute_virial=True,
+        )
+        _, _, v_hyb = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            compute_forces=True,
+            compute_virial=True,
+            hybrid_forces=True,
+        )
+
+        torch.testing.assert_close(v_std, v_hyb, rtol=1e-12, atol=1e-14)
+        assert v_hyb.grad_fn is None
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_real_space(self, device):
+        """Test hybrid_forces on ewald_real_space directly."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell, nl, nl_ptr, nl_shifts = create_dipole_system(device)
+        alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
+
+        e_std = ewald_real_space(
+            positions,
+            charges,
+            cell,
+            alpha,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+        )
+        e_hyb = ewald_real_space(
+            positions,
+            charges,
+            cell,
+            alpha,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            hybrid_forces=True,
+        )
+        torch.testing.assert_close(e_std, e_hyb, rtol=1e-12, atol=1e-14)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_reciprocal_space(self, device):
+        """Test hybrid_forces on ewald_reciprocal_space directly."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell, _, _, _ = create_dipole_system(device)
+        alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
+        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=8.0)
+
+        e_std = ewald_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            k_vectors,
+            alpha,
+        )
+        e_hyb = ewald_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            k_vectors,
+            alpha,
+            hybrid_forces=True,
+        )
+        torch.testing.assert_close(e_std, e_hyb, rtol=1e-12, atol=1e-14)
+
+
+###########################################################################################
+########################### torch.compile Tests ###########################################
+###########################################################################################
+
+
+class TestTorchCompile:
+    """Smoke tests for torch.compile compatibility with hybrid_forces mode."""
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_compile_hybrid_energy_forces(self, device):
+        """torch.compile with hybrid_forces produces same energy and forces."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell, nl, nl_ptr, nl_shifts = create_dipole_system(device)
+
+        e_eager, f_eager = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+
+        ewald_compiled = torch.compile(ewald_summation)
+        e_compiled, f_compiled = ewald_compiled(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+
+        torch.testing.assert_close(e_compiled, e_eager, atol=1e-10, rtol=0.0)
+        torch.testing.assert_close(f_compiled, f_eager, atol=1e-10, rtol=0.0)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_compile_hybrid_charge_grad(self, device):
+        """torch.compile with hybrid_forces produces correct charge gradients."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges_base, cell, nl, nl_ptr, nl_shifts = create_dipole_system(
+            device
+        )
+
+        charges_eager = charges_base.clone().requires_grad_(True)
+        e_eager, f_eager = ewald_summation(
+            positions,
+            charges_eager,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+        e_eager.sum().backward()
+        cg_eager = charges_eager.grad.clone()
+
+        charges_compiled = charges_base.clone().requires_grad_(True)
+        ewald_compiled = torch.compile(ewald_summation)
+        e_compiled, f_compiled = ewald_compiled(
+            positions,
+            charges_compiled,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+        e_compiled.sum().backward()
+        cg_compiled = charges_compiled.grad.clone()
+
+        torch.testing.assert_close(e_compiled, e_eager, atol=1e-10, rtol=0.0)
+        torch.testing.assert_close(f_compiled, f_eager, atol=1e-10, rtol=0.0)
+        torch.testing.assert_close(cg_compiled, cg_eager, atol=1e-10, rtol=0.0)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -3725,5 +3725,383 @@ class TestPMETorchCompile:
         torch.testing.assert_close(result_compiled, result_eager, rtol=1e-5, atol=1e-5)
 
 
+###########################################################################################
+########################### Hybrid Forces Tests ###########################################
+###########################################################################################
+
+
+class TestPMEHybridForces:
+    """Test hybrid_forces mode for PME.
+
+    hybrid_forces=True detaches positions/cell from the autograd graph and
+    attaches charge gradients via the straight-through trick.  Forces and
+    virial are forward-only.
+    """
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_energy_matches_standard(self, device):
+        """Forward energy values must be identical to standard mode."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell = create_dipole_system(device)
+        mesh_dims = (16, 16, 16)
+
+        e_std = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+        )
+        e_hyb = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            hybrid_forces=True,
+        )
+
+        torch.testing.assert_close(e_std, e_hyb, rtol=1e-12, atol=1e-14)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_forces_match_standard(self, device):
+        """Explicit forces must match non-hybrid mode."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell = create_dipole_system(device)
+        mesh_dims = (16, 16, 16)
+
+        _, f_std = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            compute_forces=True,
+        )
+        _, f_hyb = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+
+        torch.testing.assert_close(f_std, f_hyb, rtol=1e-12, atol=1e-14)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_positions_no_grad(self, device):
+        """Positions must not receive gradients in hybrid mode."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell = create_dipole_system(device)
+        positions = positions.clone().requires_grad_(True)
+        charges = charges.clone().requires_grad_(True)
+
+        energies = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=(16, 16, 16),
+            hybrid_forces=True,
+        )
+        energies.sum().backward()
+
+        assert positions.grad is None or torch.all(positions.grad == 0)
+        assert charges.grad is not None
+        assert torch.isfinite(charges.grad).all()
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_charge_grad_matches_autograd(self, device):
+        """Charge gradients from straight-through must match standard autograd."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges_ref, cell = create_dipole_system(device)
+        mesh_dims = (16, 16, 16)
+
+        # Standard autograd path
+        charges_ad = charges_ref.clone().requires_grad_(True)
+        e_ad = pme_reciprocal_space(
+            positions,
+            charges_ad,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+        )
+        grad_std = torch.autograd.grad(e_ad.sum(), charges_ad)[0]
+
+        # Hybrid path
+        charges_hyb = charges_ref.clone().requires_grad_(True)
+        e_hyb = pme_reciprocal_space(
+            positions,
+            charges_hyb,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            hybrid_forces=True,
+        )
+        grad_hyb = torch.autograd.grad(e_hyb.sum(), charges_hyb)[0]
+
+        torch.testing.assert_close(grad_std, grad_hyb, rtol=1e-4, atol=1e-6)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_virial_forward_only(self, device):
+        """Virial values must match standard mode and have no grad_fn."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell = create_dipole_system(device)
+        mesh_dims = (16, 16, 16)
+
+        _, _, v_std = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            compute_forces=True,
+            compute_virial=True,
+        )
+        _, _, v_hyb = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            compute_forces=True,
+            compute_virial=True,
+            hybrid_forces=True,
+        )
+
+        torch.testing.assert_close(v_std, v_hyb, rtol=1e-12, atol=1e-14)
+        assert v_hyb.grad_fn is None
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_full_pme(self, device):
+        """Test hybrid_forces on particle_mesh_ewald end-to-end."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell = create_simple_system(device, num_atoms=5)
+        num_atoms = positions.shape[0]
+        neighbor_matrix = torch.zeros(
+            (num_atoms, num_atoms - 1), dtype=torch.int32, device=device
+        )
+        for i in range(num_atoms):
+            neighbors = [j for j in range(num_atoms) if j != i]
+            neighbor_matrix[i] = torch.tensor(
+                neighbors, dtype=torch.int32, device=device
+            )
+        neighbor_matrix_shifts = torch.zeros(
+            (num_atoms, num_atoms - 1, 3), dtype=torch.int32, device=device
+        )
+
+        e_std, f_std = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=(16, 16, 16),
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            compute_forces=True,
+        )
+        e_hyb, f_hyb = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=(16, 16, 16),
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+
+        torch.testing.assert_close(e_std, e_hyb, rtol=1e-12, atol=1e-14)
+        torch.testing.assert_close(f_std, f_hyb, rtol=1e-12, atol=1e-14)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_geometry_dependent_charges_pme(self, device):
+        """End-to-end: q = f(R) with PME, total force = explicit + charge-chain-rule."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions_ref, charges_base, cell = create_dipole_system(device)
+        mesh_dims = (16, 16, 16)
+
+        weight = torch.tensor(
+            [[0.1, -0.05, 0.02], [-0.1, 0.05, -0.02]],
+            dtype=torch.float64,
+            device=device,
+        )
+        positions = positions_ref.clone().requires_grad_(True)
+
+        q = charges_base + (positions * weight).sum(dim=1)
+        q = q - q.mean()
+
+        energies, forces = pme_reciprocal_space(
+            positions,
+            q,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+
+        charge_force = -torch.autograd.grad(
+            energies.sum(), positions, retain_graph=True
+        )[0]
+        total_force = forces + charge_force
+
+        assert torch.isfinite(total_force).all()
+
+        # Verify against finite differences
+        h = 1e-5
+        for atom in range(2):
+            for dim in range(3):
+                pos_p = positions.detach().clone()
+                pos_p[atom, dim] += h
+                q_p = charges_base + (pos_p * weight).sum(dim=1)
+                q_p = q_p - q_p.mean()
+                e_p = (
+                    pme_reciprocal_space(
+                        pos_p,
+                        q_p,
+                        cell,
+                        alpha=0.3,
+                        mesh_dimensions=mesh_dims,
+                    )
+                    .sum()
+                    .item()
+                )
+
+                pos_m = positions.detach().clone()
+                pos_m[atom, dim] -= h
+                q_m = charges_base + (pos_m * weight).sum(dim=1)
+                q_m = q_m - q_m.mean()
+                e_m = (
+                    pme_reciprocal_space(
+                        pos_m,
+                        q_m,
+                        cell,
+                        alpha=0.3,
+                        mesh_dimensions=mesh_dims,
+                    )
+                    .sum()
+                    .item()
+                )
+
+                fd_force = -(e_p - e_m) / (2 * h)
+                rel_err = abs(total_force[atom, dim].item() - fd_force) / (
+                    abs(fd_force) + 1e-30
+                )
+                assert rel_err < 0.02, (
+                    f"atom {atom}, dim {dim}: "
+                    f"hybrid={total_force[atom, dim].item():.8e}, "
+                    f"FD={fd_force:.8e}, rel={rel_err:.2e}"
+                )
+
+
+###########################################################################################
+########################### torch.compile Tests ###########################################
+###########################################################################################
+
+
+class TestTorchCompile:
+    """Smoke tests for torch.compile compatibility with hybrid_forces mode."""
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_compile_hybrid_energy_forces(self, device):
+        """torch.compile with hybrid_forces produces same energy and forces."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell = create_dipole_system(device)
+        mesh_dims = (16, 16, 16)
+
+        e_eager, f_eager = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+
+        pme_compiled = torch.compile(pme_reciprocal_space)
+        e_compiled, f_compiled = pme_compiled(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+
+        torch.testing.assert_close(e_compiled, e_eager, atol=1e-10, rtol=0.0)
+        torch.testing.assert_close(f_compiled, f_eager, atol=1e-10, rtol=0.0)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_compile_hybrid_charge_grad(self, device):
+        """torch.compile with hybrid_forces produces correct charge gradients."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges_base, cell = create_dipole_system(device)
+        mesh_dims = (16, 16, 16)
+
+        charges_eager = charges_base.clone().requires_grad_(True)
+        e_eager, f_eager = pme_reciprocal_space(
+            positions,
+            charges_eager,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+        e_eager.sum().backward()
+        cg_eager = charges_eager.grad.clone()
+
+        charges_compiled = charges_base.clone().requires_grad_(True)
+        pme_compiled = torch.compile(pme_reciprocal_space)
+        e_compiled, f_compiled = pme_compiled(
+            positions,
+            charges_compiled,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+        e_compiled.sum().backward()
+        cg_compiled = charges_compiled.grad.clone()
+
+        torch.testing.assert_close(e_compiled, e_eager, atol=1e-10, rtol=0.0)
+        torch.testing.assert_close(f_compiled, f_eager, atol=1e-10, rtol=0.0)
+        torch.testing.assert_close(cg_compiled, cg_eager, atol=1e-10, rtol=0.0)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -3822,6 +3822,33 @@ class TestPMEHybridForces:
         assert torch.isfinite(charges.grad).all()
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_cell_no_grad(self, device):
+        """Cell must not receive gradients in hybrid mode."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges, cell = create_dipole_system(device)
+        positions = positions.clone().requires_grad_(True)
+        cell = cell.clone().requires_grad_(True)
+        charges = charges.clone().requires_grad_(True)
+
+        energies = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=(16, 16, 16),
+            hybrid_forces=True,
+        )
+        energies.sum().backward()
+
+        assert positions.grad is None or torch.all(positions.grad == 0)
+        assert cell.grad is None or torch.all(cell.grad == 0)
+        assert charges.grad is not None
+        assert torch.isfinite(charges.grad).all()
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_hybrid_charge_grad_matches_autograd(self, device):
         """Charge gradients from straight-through must match standard autograd."""
         if device == "cuda" and not torch.cuda.is_available():


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Add `hybrid_forces` mode for PME/Ewald electrostatics and refactor charge gradient injection across all electrostatics bindings. This addresses the efficiency problem where obtaining `dE/dq` via full autograd backward through heavy Warp kernels is 3x more expensive than necessary, since kernels already compute `dE/dq` analytically in the forward pass. The `hybrid_forces=True` flag detaches positions/cell from the autograd graph, uses forward-only analytical forces and virial, and injects charge gradients via a custom `torch.autograd.Function` (`_InjectChargeGrad`). This mode is suitable for inference and energy-only training with geometry-dependent charges (`q = q(R)`).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #50

## Changes Made

- Add `_InjectChargeGrad` (`torch.autograd.Function`) in new `nvalchemiops/torch/interactions/electrostatics/_util.py` as the shared mechanism for injecting analytical charge gradients into the autograd graph without a Warp backward tape.
- Add `hybrid_forces` parameter to `ewald_real_space`, `ewald_reciprocal_space`, `ewald_summation`, `pme_reciprocal_space`, and `particle_mesh_ewald`. When enabled, positions and cell are detached from the autograd graph, charge gradients are computed analytically, and `_InjectChargeGrad` connects them to the energy output.
- Refactor DSF (`dsf.py`) to use the shared `_InjectChargeGrad` class, replacing the inline straight-through trick (fp64 casting, scatter_add_, zero-valued correction).
- Remove `_apply_charge_straight_through` helper from `ewald.py`; all call sites now use `_InjectChargeGrad.apply`.
- Add documentation section "Geometry-Dependent Charges (Hybrid Mode)" in `docs/userguide/components/electrostatics.md` with usage examples including the strain-scaling trick for computing total forces and virial/stress.
- Add `TestHybridForces` / `TestPMEHybridForces` test classes covering: energy/forces match standard mode, positions excluded from autograd graph, charge gradient correctness, virial forward-only, geometry-dependent charges finite-difference validation.
- Add `TestTorchCompile` test classes for Ewald and PME, and extend the existing DSF compile tests to cover `_InjectChargeGrad` under `torch.compile`.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

The `hybrid_forces` mode is opt-in and does not change existing behavior. Forces and virial are forward-only outputs in hybrid mode -- `loss.backward()` will not propagate gradients through them to model parameters. This mode is designed for inference and energy-only training pipelines where charges depend on geometry.

The current JAX electrostatics bindings use `enable_backward=False` and do not implement the charge gradient injection pattern.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
