### PR TITLE
fix: use strain rate tensor in NPT/NPH drag and cell kinetic energy

### DIFF
--- a/benchmarks/dynamics/shared_utils.py
+++ b/benchmarks/dynamics/shared_utils.py
@@ -657,22 +657,18 @@ def _pack_virial_flat_to_vec9_kernel(
     sys_id = wp.tid()
     v = virial_vec9[sys_id]
     v0 = virial_vec9[sys_id][0]
-    # NOTE ON SIGN CONVENTION:
-    # - The LJ kernels accumulate virial with a negative sign convention: W = -Σ r ⊗ F.
-    # - The MTK NPT/NPH implementation in `nvalchemiops.dynamics.integrators.npt`
-    #   computes pressure as P = (kinetic + virial) / V, which expects virial in the
-    #   *positive* convention: +Σ r ⊗ F.
-    # Therefore we negate here so the integrators see the expected virial sign.
+    # All interaction kernels produce W = -dE/dε directly (see conventions.md).
+    # compute_pressure_tensor expects this sign, so no conversion is needed.
     virial_vec9[sys_id] = type(v)(
-        type(v0)(-virial_flat[0]),
-        type(v0)(-virial_flat[1]),
-        type(v0)(-virial_flat[2]),
-        type(v0)(-virial_flat[3]),
-        type(v0)(-virial_flat[4]),
-        type(v0)(-virial_flat[5]),
-        type(v0)(-virial_flat[6]),
-        type(v0)(-virial_flat[7]),
-        type(v0)(-virial_flat[8]),
+        type(v0)(virial_flat[0]),
+        type(v0)(virial_flat[1]),
+        type(v0)(virial_flat[2]),
+        type(v0)(virial_flat[3]),
+        type(v0)(virial_flat[4]),
+        type(v0)(virial_flat[5]),
+        type(v0)(virial_flat[6]),
+        type(v0)(virial_flat[7]),
+        type(v0)(virial_flat[8]),
     )
 
 
@@ -693,44 +689,43 @@ def _virial_to_stress_kernel(
 ):
     """Convert virial to stress tensor for cell optimization.
 
-    Computes: stress = P_ext - P_internal
+    Computes: stress = P_ext * I - W / V
 
-    where P_internal = -virial/V (negated because LJ virial has W = -Σ r ⊗ F).
+    where W = -dE/dε is the virial produced directly by the interaction
+    kernels (see conventions.md).  P_int = W/V is the internal pressure
+    contribution from pairwise interactions.
 
-    At equilibrium: P_internal = P_ext, so stress = 0.
-    When P_internal < P_ext: stress > 0, cell contracts (via stress_to_cell_force).
-    When P_internal > P_ext: stress < 0, cell expands.
+    At equilibrium: P_int = P_ext, so stress = 0.
+    When P_int < P_ext: stress > 0, cell contracts (via stress_to_cell_force).
+    When P_int > P_ext: stress < 0, cell expands.
     """
     sys = wp.tid()
     V = volume[sys]
     inv_V = wp.float64(1.0) / V
 
     # Virial components (row-major: xx, xy, xz, yx, yy, yz, zx, zy, zz)
-    # Negate because LJ virial uses convention W = -Σ r ⊗ F
-    # After negation: positive = compression (repulsive forces)
-    vxx = -virial_flat[0]
-    vxy = -virial_flat[1]
-    vxz = -virial_flat[2]
-    vyx = -virial_flat[3]
-    vyy = -virial_flat[4]
-    vyz = -virial_flat[5]
-    vzx = -virial_flat[6]
-    vzy = -virial_flat[7]
-    vzz = -virial_flat[8]
+    # W = -dE/dε produced directly by interaction kernels; no sign flip needed
+    wxx = virial_flat[0]
+    wxy = virial_flat[1]
+    wxz = virial_flat[2]
+    wyx = virial_flat[3]
+    wyy = virial_flat[4]
+    wyz = virial_flat[5]
+    wzx = virial_flat[6]
+    wzy = virial_flat[7]
+    wzz = virial_flat[8]
 
-    # Internal pressure (diagonal): P_int = virial/V (positive = compression)
-    # Stress for optimization: σ = P_ext - P_int
-    # This ensures σ = 0 at equilibrium, and correct sign for cell force
+    # σ = P_ext * I - W/V
     stress[sys] = wp.mat33d(
-        external_pressure - vxx * inv_V,
-        -vxy * inv_V,
-        -vxz * inv_V,
-        -vyx * inv_V,
-        external_pressure - vyy * inv_V,
-        -vyz * inv_V,
-        -vzx * inv_V,
-        -vzy * inv_V,
-        external_pressure - vzz * inv_V,
+        external_pressure - wxx * inv_V,
+        -wxy * inv_V,
+        -wxz * inv_V,
+        -wyx * inv_V,
+        external_pressure - wyy * inv_V,
+        -wyz * inv_V,
+        -wzx * inv_V,
+        -wzy * inv_V,
+        external_pressure - wzz * inv_V,
     )
 
 

--- a/examples/dynamics/_dynamics_utils.py
+++ b/examples/dynamics/_dynamics_utils.py
@@ -197,22 +197,18 @@ def _pack_virial_flat_to_vec9_kernel(
     sys_id = wp.tid()
     v = virial_vec9[sys_id]
     v0 = virial_vec9[sys_id][0]
-    # NOTE ON SIGN CONVENTION:
-    # - The LJ kernels accumulate virial with a negative sign convention: W = -Σ r ⊗ F.
-    # - The MTK NPT/NPH implementation in `nvalchemiops.dynamics.integrators.npt`
-    #   computes pressure as P = (kinetic + virial) / V, which expects virial in the
-    #   *positive* convention: +Σ r ⊗ F.
-    # Therefore we negate here so the integrators see the expected virial sign.
+    # All interaction kernels produce W = -dE/dε directly (see conventions.md).
+    # compute_pressure_tensor expects this sign, so no conversion is needed.
     virial_vec9[sys_id] = type(v)(
-        type(v0)(-virial_flat[0]),
-        type(v0)(-virial_flat[1]),
-        type(v0)(-virial_flat[2]),
-        type(v0)(-virial_flat[3]),
-        type(v0)(-virial_flat[4]),
-        type(v0)(-virial_flat[5]),
-        type(v0)(-virial_flat[6]),
-        type(v0)(-virial_flat[7]),
-        type(v0)(-virial_flat[8]),
+        type(v0)(virial_flat[0]),
+        type(v0)(virial_flat[1]),
+        type(v0)(virial_flat[2]),
+        type(v0)(virial_flat[3]),
+        type(v0)(virial_flat[4]),
+        type(v0)(virial_flat[5]),
+        type(v0)(virial_flat[6]),
+        type(v0)(virial_flat[7]),
+        type(v0)(virial_flat[8]),
     )
 
 
@@ -233,44 +229,43 @@ def _virial_to_stress_kernel(
 ):
     """Convert virial to stress tensor for cell optimization.
 
-    Computes: stress = P_ext - P_internal
+    Computes: stress = P_ext * I - W / V
 
-    where P_internal = -virial/V (negated because LJ virial has W = -Σ r ⊗ F).
+    where W = -dE/dε is the virial produced directly by the interaction
+    kernels (see conventions.md).  P_int = W/V is the internal pressure
+    contribution from pairwise interactions.
 
-    At equilibrium: P_internal = P_ext, so stress = 0.
-    When P_internal < P_ext: stress > 0, cell contracts (via stress_to_cell_force).
-    When P_internal > P_ext: stress < 0, cell expands.
+    At equilibrium: P_int = P_ext, so stress = 0.
+    When P_int < P_ext: stress > 0, cell contracts (via stress_to_cell_force).
+    When P_int > P_ext: stress < 0, cell expands.
     """
     sys = wp.tid()
     V = volume[sys]
     inv_V = wp.float64(1.0) / V
 
     # Virial components (row-major: xx, xy, xz, yx, yy, yz, zx, zy, zz)
-    # Negate because LJ virial uses convention W = -Σ r ⊗ F
-    # After negation: positive = compression (repulsive forces)
-    vxx = -virial_flat[0]
-    vxy = -virial_flat[1]
-    vxz = -virial_flat[2]
-    vyx = -virial_flat[3]
-    vyy = -virial_flat[4]
-    vyz = -virial_flat[5]
-    vzx = -virial_flat[6]
-    vzy = -virial_flat[7]
-    vzz = -virial_flat[8]
+    # W = -dE/dε produced directly by interaction kernels; no sign flip needed
+    wxx = virial_flat[0]
+    wxy = virial_flat[1]
+    wxz = virial_flat[2]
+    wyx = virial_flat[3]
+    wyy = virial_flat[4]
+    wyz = virial_flat[5]
+    wzx = virial_flat[6]
+    wzy = virial_flat[7]
+    wzz = virial_flat[8]
 
-    # Internal pressure (diagonal): P_int = virial/V (positive = compression)
-    # Stress for optimization: σ = P_ext - P_int
-    # This ensures σ = 0 at equilibrium, and correct sign for cell force
+    # σ = P_ext * I - W/V
     stress[sys] = wp.mat33d(
-        external_pressure - vxx * inv_V,
-        -vxy * inv_V,
-        -vxz * inv_V,
-        -vyx * inv_V,
-        external_pressure - vyy * inv_V,
-        -vyz * inv_V,
-        -vzx * inv_V,
-        -vzy * inv_V,
-        external_pressure - vzz * inv_V,
+        external_pressure - wxx * inv_V,
+        -wxy * inv_V,
+        -wxz * inv_V,
+        -wyx * inv_V,
+        external_pressure - wyy * inv_V,
+        -wyz * inv_V,
+        -wzx * inv_V,
+        -wzy * inv_V,
+        external_pressure - wzz * inv_V,
     )
 
 

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -137,14 +137,14 @@ def _build_identity_h_inv_kernel(
     volumes: wp.array(dtype=Any),
     h_inv_out: wp.array(dtype=Any),
 ):
-    """Build h_inv = (1/V) * I, valid for cubic cells.
+    """Build h_inv = V^{-1/3} * I, valid for cubic cells.
 
     Launch Grid: dim = [num_systems]
     """
     sys = wp.tid()
-    inv_V = type(volumes[sys])(1.0) / volumes[sys]
+    inv_L = wp.cbrt(type(volumes[sys])(1.0) / volumes[sys])
     z = type(volumes[sys])(0.0)
-    h_inv_out[sys] = type(h_inv_out[sys])(inv_V, z, z, z, inv_V, z, z, z, inv_V)
+    h_inv_out[sys] = type(h_inv_out[sys])(inv_L, z, z, z, inv_L, z, z, z, inv_L)
 
 
 _build_identity_h_inv_kernel_overload = {}
@@ -164,7 +164,7 @@ def _ensure_cells_inv(
     cell_velocities: wp.array,
     device: str | None,
 ) -> wp.array:
-    """Return cells_inv if provided, otherwise build (1/V)*I from volumes.
+    """Return cells_inv if provided, otherwise build V^{-1/3}·I from volumes.
 
     Parameters
     ----------
@@ -2078,7 +2078,7 @@ def compute_cell_kinetic_energy(
         cells to compute the exact strain rate ε̇ = ḣ h⁻¹.
     volumes : wp.array(dtype=scalar), optional
         Cell volumes. Shape (B,). Used as fallback when ``cells_inv`` is not
-        provided: computes h⁻¹ = (1/V) I, which is only valid for cubic
+        provided: computes h⁻¹ = V^{-1/3} I, which is only valid for cubic
         cells. For non-cubic cells the caller must provide ``cells_inv``.
     device : str, optional
         Warp device.
@@ -2507,7 +2507,7 @@ def npt_velocity_half_step(
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
         Cell velocity matrices ḣ = dh/dt. Shape (B,).
     volumes : wp.array(dtype=scalar)
-        Cell volumes. Shape (B,). Used to build h⁻¹ = (1/V)I when
+        Cell volumes. Shape (B,). Used to build h⁻¹ = V^{-1/3}·I when
         ``cells_inv`` is not provided (only valid for cubic cells).
     eta_dots : wp.array2d(dtype=scalar)
         Thermostat chain velocities. Shape (B, chain_length).
@@ -3343,7 +3343,7 @@ def nph_velocity_half_step(
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
         Cell velocity matrices ḣ = dh/dt.
     volumes : wp.array(dtype=scalar)
-        Cell volumes. Shape (B,). Used to build h⁻¹ = (1/V)I when
+        Cell volumes. Shape (B,). Used to build h⁻¹ = V^{-1/3}·I when
         ``cells_inv`` is not provided (only valid for cubic cells).
     num_atoms : wp.array(dtype=wp.int32)
         Atom count for single-system mode. Shape (1,).

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -2648,6 +2648,8 @@ def npt_velocity_half_step_out(
         raise ValueError(
             f"Unknown mode: '{mode}'. Expected 'isotropic', 'anisotropic', or 'triclinic'."
         )
+    if mode == "triclinic" and cells_inv is None:
+        raise ValueError("mode='triclinic' requires cells_inv parameter.")
 
     family = _NPT_VELOCITY_FAMILIES[mode]
 
@@ -3459,6 +3461,8 @@ def nph_velocity_half_step_out(
         raise ValueError(
             f"Unknown mode: '{mode}'. Expected 'isotropic', 'anisotropic', or 'triclinic'."
         )
+    if mode == "triclinic" and cells_inv is None:
+        raise ValueError("mode='triclinic' requires cells_inv parameter.")
 
     family = _NPH_VELOCITY_FAMILIES[mode]
 

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -137,9 +137,7 @@ def _build_identity_h_inv_kernel(
     volumes: wp.array(dtype=Any),
     h_inv_out: wp.array(dtype=Any),
 ):
-    """Build h_inv = (1/V) * I as a fallback when cells_inv is not provided.
-
-    This reproduces the legacy ε̇ ≈ ḣ/V approximation for cubic cells.
+    """Build h_inv = (1/V) * I, valid for cubic cells.
 
     Launch Grid: dim = [num_systems]
     """
@@ -182,7 +180,7 @@ def _ensure_cells_inv(
     Returns
     -------
     wp.array
-        Inverse cell matrices (either caller-provided or manufactured).
+        Inverse cell matrices (either caller-provided or computed).
     """
     if cells_inv is not None:
         return cells_inv
@@ -2080,7 +2078,7 @@ def compute_cell_kinetic_energy(
         cells to compute the exact strain rate ε̇ = ḣ h⁻¹.
     volumes : wp.array(dtype=scalar), optional
         Cell volumes. Shape (B,). Used as fallback when ``cells_inv`` is not
-        provided: manufactures h⁻¹ = (1/V) I, which is only valid for cubic
+        provided: computes h⁻¹ = (1/V) I, which is only valid for cubic
         cells. For non-cubic cells the caller must provide ``cells_inv``.
     device : str, optional
         Warp device.
@@ -2523,7 +2521,7 @@ def npt_velocity_half_step(
     num_atoms_per_system : wp.array(dtype=wp.int32), optional
         Number of atoms per system. Required for batched simulations.
     cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
-        Inverse cell matrices h⁻¹. Shape (B,). When provided, the exact
+        Inverse cell matrices h⁻¹. Shape (B,). When provided, the
         strain rate ε̇ = ḣ h⁻¹ is used. Required for non-cubic cells.
     mode : str, optional
         Pressure control mode. One of:
@@ -2608,7 +2606,7 @@ def npt_velocity_half_step_out(
         System state arrays.
     volumes : wp.array
         Cell volumes. Shape (B,). Used as fallback when ``cells_inv``
-        is not provided (only valid for cubic cells; for non-cubic cells the caller must provide ``cells_inv``).
+        is not provided (only valid for cubic cells).
     eta_dots : wp.array
         Thermostat chain velocities.
     num_atoms : wp.array(dtype=wp.int32)
@@ -2623,7 +2621,7 @@ def npt_velocity_half_step_out(
     num_atoms_per_system : wp.array, optional
         Atom counts per system.
     cells_inv : wp.array, optional
-        Inverse cell matrices h⁻¹. Shape (B,). When provided, the exact
+        Inverse cell matrices h⁻¹. Shape (B,). When provided, the
         strain rate ε̇ = ḣ h⁻¹ is used. Required for non-cubic cells.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".
@@ -3344,7 +3342,7 @@ def nph_velocity_half_step(
         Cell velocity matrices ḣ = dh/dt.
     volumes : wp.array(dtype=scalar)
         Cell volumes. Shape (B,). Used to build h⁻¹ = (1/V)I when
-        ``cells_inv`` is not provided (only valid for cubic cells; for non-cubic cells the caller must provide ``cells_inv``).
+        ``cells_inv`` is not provided (only valid for cubic cells).
     num_atoms : wp.array(dtype=wp.int32)
         Atom count for single-system mode. Shape (1,).
     dt : wp.array(dtype=scalar)
@@ -3355,7 +3353,7 @@ def nph_velocity_half_step(
     num_atoms_per_system : wp.array, optional
         Number of atoms per system.
     cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
-        Inverse cell matrices h⁻¹. Shape (B,). When provided, the exact
+        Inverse cell matrices h⁻¹. Shape (B,). When provided, the
         strain rate ε̇ = ḣ h⁻¹ is used. Required for non-cubic cells.
     mode : str, optional
         Pressure control mode:
@@ -3423,7 +3421,7 @@ def nph_velocity_half_step_out(
         System state arrays.
     volumes : wp.array
         Cell volumes. Shape (B,). Used as fallback when ``cells_inv``
-        is not provided (only valid for cubic cells; for non-cubic cells the caller must provide ``cells_inv``).
+        is not provided (only valid for cubic cells).
     num_atoms : wp.array(dtype=wp.int32)
         Atom count for single-system mode. Shape (1,).
     dt : wp.array(dtype=scalar)
@@ -3434,7 +3432,7 @@ def nph_velocity_half_step_out(
     batch_idx, num_atoms_per_system : wp.array, optional
         For batched simulations.
     cells_inv : wp.array, optional
-        Inverse cell matrices h⁻¹. Shape (B,). When provided, the exact
+        Inverse cell matrices h⁻¹. Shape (B,). When provided, the
         strain rate ε̇ = ḣ h⁻¹ is used. Required for non-cubic cells.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -128,6 +128,82 @@ vec3d = wp.vec3d
 
 
 # =============================================================================
+# Helper: compute h_inv from volumes when cells_inv is not provided
+# =============================================================================
+
+
+@wp.kernel
+def _build_identity_h_inv_kernel(
+    volumes: wp.array(dtype=Any),
+    h_inv_out: wp.array(dtype=Any),
+):
+    """Build h_inv = (1/V) * I as a fallback when cells_inv is not provided.
+
+    This reproduces the legacy ε̇ ≈ ḣ/V approximation for cubic cells.
+
+    Launch Grid: dim = [num_systems]
+    """
+    sys = wp.tid()
+    inv_V = type(volumes[sys])(1.0) / volumes[sys]
+    z = type(volumes[sys])(0.0)
+    h_inv_out[sys] = type(h_inv_out[sys])(inv_V, z, z, z, inv_V, z, z, z, inv_V)
+
+
+_build_identity_h_inv_kernel_overload = {}
+for _t, _m in zip(
+    [wp.float32, wp.float64],
+    [wp.mat33f, wp.mat33d],
+):
+    _build_identity_h_inv_kernel_overload[_t] = wp.overload(
+        _build_identity_h_inv_kernel,
+        [wp.array(dtype=_t), wp.array(dtype=_m)],
+    )
+
+
+def _ensure_cells_inv(
+    cells_inv: wp.array | None,
+    volumes: wp.array | None,
+    cell_velocities: wp.array,
+    device: str | None,
+) -> wp.array:
+    """Return cells_inv if provided, otherwise build (1/V)*I from volumes.
+
+    Parameters
+    ----------
+    cells_inv : wp.array or None
+        Caller-provided inverse cell matrices.
+    volumes : wp.array or None
+        Cell volumes, used as fallback.
+    cell_velocities : wp.array
+        Used only to infer mat dtype (mat33f or mat33d).
+    device : str or None
+        Warp device.
+
+    Returns
+    -------
+    wp.array
+        Inverse cell matrices (either caller-provided or manufactured).
+    """
+    if cells_inv is not None:
+        return cells_inv
+    if volumes is None:
+        raise ValueError("Either cells_inv or volumes must be provided.")
+    num_systems = volumes.shape[0]
+    mat_dtype = cell_velocities.dtype
+    if device is None:
+        device = cell_velocities.device
+    scalar_dtype = volumes.dtype
+    h_inv = wp.empty(num_systems, dtype=mat_dtype, device=device)
+    wp.launch(
+        _build_identity_h_inv_kernel_overload[scalar_dtype],
+        dim=num_systems,
+        inputs=[volumes, h_inv],
+        device=device,
+    )
+    return h_inv
+
+
+# =============================================================================
 # Shared @wp.func for NPT/NPH physics
 # =============================================================================
 
@@ -1980,9 +2056,10 @@ def compute_barostat_mass(
 
 def compute_cell_kinetic_energy(
     cell_velocities: wp.array,
-    cells_inv: wp.array,
     cell_masses: wp.array,
     kinetic_energy: wp.array,
+    cells_inv: wp.array = None,
+    volumes: wp.array = None,
     device: str = None,
 ) -> wp.array:
     """
@@ -1994,12 +2071,17 @@ def compute_cell_kinetic_energy(
     ----------
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
         Cell velocity matrices ḣ = dh/dt. Shape (B,).
-    cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d)
-        Inverse cell matrices h⁻¹. Shape (B,).
     cell_masses : wp.array
         Barostat masses. Shape (B,).
     kinetic_energy : wp.array(dtype=scalar)
         Output cell kinetic energy. Shape (B,).
+    cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
+        Inverse cell matrices h⁻¹. Shape (B,). Required for non-cubic
+        cells to compute the exact strain rate ε̇ = ḣ h⁻¹.
+    volumes : wp.array(dtype=scalar), optional
+        Cell volumes. Shape (B,). Used as fallback when ``cells_inv`` is not
+        provided: manufactures h⁻¹ = (1/V) I, which is only valid for cubic
+        cells. For non-cubic cells the caller must provide ``cells_inv``.
     device : str, optional
         Warp device.
 
@@ -2007,16 +2089,23 @@ def compute_cell_kinetic_energy(
     -------
     wp.array
         Cell kinetic energy. Shape (B,).
+
+    Notes
+    -----
+    At least one of ``cells_inv`` or ``volumes`` must be provided.
+    If both are given, ``cells_inv`` takes precedence.
     """
     if device is None:
         device = cell_velocities.device
+
+    h_inv = _ensure_cells_inv(cells_inv, volumes, cell_velocities, device)
 
     num_systems = cell_velocities.shape[0]
 
     wp.launch(
         _compute_cell_kinetic_energy_kernel,
         dim=num_systems,
-        inputs=[cell_velocities, cells_inv, cell_masses, kinetic_energy],
+        inputs=[cell_velocities, h_inv, cell_masses, kinetic_energy],
         device=device,
     )
 
@@ -2367,12 +2456,13 @@ def npt_velocity_half_step(
     masses: wp.array,
     forces: wp.array,
     cell_velocities: wp.array,
-    cells_inv: wp.array,
+    volumes: wp.array,
     eta_dots: wp.array,
     num_atoms: wp.array,
     dt: wp.array,
     batch_idx: wp.array = None,
     num_atoms_per_system: wp.array = None,
+    cells_inv: wp.array = None,
     mode: str = "isotropic",
     device: str = None,
 ) -> None:
@@ -2418,8 +2508,9 @@ def npt_velocity_half_step(
         Forces on particles. Shape (N,).
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
         Cell velocity matrices ḣ = dh/dt. Shape (B,).
-    cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d)
-        Inverse cell matrices h⁻¹. Shape (B,).
+    volumes : wp.array(dtype=scalar)
+        Cell volumes. Shape (B,). Used to build h⁻¹ = (1/V)I when
+        ``cells_inv`` is not provided (only valid for cubic cells).
     eta_dots : wp.array2d(dtype=scalar)
         Thermostat chain velocities. Shape (B, chain_length).
     num_atoms : wp.array(dtype=wp.int32)
@@ -2431,6 +2522,9 @@ def npt_velocity_half_step(
         System index for each atom. Required for batched simulations.
     num_atoms_per_system : wp.array(dtype=wp.int32), optional
         Number of atoms per system. Required for batched simulations.
+    cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
+        Inverse cell matrices h⁻¹. Shape (B,). When provided, the exact
+        strain rate ε̇ = ḣ h⁻¹ is used. Required for non-cubic cells.
     mode : str, optional
         Pressure control mode. One of:
 
@@ -2443,18 +2537,19 @@ def npt_velocity_half_step(
 
     Examples
     --------
-    Single system (isotropic):
+    Single system (isotropic, cubic cell):
 
     >>> npt_velocity_half_step(
-    ...     velocities, masses, forces, cell_velocities, cells_inv,
+    ...     velocities, masses, forces, cell_velocities, volumes,
     ...     eta_dots, num_atoms=100, dt=0.001
     ... )
 
-    Triclinic cell:
+    Non-cubic cell (pass cells_inv for exact strain rate):
 
     >>> npt_velocity_half_step(
-    ...     velocities, masses, forces, cell_velocities, cells_inv,
-    ...     eta_dots, num_atoms=100, dt=0.001, mode="triclinic"
+    ...     velocities, masses, forces, cell_velocities, volumes,
+    ...     eta_dots, num_atoms=100, dt=0.001,
+    ...     cells_inv=cells_inv, mode="triclinic"
     ... )
 
     See Also
@@ -2462,18 +2557,20 @@ def npt_velocity_half_step(
     npt_barostat_half_step : Cell velocity update step.
     npt_position_update : Position update step.
     """
+    # In-place: delegate to _out with velocities as both input and output
     npt_velocity_half_step_out(
         velocities,
         masses,
         forces,
         cell_velocities,
-        cells_inv,
+        volumes,
         eta_dots,
         num_atoms,
         dt,
         velocities_out=velocities,
         batch_idx=batch_idx,
         num_atoms_per_system=num_atoms_per_system,
+        cells_inv=cells_inv,
         mode=mode,
         device=device,
         _skip_validation=True,
@@ -2485,13 +2582,14 @@ def npt_velocity_half_step_out(
     masses: wp.array,
     forces: wp.array,
     cell_velocities: wp.array,
-    cells_inv: wp.array,
+    volumes: wp.array,
     eta_dots: wp.array,
     num_atoms: wp.array,
     dt: wp.array,
     velocities_out: wp.array,
     batch_idx: wp.array = None,
     num_atoms_per_system: wp.array = None,
+    cells_inv: wp.array = None,
     mode: str = "isotropic",
     device: str = None,
     _skip_validation: bool = False,
@@ -2508,8 +2606,9 @@ def npt_velocity_half_step_out(
         Input velocities (not modified when velocities_out differs).
     masses, forces, cell_velocities : wp.array
         System state arrays.
-    cells_inv : wp.array
-        Inverse cell matrices h⁻¹. Shape (B,).
+    volumes : wp.array
+        Cell volumes. Shape (B,). Used as fallback when ``cells_inv``
+        is not provided (only valid for cubic cells; for non-cubic cells the caller must provide ``cells_inv``).
     eta_dots : wp.array
         Thermostat chain velocities.
     num_atoms : wp.array(dtype=wp.int32)
@@ -2523,6 +2622,9 @@ def npt_velocity_half_step_out(
         System indices for batched simulations.
     num_atoms_per_system : wp.array, optional
         Atom counts per system.
+    cells_inv : wp.array, optional
+        Inverse cell matrices h⁻¹. Shape (B,). When provided, the exact
+        strain rate ε̇ = ḣ h⁻¹ is used. Required for non-cubic cells.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".
     device : str, optional
@@ -2538,6 +2640,8 @@ def npt_velocity_half_step_out(
 
     if not _skip_validation:
         validate_out_array(velocities_out, velocities, "velocities_out")
+
+    h_inv = _ensure_cells_inv(cells_inv, volumes, cell_velocities, device)
 
     exec_mode = resolve_execution_mode(batch_idx, None)
     n_atoms = velocities.shape[0]
@@ -2558,7 +2662,7 @@ def npt_velocity_half_step_out(
             masses,
             forces,
             cell_velocities,
-            cells_inv,
+            h_inv,
             eta_dots,
             num_atoms,
             dt,
@@ -2570,7 +2674,7 @@ def npt_velocity_half_step_out(
             forces,
             batch_idx,
             cell_velocities,
-            cells_inv,
+            h_inv,
             eta_dots,
             num_atoms_per_system,
             dt,
@@ -2893,12 +2997,13 @@ def run_npt_step(
         masses,
         forces,
         cell_velocities,
-        cells_inv,
+        volumes,
         eta_dot,
         num_atoms,
         dt,
         batch_idx=batch_idx,
         num_atoms_per_system=num_atoms_per_system,
+        cells_inv=cells_inv,
         device=device,
     )
 
@@ -2949,12 +3054,13 @@ def run_npt_step(
         masses,
         forces,
         cell_velocities,
-        cells_inv,
+        volumes,
         eta_dot,
         num_atoms,
         dt,
         batch_idx=batch_idx,
         num_atoms_per_system=num_atoms_per_system,
+        cells_inv=cells_inv,
         device=device,
     )
 
@@ -3191,11 +3297,12 @@ def nph_velocity_half_step(
     masses: wp.array,
     forces: wp.array,
     cell_velocities: wp.array,
-    cells_inv: wp.array,
+    volumes: wp.array,
     num_atoms: wp.array,
     dt: wp.array,
     batch_idx: wp.array = None,
     num_atoms_per_system: wp.array = None,
+    cells_inv: wp.array = None,
     mode: str = "isotropic",
     device: str = None,
 ) -> None:
@@ -3235,8 +3342,9 @@ def nph_velocity_half_step(
         Forces on particles.
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
         Cell velocity matrices ḣ = dh/dt.
-    cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d)
-        Inverse cell matrices h^-1. Shape (B,).
+    volumes : wp.array(dtype=scalar)
+        Cell volumes. Shape (B,). Used to build h⁻¹ = (1/V)I when
+        ``cells_inv`` is not provided (only valid for cubic cells; for non-cubic cells the caller must provide ``cells_inv``).
     num_atoms : wp.array(dtype=wp.int32)
         Atom count for single-system mode. Shape (1,).
     dt : wp.array(dtype=scalar)
@@ -3246,6 +3354,9 @@ def nph_velocity_half_step(
         System index for each atom.
     num_atoms_per_system : wp.array, optional
         Number of atoms per system.
+    cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
+        Inverse cell matrices h⁻¹. Shape (B,). When provided, the exact
+        strain rate ε̇ = ḣ h⁻¹ is used. Required for non-cubic cells.
     mode : str, optional
         Pressure control mode:
 
@@ -3261,17 +3372,19 @@ def nph_velocity_half_step(
     nph_barostat_half_step : Cell velocity update.
     npt_velocity_half_step : Velocity update with thermostat.
     """
+    # In-place: delegate to _out with velocities as both input and output
     nph_velocity_half_step_out(
         velocities,
         masses,
         forces,
         cell_velocities,
-        cells_inv,
+        volumes,
         num_atoms,
         dt,
         velocities_out=velocities,
         batch_idx=batch_idx,
         num_atoms_per_system=num_atoms_per_system,
+        cells_inv=cells_inv,
         mode=mode,
         device=device,
         _skip_validation=True,
@@ -3286,12 +3399,13 @@ def nph_velocity_half_step_out(
     masses: wp.array,
     forces: wp.array,
     cell_velocities: wp.array,
-    cells_inv: wp.array,
+    volumes: wp.array,
     num_atoms: wp.array,
     dt: wp.array,
     velocities_out: wp.array,
     batch_idx: wp.array = None,
     num_atoms_per_system: wp.array = None,
+    cells_inv: wp.array = None,
     mode: str = "isotropic",
     device: str = None,
     _skip_validation: bool = False,
@@ -3307,8 +3421,9 @@ def nph_velocity_half_step_out(
         Input velocities (not modified when velocities_out differs).
     masses, forces, cell_velocities : wp.array
         System state arrays.
-    cells_inv : wp.array
-        Inverse cell matrices h^-1. Shape (B,).
+    volumes : wp.array
+        Cell volumes. Shape (B,). Used as fallback when ``cells_inv``
+        is not provided (only valid for cubic cells; for non-cubic cells the caller must provide ``cells_inv``).
     num_atoms : wp.array(dtype=wp.int32)
         Atom count for single-system mode. Shape (1,).
     dt : wp.array(dtype=scalar)
@@ -3318,6 +3433,9 @@ def nph_velocity_half_step_out(
         Pre-allocated output array.
     batch_idx, num_atoms_per_system : wp.array, optional
         For batched simulations.
+    cells_inv : wp.array, optional
+        Inverse cell matrices h⁻¹. Shape (B,). When provided, the exact
+        strain rate ε̇ = ḣ h⁻¹ is used. Required for non-cubic cells.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".
     device : str, optional
@@ -3333,6 +3451,8 @@ def nph_velocity_half_step_out(
 
     if not _skip_validation:
         validate_out_array(velocities_out, velocities, "velocities_out")
+
+    h_inv = _ensure_cells_inv(cells_inv, volumes, cell_velocities, device)
 
     exec_mode = resolve_execution_mode(batch_idx, None)
     n_atoms = velocities.shape[0]
@@ -3353,7 +3473,7 @@ def nph_velocity_half_step_out(
             masses,
             forces,
             cell_velocities,
-            cells_inv,
+            h_inv,
             num_atoms,
             dt,
             velocities_out,
@@ -3364,7 +3484,7 @@ def nph_velocity_half_step_out(
             forces,
             batch_idx,
             cell_velocities,
-            cells_inv,
+            h_inv,
             num_atoms_per_system,
             dt,
             velocities_out,
@@ -3557,11 +3677,12 @@ def run_nph_step(
         masses,
         forces,
         cell_velocities,
-        cells_inv,
+        volumes,
         num_atoms,
         dt,
         batch_idx=batch_idx,
         num_atoms_per_system=num_atoms_per_system,
+        cells_inv=cells_inv,
         device=device,
     )
 
@@ -3612,11 +3733,12 @@ def run_nph_step(
         masses,
         forces,
         cell_velocities,
-        cells_inv,
+        volumes,
         num_atoms,
         dt,
         batch_idx=batch_idx,
         num_atoms_per_system=num_atoms_per_system,
+        cells_inv=cells_inv,
         device=device,
     )
 

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -35,6 +35,17 @@ Pressure Control Modes
 - Anisotropic (orthorhombic): Independent x, y, z pressure control
 - Anisotropic (triclinic): Full stress tensor control (9 components)
 
+Conventions
+-----------
+**Cell velocities** (``cell_velocities``) are the absolute time derivative
+of the cell matrix: ḣ = dh/dt.  The strain rate tensor ε̇ = ḣ h⁻¹ is
+computed internally wherever it is needed (drag, position update, cell
+kinetic energy).  Callers should *not* pre-convert to strain rate.
+
+**Virial sign**: ``compute_pressure_tensor`` expects the virial
+W = -dE/dε as defined in ``docs/userguide/about/conventions.md``.
+All interaction kernels in this library produce this sign directly.
+
 References
 ----------
 - Martyna, Tobias, Klein, J. Chem. Phys. 101, 4177 (1994)
@@ -129,23 +140,26 @@ def _npt_accel(f: Any, m: Any) -> Any:
 
 
 @wp.func
-def _drag_isotropic(h_dot: Any, V: Any, coupling: Any, eta_dot_1: Any, v: Any) -> Any:
-    """Isotropic drag: (coupling * Tr(h_dot)/(3V) + eta_dot_1) * v."""
-    trace_h_dot = h_dot[0, 0] + h_dot[1, 1] + h_dot[2, 2]
-    eps_dot = trace_h_dot / (type(V)(3.0) * V)
-    return (coupling * eps_dot + eta_dot_1) * v
+def _drag_isotropic(
+    h_dot: Any, h_inv: Any, coupling: Any, eta_dot_1: Any, v: Any
+) -> Any:
+    """Isotropic drag: (coupling * Tr(ε̇)/3 + eta_dot_1) * v, where ε̇ = ḣ h⁻¹."""
+    eps_dot = wp.mul(h_dot, h_inv)
+    trace_eps = eps_dot[0, 0] + eps_dot[1, 1] + eps_dot[2, 2]
+    eps_scalar = trace_eps / type(trace_eps)(3.0)
+    return (coupling * eps_scalar + eta_dot_1) * v
 
 
 @wp.func
-def _drag_anisotropic(h_dot: Any, V: Any, coupling: Any, eta_dot_1: Any, v: Any) -> Any:
-    """Anisotropic (diagonal) drag."""
-    eps_dot_xx = h_dot[0, 0] / V
-    eps_dot_yy = h_dot[1, 1] / V
-    eps_dot_zz = h_dot[2, 2] / V
+def _drag_anisotropic(
+    h_dot: Any, h_inv: Any, coupling: Any, eta_dot_1: Any, v: Any
+) -> Any:
+    """Anisotropic (diagonal) drag using ε̇ = ḣ h⁻¹."""
+    eps_dot = wp.mul(h_dot, h_inv)
     return type(v)(
-        (coupling * eps_dot_xx + eta_dot_1) * v[0],
-        (coupling * eps_dot_yy + eta_dot_1) * v[1],
-        (coupling * eps_dot_zz + eta_dot_1) * v[2],
+        (coupling * eps_dot[0, 0] + eta_dot_1) * v[0],
+        (coupling * eps_dot[1, 1] + eta_dot_1) * v[1],
+        (coupling * eps_dot[2, 2] + eta_dot_1) * v[2],
     )
 
 
@@ -153,8 +167,8 @@ def _drag_anisotropic(h_dot: Any, V: Any, coupling: Any, eta_dot_1: Any, v: Any)
 def _drag_triclinic(
     h_dot: Any, h_inv: Any, coupling: Any, eta_dot_1: Any, v: Any
 ) -> Any:
-    """Triclinic (full tensor) drag: (coupling * h_dot @ h_inv + eta_dot_1 * I) @ v."""
-    eps_dot = h_dot * h_inv
+    """Triclinic (full tensor) drag: (coupling * ḣ h⁻¹ + eta_dot_1 * I) @ v."""
+    eps_dot = wp.mul(h_dot, h_inv)
     drag_x = (
         coupling * (eps_dot[0, 0] * v[0] + eps_dot[0, 1] * v[1] + eps_dot[0, 2] * v[2])
         + eta_dot_1 * v[0]
@@ -440,22 +454,24 @@ def _compute_scalar_pressure_kernel(
 @wp.kernel
 def _compute_cell_kinetic_energy_kernel(
     cell_velocities: wp.array(dtype=Any),
+    cells_inv: wp.array(dtype=Any),
     cell_masses: wp.array(dtype=Any),
     kinetic_energy: wp.array(dtype=Any),
 ):
-    """Compute cell kinetic energy: KE = 0.5 * W * ||ḣ||²_F.
+    """Compute cell kinetic energy: KE = 0.5 * W * ||ε̇||²_F, where ε̇ = ḣ h⁻¹.
 
     Launch Grid: dim = [num_systems]
     """
     sys_id = wp.tid()
     h_dot = cell_velocities[sys_id]
+    h_inv = cells_inv[sys_id]
     W = cell_masses[sys_id]
 
-    # Frobenius norm squared
+    eps_dot = wp.mul(h_dot, h_inv)
     ke = type(W)(0.0)
     for i in range(3):
         for j in range(3):
-            ke = ke + h_dot[i, j] * h_dot[i, j]
+            ke = ke + eps_dot[i, j] * eps_dot[i, j]
 
     kinetic_energy[sys_id] = type(W)(0.5) * W * ke
 
@@ -487,7 +503,7 @@ def _npt_velocity_half_step_single_kernel(
     masses: wp.array(dtype=Any),
     forces: wp.array(dtype=Any),
     cell_velocity: wp.array(dtype=Any),
-    volume: wp.array(dtype=Any),
+    cell_inv: wp.array(dtype=Any),
     eta_dot: wp.array2d(dtype=Any),
     num_atoms: wp.array(dtype=wp.int32),
     dt: wp.array(dtype=Any),
@@ -496,6 +512,8 @@ def _npt_velocity_half_step_single_kernel(
     """NPT isotropic velocity half-step, single system (out-only).
 
     v_new = v + dt/2 * (F/m - (1 + 1/N_f) * ε̇ * v - η̇₁ * v)
+
+    where ε̇ = Tr(ḣ h⁻¹)/3 is the isotropic strain rate.
 
     For in-place: host passes same array as velocities and velocities_out.
 
@@ -506,14 +524,14 @@ def _npt_velocity_half_step_single_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocity[0]
+    h_inv = cell_inv[0]
     eta_dot_1 = eta_dot[0, 0]
 
-    V = volume[0]
     N_f = type(m)(3 * num_atoms[0])
     coupling = type(m)(1.0) + type(m)(1.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_isotropic(h_dot, V, coupling, eta_dot_1, v)
+    drag = _drag_isotropic(h_dot, h_inv, coupling, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -525,7 +543,7 @@ def _npt_velocity_half_step_kernel(
     forces: wp.array(dtype=Any),
     batch_idx: wp.array(dtype=wp.int32),
     cell_velocities: wp.array(dtype=Any),
-    volumes: wp.array(dtype=Any),
+    cells_inv: wp.array(dtype=Any),
     eta_dots: wp.array2d(dtype=Any),
     num_atoms_per_system: wp.array(dtype=wp.int32),
     dt: wp.array(dtype=Any),
@@ -543,15 +561,15 @@ def _npt_velocity_half_step_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocities[sys_id]
+    h_inv = cells_inv[sys_id]
     eta_dot_1 = eta_dots[sys_id, 0]
     N = num_atoms_per_system[sys_id]
 
-    V = volumes[sys_id]
     N_f = type(m)(3 * N)
     coupling = type(m)(1.0) + type(m)(1.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_isotropic(h_dot, V, coupling, eta_dot_1, v)
+    drag = _drag_isotropic(h_dot, h_inv, coupling, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -567,7 +585,7 @@ def _nph_velocity_half_step_single_kernel(
     masses: wp.array(dtype=Any),
     forces: wp.array(dtype=Any),
     cell_velocity: wp.array(dtype=Any),
-    volume: wp.array(dtype=Any),
+    cell_inv: wp.array(dtype=Any),
     num_atoms: wp.array(dtype=wp.int32),
     dt: wp.array(dtype=Any),
     velocities_out: wp.array(dtype=Any),
@@ -575,6 +593,8 @@ def _nph_velocity_half_step_single_kernel(
     """NPH isotropic velocity half-step, single system (out-only).
 
     v_new = v + dt/2 * (F/m - (1 + 1/N_f) * ε̇ * v)
+
+    where ε̇ = Tr(ḣ h⁻¹)/3 is the isotropic strain rate.
 
     For in-place: host passes same array as velocities and velocities_out.
 
@@ -585,13 +605,13 @@ def _nph_velocity_half_step_single_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocity[0]
+    h_inv = cell_inv[0]
 
-    V = volume[0]
     N_f = type(m)(3 * num_atoms[0])
     coupling = type(m)(1.0) + type(m)(1.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_isotropic(h_dot, V, coupling, type(m)(0.0), v)
+    drag = _drag_isotropic(h_dot, h_inv, coupling, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -603,7 +623,7 @@ def _nph_velocity_half_step_kernel(
     forces: wp.array(dtype=Any),
     batch_idx: wp.array(dtype=wp.int32),
     cell_velocities: wp.array(dtype=Any),
-    volumes: wp.array(dtype=Any),
+    cells_inv: wp.array(dtype=Any),
     num_atoms_per_system: wp.array(dtype=wp.int32),
     dt: wp.array(dtype=Any),
     velocities_out: wp.array(dtype=Any),
@@ -620,14 +640,14 @@ def _nph_velocity_half_step_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocities[sys_id]
+    h_inv = cells_inv[sys_id]
     N = num_atoms_per_system[sys_id]
 
-    V = volumes[sys_id]
     N_f = type(m)(3 * N)
     coupling = type(m)(1.0) + type(m)(1.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_isotropic(h_dot, V, coupling, type(m)(0.0), v)
+    drag = _drag_isotropic(h_dot, h_inv, coupling, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1171,7 +1191,7 @@ def _npt_velocity_half_step_aniso_single_kernel(
     masses: wp.array(dtype=Any),
     forces: wp.array(dtype=Any),
     cell_velocity: wp.array(dtype=Any),
-    volume: wp.array(dtype=Any),
+    cell_inv: wp.array(dtype=Any),
     eta_dot: wp.array2d(dtype=Any),
     num_atoms: wp.array(dtype=wp.int32),
     dt: wp.array(dtype=Any),
@@ -1188,14 +1208,14 @@ def _npt_velocity_half_step_aniso_single_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocity[0]
+    h_inv = cell_inv[0]
     eta_dot_1 = eta_dot[0, 0]
-    V = volume[0]
 
     N_f = type(m)(3 * num_atoms[0])
     coupling = type(m)(1.0) + type(m)(1.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_anisotropic(h_dot, V, coupling, eta_dot_1, v)
+    drag = _drag_anisotropic(h_dot, h_inv, coupling, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1207,7 +1227,7 @@ def _npt_velocity_half_step_aniso_kernel(
     forces: wp.array(dtype=Any),
     batch_idx: wp.array(dtype=wp.int32),
     cell_velocities: wp.array(dtype=Any),
-    volumes: wp.array(dtype=Any),
+    cells_inv: wp.array(dtype=Any),
     eta_dots: wp.array2d(dtype=Any),
     num_atoms_per_system: wp.array(dtype=wp.int32),
     dt: wp.array(dtype=Any),
@@ -1225,15 +1245,15 @@ def _npt_velocity_half_step_aniso_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocities[sys_id]
+    h_inv = cells_inv[sys_id]
     eta_dot_1 = eta_dots[sys_id, 0]
     N = num_atoms_per_system[sys_id]
-    V = volumes[sys_id]
 
     N_f = type(m)(3 * N)
     coupling = type(m)(1.0) + type(m)(1.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_anisotropic(h_dot, V, coupling, eta_dot_1, v)
+    drag = _drag_anisotropic(h_dot, h_inv, coupling, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1250,7 +1270,6 @@ def _npt_velocity_half_step_triclinic_single_kernel(
     forces: wp.array(dtype=Any),
     cell_velocity: wp.array(dtype=Any),
     cell_inv: wp.array(dtype=Any),
-    volume: wp.array(dtype=Any),
     eta_dot: wp.array2d(dtype=Any),
     num_atoms: wp.array(dtype=wp.int32),
     dt: wp.array(dtype=Any),
@@ -1287,7 +1306,6 @@ def _npt_velocity_half_step_triclinic_kernel(
     batch_idx: wp.array(dtype=wp.int32),
     cell_velocities: wp.array(dtype=Any),
     cells_inv: wp.array(dtype=Any),
-    volumes: wp.array(dtype=Any),
     eta_dots: wp.array2d(dtype=Any),
     num_atoms_per_system: wp.array(dtype=wp.int32),
     dt: wp.array(dtype=Any),
@@ -1330,7 +1348,6 @@ def _nph_velocity_half_step_triclinic_single_kernel(
     forces: wp.array(dtype=Any),
     cell_velocity: wp.array(dtype=Any),
     cell_inv: wp.array(dtype=Any),
-    volume: wp.array(dtype=Any),
     num_atoms: wp.array(dtype=wp.int32),
     dt: wp.array(dtype=Any),
     velocities_out: wp.array(dtype=Any),
@@ -1365,7 +1382,6 @@ def _nph_velocity_half_step_triclinic_kernel(
     batch_idx: wp.array(dtype=wp.int32),
     cell_velocities: wp.array(dtype=Any),
     cells_inv: wp.array(dtype=Any),
-    volumes: wp.array(dtype=Any),
     num_atoms_per_system: wp.array(dtype=wp.int32),
     dt: wp.array(dtype=Any),
     velocities_out: wp.array(dtype=Any),
@@ -1400,7 +1416,7 @@ def _nph_velocity_half_step_aniso_single_kernel(
     masses: wp.array(dtype=Any),
     forces: wp.array(dtype=Any),
     cell_velocity: wp.array(dtype=Any),
-    volume: wp.array(dtype=Any),
+    cell_inv: wp.array(dtype=Any),
     num_atoms: wp.array(dtype=wp.int32),
     dt: wp.array(dtype=Any),
     velocities_out: wp.array(dtype=Any),
@@ -1416,13 +1432,13 @@ def _nph_velocity_half_step_aniso_single_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocity[0]
-    V = volume[0]
+    h_inv = cell_inv[0]
 
     N_f = type(m)(3 * num_atoms[0])
     coupling = type(m)(1.0) + type(m)(1.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_anisotropic(h_dot, V, coupling, type(m)(0.0), v)
+    drag = _drag_anisotropic(h_dot, h_inv, coupling, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1434,7 +1450,7 @@ def _nph_velocity_half_step_aniso_kernel(
     forces: wp.array(dtype=Any),
     batch_idx: wp.array(dtype=wp.int32),
     cell_velocities: wp.array(dtype=Any),
-    volumes: wp.array(dtype=Any),
+    cells_inv: wp.array(dtype=Any),
     num_atoms_per_system: wp.array(dtype=wp.int32),
     dt: wp.array(dtype=Any),
     velocities_out: wp.array(dtype=Any),
@@ -1451,14 +1467,14 @@ def _nph_velocity_half_step_aniso_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocities[sys_id]
+    h_inv = cells_inv[sys_id]
     N = num_atoms_per_system[sys_id]
-    V = volumes[sys_id]
 
     N_f = type(m)(3 * N)
     coupling = type(m)(1.0) + type(m)(1.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_anisotropic(h_dot, V, coupling, type(m)(0.0), v)
+    drag = _drag_anisotropic(h_dot, h_inv, coupling, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1613,7 +1629,7 @@ def compute_pressure_tensor(
     masses : wp.array
         Particle masses. Shape (N,).
     virial_tensors : wp.array(dtype=vec9f or vec9d)
-        Virial tensor from forces. Shape (B,).
+        Virial tensor from forces (physics sign). Shape (B,).
     cells : wp.array(dtype=wp.mat33f or wp.mat33d)
         Cell matrices. Shape (B,).
     kinetic_tensors : wp.array(dtype=scalar, ndim=2)
@@ -1964,6 +1980,7 @@ def compute_barostat_mass(
 
 def compute_cell_kinetic_energy(
     cell_velocities: wp.array,
+    cells_inv: wp.array,
     cell_masses: wp.array,
     kinetic_energy: wp.array,
     device: str = None,
@@ -1971,12 +1988,14 @@ def compute_cell_kinetic_energy(
     """
     Compute kinetic energy of cell degrees of freedom.
 
-    KE_cell = 0.5 * W * ||ḣ||²_F
+    KE_cell = 0.5 * W * ||ε̇||²_F, where ε̇ = ḣ h⁻¹
 
     Parameters
     ----------
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
-        Cell velocity matrices. Shape (B,).
+        Cell velocity matrices ḣ = dh/dt. Shape (B,).
+    cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d)
+        Inverse cell matrices h⁻¹. Shape (B,).
     cell_masses : wp.array
         Barostat masses. Shape (B,).
     kinetic_energy : wp.array(dtype=scalar)
@@ -1997,7 +2016,7 @@ def compute_cell_kinetic_energy(
     wp.launch(
         _compute_cell_kinetic_energy_kernel,
         dim=num_systems,
-        inputs=[cell_velocities, cell_masses, kinetic_energy],
+        inputs=[cell_velocities, cells_inv, cell_masses, kinetic_energy],
         device=device,
     )
 
@@ -2348,13 +2367,12 @@ def npt_velocity_half_step(
     masses: wp.array,
     forces: wp.array,
     cell_velocities: wp.array,
-    volumes: wp.array,
+    cells_inv: wp.array,
     eta_dots: wp.array,
     num_atoms: wp.array,
     dt: wp.array,
     batch_idx: wp.array = None,
     num_atoms_per_system: wp.array = None,
-    cells_inv: wp.array = None,
     mode: str = "isotropic",
     device: str = None,
 ) -> None:
@@ -2378,18 +2396,17 @@ def npt_velocity_half_step(
 
     - F_i / m_i is the acceleration from forces
     - γ = 1 + 1/N_f is the coupling factor (N_f = 3N degrees of freedom)
-    - ε̇ is the strain rate from cell velocity
+    - ε̇ = ḣ h⁻¹ is the strain rate tensor
     - η̇₁ is the first thermostat chain velocity
 
     **Isotropic mode** (default):
-        Uses scalar strain rate ε̇ = Tr(ḣ)/V
+        Uses scalar strain rate ε̇ = Tr(ḣ h⁻¹)/3
 
     **Anisotropic mode**:
-        Uses diagonal strain rates ε̇_ii = ḣ_ii/V for direction-dependent drag
+        Uses diagonal strain rates ε̇_ii = (ḣ h⁻¹)_ii for direction-dependent drag
 
     **Triclinic mode**:
-        Uses full strain rate tensor ε̇ = ḣ @ h⁻¹ for full coupling.
-        Requires ``cells_inv`` parameter.
+        Uses full strain rate tensor ε̇ = ḣ h⁻¹ for full coupling
 
     Parameters
     ----------
@@ -2400,9 +2417,9 @@ def npt_velocity_half_step(
     forces : wp.array(dtype=wp.vec3f or wp.vec3d)
         Forces on particles. Shape (N,).
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
-        Cell velocity matrices ḣ. Shape (B,).
-    volumes : wp.array(dtype=scalar)
-        Cell volumes. Shape (B,).
+        Cell velocity matrices ḣ = dh/dt. Shape (B,).
+    cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d)
+        Inverse cell matrices h⁻¹. Shape (B,).
     eta_dots : wp.array2d(dtype=scalar)
         Thermostat chain velocities. Shape (B, chain_length).
     num_atoms : wp.array(dtype=wp.int32)
@@ -2414,14 +2431,12 @@ def npt_velocity_half_step(
         System index for each atom. Required for batched simulations.
     num_atoms_per_system : wp.array(dtype=wp.int32), optional
         Number of atoms per system. Required for batched simulations.
-    cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
-        Inverse cell matrices h⁻¹. Shape (B,). **Required for triclinic mode.**
     mode : str, optional
         Pressure control mode. One of:
 
         - ``"isotropic"`` (default): Uniform scalar strain rate coupling
         - ``"anisotropic"``: Diagonal strain rate coupling (orthorhombic)
-        - ``"triclinic"``: Full tensor strain rate coupling (requires cells_inv)
+        - ``"triclinic"``: Full tensor strain rate coupling
 
     device : str, optional
         Warp device.
@@ -2431,16 +2446,15 @@ def npt_velocity_half_step(
     Single system (isotropic):
 
     >>> npt_velocity_half_step(
-    ...     velocities, masses, forces, cell_velocities, volumes,
+    ...     velocities, masses, forces, cell_velocities, cells_inv,
     ...     eta_dots, num_atoms=100, dt=0.001
     ... )
 
     Triclinic cell:
 
     >>> npt_velocity_half_step(
-    ...     velocities, masses, forces, cell_velocities, volumes,
-    ...     eta_dots, num_atoms=100, dt=0.001,
-    ...     cells_inv=cells_inv, mode="triclinic"
+    ...     velocities, masses, forces, cell_velocities, cells_inv,
+    ...     eta_dots, num_atoms=100, dt=0.001, mode="triclinic"
     ... )
 
     See Also
@@ -2448,20 +2462,18 @@ def npt_velocity_half_step(
     npt_barostat_half_step : Cell velocity update step.
     npt_position_update : Position update step.
     """
-    # In-place: delegate to _out with velocities as both input and output
     npt_velocity_half_step_out(
         velocities,
         masses,
         forces,
         cell_velocities,
-        volumes,
+        cells_inv,
         eta_dots,
         num_atoms,
         dt,
         velocities_out=velocities,
         batch_idx=batch_idx,
         num_atoms_per_system=num_atoms_per_system,
-        cells_inv=cells_inv,
         mode=mode,
         device=device,
         _skip_validation=True,
@@ -2473,14 +2485,13 @@ def npt_velocity_half_step_out(
     masses: wp.array,
     forces: wp.array,
     cell_velocities: wp.array,
-    volumes: wp.array,
+    cells_inv: wp.array,
     eta_dots: wp.array,
     num_atoms: wp.array,
     dt: wp.array,
     velocities_out: wp.array,
     batch_idx: wp.array = None,
     num_atoms_per_system: wp.array = None,
-    cells_inv: wp.array = None,
     mode: str = "isotropic",
     device: str = None,
     _skip_validation: bool = False,
@@ -2495,8 +2506,12 @@ def npt_velocity_half_step_out(
     ----------
     velocities : wp.array
         Input velocities (not modified when velocities_out differs).
-    masses, forces, cell_velocities, volumes, eta_dots : wp.array
+    masses, forces, cell_velocities : wp.array
         System state arrays.
+    cells_inv : wp.array
+        Inverse cell matrices h⁻¹. Shape (B,).
+    eta_dots : wp.array
+        Thermostat chain velocities.
     num_atoms : wp.array(dtype=wp.int32)
         Atom count for single-system mode. Shape (1,).
     dt : wp.array(dtype=scalar)
@@ -2508,8 +2523,6 @@ def npt_velocity_half_step_out(
         System indices for batched simulations.
     num_atoms_per_system : wp.array, optional
         Atom counts per system.
-    cells_inv : wp.array, optional
-        Inverse cell matrices. Required for triclinic mode.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".
     device : str, optional
@@ -2533,11 +2546,8 @@ def npt_velocity_half_step_out(
         raise ValueError(
             f"Unknown mode: '{mode}'. Expected 'isotropic', 'anisotropic', or 'triclinic'."
         )
-    if mode == "triclinic" and cells_inv is None:
-        raise ValueError("mode='triclinic' requires cells_inv parameter.")
 
     family = _NPT_VELOCITY_FAMILIES[mode]
-    extra = [cells_inv] if mode == "triclinic" else []
 
     launch_family(
         family,
@@ -2548,8 +2558,7 @@ def npt_velocity_half_step_out(
             masses,
             forces,
             cell_velocities,
-            *extra,
-            volumes,
+            cells_inv,
             eta_dots,
             num_atoms,
             dt,
@@ -2561,8 +2570,7 @@ def npt_velocity_half_step_out(
             forces,
             batch_idx,
             cell_velocities,
-            *extra,
-            volumes,
+            cells_inv,
             eta_dots,
             num_atoms_per_system,
             dt,
@@ -2878,13 +2886,14 @@ def run_npt_step(
         device=device,
     )
 
-    # 3. Velocity half-step
+    # 3. Velocity half-step (needs h^-1 for strain rate)
+    compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
     npt_velocity_half_step(
         velocities,
         masses,
         forces,
         cell_velocities,
-        volumes,
+        cells_inv,
         eta_dot,
         num_atoms,
         dt,
@@ -2893,8 +2902,7 @@ def run_npt_step(
         device=device,
     )
 
-    # 4. Position update
-    compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
+    # 4. Position update (reuses cells_inv from step 3)
     npt_position_update(
         positions,
         velocities,
@@ -2913,8 +2921,9 @@ def run_npt_step(
     if compute_forces_fn is not None:
         compute_forces_fn(positions, cells, forces, virial_tensors)
 
-    # Recompute pressure and volumes
+    # Recompute pressure, volumes, and cell inverses after cell update
     compute_cell_volume(cells, volumes=volumes, device=device)
+    compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
     compute_kinetic_energy(
         velocities,
         masses,
@@ -2940,7 +2949,7 @@ def run_npt_step(
         masses,
         forces,
         cell_velocities,
-        volumes,
+        cells_inv,
         eta_dot,
         num_atoms,
         dt,
@@ -3182,12 +3191,11 @@ def nph_velocity_half_step(
     masses: wp.array,
     forces: wp.array,
     cell_velocities: wp.array,
-    volumes: wp.array,
+    cells_inv: wp.array,
     num_atoms: wp.array,
     dt: wp.array,
     batch_idx: wp.array = None,
     num_atoms_per_system: wp.array = None,
-    cells_inv: wp.array = None,
     mode: str = "isotropic",
     device: str = None,
 ) -> None:
@@ -3209,13 +3217,13 @@ def nph_velocity_half_step(
 
         \\dot{v}_i = \\frac{F_i}{m_i} - \\gamma \\cdot \\dot{\\varepsilon} \\cdot v_i
 
-    where γ = 1 + 1/N_f is the coupling factor.
+    where γ = 1 + 1/N_f is the coupling factor and ε̇ = ḣ h⁻¹.
 
-    **Isotropic mode**: Uses scalar strain rate ε̇ = Tr(ḣ)/V
+    **Isotropic mode**: Uses scalar strain rate ε̇ = Tr(ḣ h⁻¹)/3
 
-    **Anisotropic mode**: Uses diagonal strain rates ε̇_ii = ḣ_ii/V
+    **Anisotropic mode**: Uses diagonal strain rates ε̇_ii = (ḣ h⁻¹)_ii
 
-    **Triclinic mode**: Uses full strain rate tensor ε̇ = ḣ @ h⁻¹
+    **Triclinic mode**: Uses full strain rate tensor ε̇ = ḣ h⁻¹
 
     Parameters
     ----------
@@ -3226,9 +3234,9 @@ def nph_velocity_half_step(
     forces : wp.array(dtype=wp.vec3f or wp.vec3d)
         Forces on particles.
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
-        Cell velocity matrices.
-    volumes : wp.array(dtype=scalar)
-        Cell volumes.
+        Cell velocity matrices ḣ = dh/dt.
+    cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d)
+        Inverse cell matrices h^-1. Shape (B,).
     num_atoms : wp.array(dtype=wp.int32)
         Atom count for single-system mode. Shape (1,).
     dt : wp.array(dtype=scalar)
@@ -3238,14 +3246,12 @@ def nph_velocity_half_step(
         System index for each atom.
     num_atoms_per_system : wp.array, optional
         Number of atoms per system.
-    cells_inv : wp.array, optional
-        Inverse cell matrices. Required for triclinic mode.
     mode : str, optional
         Pressure control mode:
 
         - ``"isotropic"``: Uniform scalar strain rate coupling
         - ``"anisotropic"``: Diagonal strain rate coupling (orthorhombic)
-        - ``"triclinic"``: Full tensor coupling (requires cells_inv)
+        - ``"triclinic"``: Full tensor coupling
 
     device : str, optional
         Warp device.
@@ -3255,19 +3261,17 @@ def nph_velocity_half_step(
     nph_barostat_half_step : Cell velocity update.
     npt_velocity_half_step : Velocity update with thermostat.
     """
-    # In-place: delegate to _out with velocities as both input and output
     nph_velocity_half_step_out(
         velocities,
         masses,
         forces,
         cell_velocities,
-        volumes,
+        cells_inv,
         num_atoms,
         dt,
         velocities_out=velocities,
         batch_idx=batch_idx,
         num_atoms_per_system=num_atoms_per_system,
-        cells_inv=cells_inv,
         mode=mode,
         device=device,
         _skip_validation=True,
@@ -3282,13 +3286,12 @@ def nph_velocity_half_step_out(
     masses: wp.array,
     forces: wp.array,
     cell_velocities: wp.array,
-    volumes: wp.array,
+    cells_inv: wp.array,
     num_atoms: wp.array,
     dt: wp.array,
     velocities_out: wp.array,
     batch_idx: wp.array = None,
     num_atoms_per_system: wp.array = None,
-    cells_inv: wp.array = None,
     mode: str = "isotropic",
     device: str = None,
     _skip_validation: bool = False,
@@ -3302,8 +3305,10 @@ def nph_velocity_half_step_out(
     ----------
     velocities : wp.array
         Input velocities (not modified when velocities_out differs).
-    masses, forces, cell_velocities, volumes : wp.array
+    masses, forces, cell_velocities : wp.array
         System state arrays.
+    cells_inv : wp.array
+        Inverse cell matrices h^-1. Shape (B,).
     num_atoms : wp.array(dtype=wp.int32)
         Atom count for single-system mode. Shape (1,).
     dt : wp.array(dtype=scalar)
@@ -3313,8 +3318,6 @@ def nph_velocity_half_step_out(
         Pre-allocated output array.
     batch_idx, num_atoms_per_system : wp.array, optional
         For batched simulations.
-    cells_inv : wp.array, optional
-        Inverse cell matrices. Required for triclinic mode.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".
     device : str, optional
@@ -3338,11 +3341,8 @@ def nph_velocity_half_step_out(
         raise ValueError(
             f"Unknown mode: '{mode}'. Expected 'isotropic', 'anisotropic', or 'triclinic'."
         )
-    if mode == "triclinic" and cells_inv is None:
-        raise ValueError("mode='triclinic' requires cells_inv parameter.")
 
     family = _NPH_VELOCITY_FAMILIES[mode]
-    extra = [cells_inv] if mode == "triclinic" else []
 
     launch_family(
         family,
@@ -3353,8 +3353,7 @@ def nph_velocity_half_step_out(
             masses,
             forces,
             cell_velocities,
-            *extra,
-            volumes,
+            cells_inv,
             num_atoms,
             dt,
             velocities_out,
@@ -3365,8 +3364,7 @@ def nph_velocity_half_step_out(
             forces,
             batch_idx,
             cell_velocities,
-            *extra,
-            volumes,
+            cells_inv,
             num_atoms_per_system,
             dt,
             velocities_out,
@@ -3552,13 +3550,14 @@ def run_nph_step(
         device=device,
     )
 
-    # 2. Velocity half-step
+    # 2. Velocity half-step (needs h^-1 for strain rate)
+    compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
     nph_velocity_half_step(
         velocities,
         masses,
         forces,
         cell_velocities,
-        volumes,
+        cells_inv,
         num_atoms,
         dt,
         batch_idx=batch_idx,
@@ -3566,8 +3565,7 @@ def run_nph_step(
         device=device,
     )
 
-    # 3. Position update
-    compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
+    # 3. Position update (reuses cells_inv from step 2)
     nph_position_update(
         positions,
         velocities,
@@ -3586,8 +3584,9 @@ def run_nph_step(
     if compute_forces_fn is not None:
         compute_forces_fn(positions, cells, forces, virial_tensors)
 
-    # Recompute pressure and volumes
+    # Recompute pressure, volumes, and cell inverses after cell update
     compute_cell_volume(cells, volumes=volumes, device=device)
+    compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
     compute_kinetic_energy(
         velocities,
         masses,
@@ -3613,7 +3612,7 @@ def run_nph_step(
         masses,
         forces,
         cell_velocities,
-        volumes,
+        cells_inv,
         num_atoms,
         dt,
         batch_idx=batch_idx,

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -433,11 +433,14 @@ class TestBarostatUtilitiesAPI:
             h_dot_np[2, 2],
         )
         cell_velocities = wp.array([h_dot_mat], dtype=mat_dtype, device=device)
+        cells_inv = wp.array(
+            [mat_dtype(1, 0, 0, 0, 1, 0, 0, 0, 1)], dtype=mat_dtype, device=device
+        )
         cell_masses = wp.array([100.0], dtype=scalar_dtype, device=device)
         ke_out = wp.empty(1, dtype=scalar_dtype, device=device)
 
         ke = compute_cell_kinetic_energy(
-            cell_velocities, cell_masses, ke_out, device=device
+            cell_velocities, cells_inv, cell_masses, ke_out, device=device
         )
         wp.synchronize_device(device)
 
@@ -486,7 +489,7 @@ class TestNPTIntegrationAPI:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["volumes"],
+            system["cells_inv"],
             system["eta_dot"],
             system["num_atoms_per_system"],
             dt=system["dt"],
@@ -569,7 +572,7 @@ class TestNPHIntegrationAPI:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["volumes"],
+            system["cells_inv"],
             system["num_atoms_per_system"],
             dt=system["dt"],
             device=device,
@@ -638,7 +641,7 @@ class TestNonMutatingAPIs:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["volumes"],
+            system["cells_inv"],
             system["eta_dot"],
             system["num_atoms_per_system"],
             system["dt"],
@@ -694,7 +697,7 @@ class TestNonMutatingAPIs:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["volumes"],
+            system["cells_inv"],
             system["num_atoms_per_system"],
             system["dt"],
             velocities_out,
@@ -774,7 +777,7 @@ class TestMutatingNonMutatingConsistency:
         system1 = setup_npt_system(10, dtype, device, seed=42)
         system2 = setup_npt_system(10, dtype, device, seed=42)
 
-        volumes = system1["volumes"]
+        cells_inv = system1["cells_inv"]
 
         # Mutating
         npt_velocity_half_step(
@@ -782,7 +785,7 @@ class TestMutatingNonMutatingConsistency:
             system1["masses"],
             system1["forces"],
             system1["cell_velocities"],
-            volumes,
+            cells_inv,
             system1["eta_dot"],
             system1["num_atoms_per_system"],
             system1["dt"],
@@ -796,7 +799,7 @@ class TestMutatingNonMutatingConsistency:
             system2["masses"],
             system2["forces"],
             system2["cell_velocities"],
-            volumes,
+            cells_inv,
             system2["eta_dot"],
             system2["num_atoms_per_system"],
             system2["dt"],
@@ -1230,13 +1233,16 @@ class TestBatchedIntegration:
         volumes = wp.empty(num_systems, dtype=scalar_dtype, device=device)
         compute_cell_volume(cells, volumes, device=device)
 
+        cells_inv = wp.empty(num_systems, dtype=mat_dtype, device=device)
+        compute_cell_inverse(cells, cells_inv, device=device)
+
         dt = wp.array([0.001, 0.001], dtype=scalar_dtype, device=device)
         nph_velocity_half_step(
             velocities,
             masses,
             forces,
             cell_velocities,
-            volumes,
+            cells_inv,
             num_atoms_per_system,
             dt=dt,
             batch_idx=batch_idx,
@@ -1314,6 +1320,10 @@ def setup_aniso_system(num_atoms, dtype, device, seed=42):
     volumes = wp.empty(1, dtype=scalar_dtype, device=device)
     compute_cell_volume(cells, volumes, device=device)
 
+    # Cell inverse
+    cells_inv = wp.empty(1, dtype=mat_dtype, device=device)
+    compute_cell_inverse(cells, cells_inv, device=device)
+
     # Thermostat state
     chain_length = 3
     eta = wp.zeros((1, chain_length), dtype=scalar_dtype, device=device)
@@ -1370,6 +1380,7 @@ def setup_aniso_system(num_atoms, dtype, device, seed=42):
         "cells": cells,
         "cell_velocities": cell_velocities,
         "volumes": volumes,
+        "cells_inv": cells_inv,
         "eta": eta,
         "eta_dot": eta_dot,
         "thermostat_masses": thermostat_masses,
@@ -1559,7 +1570,7 @@ class TestAnisotropicVelocityUpdate:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["volumes"],
+            system["cells_inv"],
             system["eta_dot"],
             system["num_atoms_per_system"],
             dt=system["dt"],
@@ -1579,7 +1590,7 @@ class TestAnisotropicVelocityUpdate:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["volumes"],
+            system["cells_inv"],
             system["num_atoms_per_system"],
             dt=system["dt"],
             mode="anisotropic",  # Use unified API with mode
@@ -1599,7 +1610,7 @@ class TestAnisotropicVelocityUpdate:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["volumes"],
+            system["cells_inv"],
             system["eta_dot"],
             system["num_atoms_per_system"],
             system["dt"],
@@ -1622,7 +1633,7 @@ class TestAnisotropicVelocityUpdate:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["volumes"],
+            system["cells_inv"],
             system["num_atoms_per_system"],
             system["dt"],
             vel_out,
@@ -1854,11 +1865,10 @@ class TestTriclinicVelocityCoupling:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["volumes"],
+            system["cells_inv"],
             system["eta_dots"],
             num_atoms=system["num_atoms_per_system"],
             dt=system["dt"],
-            cells_inv=system["cells_inv"],
             mode="triclinic",
             device=device,
         )
@@ -1876,12 +1886,11 @@ class TestTriclinicVelocityCoupling:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["volumes"],
+            system["cells_inv"],
             system["eta_dots"],
             system["num_atoms_per_system"],
             system["dt"],
             vel_out,
-            cells_inv=system["cells_inv"],
             mode="triclinic",
             device=device,
         )
@@ -1898,10 +1907,9 @@ class TestTriclinicVelocityCoupling:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["volumes"],
+            system["cells_inv"],
             num_atoms=system["num_atoms_per_system"],
             dt=system["dt"],
-            cells_inv=system["cells_inv"],
             mode="triclinic",
             device=device,
         )
@@ -1919,11 +1927,10 @@ class TestTriclinicVelocityCoupling:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["volumes"],
+            system["cells_inv"],
             system["num_atoms_per_system"],
             system["dt"],
             vel_out,
-            cells_inv=system["cells_inv"],
             mode="triclinic",
             device=device,
         )
@@ -2000,11 +2007,6 @@ class TestTriclinicVelocityCoupling:
         cells_inv = wp.array(
             [cell_inv_mat, cell_inv_mat], dtype=mat_dtype, device=device
         )
-        volumes = wp.array(
-            [np.linalg.det(cell_np), np.linalg.det(cell_np)],
-            dtype=scalar_dtype,
-            device=device,
-        )
         eta_dots = wp.zeros((num_systems, 3), dtype=scalar_dtype, device=device)
 
         dt = wp.array([0.001, 0.001], dtype=scalar_dtype, device=device)
@@ -2013,13 +2015,12 @@ class TestTriclinicVelocityCoupling:
             masses,
             forces,
             cell_velocities,
-            volumes,
+            cells_inv,
             eta_dots,
             num_atoms=num_atoms_per_system,
             dt=dt,
             batch_idx=batch_idx,
             num_atoms_per_system=num_atoms_per_system,
-            cells_inv=cells_inv,
             mode="triclinic",
             device=device,
         )
@@ -2375,11 +2376,16 @@ class TestNPTDeviceInference:
         mat_dtype = wp.mat33f if dtype == "float32" else wp.mat33d
         scalar_dtype = wp.float32 if dtype == "float32" else wp.float64
         cell_velocities = wp.zeros(1, dtype=mat_dtype, device=device)
+        cells_inv = wp.array(
+            [mat_dtype(1, 0, 0, 0, 1, 0, 0, 0, 1)], dtype=mat_dtype, device=device
+        )
         cell_masses = wp.array([100.0], dtype=scalar_dtype, device=device)
         ke_out = wp.empty(1, dtype=scalar_dtype, device=device)
 
         # Call without explicit device
-        result = compute_cell_kinetic_energy(cell_velocities, cell_masses, ke_out)
+        result = compute_cell_kinetic_energy(
+            cell_velocities, cells_inv, cell_masses, ke_out
+        )
 
         wp.synchronize_device(device)
         assert result.shape[0] == 1
@@ -2489,7 +2495,6 @@ class TestNPTDeviceInference:
         cells_inv_np_batch = np.stack([cell_inv_np, cell_inv_np])
         cells_inv = make_cells_batch(cells_inv_np_batch, dtype, device)
         cell_velocities = wp.zeros(num_systems, dtype=mat_dtype, device=device)
-        volumes = wp.array([1000.0] * num_systems, dtype=scalar_dtype, device=device)
         eta_dots = wp.zeros((num_systems, 3), dtype=scalar_dtype, device=device)
         num_atoms_per_system = wp.array([10, 10], dtype=wp.int32, device=device)
 
@@ -2500,14 +2505,13 @@ class TestNPTDeviceInference:
             masses,
             forces,
             cell_velocities,
-            volumes,
+            cells_inv,
             eta_dots,
             num_atoms_per_system,
             dt,
             result,
             batch_idx=batch_idx,
             num_atoms_per_system=num_atoms_per_system,
-            cells_inv=cells_inv,
             mode="triclinic",
             device=device,
         )
@@ -2543,7 +2547,6 @@ class TestNPTDeviceInference:
         cells_inv_np_batch = np.stack([cell_inv_np, cell_inv_np])
         cells_inv = make_cells_batch(cells_inv_np_batch, dtype, device)
         cell_velocities = wp.zeros(num_systems, dtype=mat_dtype, device=device)
-        volumes = wp.array([1000.0] * num_systems, dtype=scalar_dtype, device=device)
         num_atoms_per_system = wp.array([10, 10], dtype=wp.int32, device=device)
 
         result = wp.empty_like(velocities)
@@ -2553,13 +2556,12 @@ class TestNPTDeviceInference:
             masses,
             forces,
             cell_velocities,
-            volumes,
+            cells_inv,
             num_atoms_per_system,
             dt,
             result,
             batch_idx=batch_idx,
             num_atoms_per_system=num_atoms_per_system,
-            cells_inv=cells_inv,
             mode="triclinic",
             device=device,
         )
@@ -2680,7 +2682,6 @@ class TestNPTCoverageExtras:
         cells_inv_np_batch = np.stack([cell_inv_np, cell_inv_np])
         cells_inv = make_cells_batch(cells_inv_np_batch, "float32", device)
         cell_velocities = wp.zeros(num_systems, dtype=wp.mat33f, device=device)
-        volumes = wp.array([1000.0] * num_systems, dtype=wp.float32, device=device)
         num_atoms_per_system = wp.array([10, 10], dtype=wp.int32, device=device)
 
         dt = wp.array([0.001, 0.001], dtype=wp.float32, device=device)
@@ -2690,12 +2691,11 @@ class TestNPTCoverageExtras:
             masses,
             forces,
             cell_velocities,
-            volumes,
+            cells_inv,
             num_atoms=num_atoms_per_system,
             dt=dt,
             batch_idx=batch_idx,
             num_atoms_per_system=num_atoms_per_system,
-            cells_inv=cells_inv,
             mode="triclinic",
             device=device,
         )
@@ -2724,7 +2724,6 @@ class TestNPTCoverageExtras:
         cells_inv_np_batch = np.stack([cell_inv_np, cell_inv_np])
         cells_inv = make_cells_batch(cells_inv_np_batch, "float32", device)
         cell_velocities = wp.zeros(num_systems, dtype=wp.mat33f, device=device)
-        volumes = wp.array([1000.0] * num_systems, dtype=wp.float32, device=device)
         # eta_dots must be 2D: (B, chain_length)
         eta_dots = wp.zeros(
             (num_systems, chain_length), dtype=wp.float32, device=device
@@ -2738,13 +2737,12 @@ class TestNPTCoverageExtras:
             masses,
             forces,
             cell_velocities,
-            volumes,
+            cells_inv,
             eta_dots,
             num_atoms=num_atoms_per_system,
             dt=dt,
             batch_idx=batch_idx,
             num_atoms_per_system=num_atoms_per_system,
-            cells_inv=cells_inv,
             mode="triclinic",
             device=device,
         )
@@ -3000,10 +2998,16 @@ class TestAdditionalCoverage:
             device=device,
         )
         cell_masses = wp.array([100.0, 100.0], dtype=wp.float32, device=device)
+        cells_inv = wp.array(
+            [wp.mat33f(1, 0, 0, 0, 1, 0, 0, 0, 1)] * num_systems,
+            dtype=wp.mat33f,
+            device=device,
+        )
         kinetic_energy = wp.empty(num_systems, dtype=wp.float32, device=device)
 
         result = compute_cell_kinetic_energy(
             cell_velocities,
+            cells_inv,
             cell_masses,
             kinetic_energy,
             device=device,
@@ -3132,7 +3136,6 @@ class TestAdditionalCoverage:
             [wp.mat33f(*cell_inv_np.flatten())], dtype=wp.mat33f, device=device
         )
         cell_velocities = wp.zeros(num_systems, dtype=wp.mat33f, device=device)
-        volumes = wp.array([1000.0], dtype=wp.float32, device=device)
         eta_dot_0 = wp.zeros((num_systems, 1), dtype=wp.float32, device=device)
 
         num_atoms_arr = wp.array([num_atoms], dtype=wp.int32, device=device)
@@ -3143,11 +3146,10 @@ class TestAdditionalCoverage:
             masses,
             forces,
             cell_velocities,
-            volumes,
+            cells_inv,
             eta_dot_0,
             num_atoms_arr,
             dt=dt,
-            cells_inv=cells_inv,
         )
 
         wp.synchronize_device(device)
@@ -3326,14 +3328,13 @@ class TestSingleBatchEquivalence:
             s["masses"],
             s["forces"],
             s["cell_velocities"],
-            s["volumes"],
+            s["cells_inv"],
             s["eta_dots"],
             s["num_atoms_per_system"],
             dt=s["dt"],
             velocities_out=vel_out_single,
             batch_idx=None,
             num_atoms_per_system=s["num_atoms_per_system"],
-            cells_inv=s["cells_inv"],
             mode=mode,
             device=device,
         )
@@ -3344,14 +3345,13 @@ class TestSingleBatchEquivalence:
             s["masses"],
             s["forces"],
             s["cell_velocities"],
-            s["volumes"],
+            s["cells_inv"],
             s["eta_dots"],
             s["num_atoms_per_system"],
             dt=s["dt"],
             velocities_out=vel_out_batch,
             batch_idx=s["batch_idx"],
             num_atoms_per_system=s["num_atoms_per_system"],
-            cells_inv=s["cells_inv"],
             mode=mode,
             device=device,
         )
@@ -3376,13 +3376,12 @@ class TestSingleBatchEquivalence:
             s["masses"],
             s["forces"],
             s["cell_velocities"],
-            s["volumes"],
+            s["cells_inv"],
             s["num_atoms_per_system"],
             dt=s["dt"],
             velocities_out=vel_out_single,
             batch_idx=None,
             num_atoms_per_system=s["num_atoms_per_system"],
-            cells_inv=s["cells_inv"],
             mode=mode,
             device=device,
         )
@@ -3393,13 +3392,12 @@ class TestSingleBatchEquivalence:
             s["masses"],
             s["forces"],
             s["cell_velocities"],
-            s["volumes"],
+            s["cells_inv"],
             s["num_atoms_per_system"],
             dt=s["dt"],
             velocities_out=vel_out_batch,
             batch_idx=s["batch_idx"],
             num_atoms_per_system=s["num_atoms_per_system"],
-            cells_inv=s["cells_inv"],
             mode=mode,
             device=device,
         )

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -445,9 +445,47 @@ class TestBarostatUtilitiesAPI:
         wp.synchronize_device(device)
 
         assert ke.shape[0] == 1
-        # KE = 0.5 * W * ||h_dot||^2_F = 0.5 * 100 * (3 * 0.01) = 1.5
+        # KE = 0.5 * W * ||ε̇||²_F where ε̇ = ḣ h⁻¹
+        # With h⁻¹ = I: ε̇ = ḣ, so ||ε̇||²_F = 3 * 0.1² = 0.03
         expected = 0.5 * 100.0 * 0.03
         np.testing.assert_allclose(ke.numpy()[0], expected, rtol=1e-5)
+
+    def test_compute_cell_kinetic_energy_non_identity_cell(self, dtype, device):
+        """Test cell KE with non-identity h⁻¹ to exercise strain-rate path."""
+        mat_dtype = wp.mat33f if dtype == "float32" else wp.mat33d
+        scalar_dtype = wp.float32 if dtype == "float32" else wp.float64
+        np_dtype = np.float32 if dtype == "float32" else np.float64
+
+        # Non-cubic cell: h = diag(2, 3, 4), h⁻¹ = diag(0.5, 1/3, 0.25)
+        h_inv_np = np.diag([0.5, 1.0 / 3.0, 0.25]).astype(np_dtype)
+        # ḣ = diag(0.2, 0.3, 0.4)
+        h_dot_np = np.diag([0.2, 0.3, 0.4]).astype(np_dtype)
+        # ε̇ = ḣ h⁻¹ = diag(0.1, 0.1, 0.1) — same strain rate, different ḣ
+        eps_dot_np = h_dot_np @ h_inv_np
+
+        h_dot_mat = mat_dtype(*h_dot_np.flatten())
+        h_inv_mat = mat_dtype(*h_inv_np.flatten())
+        cell_velocities = wp.array([h_dot_mat], dtype=mat_dtype, device=device)
+        cells_inv = wp.array([h_inv_mat], dtype=mat_dtype, device=device)
+        W = 100.0
+        cell_masses = wp.array([W], dtype=scalar_dtype, device=device)
+        ke_out = wp.empty(1, dtype=scalar_dtype, device=device)
+
+        ke = compute_cell_kinetic_energy(
+            cell_velocities, cells_inv, cell_masses, ke_out, device=device
+        )
+        wp.synchronize_device(device)
+
+        # KE = 0.5 * W * ||ε̇||²_F = 0.5 * 100 * (0.1² + 0.1² + 0.1²) = 1.5
+        frob_sq = float(np.sum(eps_dot_np**2))
+        expected = 0.5 * W * frob_sq
+        np.testing.assert_allclose(ke.numpy()[0], expected, rtol=1e-5)
+
+        # Verify this differs from naive ||ḣ||²_F
+        naive_frob_sq = float(np.sum(h_dot_np**2))
+        assert not np.isclose(frob_sq, naive_frob_sq), (
+            "Test is degenerate: ||ε̇||² == ||ḣ||² — use a non-identity h⁻¹"
+        )
 
     def test_compute_barostat_potential_energy_runs(self, dtype, device):
         """Test barostat potential energy computation."""

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -440,7 +440,7 @@ class TestBarostatUtilitiesAPI:
         ke_out = wp.empty(1, dtype=scalar_dtype, device=device)
 
         ke = compute_cell_kinetic_energy(
-            cell_velocities, cells_inv, cell_masses, ke_out, device=device
+            cell_velocities, cell_masses, ke_out, cells_inv=cells_inv, device=device
         )
         wp.synchronize_device(device)
 
@@ -472,7 +472,7 @@ class TestBarostatUtilitiesAPI:
         ke_out = wp.empty(1, dtype=scalar_dtype, device=device)
 
         ke = compute_cell_kinetic_energy(
-            cell_velocities, cells_inv, cell_masses, ke_out, device=device
+            cell_velocities, cell_masses, ke_out, cells_inv=cells_inv, device=device
         )
         wp.synchronize_device(device)
 
@@ -527,10 +527,11 @@ class TestNPTIntegrationAPI:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["cells_inv"],
+            system["volumes"],
             system["eta_dot"],
             system["num_atoms_per_system"],
             dt=system["dt"],
+            cells_inv=system["cells_inv"],
             device=device,
         )
         wp.synchronize_device(device)
@@ -610,9 +611,10 @@ class TestNPHIntegrationAPI:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["cells_inv"],
+            system["volumes"],
             system["num_atoms_per_system"],
             dt=system["dt"],
+            cells_inv=system["cells_inv"],
             device=device,
         )
         wp.synchronize_device(device)
@@ -679,11 +681,12 @@ class TestNonMutatingAPIs:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["cells_inv"],
+            system["volumes"],
             system["eta_dot"],
             system["num_atoms_per_system"],
             system["dt"],
             velocities_out,
+            cells_inv=system["cells_inv"],
             device=device,
         )
         wp.synchronize_device(device)
@@ -735,10 +738,11 @@ class TestNonMutatingAPIs:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["cells_inv"],
+            system["volumes"],
             system["num_atoms_per_system"],
             system["dt"],
             velocities_out,
+            cells_inv=system["cells_inv"],
             device=device,
         )
         wp.synchronize_device(device)
@@ -815,6 +819,7 @@ class TestMutatingNonMutatingConsistency:
         system1 = setup_npt_system(10, dtype, device, seed=42)
         system2 = setup_npt_system(10, dtype, device, seed=42)
 
+        volumes = system1["volumes"]
         cells_inv = system1["cells_inv"]
 
         # Mutating
@@ -823,10 +828,11 @@ class TestMutatingNonMutatingConsistency:
             system1["masses"],
             system1["forces"],
             system1["cell_velocities"],
-            cells_inv,
+            volumes,
             system1["eta_dot"],
             system1["num_atoms_per_system"],
             system1["dt"],
+            cells_inv=cells_inv,
             device=device,
         )
 
@@ -837,11 +843,12 @@ class TestMutatingNonMutatingConsistency:
             system2["masses"],
             system2["forces"],
             system2["cell_velocities"],
-            cells_inv,
+            volumes,
             system2["eta_dot"],
             system2["num_atoms_per_system"],
             system2["dt"],
             velocities_out,
+            cells_inv=cells_inv,
             device=device,
         )
 
@@ -1280,11 +1287,12 @@ class TestBatchedIntegration:
             masses,
             forces,
             cell_velocities,
-            cells_inv,
+            volumes,
             num_atoms_per_system,
             dt=dt,
             batch_idx=batch_idx,
             num_atoms_per_system=num_atoms_per_system,
+            cells_inv=cells_inv,
             device=device,
         )
         wp.synchronize_device(device)
@@ -1608,10 +1616,11 @@ class TestAnisotropicVelocityUpdate:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["cells_inv"],
+            system["volumes"],
             system["eta_dot"],
             system["num_atoms_per_system"],
             dt=system["dt"],
+            cells_inv=system["cells_inv"],
             mode="anisotropic",  # Use unified API with mode
             device=device,
         )
@@ -1628,9 +1637,10 @@ class TestAnisotropicVelocityUpdate:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["cells_inv"],
+            system["volumes"],
             system["num_atoms_per_system"],
             dt=system["dt"],
+            cells_inv=system["cells_inv"],
             mode="anisotropic",  # Use unified API with mode
             device=device,
         )
@@ -1648,11 +1658,12 @@ class TestAnisotropicVelocityUpdate:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["cells_inv"],
+            system["volumes"],
             system["eta_dot"],
             system["num_atoms_per_system"],
             system["dt"],
             vel_out,
+            cells_inv=system["cells_inv"],
             mode="anisotropic",  # Use mode parameter
             device=device,
         )
@@ -1671,10 +1682,11 @@ class TestAnisotropicVelocityUpdate:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["cells_inv"],
+            system["volumes"],
             system["num_atoms_per_system"],
             system["dt"],
             vel_out,
+            cells_inv=system["cells_inv"],
             mode="anisotropic",  # Use mode parameter
             device=device,
         )
@@ -1903,10 +1915,11 @@ class TestTriclinicVelocityCoupling:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["cells_inv"],
+            system["volumes"],
             system["eta_dots"],
             num_atoms=system["num_atoms_per_system"],
             dt=system["dt"],
+            cells_inv=system["cells_inv"],
             mode="triclinic",
             device=device,
         )
@@ -1924,11 +1937,12 @@ class TestTriclinicVelocityCoupling:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["cells_inv"],
+            system["volumes"],
             system["eta_dots"],
             system["num_atoms_per_system"],
             system["dt"],
             vel_out,
+            cells_inv=system["cells_inv"],
             mode="triclinic",
             device=device,
         )
@@ -1945,9 +1959,10 @@ class TestTriclinicVelocityCoupling:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["cells_inv"],
+            system["volumes"],
             num_atoms=system["num_atoms_per_system"],
             dt=system["dt"],
+            cells_inv=system["cells_inv"],
             mode="triclinic",
             device=device,
         )
@@ -1965,10 +1980,11 @@ class TestTriclinicVelocityCoupling:
             system["masses"],
             system["forces"],
             system["cell_velocities"],
-            system["cells_inv"],
+            system["volumes"],
             system["num_atoms_per_system"],
             system["dt"],
             vel_out,
+            cells_inv=system["cells_inv"],
             mode="triclinic",
             device=device,
         )
@@ -2045,6 +2061,11 @@ class TestTriclinicVelocityCoupling:
         cells_inv = wp.array(
             [cell_inv_mat, cell_inv_mat], dtype=mat_dtype, device=device
         )
+        volumes = wp.array(
+            [np.linalg.det(cell_np), np.linalg.det(cell_np)],
+            dtype=scalar_dtype,
+            device=device,
+        )
         eta_dots = wp.zeros((num_systems, 3), dtype=scalar_dtype, device=device)
 
         dt = wp.array([0.001, 0.001], dtype=scalar_dtype, device=device)
@@ -2053,12 +2074,13 @@ class TestTriclinicVelocityCoupling:
             masses,
             forces,
             cell_velocities,
-            cells_inv,
+            volumes,
             eta_dots,
             num_atoms=num_atoms_per_system,
             dt=dt,
             batch_idx=batch_idx,
             num_atoms_per_system=num_atoms_per_system,
+            cells_inv=cells_inv,
             mode="triclinic",
             device=device,
         )
@@ -2422,7 +2444,7 @@ class TestNPTDeviceInference:
 
         # Call without explicit device
         result = compute_cell_kinetic_energy(
-            cell_velocities, cells_inv, cell_masses, ke_out
+            cell_velocities, cell_masses, ke_out, cells_inv=cells_inv
         )
 
         wp.synchronize_device(device)
@@ -2533,6 +2555,7 @@ class TestNPTDeviceInference:
         cells_inv_np_batch = np.stack([cell_inv_np, cell_inv_np])
         cells_inv = make_cells_batch(cells_inv_np_batch, dtype, device)
         cell_velocities = wp.zeros(num_systems, dtype=mat_dtype, device=device)
+        volumes = wp.array([1000.0] * num_systems, dtype=scalar_dtype, device=device)
         eta_dots = wp.zeros((num_systems, 3), dtype=scalar_dtype, device=device)
         num_atoms_per_system = wp.array([10, 10], dtype=wp.int32, device=device)
 
@@ -2543,13 +2566,14 @@ class TestNPTDeviceInference:
             masses,
             forces,
             cell_velocities,
-            cells_inv,
+            volumes,
             eta_dots,
             num_atoms_per_system,
             dt,
             result,
             batch_idx=batch_idx,
             num_atoms_per_system=num_atoms_per_system,
+            cells_inv=cells_inv,
             mode="triclinic",
             device=device,
         )
@@ -2585,6 +2609,7 @@ class TestNPTDeviceInference:
         cells_inv_np_batch = np.stack([cell_inv_np, cell_inv_np])
         cells_inv = make_cells_batch(cells_inv_np_batch, dtype, device)
         cell_velocities = wp.zeros(num_systems, dtype=mat_dtype, device=device)
+        volumes = wp.array([1000.0] * num_systems, dtype=scalar_dtype, device=device)
         num_atoms_per_system = wp.array([10, 10], dtype=wp.int32, device=device)
 
         result = wp.empty_like(velocities)
@@ -2594,12 +2619,13 @@ class TestNPTDeviceInference:
             masses,
             forces,
             cell_velocities,
-            cells_inv,
+            volumes,
             num_atoms_per_system,
             dt,
             result,
             batch_idx=batch_idx,
             num_atoms_per_system=num_atoms_per_system,
+            cells_inv=cells_inv,
             mode="triclinic",
             device=device,
         )
@@ -2720,6 +2746,7 @@ class TestNPTCoverageExtras:
         cells_inv_np_batch = np.stack([cell_inv_np, cell_inv_np])
         cells_inv = make_cells_batch(cells_inv_np_batch, "float32", device)
         cell_velocities = wp.zeros(num_systems, dtype=wp.mat33f, device=device)
+        volumes = wp.array([1000.0] * num_systems, dtype=wp.float32, device=device)
         num_atoms_per_system = wp.array([10, 10], dtype=wp.int32, device=device)
 
         dt = wp.array([0.001, 0.001], dtype=wp.float32, device=device)
@@ -2729,11 +2756,12 @@ class TestNPTCoverageExtras:
             masses,
             forces,
             cell_velocities,
-            cells_inv,
+            volumes,
             num_atoms=num_atoms_per_system,
             dt=dt,
             batch_idx=batch_idx,
             num_atoms_per_system=num_atoms_per_system,
+            cells_inv=cells_inv,
             mode="triclinic",
             device=device,
         )
@@ -2762,6 +2790,7 @@ class TestNPTCoverageExtras:
         cells_inv_np_batch = np.stack([cell_inv_np, cell_inv_np])
         cells_inv = make_cells_batch(cells_inv_np_batch, "float32", device)
         cell_velocities = wp.zeros(num_systems, dtype=wp.mat33f, device=device)
+        volumes = wp.array([1000.0] * num_systems, dtype=wp.float32, device=device)
         # eta_dots must be 2D: (B, chain_length)
         eta_dots = wp.zeros(
             (num_systems, chain_length), dtype=wp.float32, device=device
@@ -2775,12 +2804,13 @@ class TestNPTCoverageExtras:
             masses,
             forces,
             cell_velocities,
-            cells_inv,
+            volumes,
             eta_dots,
             num_atoms=num_atoms_per_system,
             dt=dt,
             batch_idx=batch_idx,
             num_atoms_per_system=num_atoms_per_system,
+            cells_inv=cells_inv,
             mode="triclinic",
             device=device,
         )
@@ -3045,9 +3075,9 @@ class TestAdditionalCoverage:
 
         result = compute_cell_kinetic_energy(
             cell_velocities,
-            cells_inv,
             cell_masses,
             kinetic_energy,
+            cells_inv=cells_inv,
             device=device,
         )
 
@@ -3175,6 +3205,7 @@ class TestAdditionalCoverage:
             [wp.mat33f(*cell_inv_np.flatten())], dtype=wp.mat33f, device=device
         )
         cell_velocities = wp.zeros(num_systems, dtype=wp.mat33f, device=device)
+        volumes = wp.array([1000.0], dtype=wp.float32, device=device)
         eta_dot_0 = wp.zeros((num_systems, 1), dtype=wp.float32, device=device)
 
         num_atoms_arr = wp.array([num_atoms], dtype=wp.int32, device=device)
@@ -3185,10 +3216,11 @@ class TestAdditionalCoverage:
             masses,
             forces,
             cell_velocities,
-            cells_inv,
+            volumes,
             eta_dot_0,
             num_atoms_arr,
             dt=dt,
+            cells_inv=cells_inv,
         )
 
         wp.synchronize_device(device)
@@ -3367,13 +3399,14 @@ class TestSingleBatchEquivalence:
             s["masses"],
             s["forces"],
             s["cell_velocities"],
-            s["cells_inv"],
+            s["volumes"],
             s["eta_dots"],
             s["num_atoms_per_system"],
             dt=s["dt"],
             velocities_out=vel_out_single,
             batch_idx=None,
             num_atoms_per_system=s["num_atoms_per_system"],
+            cells_inv=s["cells_inv"],
             mode=mode,
             device=device,
         )
@@ -3384,13 +3417,14 @@ class TestSingleBatchEquivalence:
             s["masses"],
             s["forces"],
             s["cell_velocities"],
-            s["cells_inv"],
+            s["volumes"],
             s["eta_dots"],
             s["num_atoms_per_system"],
             dt=s["dt"],
             velocities_out=vel_out_batch,
             batch_idx=s["batch_idx"],
             num_atoms_per_system=s["num_atoms_per_system"],
+            cells_inv=s["cells_inv"],
             mode=mode,
             device=device,
         )
@@ -3415,12 +3449,13 @@ class TestSingleBatchEquivalence:
             s["masses"],
             s["forces"],
             s["cell_velocities"],
-            s["cells_inv"],
+            s["volumes"],
             s["num_atoms_per_system"],
             dt=s["dt"],
             velocities_out=vel_out_single,
             batch_idx=None,
             num_atoms_per_system=s["num_atoms_per_system"],
+            cells_inv=s["cells_inv"],
             mode=mode,
             device=device,
         )
@@ -3431,12 +3466,13 @@ class TestSingleBatchEquivalence:
             s["masses"],
             s["forces"],
             s["cell_velocities"],
-            s["cells_inv"],
+            s["volumes"],
             s["num_atoms_per_system"],
             dt=s["dt"],
             velocities_out=vel_out_batch,
             batch_idx=s["batch_idx"],
             num_atoms_per_system=s["num_atoms_per_system"],
+            cells_inv=s["cells_inv"],
             mode=mode,
             device=device,
         )
@@ -3600,6 +3636,8 @@ class TestNonCubicDrag:
         masses = wp.array([1.0], dtype=scalar_dtype, device=device)
         forces = wp.zeros(num_atoms, dtype=vec_dtype, device=device)
 
+        V = float(np.linalg.det(h_np))
+        volumes = wp.array([V], dtype=scalar_dtype, device=device)
         eta_dot = wp.zeros((1, 1), dtype=scalar_dtype, device=device)
         num_atoms_arr = wp.array([num_atoms], dtype=wp.int32, device=device)
         dt = wp.array([dt_val], dtype=scalar_dtype, device=device)
@@ -3610,11 +3648,12 @@ class TestNonCubicDrag:
             masses,
             forces,
             cell_velocities,
-            cells_inv,
+            volumes,
             eta_dot,
             num_atoms_arr,
             dt,
             vel_out,
+            cells_inv=cells_inv,
             mode="isotropic",
             device=device,
         )
@@ -3677,6 +3716,8 @@ class TestNonCubicDrag:
         masses = wp.array([1.0], dtype=scalar_dtype, device=device)
         forces = wp.zeros(num_atoms, dtype=vec_dtype, device=device)
 
+        V = float(np.linalg.det(h_np))
+        volumes = wp.array([V], dtype=scalar_dtype, device=device)
         eta_dot = wp.zeros((1, 1), dtype=scalar_dtype, device=device)
         num_atoms_arr = wp.array([num_atoms], dtype=wp.int32, device=device)
         dt = wp.array([dt_val], dtype=scalar_dtype, device=device)
@@ -3687,11 +3728,12 @@ class TestNonCubicDrag:
             masses,
             forces,
             cell_velocities,
-            cells_inv,
+            volumes,
             eta_dot,
             num_atoms_arr,
             dt,
             vel_out,
+            cells_inv=cells_inv,
             mode="anisotropic",
             device=device,
         )

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -3053,7 +3053,8 @@ class TestAdditionalCoverage:
 
         wp.synchronize_device(device)
         assert result is kinetic_energy
-        # KE = 0.5 * W * ||ḣ||²_F = 0.5 * 100 * (3 * 0.01) = 1.5
+        # KE = 0.5 * W * ||ε̇||²_F where ε̇ = ḣ h⁻¹
+        # With h⁻¹ = I: ε̇ = ḣ, so ||ε̇||²_F = 3 * 0.1² = 0.03
         np.testing.assert_allclose(result.numpy()[0], 1.5, rtol=1e-4)
 
     @pytest.mark.parametrize("device", DEVICES)
@@ -3446,4 +3447,286 @@ class TestSingleBatchEquivalence:
             vel_out_batch.numpy(),
             rtol=1e-5,
             atol=1e-7,
+        )
+
+
+# ==============================================================================
+# Virial sign convention tests (library API only)
+# ==============================================================================
+
+
+class TestVirialSignConvention:
+    """Verify compute_pressure_tensor passes virial through without negation.
+
+    The library convention is W = -dE/dε (see conventions.md).  The pressure
+    tensor kernel computes P = (KE_tensor + W) / V.  These tests confirm W
+    is added directly — any internal negation would be caught.
+    """
+
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_pressure_tensor_virial_sign(self, device):
+        """P = W/V when kinetic contribution is zero."""
+        scalar_dtype = wp.float64
+        vec_dtype = wp.vec3d
+        vec9_dtype = vec9d
+        mat_dtype = wp.mat33d
+
+        # Cubic cell V = 1000
+        cell_np = np.diag([10.0, 10.0, 10.0])
+        cells = wp.array(
+            [mat_dtype(*cell_np.flatten())], dtype=mat_dtype, device=device
+        )
+        volumes = wp.empty(1, dtype=scalar_dtype, device=device)
+        compute_cell_volume(cells, volumes=volumes, device=device)
+
+        # Known virial W = (10, 1, 2, 3, 20, 4, 5, 6, 30) row-major
+        W = np.array([10.0, 1.0, 2.0, 3.0, 20.0, 4.0, 5.0, 6.0, 30.0])
+        virial_tensors = wp.array(W.reshape(1, 9), dtype=vec9_dtype, device=device)
+
+        # Zero velocities → kinetic tensor = 0
+        num_atoms = 1
+        velocities = wp.zeros(num_atoms, dtype=vec_dtype, device=device)
+        masses = wp.array([1.0], dtype=scalar_dtype, device=device)
+
+        kinetic_tensors = wp.zeros((1, 9), dtype=scalar_dtype, device=device)
+        pressure_tensors = wp.empty(1, dtype=vec9_dtype, device=device)
+
+        compute_pressure_tensor(
+            velocities,
+            masses,
+            virial_tensors,
+            cells,
+            kinetic_tensors,
+            pressure_tensors,
+            volumes,
+            device=device,
+        )
+        wp.synchronize_device(device)
+
+        P = pressure_tensors.numpy()[0]
+        V = 1000.0
+        expected = W / V
+        np.testing.assert_allclose(P, expected, rtol=1e-12)
+
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_pressure_tensor_with_kinetic(self, device):
+        """P = (KE_tensor + W) / V with both contributions non-zero."""
+        scalar_dtype = wp.float64
+        vec_dtype = wp.vec3d
+        vec9_dtype = vec9d
+        mat_dtype = wp.mat33d
+
+        cell_np = np.diag([10.0, 10.0, 10.0])
+        cells = wp.array(
+            [mat_dtype(*cell_np.flatten())], dtype=mat_dtype, device=device
+        )
+        volumes = wp.empty(1, dtype=scalar_dtype, device=device)
+        compute_cell_volume(cells, volumes=volumes, device=device)
+
+        W = np.array([10.0, 0.0, 0.0, 0.0, 20.0, 0.0, 0.0, 0.0, 30.0])
+        virial_tensors = wp.array(W.reshape(1, 9), dtype=vec9_dtype, device=device)
+
+        # Single atom with velocity (1, 2, 3), mass 2
+        # KE_tensor_ij = m * v_i * v_j
+        # KE = 2 * [[1,2,3],[2,4,6],[3,6,9]] row-major
+        velocities = wp.array([[1.0, 2.0, 3.0]], dtype=vec_dtype, device=device)
+        masses = wp.array([2.0], dtype=scalar_dtype, device=device)
+
+        kinetic_tensors = wp.zeros((1, 9), dtype=scalar_dtype, device=device)
+        pressure_tensors = wp.empty(1, dtype=vec9_dtype, device=device)
+
+        compute_pressure_tensor(
+            velocities,
+            masses,
+            virial_tensors,
+            cells,
+            kinetic_tensors,
+            pressure_tensors,
+            volumes,
+            device=device,
+        )
+        wp.synchronize_device(device)
+
+        P = pressure_tensors.numpy()[0]
+        V = 1000.0
+        m = 2.0
+        v = np.array([1.0, 2.0, 3.0])
+        KE = m * np.outer(v, v).flatten()
+        expected = (KE + W) / V
+        np.testing.assert_allclose(P, expected, rtol=1e-10)
+
+
+# ==============================================================================
+# Non-cubic cells_inv integration tests for drag
+# ==============================================================================
+
+
+class TestNonCubicDrag:
+    """Verify drag uses ε̇ = ḣ h⁻¹ (not ḣ/V) with orthorhombic cells."""
+
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_isotropic_drag_non_cubic(self, device):
+        """Isotropic velocity half-step with orthorhombic cell h = diag(10,12,8).
+
+        With ḣ = diag(0.1, 0.12, 0.08), we get ε̇ = ḣ h⁻¹ = diag(0.01, 0.01, 0.01)
+        so Tr(ε̇)/3 = 0.01.  The naive formula Tr(ḣ)/(3V) = 0.3/(3*960) ≈ 1.04e-4
+        gives a very different drag.  Large dt amplifies the difference.
+        """
+        np_dtype = np.float64
+        scalar_dtype = wp.float64
+        mat_dtype = wp.mat33d
+        vec_dtype = wp.vec3d
+
+        num_atoms = 1
+        dt_val = 1.0
+
+        # Orthorhombic cell
+        h_np = np.diag([10.0, 12.0, 8.0]).astype(np_dtype)
+        h_inv_np = np.linalg.inv(h_np).astype(np_dtype)
+
+        cells_inv = wp.array(
+            [mat_dtype(*h_inv_np.flatten())], dtype=mat_dtype, device=device
+        )
+
+        # ḣ chosen so ε̇ = ḣ h⁻¹ = 0.01 * I (uniform strain rate)
+        h_dot_np = np.diag([0.1, 0.12, 0.08]).astype(np_dtype)
+        cell_velocities = wp.array(
+            [mat_dtype(*h_dot_np.flatten())], dtype=mat_dtype, device=device
+        )
+
+        # Single atom: v = (1,1,1), m = 1, F = 0, η̇₁ = 0
+        v_np = np.array([[1.0, 1.0, 1.0]], dtype=np_dtype)
+        velocities = wp.array(v_np, dtype=vec_dtype, device=device)
+        masses = wp.array([1.0], dtype=scalar_dtype, device=device)
+        forces = wp.zeros(num_atoms, dtype=vec_dtype, device=device)
+
+        eta_dot = wp.zeros((1, 1), dtype=scalar_dtype, device=device)
+        num_atoms_arr = wp.array([num_atoms], dtype=wp.int32, device=device)
+        dt = wp.array([dt_val], dtype=scalar_dtype, device=device)
+
+        vel_out = wp.empty(num_atoms, dtype=vec_dtype, device=device)
+        npt_velocity_half_step_out(
+            velocities,
+            masses,
+            forces,
+            cell_velocities,
+            cells_inv,
+            eta_dot,
+            num_atoms_arr,
+            dt,
+            vel_out,
+            mode="isotropic",
+            device=device,
+        )
+        wp.synchronize_device(device)
+
+        # Expected: v_new = v + dt/2 * (F/m - drag)
+        # drag = coupling * Tr(ε̇)/3 * v  (η̇₁ = 0)
+        # coupling = 1 + 1/N_f = 1 + 1/3 = 4/3
+        # Tr(ε̇)/3 = 0.01
+        # drag = (4/3) * 0.01 * v = 0.01333... * v
+        eps_dot = h_dot_np @ h_inv_np
+        trace_eps_3 = np.trace(eps_dot) / 3.0
+        N_f = 3.0 * num_atoms
+        coupling = 1.0 + 1.0 / N_f
+        drag = coupling * trace_eps_3 * v_np
+        expected = v_np + (dt_val / 2.0) * (0.0 - drag)
+
+        actual = vel_out.numpy()
+        np.testing.assert_allclose(actual, expected, rtol=1e-10)
+
+        # Also verify this differs from the naive Tr(ḣ)/(3V) formula
+        V = np.linalg.det(h_np)
+        naive_eps = (h_dot_np[0, 0] + h_dot_np[1, 1] + h_dot_np[2, 2]) / (3.0 * V)
+        naive_drag = coupling * naive_eps * v_np
+        naive_expected = v_np + (dt_val / 2.0) * (0.0 - naive_drag)
+        assert not np.allclose(actual, naive_expected, rtol=1e-5), (
+            "Test is degenerate: correct and naive formulas give the same result"
+        )
+
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_anisotropic_drag_non_cubic(self, device):
+        """Anisotropic velocity half-step with non-uniform strain rates.
+
+        h = diag(10, 12, 8), ḣ = diag(0.2, 0.12, 0.16)
+        → ε̇ = diag(0.02, 0.01, 0.02) — different per-axis strain rates.
+        Large dt amplifies the difference vs the naive ḣ/V formula.
+        """
+        np_dtype = np.float64
+        scalar_dtype = wp.float64
+        mat_dtype = wp.mat33d
+        vec_dtype = wp.vec3d
+
+        num_atoms = 1
+        dt_val = 1.0
+
+        h_np = np.diag([10.0, 12.0, 8.0]).astype(np_dtype)
+        h_inv_np = np.linalg.inv(h_np).astype(np_dtype)
+        cells_inv = wp.array(
+            [mat_dtype(*h_inv_np.flatten())], dtype=mat_dtype, device=device
+        )
+
+        # Non-uniform ḣ → different ε̇ per axis
+        h_dot_np = np.diag([0.2, 0.12, 0.16]).astype(np_dtype)
+        cell_velocities = wp.array(
+            [mat_dtype(*h_dot_np.flatten())], dtype=mat_dtype, device=device
+        )
+
+        v_np = np.array([[1.0, 2.0, 3.0]], dtype=np_dtype)
+        velocities = wp.array(v_np, dtype=vec_dtype, device=device)
+        masses = wp.array([1.0], dtype=scalar_dtype, device=device)
+        forces = wp.zeros(num_atoms, dtype=vec_dtype, device=device)
+
+        eta_dot = wp.zeros((1, 1), dtype=scalar_dtype, device=device)
+        num_atoms_arr = wp.array([num_atoms], dtype=wp.int32, device=device)
+        dt = wp.array([dt_val], dtype=scalar_dtype, device=device)
+
+        vel_out = wp.empty(num_atoms, dtype=vec_dtype, device=device)
+        npt_velocity_half_step_out(
+            velocities,
+            masses,
+            forces,
+            cell_velocities,
+            cells_inv,
+            eta_dot,
+            num_atoms_arr,
+            dt,
+            vel_out,
+            mode="anisotropic",
+            device=device,
+        )
+        wp.synchronize_device(device)
+
+        # drag_i = (coupling * ε̇_ii + η̇₁) * v_i
+        eps_dot = h_dot_np @ h_inv_np
+        N_f = 3.0 * num_atoms
+        coupling = 1.0 + 1.0 / N_f
+        drag = np.array(
+            [
+                [
+                    (coupling * eps_dot[0, 0]) * v_np[0, 0],
+                    (coupling * eps_dot[1, 1]) * v_np[0, 1],
+                    (coupling * eps_dot[2, 2]) * v_np[0, 2],
+                ]
+            ]
+        )
+        expected = v_np + (dt_val / 2.0) * (0.0 - drag)
+
+        actual = vel_out.numpy()
+        np.testing.assert_allclose(actual, expected, rtol=1e-10)
+
+        # Naive formula: ε̇_ii = ḣ_ii / V gives uniform rate, losing axis info
+        V = np.linalg.det(h_np)
+        naive_drag = np.array(
+            [
+                [
+                    (coupling * h_dot_np[0, 0] / V) * v_np[0, 0],
+                    (coupling * h_dot_np[1, 1] / V) * v_np[0, 1],
+                    (coupling * h_dot_np[2, 2] / V) * v_np[0, 2],
+                ]
+            ]
+        )
+        naive_expected = v_np + (dt_val / 2.0) * (0.0 - naive_drag)
+        assert not np.allclose(actual, naive_expected, rtol=1e-5), (
+            "Test is degenerate: correct and naive formulas give the same result"
         )

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -487,6 +487,32 @@ class TestBarostatUtilitiesAPI:
             "Test is degenerate: ||ε̇||² == ||ḣ||² — use a non-identity h⁻¹"
         )
 
+    def test_compute_cell_kinetic_energy_volumes_fallback(self, dtype, device):
+        """Test cell KE using volumes-only fallback (no cells_inv) for non-unit cubic cell."""
+        mat_dtype = wp.mat33f if dtype == "float32" else wp.mat33d
+        scalar_dtype = wp.float32 if dtype == "float32" else wp.float64
+
+        L = 10.0
+        V = L**3
+        h_dot_np = np.diag([0.1, 0.1, 0.1])
+        h_dot_mat = mat_dtype(*h_dot_np.flatten())
+        cell_velocities = wp.array([h_dot_mat], dtype=mat_dtype, device=device)
+
+        volumes = wp.array([V], dtype=scalar_dtype, device=device)
+        W = 100.0
+        cell_masses = wp.array([W], dtype=scalar_dtype, device=device)
+        ke_out = wp.empty(1, dtype=scalar_dtype, device=device)
+
+        ke = compute_cell_kinetic_energy(
+            cell_velocities, cell_masses, ke_out, volumes=volumes, device=device
+        )
+        wp.synchronize_device(device)
+
+        # ε̇ = ḣ · V^{-1/3}·I = diag(0.01, 0.01, 0.01)
+        eps_dot = 0.1 / L
+        expected = 0.5 * W * 3.0 * eps_dot**2
+        np.testing.assert_allclose(ke.numpy()[0], expected, rtol=1e-4)
+
     def test_compute_barostat_potential_energy_runs(self, dtype, device):
         """Test barostat potential energy computation."""
         scalar_dtype = wp.float32 if dtype == "float32" else wp.float64


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Fix incorrect strain rate computation in NPT/NPH drag functions and cell kinetic energy, and remove a double sign flip in example/benchmark virial/stress helpers. The public Python API is backward-compatible: `cells_inv` is added as an optional keyword argument and a fallback path computes `h⁻¹ = (1/V)I` from `volumes` when it is omitted.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

### Bug 1: Drag functions use V instead of h⁻¹ for strain rate

`_drag_isotropic` and `_drag_anisotropic` computed `ε̇ ≈ ḣ/V` which is only correct for cubic cells. The correct strain rate tensor is `ε̇ = ḣ h⁻¹`. All three drag helpers now take `h_inv` instead of `V` and compute `eps_dot = wp.mul(h_dot, h_inv)`.

### Bug 2: Triclinic drag uses element-wise multiply

`_drag_triclinic` used Python `*` (element-wise) for `h_dot * h_inv` instead of `wp.mul` (matrix multiply). Fixed to `wp.mul(h_dot, h_inv)`.

### Bug 3: Cell kinetic energy uses ||ḣ||² instead of ||ε̇||²

`_compute_cell_kinetic_energy_kernel` computed `0.5 W ||ḣ||²_F`. The MTK equations require `0.5 W ||ε̇||²_F` where `ε̇ = ḣ h⁻¹`. The kernel now takes `cells_inv` and computes the Frobenius norm of the strain rate tensor.

### Bug 4: Double virial sign flip in example/benchmark helpers

Since commit 4ce45a7 all interaction kernels produce `W = −dE/dε` directly. The helpers `_pack_virial_flat_to_vec9_kernel` and `_virial_to_stress_kernel` in both `examples/dynamics/_dynamics_utils.py` and `benchmarks/dynamics/shared_utils.py` still negated the virial, causing a double sign flip and incorrect pressure. Negations removed; comments updated to reference `conventions.md`.

### Backward-compatible `cells_inv` API

The Warp kernels now take `h_inv`/`cells_inv` instead of `volume`/`volumes`. The public Python functions (`npt_velocity_half_step`, `npt_velocity_half_step_out`, `nph_velocity_half_step`, `nph_velocity_half_step_out`, `compute_cell_kinetic_energy`) keep their original signatures with `volumes` as a positional argument and accept `cells_inv` as a new optional keyword. When `cells_inv` is omitted, a helper kernel `_build_identity_h_inv_kernel` computes `h⁻¹ = (1/V)I`, preserving the legacy cubic-cell behavior. For non-cubic cells callers must provide `cells_inv`.

### Documentation

- Added a "Conventions" section to the `npt.py` module docstring documenting the `ḣ` (absolute cell velocity) convention and `W = −dE/dε` virial sign.
- Updated `compute_pressure_tensor` docstring to state it expects `W = −dE/dε` per `conventions.md`.
- Updated docstrings for all 5 public functions to document `volumes` (cubic-cell fallback) and `cells_inv` (required for non-cubic cells).
- Updated inline comments in drag helpers and velocity kernels to show the strain rate derivation.

## Testing

- [x] Linting passes (`make lint`)
- [x] Unit tests pass locally (`make pytest`) — requires GPU
- [x] New tests added for new functionality meets coverage expectations?

New test coverage:
- `test_compute_cell_kinetic_energy_non_identity_cell`: exercises the `ε̇ = ḣ h⁻¹` path with non-identity `cells_inv` and verifies the result differs from the naive `||ḣ||²` formula.
- `TestVirialSignConvention`: verifies `compute_pressure_tensor` passes virial through without negation (`test_pressure_tensor_virial_sign`, `test_pressure_tensor_with_kinetic`).
- `TestNonCubicDrag`: validates isotropic and anisotropic drag with non-cubic cells where `ε̇ = ḣ h⁻¹ ≠ ḣ/V` (`test_isotropic_drag_non_cubic`, `test_anisotropic_drag_non_cubic`).
- Existing test callsites updated to pass `cells_inv` as keyword argument.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

These bugs are invisible for cubic simulation boxes where `h = diag(L)`, `h⁻¹ = diag(1/L)`, and `V = L³`, so existing cubic-cell tests pass unchanged. The errors only manifest for non-cubic orthorhombic and triclinic cells.

The virial sign fix is independent of the strain rate fix but is included here because both affect the same NPT integration pathway and were identified in the same audit.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
