### PR TITLE
fix: detach charges and cell in PME reciprocal virial background corr…

### DIFF
--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -1739,20 +1739,20 @@ def _pme_reciprocal_space_impl(
         # contribution is W_bg = -d(-E_bg)/dε = dE_bg/dε = -E_bg * I.
         eye = torch.eye(3, device=device, dtype=input_dtype)
         if is_batch:
-            num_systems = cell.shape[0]
+            num_systems = cell_spline.shape[0]
             total_charges = torch.zeros(
                 num_systems,
                 dtype=input_dtype,
                 device=device,
             )
-            total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
-            volumes = torch.abs(torch.linalg.det(cell)).to(input_dtype)
+            total_charges.scatter_add_(0, batch_idx, chg_spline.to(input_dtype))
+            volumes = torch.abs(torch.linalg.det(cell_spline)).to(input_dtype)
             alpha_batch = alpha.to(input_dtype)
             e_bg = PI * total_charges**2 / (2.0 * alpha_batch**2 * volumes)
             virial = virial - e_bg[:, None, None] * eye
         else:
-            total_charge = charges.sum().to(input_dtype)
-            volume = torch.abs(torch.det(cell)).to(input_dtype)
+            total_charge = chg_spline.sum().to(input_dtype)
+            volume = torch.abs(torch.det(cell_spline)).to(input_dtype)
             alpha_val = alpha.to(input_dtype)
             e_bg = PI * total_charge**2 / (2.0 * alpha_val**2 * volume)
             virial = virial - e_bg * eye

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -3940,6 +3940,35 @@ class TestPMEHybridForces:
         assert v_hyb.grad_fn is None
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_virial_detached_with_grad_charges(self, device):
+        """Virial must have no grad_fn even when charges require grad."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions, _, cell = create_dipole_system(device)
+
+        charge_model = torch.nn.Linear(3, 1, bias=False).to(
+            device=device, dtype=positions.dtype
+        )
+        charge_model.train()
+        charges = charge_model(positions).squeeze(-1)
+
+        _, _, v_hyb = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=(16, 16, 16),
+            compute_forces=True,
+            compute_virial=True,
+            hybrid_forces=True,
+        )
+
+        assert charges.requires_grad is True
+        assert v_hyb.grad_fn is None
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_hybrid_full_pme(self, device):
         """Test hybrid_forces on particle_mesh_ewald end-to-end."""
         if device == "cuda" and not torch.cuda.is_available():

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -3954,7 +3954,16 @@ class TestPMEHybridForces:
         charge_model.train()
         charges = charge_model(positions).squeeze(-1)
 
-        _, _, v_hyb = pme_reciprocal_space(
+        e_std, _, v_std = pme_reciprocal_space(
+            positions,
+            charges.detach(),
+            cell,
+            alpha=0.3,
+            mesh_dimensions=(16, 16, 16),
+            compute_forces=True,
+            compute_virial=True,
+        )
+        e_hyb, _, v_hyb = pme_reciprocal_space(
             positions,
             charges,
             cell,
@@ -3966,7 +3975,10 @@ class TestPMEHybridForces:
         )
 
         assert charges.requires_grad is True
+        torch.testing.assert_close(v_std, v_hyb, rtol=1e-12, atol=1e-14)
         assert v_hyb.grad_fn is None
+        assert e_hyb.sum().requires_grad is True
+        torch.autograd.grad(e_hyb.sum(), charges, retain_graph=True)
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_hybrid_full_pme(self, device):


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

When `hybrid_forces=True`, the reciprocal-space background virial correction in `_pme_reciprocal_space_impl` used the original `charges` and `cell` tensors instead of the detached. This caused the returned virial to retain a `grad_fn` when charges have `requires_grad=True`, violating the documented "forward-only" contract of the hybrid forces mode.

Thanks @vsimkus for reporting.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Relates to #57 (feat: Add hybrid forces mode for PME/Ewald)

## Changes Made

- In `_pme_reciprocal_space_impl` (`nvalchemiops/torch/interactions/electrostatics/pme.py`), replaced `charges` with `chg_spline` and `cell` with `cell_spline` in the background virial correction block (both batch and single-system paths). These variables are identical when `hybrid_forces=False` and are the `.detach()`-ed copies when `hybrid_forces=True`, so no behavioral change occurs outside of hybrid mode.
- Added `test_hybrid_virial_detached_with_grad_charges` to `TestPMEHybridForces` in `test/interactions/electrostatics/bindings/torch/test_pme.py`. The test creates charges via `torch.nn.Linear` so they carry `requires_grad=True`, calls `pme_reciprocal_space` with `hybrid_forces=True` and `compute_virial=True`, and asserts the virial has no `grad_fn`.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

The existing `test_hybrid_virial_forward_only` test did not catch this bug because `create_dipole_system` returns charges with `requires_grad=False`. The `charges.sum()` operation on a leaf tensor without grad produces no `grad_fn`, so the `v_hyb.grad_fn is None` assertion passed vacuously. The new test explicitly uses charges that flow through an `nn.Linear` to reproduce the issue.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
