### PR TITLE
fix: add background energy virial correction for non-neutral Ewald/PME systems

### DIFF
--- a/nvalchemiops/jax/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/jax/interactions/electrostatics/ewald.py
@@ -1064,6 +1064,20 @@ def ewald_reciprocal_space(
                 virial,
                 launch_dims=(num_k, num_systems),
             )
+
+            total_charges_v = (
+                jnp.zeros(
+                    num_systems,
+                    dtype=dtype,
+                )
+                .at[batch_idx.astype(jnp.int32)]
+                .add(charges_cast)
+            )
+            volumes_v = jnp.abs(jnp.linalg.det(cell_cast)).astype(dtype)
+            alpha_v = alpha_arr.astype(dtype)
+            e_bg = PI * total_charges_v**2 / (2.0 * alpha_v**2 * volumes_v)
+            eye = jnp.eye(3, dtype=dtype)
+            virial = virial - e_bg[:, jnp.newaxis, jnp.newaxis] * eye
         else:
             virial = jnp.zeros((1, 3, 3), dtype=dtype)
             (virial,) = _jax_ewald_reciprocal_virial[dtype](
@@ -1075,6 +1089,13 @@ def ewald_reciprocal_space(
                 virial,
                 launch_dims=(num_k,),
             )
+
+            q_total = charges_cast.sum().astype(dtype)
+            vol_v = jnp.abs(jnp.linalg.det(cell_cast.squeeze(0))).astype(dtype)
+            alpha_val_v = alpha_arr.astype(dtype).squeeze()
+            e_bg = PI * q_total**2 / (2.0 * alpha_val_v**2 * vol_v)
+            eye = jnp.eye(3, dtype=dtype)
+            virial = virial - e_bg * eye
 
     # Apply corrections to charge gradients if requested
     if compute_charge_gradients:

--- a/nvalchemiops/jax/interactions/electrostatics/pme.py
+++ b/nvalchemiops/jax/interactions/electrostatics/pme.py
@@ -861,6 +861,27 @@ def pme_reciprocal_space(
         )
         del mesh_fft_raw  # Free before force field meshes are allocated
 
+        eye = jnp.eye(3, dtype=input_dtype)
+        if is_batch:
+            total_charges = (
+                jnp.zeros(
+                    cell.shape[0],
+                    dtype=input_dtype,
+                )
+                .at[batch_idx]
+                .add(charges.astype(input_dtype))
+            )
+            volumes = jnp.abs(jnp.linalg.det(cell)).astype(input_dtype)
+            alpha_batch = alpha.astype(input_dtype)
+            e_bg = jnp.pi * total_charges**2 / (2.0 * alpha_batch**2 * volumes)
+            virial = virial - e_bg[:, jnp.newaxis, jnp.newaxis] * eye
+        else:
+            total_charge = charges.sum().astype(input_dtype)
+            volume = jnp.abs(jnp.linalg.det(cell.squeeze(0))).astype(input_dtype)
+            alpha_val = alpha.astype(input_dtype).squeeze()
+            e_bg = jnp.pi * total_charge**2 / (2.0 * alpha_val**2 * volume)
+            virial = virial - e_bg * eye
+
     # Step 6: Inverse FFT to get potential mesh
     potential_mesh = jnp.fft.irfftn(
         convolved_mesh, s=mesh_dimensions, axes=fft_dims, norm="forward"

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -1488,6 +1488,14 @@ def _ewald_reciprocal_space_energy(
         else:
             virial = torch.zeros(1, 3, 3, device=positions.device, dtype=input_dtype)
 
+    if compute_virial:
+        q_total = charges.sum().to(input_dtype)
+        vol = torch.abs(torch.det(cell[0].to(input_dtype)))
+        alpha_val = alpha.to(input_dtype).squeeze()
+        e_bg = math.pi * q_total**2 / (2.0 * alpha_val**2 * vol)
+        eye = torch.eye(3, device=positions.device, dtype=input_dtype)
+        virial = virial - e_bg * eye
+
     if needs_grad_flag:
         backward_kw = dict(
             energies=wp_energies,
@@ -1653,6 +1661,14 @@ def _ewald_reciprocal_space_energy_forces(
             )
         else:
             virial = torch.zeros(1, 3, 3, device=positions.device, dtype=input_dtype)
+
+    if compute_virial:
+        q_total = charges.sum().to(input_dtype)
+        vol = torch.abs(torch.det(cell[0].to(input_dtype)))
+        alpha_val = alpha.to(input_dtype).squeeze()
+        e_bg = math.pi * q_total**2 / (2.0 * alpha_val**2 * vol)
+        eye = torch.eye(3, device=positions.device, dtype=input_dtype)
+        virial = virial - e_bg * eye
 
     if needs_grad_flag:
         backward_kw = dict(
@@ -1837,6 +1853,14 @@ def _ewald_reciprocal_space_energy_forces_charge_grad(
     self_energy_grad = 2.0 * alpha_t / math.sqrt(math.pi) * charges
     background_grad = math.pi / (alpha_t * alpha_t) * total_charge[0]
     charge_grads = charge_grads - self_energy_grad - background_grad
+
+    if compute_virial:
+        q_total = charges.sum().to(input_dtype)
+        vol = torch.abs(torch.det(cell[0].to(input_dtype)))
+        alpha_val = alpha.to(input_dtype).squeeze()
+        e_bg = math.pi * q_total**2 / (2.0 * alpha_val**2 * vol)
+        eye = torch.eye(3, device=positions.device, dtype=input_dtype)
+        virial = virial - e_bg * eye
 
     if needs_grad_flag:
         backward_kw = dict(
@@ -2041,6 +2065,19 @@ def _batch_ewald_reciprocal_space_energy(
                 num_systems, 3, 3, device=positions.device, dtype=input_dtype
             )
 
+    if compute_virial:
+        total_charges = torch.zeros(
+            num_systems,
+            dtype=input_dtype,
+            device=positions.device,
+        )
+        total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
+        volumes = torch.abs(torch.linalg.det(cell)).to(input_dtype)
+        alpha_batch = alpha.to(input_dtype)
+        e_bg = math.pi * total_charges**2 / (2.0 * alpha_batch**2 * volumes)
+        eye = torch.eye(3, device=positions.device, dtype=input_dtype)
+        virial = virial - e_bg[:, None, None] * eye
+
     if needs_grad_flag:
         backward_kw = dict(
             energies=wp_energies,
@@ -2244,6 +2281,19 @@ def _batch_ewald_reciprocal_space_energy_forces(
             virial = torch.zeros(
                 num_systems, 3, 3, device=positions.device, dtype=input_dtype
             )
+
+    if compute_virial:
+        total_charges = torch.zeros(
+            num_systems,
+            dtype=input_dtype,
+            device=positions.device,
+        )
+        total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
+        volumes = torch.abs(torch.linalg.det(cell)).to(input_dtype)
+        alpha_batch = alpha.to(input_dtype)
+        e_bg = math.pi * total_charges**2 / (2.0 * alpha_batch**2 * volumes)
+        eye = torch.eye(3, device=positions.device, dtype=input_dtype)
+        virial = virial - e_bg[:, None, None] * eye
 
     if needs_grad_flag:
         backward_kw = dict(
@@ -2471,6 +2521,19 @@ def _batch_ewald_reciprocal_space_energy_forces_charge_grad(
         math.pi / (alpha_per_atom * alpha_per_atom) * total_charge_per_atom
     )
     charge_grads = charge_grads - self_energy_grad - background_grad
+
+    if compute_virial:
+        total_charges = torch.zeros(
+            num_systems,
+            dtype=input_dtype,
+            device=positions.device,
+        )
+        total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
+        volumes = torch.abs(torch.linalg.det(cell)).to(input_dtype)
+        alpha_batch = alpha.to(input_dtype)
+        e_bg = math.pi * total_charges**2 / (2.0 * alpha_batch**2 * volumes)
+        eye = torch.eye(3, device=positions.device, dtype=input_dtype)
+        virial = virial - e_bg[:, None, None] * eye
 
     if needs_grad_flag:
         backward_kw = dict(

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -1733,6 +1733,30 @@ def _pme_reciprocal_space_impl(
         )
         del mesh_fft_raw  # Free before force field meshes are allocated
 
+        # Background virial correction for non-neutral systems.
+        # E_bg = pi * Q^2 / (2 * alpha^2 * V) is subtracted from energy.
+        # Since dE_bg/dε = -E_bg * I (volume derivative), the virial
+        # contribution is W_bg = -d(-E_bg)/dε = dE_bg/dε = -E_bg * I.
+        eye = torch.eye(3, device=device, dtype=input_dtype)
+        if is_batch:
+            num_systems = cell.shape[0]
+            total_charges = torch.zeros(
+                num_systems,
+                dtype=input_dtype,
+                device=device,
+            )
+            total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
+            volumes = torch.abs(torch.linalg.det(cell)).to(input_dtype)
+            alpha_batch = alpha.to(input_dtype)
+            e_bg = PI * total_charges**2 / (2.0 * alpha_batch**2 * volumes)
+            virial = virial - e_bg[:, None, None] * eye
+        else:
+            total_charge = charges.sum().to(input_dtype)
+            volume = torch.abs(torch.det(cell)).to(input_dtype)
+            alpha_val = alpha.to(input_dtype)
+            e_bg = PI * total_charge**2 / (2.0 * alpha_val**2 * volume)
+            virial = virial - e_bg * eye
+
     # Step 9: Compute forces if needed
     forces = None
     if compute_forces:

--- a/test/interactions/electrostatics/bindings/jax/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/jax/test_ewald.py
@@ -1322,7 +1322,7 @@ class TestEdgeCases:
 class TestEwaldJIT:
     """Smoke tests for Ewald summation compatibility with jax.jit."""
 
-    def test_jit_real_space(self):
+    def test_jit_real_space(self, device):  # noqa: ARG002
         """Test ewald_real_space works under jax.jit."""
         positions = jnp.array([[0.0, 0.0, 0.0], [3.0, 0.0, 0.0]], dtype=jnp.float64)
         charges = jnp.array([1.0, -1.0], dtype=jnp.float64)
@@ -1358,7 +1358,7 @@ class TestEwaldJIT:
         assert energies.shape == (2,)
         assert jnp.all(jnp.isfinite(energies))
 
-    def test_jit_reciprocal_space(self):
+    def test_jit_reciprocal_space(self, device):  # noqa: ARG002
         """Test ewald_reciprocal_space works under jax.jit."""
         positions = jnp.array(
             [[0.0, 0.0, 0.0], [3.0, 0.0, 0.0], [0.0, 3.0, 0.0], [3.0, 3.0, 0.0]],
@@ -1386,7 +1386,7 @@ class TestEwaldJIT:
         assert energies.shape == (4,)
         assert jnp.all(jnp.isfinite(energies))
 
-    def test_jit_batched_reciprocal_space(self):
+    def test_jit_batched_reciprocal_space(self, device):  # noqa: ARG002
         """Test ewald_reciprocal_space works under jax.jit with batched inputs."""
         positions = jnp.array(
             [

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -6151,7 +6151,6 @@ class TestEwaldNonNeutralVirial:
         )
 
 
-
 class TestEwaldDifferentiableVirial:
     """Stress-loss gradients through Ewald virial path."""
 

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -6145,10 +6145,11 @@ class TestEwaldNonNeutralVirial:
         torch.testing.assert_close(
             explicit_virial,
             fd_virial,
-            atol=2e-2,
-            rtol=2e-2,
+            atol=1e-4,
+            rtol=1e-4,
             msg="Ewald total virial does not match FD for non-neutral system",
         )
+
 
 
 class TestEwaldDifferentiableVirial:

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -3481,10 +3481,11 @@ class TestPMENonNeutralVirial:
         torch.testing.assert_close(
             explicit_virial,
             fd_virial,
-            atol=2e-2,
-            rtol=2e-2,
+            atol=1e-4,
+            rtol=1e-4,
             msg="PME reciprocal virial does not match FD for non-neutral system",
         )
+
 
 
 class TestPMEDifferentiableVirial:

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -3487,7 +3487,6 @@ class TestPMENonNeutralVirial:
         )
 
 
-
 class TestPMEDifferentiableVirial:
     """Stress-loss gradients through PME virial path."""
 

--- a/test/interactions/electrostatics/bindings/torch/test_utils.py
+++ b/test/interactions/electrostatics/bindings/torch/test_utils.py
@@ -538,7 +538,7 @@ def make_non_neutral_system(device: torch.device):
         dtype=VIRIAL_DTYPE,
         device=device,
     )
-    charges = torch.tensor([1.0, -0.5], dtype=VIRIAL_DTYPE, device=device)
+    charges = torch.tensor([1.0, -3.5], dtype=VIRIAL_DTYPE, device=device)
     return positions, charges, cell
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Fix missing background energy virial contribution in PME and Ewald reciprocal space calculations for non-neutral systems. The background energy term E_bg = pi * Q^2 / (2 * alpha^2 * V) was correctly subtracted from the energy but its derivative with respect to strain was not included in the explicit virial tensor, causing a discrepancy between explicit virial and finite-difference / autograd virial for charged systems.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #61

## Changes Made

- Add background virial correction W_bg = -E_bg * I to PME reciprocal space virial in both PyTorch and JAX backends, handling single-system and batch cases
- Add the same background virial correction to all six Ewald reciprocal space variants in PyTorch (energy-only, energy+forces, energy+forces+charge_grad, and their batch counterparts) and both JAX variants (single and batch)
- Tighten non-neutral virial test tolerances from atol/rtol=2e-2 to 1e-4 to reflect the corrected implementation
- Increase charge imbalance in `make_non_neutral_system` from [1.0, -0.5] to [1.0, -3.5] for stronger test coverage and remove redundant high-charge test cases

## Testing

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Existing non-neutral virial finite-difference tests (`test_ewald_total_virial_fd_non_neutral`, `test_pme_reciprocal_virial_fd_non_neutral`) now pass with 100x tighter tolerances (1e-4 vs 2e-2). No new tests needed since the existing tests already cover the affected code paths with the updated charge imbalance.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

The mathematical derivation: E_bg = pi * Q_total^2 / (2 * alpha^2 * V) is subtracted from the reciprocal energy for non-neutral systems. Since V scales as V * det(I + epsilon) under strain, dV/d(epsilon) = V * I, giving dE_bg/d(epsilon) = -E_bg * I. The virial contribution is therefore W_bg = -E_bg * I, which must be subtracted from the reciprocal virial tensor.

Files changed:
- `nvalchemiops/torch/interactions/electrostatics/pme.py` - PyTorch PME virial fix
- `nvalchemiops/torch/interactions/electrostatics/ewald.py` - PyTorch Ewald virial fix (6 functions)
- `nvalchemiops/jax/interactions/electrostatics/pme.py` - JAX PME virial fix
- `nvalchemiops/jax/interactions/electrostatics/ewald.py` - JAX Ewald virial fix (2 paths)
- `test/interactions/electrostatics/bindings/torch/test_utils.py` - stronger charge imbalance
- `test/interactions/electrostatics/bindings/torch/test_ewald.py` - tightened tolerances
- `test/interactions/electrostatics/bindings/torch/test_pme.py` - tightened tolerances
