### PR TITLE
fix: support retain_graph=True in warp_custom_op backward

### DIFF
--- a/nvalchemiops/torch/autograd.py
+++ b/nvalchemiops/torch/autograd.py
@@ -410,6 +410,13 @@ def warp_custom_op(
     The decorated function should still call ``attach_for_backward()`` at the
     end of grad-enabled forward execution so the registered forward op can
     collect the runtime Warp tape and arrays from the real output tensor.
+
+    ``retain_graph=True`` is supported: the Warp tape is preserved across
+    backward passes and zeroed before each replay.  ``create_graph=True``
+    is **not** supported -- Warp backward ops do not register a second-order
+    autograd formula, so higher-order differentiation through them will raise.
+    Use ``hybrid_forces=True`` in electrostatics APIs when you need to combine
+    explicit Warp forces with autograd-based charge-gradient forces.
     """
     # Non-differentiable input names (won't receive gradients)
     NON_GRAD_INPUTS = {
@@ -429,13 +436,13 @@ def warp_custom_op(
         _state_counter = itertools.count(1)
         _state_registry: dict[int, _RegisteredBackwardState] = {}
 
-        def _pop_state(token_id: int) -> _RegisteredBackwardState:
-            state = _state_registry.pop(token_id, None)
+        def _get_state(token_id: int) -> _RegisteredBackwardState:
+            state = _state_registry.get(token_id, None)
             if state is None:
                 raise RuntimeError(
                     f"Missing registered Warp backward state for token {token_id}. "
-                    "The forward custom op likely did not attach a tape, or the state "
-                    "was released before backward executed."
+                    "The forward custom op likely did not attach a tape, or the "
+                    "graph was freed before backward executed."
                 )
             return state
 
@@ -634,8 +641,9 @@ def warp_custom_op(
                 if is_fake(token):
                     device = _first_tensor_device(*grad_outputs, *tensor_inputs)
                     return _zero_grads_for_inputs(tensor_inputs, device)
-                state = _pop_state(int(token.item()))
+                state = _get_state(int(token.item()))
                 with warp_stream_from_torch(*grad_outputs, *tensor_inputs):
+                    state.tape.zero()
                     _set_output_gradients(state.arrays, output_names, grad_outputs)
                     state.tape.backward()
                 gradients = _extract_tensor_input_gradients(

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -6801,6 +6801,86 @@ class TestHybridForces:
 
 
 ###########################################################################################
+######################### retain_graph Tests ##############################################
+###########################################################################################
+
+
+class TestRetainGraph:
+    """Verify that retain_graph=True allows multiple backward passes."""
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_retain_graph_grad_then_backward(self, device):
+        """autograd.grad with retain_graph followed by energy.backward must succeed."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges_base, cell, nl, nl_ptr, nl_shifts = create_dipole_system(
+            device
+        )
+
+        weight = torch.tensor(
+            [[0.1, -0.05, 0.02], [-0.1, 0.05, -0.02]],
+            dtype=torch.float64,
+            device=device,
+            requires_grad=True,
+        )
+        charges = charges_base + (positions * weight).sum(dim=1)
+        charges = charges - charges.mean()
+
+        energies = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+        )
+        energy = energies.sum()
+
+        (dE_dq,) = torch.autograd.grad(energy, charges, retain_graph=True)
+        assert torch.isfinite(dE_dq).all()
+
+        energy.backward()
+        assert weight.grad is not None
+        assert torch.isfinite(weight.grad).all()
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_retain_graph_double_backward(self, device):
+        """Two successive backward calls on the same graph must produce identical grads."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, charges_base, cell, nl, nl_ptr, nl_shifts = create_dipole_system(
+            device
+        )
+
+        charges_1 = charges_base.clone().requires_grad_(True)
+        energies = ewald_summation(
+            positions,
+            charges_1,
+            cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_list=nl,
+            neighbor_ptr=nl_ptr,
+            neighbor_shifts=nl_shifts,
+        )
+        energy = energies.sum()
+        energy.backward(retain_graph=True)
+        grad_first = charges_1.grad.clone()
+
+        charges_1.grad = None
+        energy.backward()
+        grad_second = charges_1.grad.clone()
+
+        torch.testing.assert_close(grad_first, grad_second, rtol=0.0, atol=0.0)
+
+
+###########################################################################################
 ########################### torch.compile Tests ###########################################
 ###########################################################################################
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Fix `retain_graph=True` support in `warp_custom_op` backward pass. The Warp tape state was destructively consumed on the first backward call, causing subsequent passes through the same graph to fail with a missing-state error.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #63 

## Changes Made

- Replace `_pop_state` (destructive `.pop()`) with `_get_state` (non-destructive `.get()`) in `warp_custom_op` backward so the tape survives across multiple backward passes
- Add `state.tape.zero()` before each backward replay to prevent gradient accumulation from prior passes
- Update error message to reflect new semantics (graph freed vs state released)
- Add `retain_graph`/`create_graph` support notes to the `warp_custom_op` docstring
- Add `TestRetainGraph` class with two tests: `autograd.grad` + `backward()` pattern, and double `backward(retain_graph=True)` pattern

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

New tests:
- `TestRetainGraph::test_retain_graph_grad_then_backward` -- exercises `autograd.grad(retain_graph=True)` followed by `energy.backward()` through Ewald ops with geometry-dependent charges
- `TestRetainGraph::test_retain_graph_double_backward` -- calls `energy.backward(retain_graph=True)` twice and asserts identical gradients

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

This fix covers `retain_graph=True` without `create_graph=True`. The `create_graph=True` + `loss.backward()` pattern (second-order differentiation through Warp ops) is a separate limitation documented in the updated docstring for `warp_custom_op`. Users needing that pattern should use `hybrid_forces=True` in the electrostatics APIs, which keeps Warp ops out of the autograd graph entirely.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
