### PR TITLE
feat(jax): add graph_mode kwarg to neighbor lists for CUDA graph replay

### DIFF
--- a/benchmarks/dynamics/shared_utils.py
+++ b/benchmarks/dynamics/shared_utils.py
@@ -69,7 +69,6 @@ from nvalchemiops.neighbors.cell_list import build_cell_list, query_cell_list
 from nvalchemiops.neighbors.neighbor_utils import (
     selective_zero_num_neighbors,
     selective_zero_num_neighbors_single,
-    zero_array,
 )
 from nvalchemiops.neighbors.rebuild_detection import (
     check_batch_neighbor_list_rebuild,
@@ -900,7 +899,7 @@ class NeighborListManager:
             rebuild check uses minimum-image convention (MIC).
         """
         # 1. Zero rebuild flag — kernel only sets True, never clears
-        zero_array(self.wp_rebuild_flag, self.device)
+        self.wp_rebuild_flag.zero_()
 
         # 2. GPU-side displacement check — writes True if any atom moved > skin/2
         check_neighbor_list_rebuild(
@@ -917,7 +916,7 @@ class NeighborListManager:
         )
 
         # 3. Always rebuild cell structure (cheap O(N) spatial binning)
-        zero_array(self.wp_atoms_per_cell_count, self.device)
+        self.wp_atoms_per_cell_count.zero_()
         build_cell_list(
             positions_wp,
             cell_wp,
@@ -1110,7 +1109,7 @@ class BatchedNeighborListManager:
             the rebuild check uses minimum-image convention (MIC).
         """
         # 1. Zero per-system flags — kernel only sets True, never clears
-        zero_array(self.wp_rebuild_flags, self.device)
+        self.wp_rebuild_flags.zero_()
 
         # 2. GPU-side per-system displacement check — no CPU sync
         check_batch_neighbor_list_rebuild(
@@ -1128,7 +1127,7 @@ class BatchedNeighborListManager:
         )
 
         # 3. Always rebuild cell structure (cheap O(N) spatial binning)
-        zero_array(self.wp_atoms_per_cell_count, self.device)
+        self.wp_atoms_per_cell_count.zero_()
         batch_build_cell_list(
             positions_wp,
             cells_wp,

--- a/docs/modules/warp/neighbors.rst
+++ b/docs/modules/warp/neighbors.rst
@@ -65,6 +65,5 @@ Exceptions
 Utility Functions
 ^^^^^^^^^^^^^^^^^
 
-.. autofunction:: nvalchemiops.neighbors.neighbor_utils.zero_array
 .. autofunction:: nvalchemiops.neighbors.neighbor_utils.estimate_max_neighbors
 .. autofunction:: nvalchemiops.neighbors.neighbor_utils.compute_naive_num_shifts

--- a/nvalchemiops/jax/neighbors/cell_list.py
+++ b/nvalchemiops/jax/neighbors/cell_list.py
@@ -25,6 +25,7 @@ import warp as wp
 from warp.jax_experimental import GraphMode, jax_callable, jax_kernel
 
 from nvalchemiops.jax.neighbors.neighbor_utils import (
+    _validate_graph_mode,
     get_neighbor_list_from_neighbor_matrix,
 )
 from nvalchemiops.neighbors.cell_list import (
@@ -127,13 +128,6 @@ __all__ = [
 ]
 
 
-def _validate_graph_mode(graph_mode: str) -> Literal["none", "warp"]:
-    """Validate the public graph-mode string."""
-    if graph_mode not in {"none", "warp"}:
-        raise ValueError("graph_mode must be one of {'none', 'warp'}")
-    return graph_mode
-
-
 def _reset_query_outputs(
     neighbor_matrix,
     neighbor_matrix_shifts,
@@ -161,6 +155,12 @@ def _run_graph_build_cell_list(
 ) -> None:
     """Execute the fused cell-list build callback."""
     atoms_per_cell_count.zero_()
+    # Graph-capture contract: ``_warp_build_cell_list`` is the Python-level
+    # Warp launcher and takes a device string. Inside this jax_callable body
+    # the device is a Python constant captured once at CUDA-graph capture
+    # time, so subsequent replays reuse the same device. If the launcher
+    # signature ever grows a stream/context parameter, that argument must
+    # also be hoisted out of the per-replay path here.
     _warp_build_cell_list(
         positions,
         cell,
@@ -211,6 +211,12 @@ def _run_graph_query_cell_list(
             inputs=[num_neighbors, rebuild_flags],
         )
 
+    # Graph-capture contract: ``_warp_query_cell_list`` is the Python-level
+    # Warp launcher and takes a device string. Inside this jax_callable body
+    # the device is a Python constant captured once at CUDA-graph capture
+    # time, so subsequent replays reuse the same device. If the launcher
+    # signature ever grows a stream/context parameter, that argument must
+    # also be hoisted out of the per-replay path here.
     _warp_query_cell_list(
         positions,
         cell,

--- a/nvalchemiops/jax/neighbors/cell_list.py
+++ b/nvalchemiops/jax/neighbors/cell_list.py
@@ -17,10 +17,12 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import jax_kernel
+from warp.jax_experimental import GraphMode, jax_callable, jax_kernel
 
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     get_neighbor_list_from_neighbor_matrix,
@@ -32,7 +34,16 @@ from nvalchemiops.neighbors.cell_list import (
     _cell_list_construct_bin_size_overload,
     _cell_list_count_atoms_per_bin_overload,
 )
-from nvalchemiops.neighbors.neighbor_utils import estimate_max_neighbors
+from nvalchemiops.neighbors.cell_list import (
+    build_cell_list as _warp_build_cell_list,
+)
+from nvalchemiops.neighbors.cell_list import (
+    query_cell_list as _warp_query_cell_list,
+)
+from nvalchemiops.neighbors.neighbor_utils import (
+    _selective_zero_num_neighbors_single,
+    estimate_max_neighbors,
+)
 
 # ==============================================================================
 # JAX Kernel Wrappers
@@ -114,6 +125,528 @@ __all__ = [
     "query_cell_list",
     "estimate_cell_list_sizes",
 ]
+
+
+def _validate_graph_mode(graph_mode: str) -> Literal["none", "warp"]:
+    """Validate the public graph-mode string."""
+    if graph_mode not in {"none", "warp"}:
+        raise ValueError("graph_mode must be one of {'none', 'warp'}")
+    return graph_mode
+
+
+def _reset_query_outputs(
+    neighbor_matrix,
+    neighbor_matrix_shifts,
+    num_neighbors,
+    fill_value,
+) -> None:
+    """Reset query outputs inside the Warp callback."""
+    neighbor_matrix.fill_(fill_value)
+    num_neighbors.zero_()
+    neighbor_matrix_shifts.zero_()
+
+
+def _run_graph_build_cell_list(
+    positions,
+    cell,
+    pbc,
+    cells_per_dimension,
+    atom_periodic_shifts,
+    atom_to_cell_mapping,
+    atoms_per_cell_count,
+    cell_atom_start_indices,
+    cell_atom_list,
+    cutoff,
+    wp_dtype,
+) -> None:
+    """Execute the fused cell-list build callback."""
+    atoms_per_cell_count.zero_()
+    _warp_build_cell_list(
+        positions,
+        cell,
+        pbc,
+        cutoff,
+        cells_per_dimension,
+        atom_periodic_shifts,
+        atom_to_cell_mapping,
+        atoms_per_cell_count,
+        cell_atom_start_indices,
+        cell_atom_list,
+        wp_dtype,
+        str(positions.device),
+    )
+
+
+def _run_graph_query_cell_list(
+    positions,
+    cell,
+    pbc,
+    cells_per_dimension,
+    neighbor_search_radius,
+    atom_periodic_shifts,
+    atom_to_cell_mapping,
+    atoms_per_cell_count,
+    cell_atom_start_indices,
+    cell_atom_list,
+    neighbor_matrix,
+    neighbor_matrix_shifts,
+    num_neighbors,
+    cutoff,
+    fill_value,
+    wp_dtype,
+    rebuild_flags=None,
+) -> None:
+    """Execute the fused cell-list query callback."""
+    if rebuild_flags is None:
+        _reset_query_outputs(
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            num_neighbors,
+            fill_value,
+        )
+    else:
+        wp.launch(
+            kernel=_selective_zero_num_neighbors_single,
+            dim=num_neighbors.shape[0],
+            inputs=[num_neighbors, rebuild_flags],
+        )
+
+    _warp_query_cell_list(
+        positions,
+        cell,
+        pbc,
+        cutoff,
+        cells_per_dimension,
+        neighbor_search_radius,
+        atom_periodic_shifts,
+        atom_to_cell_mapping,
+        atoms_per_cell_count,
+        cell_atom_start_indices,
+        cell_atom_list,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        wp_dtype,
+        str(positions.device),
+        half_fill=False,
+        rebuild_flags=rebuild_flags,
+    )
+
+
+def _run_graph_cell_list(
+    positions,
+    cell,
+    pbc,
+    neighbor_search_radius,
+    cells_per_dimension,
+    atom_periodic_shifts,
+    atom_to_cell_mapping,
+    atoms_per_cell_count,
+    cell_atom_start_indices,
+    cell_atom_list,
+    neighbor_matrix,
+    neighbor_matrix_shifts,
+    num_neighbors,
+    cutoff,
+    fill_value,
+    wp_dtype,
+) -> None:
+    """Execute the fused cell-list build+query callback."""
+    _run_graph_build_cell_list(
+        positions,
+        cell,
+        pbc,
+        cells_per_dimension,
+        atom_periodic_shifts,
+        atom_to_cell_mapping,
+        atoms_per_cell_count,
+        cell_atom_start_indices,
+        cell_atom_list,
+        cutoff,
+        wp_dtype,
+    )
+    _run_graph_query_cell_list(
+        positions,
+        cell,
+        pbc,
+        cells_per_dimension,
+        neighbor_search_radius,
+        atom_periodic_shifts,
+        atom_to_cell_mapping,
+        atoms_per_cell_count,
+        cell_atom_start_indices,
+        cell_atom_list,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff,
+        fill_value,
+        wp_dtype,
+    )
+
+
+def _graph_build_cell_list_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    cell: wp.array(dtype=wp.mat33f),
+    pbc: wp.array(dtype=wp.bool),
+    cells_per_dimension: wp.array(dtype=wp.int32),
+    atom_periodic_shifts: wp.array(dtype=wp.vec3i),
+    atom_to_cell_mapping: wp.array(dtype=wp.vec3i),
+    atoms_per_cell_count: wp.array(dtype=wp.int32),
+    cell_atom_start_indices: wp.array(dtype=wp.int32),
+    cell_atom_list: wp.array(dtype=wp.int32),
+    cutoff: wp.float32,
+) -> None:
+    _run_graph_build_cell_list(
+        positions,
+        cell,
+        pbc,
+        cells_per_dimension,
+        atom_periodic_shifts,
+        atom_to_cell_mapping,
+        atoms_per_cell_count,
+        cell_atom_start_indices,
+        cell_atom_list,
+        cutoff,
+        wp.float32,
+    )
+
+
+def _graph_build_cell_list_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    cell: wp.array(dtype=wp.mat33d),
+    pbc: wp.array(dtype=wp.bool),
+    cells_per_dimension: wp.array(dtype=wp.int32),
+    atom_periodic_shifts: wp.array(dtype=wp.vec3i),
+    atom_to_cell_mapping: wp.array(dtype=wp.vec3i),
+    atoms_per_cell_count: wp.array(dtype=wp.int32),
+    cell_atom_start_indices: wp.array(dtype=wp.int32),
+    cell_atom_list: wp.array(dtype=wp.int32),
+    cutoff: wp.float64,
+) -> None:
+    _run_graph_build_cell_list(
+        positions,
+        cell,
+        pbc,
+        cells_per_dimension,
+        atom_periodic_shifts,
+        atom_to_cell_mapping,
+        atoms_per_cell_count,
+        cell_atom_start_indices,
+        cell_atom_list,
+        cutoff,
+        wp.float64,
+    )
+
+
+def _graph_query_cell_list_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    cell: wp.array(dtype=wp.mat33f),
+    pbc: wp.array(dtype=wp.bool),
+    cells_per_dimension: wp.array(dtype=wp.int32),
+    neighbor_search_radius: wp.array(dtype=wp.int32),
+    atom_periodic_shifts: wp.array(dtype=wp.vec3i),
+    atom_to_cell_mapping: wp.array(dtype=wp.vec3i),
+    atoms_per_cell_count: wp.array(dtype=wp.int32),
+    cell_atom_start_indices: wp.array(dtype=wp.int32),
+    cell_atom_list: wp.array(dtype=wp.int32),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float32,
+    fill_value: wp.int32,
+) -> None:
+    _run_graph_query_cell_list(
+        positions,
+        cell,
+        pbc,
+        cells_per_dimension,
+        neighbor_search_radius,
+        atom_periodic_shifts,
+        atom_to_cell_mapping,
+        atoms_per_cell_count,
+        cell_atom_start_indices,
+        cell_atom_list,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff,
+        fill_value,
+        wp.float32,
+    )
+
+
+def _graph_query_cell_list_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    cell: wp.array(dtype=wp.mat33d),
+    pbc: wp.array(dtype=wp.bool),
+    cells_per_dimension: wp.array(dtype=wp.int32),
+    neighbor_search_radius: wp.array(dtype=wp.int32),
+    atom_periodic_shifts: wp.array(dtype=wp.vec3i),
+    atom_to_cell_mapping: wp.array(dtype=wp.vec3i),
+    atoms_per_cell_count: wp.array(dtype=wp.int32),
+    cell_atom_start_indices: wp.array(dtype=wp.int32),
+    cell_atom_list: wp.array(dtype=wp.int32),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float64,
+    fill_value: wp.int32,
+) -> None:
+    _run_graph_query_cell_list(
+        positions,
+        cell,
+        pbc,
+        cells_per_dimension,
+        neighbor_search_radius,
+        atom_periodic_shifts,
+        atom_to_cell_mapping,
+        atoms_per_cell_count,
+        cell_atom_start_indices,
+        cell_atom_list,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff,
+        fill_value,
+        wp.float64,
+    )
+
+
+def _graph_query_cell_list_selective_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    cell: wp.array(dtype=wp.mat33f),
+    pbc: wp.array(dtype=wp.bool),
+    cells_per_dimension: wp.array(dtype=wp.int32),
+    neighbor_search_radius: wp.array(dtype=wp.int32),
+    atom_periodic_shifts: wp.array(dtype=wp.vec3i),
+    atom_to_cell_mapping: wp.array(dtype=wp.vec3i),
+    atoms_per_cell_count: wp.array(dtype=wp.int32),
+    cell_atom_start_indices: wp.array(dtype=wp.int32),
+    cell_atom_list: wp.array(dtype=wp.int32),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float32,
+    fill_value: wp.int32,
+    rebuild_flags: wp.array(dtype=wp.bool),
+) -> None:
+    _run_graph_query_cell_list(
+        positions,
+        cell,
+        pbc,
+        cells_per_dimension,
+        neighbor_search_radius,
+        atom_periodic_shifts,
+        atom_to_cell_mapping,
+        atoms_per_cell_count,
+        cell_atom_start_indices,
+        cell_atom_list,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff,
+        fill_value,
+        wp.float32,
+        rebuild_flags=rebuild_flags,
+    )
+
+
+def _graph_query_cell_list_selective_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    cell: wp.array(dtype=wp.mat33d),
+    pbc: wp.array(dtype=wp.bool),
+    cells_per_dimension: wp.array(dtype=wp.int32),
+    neighbor_search_radius: wp.array(dtype=wp.int32),
+    atom_periodic_shifts: wp.array(dtype=wp.vec3i),
+    atom_to_cell_mapping: wp.array(dtype=wp.vec3i),
+    atoms_per_cell_count: wp.array(dtype=wp.int32),
+    cell_atom_start_indices: wp.array(dtype=wp.int32),
+    cell_atom_list: wp.array(dtype=wp.int32),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float64,
+    fill_value: wp.int32,
+    rebuild_flags: wp.array(dtype=wp.bool),
+) -> None:
+    _run_graph_query_cell_list(
+        positions,
+        cell,
+        pbc,
+        cells_per_dimension,
+        neighbor_search_radius,
+        atom_periodic_shifts,
+        atom_to_cell_mapping,
+        atoms_per_cell_count,
+        cell_atom_start_indices,
+        cell_atom_list,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff,
+        fill_value,
+        wp.float64,
+        rebuild_flags=rebuild_flags,
+    )
+
+
+def _graph_cell_list_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    cell: wp.array(dtype=wp.mat33f),
+    pbc: wp.array(dtype=wp.bool),
+    neighbor_search_radius: wp.array(dtype=wp.int32),
+    cells_per_dimension: wp.array(dtype=wp.int32),
+    atom_periodic_shifts: wp.array(dtype=wp.vec3i),
+    atom_to_cell_mapping: wp.array(dtype=wp.vec3i),
+    atoms_per_cell_count: wp.array(dtype=wp.int32),
+    cell_atom_start_indices: wp.array(dtype=wp.int32),
+    cell_atom_list: wp.array(dtype=wp.int32),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float32,
+    fill_value: wp.int32,
+) -> None:
+    _run_graph_cell_list(
+        positions,
+        cell,
+        pbc,
+        neighbor_search_radius,
+        cells_per_dimension,
+        atom_periodic_shifts,
+        atom_to_cell_mapping,
+        atoms_per_cell_count,
+        cell_atom_start_indices,
+        cell_atom_list,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff,
+        fill_value,
+        wp.float32,
+    )
+
+
+def _graph_cell_list_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    cell: wp.array(dtype=wp.mat33d),
+    pbc: wp.array(dtype=wp.bool),
+    neighbor_search_radius: wp.array(dtype=wp.int32),
+    cells_per_dimension: wp.array(dtype=wp.int32),
+    atom_periodic_shifts: wp.array(dtype=wp.vec3i),
+    atom_to_cell_mapping: wp.array(dtype=wp.vec3i),
+    atoms_per_cell_count: wp.array(dtype=wp.int32),
+    cell_atom_start_indices: wp.array(dtype=wp.int32),
+    cell_atom_list: wp.array(dtype=wp.int32),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float64,
+    fill_value: wp.int32,
+) -> None:
+    _run_graph_cell_list(
+        positions,
+        cell,
+        pbc,
+        neighbor_search_radius,
+        cells_per_dimension,
+        atom_periodic_shifts,
+        atom_to_cell_mapping,
+        atoms_per_cell_count,
+        cell_atom_start_indices,
+        cell_atom_list,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff,
+        fill_value,
+        wp.float64,
+    )
+
+
+_jax_graph_build_cell_list_f32 = jax_callable(
+    _graph_build_cell_list_f32,
+    num_outputs=6,
+    in_out_argnames=[
+        "cells_per_dimension",
+        "atom_periodic_shifts",
+        "atom_to_cell_mapping",
+        "atoms_per_cell_count",
+        "cell_atom_start_indices",
+        "cell_atom_list",
+    ],
+    graph_mode=GraphMode.WARP,
+)
+_jax_graph_build_cell_list_f64 = jax_callable(
+    _graph_build_cell_list_f64,
+    num_outputs=6,
+    in_out_argnames=[
+        "cells_per_dimension",
+        "atom_periodic_shifts",
+        "atom_to_cell_mapping",
+        "atoms_per_cell_count",
+        "cell_atom_start_indices",
+        "cell_atom_list",
+    ],
+    graph_mode=GraphMode.WARP,
+)
+_jax_graph_query_cell_list_f32 = jax_callable(
+    _graph_query_cell_list_f32,
+    num_outputs=3,
+    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
+    graph_mode=GraphMode.WARP,
+)
+_jax_graph_query_cell_list_f64 = jax_callable(
+    _graph_query_cell_list_f64,
+    num_outputs=3,
+    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
+    graph_mode=GraphMode.WARP,
+)
+_jax_graph_query_cell_list_selective_f32 = jax_callable(
+    _graph_query_cell_list_selective_f32,
+    num_outputs=3,
+    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
+    graph_mode=GraphMode.WARP,
+)
+_jax_graph_query_cell_list_selective_f64 = jax_callable(
+    _graph_query_cell_list_selective_f64,
+    num_outputs=3,
+    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
+    graph_mode=GraphMode.WARP,
+)
+_jax_graph_cell_list_f32 = jax_callable(
+    _graph_cell_list_f32,
+    num_outputs=9,
+    in_out_argnames=[
+        "cells_per_dimension",
+        "atom_periodic_shifts",
+        "atom_to_cell_mapping",
+        "atoms_per_cell_count",
+        "cell_atom_start_indices",
+        "cell_atom_list",
+        "neighbor_matrix",
+        "neighbor_matrix_shifts",
+        "num_neighbors",
+    ],
+    graph_mode=GraphMode.WARP,
+)
+_jax_graph_cell_list_f64 = jax_callable(
+    _graph_cell_list_f64,
+    num_outputs=9,
+    in_out_argnames=[
+        "cells_per_dimension",
+        "atom_periodic_shifts",
+        "atom_to_cell_mapping",
+        "atoms_per_cell_count",
+        "cell_atom_start_indices",
+        "cell_atom_list",
+        "neighbor_matrix",
+        "neighbor_matrix_shifts",
+        "num_neighbors",
+    ],
+    graph_mode=GraphMode.WARP,
+)
 
 
 def estimate_cell_list_sizes(
@@ -210,6 +743,7 @@ def build_cell_list(
     cell_atom_start_indices: jax.Array | None = None,
     cell_atom_list: jax.Array | None = None,
     max_total_cells: int | None = None,
+    graph_mode: Literal["none", "warp"] = "none",
 ) -> tuple[
     jax.Array,
     jax.Array,
@@ -270,10 +804,16 @@ def build_cell_list(
     When calling inside ``jax.jit``, ``max_total_cells`` **must** be provided
     to avoid calling ``estimate_cell_list_sizes``, which is not JIT-compatible.
 
+    ``graph_mode="warp"`` uses a fused ``jax_callable`` that captures the full
+    Warp-side build sequence. For replay-friendly usage inside ``jax.jit``,
+    donate and reuse the optional cell-list buffers.
+
     See Also
     --------
     query_cell_list : Query the built cell list for neighbors
     """
+    graph_mode = _validate_graph_mode(graph_mode)
+
     if cell.ndim == 2:
         cell = cell[jnp.newaxis, :, :]
     if pbc.ndim == 1:
@@ -298,6 +838,8 @@ def build_cell_list(
         atom_to_cell_mapping = jnp.zeros((positions.shape[0], 3), dtype=jnp.int32)
     if atoms_per_cell_count is None:
         atoms_per_cell_count = jnp.zeros(max_total_cells, dtype=jnp.int32)
+    elif graph_mode == "none":
+        atoms_per_cell_count = atoms_per_cell_count.at[:].set(jnp.int32(0))
     if cell_atom_start_indices is None:
         cell_atom_start_indices = jnp.zeros(max_total_cells, dtype=jnp.int32)
     if cell_atom_list is None:
@@ -324,50 +866,76 @@ def build_cell_list(
     pbc_1d = pbc.squeeze() if pbc.ndim == 2 else pbc
     pbc_bool = pbc_1d.astype(jnp.bool_)
 
-    # Step 1: Construct bin sizes
-    (cells_per_dimension,) = _construct_bin_size(
-        cell,
-        pbc_bool,
-        cells_per_dimension,
-        float(cutoff),
-        int(max_total_cells),
-        launch_dims=(1,),
-    )
+    if graph_mode == "warp":
+        graph_build = (
+            _jax_graph_build_cell_list_f64
+            if positions.dtype == jnp.float64
+            else _jax_graph_build_cell_list_f32
+        )
+        (
+            cells_per_dimension,
+            atom_periodic_shifts,
+            atom_to_cell_mapping,
+            atoms_per_cell_count,
+            cell_atom_start_indices,
+            cell_atom_list,
+        ) = graph_build(
+            positions,
+            cell,
+            pbc_bool,
+            cells_per_dimension,
+            atom_periodic_shifts,
+            atom_to_cell_mapping,
+            atoms_per_cell_count,
+            cell_atom_start_indices,
+            cell_atom_list,
+            float(cutoff),
+        )
+    else:
+        # Step 1: Construct bin sizes
+        (cells_per_dimension,) = _construct_bin_size(
+            cell,
+            pbc_bool,
+            cells_per_dimension,
+            float(cutoff),
+            int(max_total_cells),
+            launch_dims=(1,),
+        )
 
-    # Step 2: Count atoms per bin
-    atoms_per_cell_count, atom_periodic_shifts = _count_atoms(
-        positions,
-        cell,
-        pbc_bool,
-        cells_per_dimension,
-        atoms_per_cell_count,
-        atom_periodic_shifts,
-        launch_dims=(total_atoms,),
-    )
+        # Step 2: Count atoms per bin
+        atoms_per_cell_count, atom_periodic_shifts = _count_atoms(
+            positions,
+            cell,
+            pbc_bool,
+            cells_per_dimension,
+            atoms_per_cell_count,
+            atom_periodic_shifts,
+            launch_dims=(total_atoms,),
+        )
 
-    # Step 3: Compute exclusive prefix sum (replaces wp.utils.array_scan)
-    cell_atom_start_indices = jnp.concatenate(
-        [
-            jnp.array([0], dtype=jnp.int32),
-            jnp.cumsum(atoms_per_cell_count[:-1], dtype=jnp.int32),
-        ]
-    )
+        # Step 3: Compute exclusive prefix sum (replaces wp.utils.array_scan)
+        cell_atom_start_indices = jnp.concatenate(
+            [
+                jnp.array([0], dtype=jnp.int32),
+                jnp.cumsum(atoms_per_cell_count[:-1], dtype=jnp.int32),
+            ]
+        )
 
-    # Step 4: Zero counts before second pass
-    atoms_per_cell_count = jnp.zeros_like(atoms_per_cell_count)
+        # Step 4: Zero counts before second pass
+        atoms_per_cell_count = jnp.zeros_like(atoms_per_cell_count)
 
-    # Step 5: Bin atoms
-    atom_to_cell_mapping, atoms_per_cell_count, cell_atom_list = _bin_atoms(
-        positions,
-        cell,
-        pbc_bool,
-        cells_per_dimension,
-        atom_to_cell_mapping,
-        atoms_per_cell_count,
-        cell_atom_start_indices,
-        cell_atom_list,
-        launch_dims=(total_atoms,),
-    )
+        # Step 5: Bin atoms
+        atom_to_cell_mapping, atoms_per_cell_count, cell_atom_list = _bin_atoms(
+            positions,
+            cell,
+            pbc_bool,
+            cells_per_dimension,
+            atom_to_cell_mapping,
+            atoms_per_cell_count,
+            cell_atom_start_indices,
+            cell_atom_list,
+            launch_dims=(total_atoms,),
+        )
 
     return (
         cells_per_dimension,
@@ -397,6 +965,7 @@ def query_cell_list(
     neighbor_matrix_shifts: jax.Array | None = None,
     num_neighbors: jax.Array | None = None,
     rebuild_flags: jax.Array | None = None,
+    graph_mode: Literal["none", "warp"] = "none",
 ) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Query cell list to find neighbors within cutoff.
 
@@ -445,6 +1014,8 @@ def query_cell_list(
     build_cell_list : Build cell list before querying
     cell_list : Combined build and query operation
     """
+    graph_mode = _validate_graph_mode(graph_mode)
+
     if max_neighbors is None:
         max_neighbors = estimate_max_neighbors(cutoff)
 
@@ -454,12 +1025,12 @@ def query_cell_list(
             positions.shape[0],
             dtype=jnp.int32,
         )
-    elif rebuild_flags is None:
+    elif rebuild_flags is None and graph_mode == "none":
         neighbor_matrix = neighbor_matrix.at[:].set(jnp.int32(positions.shape[0]))
 
     if num_neighbors is None:
         num_neighbors = jnp.zeros(positions.shape[0], dtype=jnp.int32)
-    elif rebuild_flags is None:
+    elif rebuild_flags is None and graph_mode == "none":
         num_neighbors = num_neighbors.at[:].set(jnp.int32(0))
 
     if neighbor_matrix_shifts is None:
@@ -467,7 +1038,7 @@ def query_cell_list(
             (positions.shape[0], max_neighbors, 3),
             dtype=jnp.int32,
         )
-    elif rebuild_flags is None:
+    elif rebuild_flags is None and graph_mode == "none":
         neighbor_matrix_shifts = neighbor_matrix_shifts.at[:].set(jnp.int32(0))
 
     # Select kernel based on dtype
@@ -489,7 +1060,57 @@ def query_cell_list(
     pbc_1d = pbc.squeeze() if pbc.ndim == 2 else pbc
     pbc_bool = pbc_1d.astype(jnp.bool_)
 
-    if rebuild_flags is not None:
+    if graph_mode == "warp":
+        fill_value = int(positions.shape[0])
+        if rebuild_flags is not None:
+            rf = rebuild_flags.flatten()[:1].astype(jnp.bool_)
+            graph_query = (
+                _jax_graph_query_cell_list_selective_f64
+                if positions.dtype == jnp.float64
+                else _jax_graph_query_cell_list_selective_f32
+            )
+            neighbor_matrix, neighbor_matrix_shifts, num_neighbors = graph_query(
+                positions,
+                cell,
+                pbc_bool,
+                cells_per_dimension,
+                neighbor_search_radius,
+                atom_periodic_shifts,
+                atom_to_cell_mapping,
+                atoms_per_cell_count,
+                cell_atom_start_indices,
+                cell_atom_list,
+                neighbor_matrix,
+                neighbor_matrix_shifts,
+                num_neighbors,
+                float(cutoff),
+                fill_value,
+                rf,
+            )
+        else:
+            graph_query = (
+                _jax_graph_query_cell_list_f64
+                if positions.dtype == jnp.float64
+                else _jax_graph_query_cell_list_f32
+            )
+            neighbor_matrix, neighbor_matrix_shifts, num_neighbors = graph_query(
+                positions,
+                cell,
+                pbc_bool,
+                cells_per_dimension,
+                neighbor_search_radius,
+                atom_periodic_shifts,
+                atom_to_cell_mapping,
+                atoms_per_cell_count,
+                cell_atom_start_indices,
+                cell_atom_list,
+                neighbor_matrix,
+                neighbor_matrix_shifts,
+                num_neighbors,
+                float(cutoff),
+                fill_value,
+            )
+    elif rebuild_flags is not None:
         rf = rebuild_flags.flatten()[:1].astype(jnp.bool_)
         num_neighbors = jnp.where(rf[0], jnp.zeros_like(num_neighbors), num_neighbors)
         neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
@@ -544,6 +1165,17 @@ def cell_list(
     max_neighbors: int | None = None,
     max_total_cells: int | None = None,
     return_neighbor_list: bool = False,
+    cells_per_dimension: jax.Array | None = None,
+    neighbor_search_radius: jax.Array | None = None,
+    atom_periodic_shifts: jax.Array | None = None,
+    atom_to_cell_mapping: jax.Array | None = None,
+    atoms_per_cell_count: jax.Array | None = None,
+    cell_atom_start_indices: jax.Array | None = None,
+    cell_atom_list: jax.Array | None = None,
+    neighbor_matrix: jax.Array | None = None,
+    neighbor_matrix_shifts: jax.Array | None = None,
+    num_neighbors: jax.Array | None = None,
+    graph_mode: Literal["none", "warp"] = "none",
 ) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Build and query spatial cell list for efficient neighbor finding.
 
@@ -566,6 +1198,10 @@ def cell_list(
         Maximum number of cells to allocate. If None, will be estimated.
     return_neighbor_list : bool, optional
         If True, convert result to COO neighbor list format. Default is False.
+    graph_mode : {"none", "warp"}, default="none"
+        Execution mode for the underlying Warp launches. ``"warp"`` is
+        intended for jitted call sites that donate and reuse the optional
+        cell-list caches and output buffers.
 
     Returns
     -------
@@ -591,43 +1227,151 @@ def cell_list(
     query_cell_list : Query cell list separately
     naive_neighbor_list : Naive O(N^2) method
     """
+    graph_mode = _validate_graph_mode(graph_mode)
+
     if cell is None:
         cell = jnp.eye(3, dtype=jnp.float32)[jnp.newaxis, :, :]
     if pbc is None:
         pbc = jnp.ones((1, 3), dtype=jnp.bool_)
 
-    # Build cell list
-    (
-        cells_per_dimension,
-        atom_periodic_shifts,
-        atom_to_cell_mapping,
-        atoms_per_cell_count,
-        cell_atom_start_indices,
-        cell_atom_list,
-        neighbor_search_radius,
-    ) = build_cell_list(
-        positions,
-        cutoff,
-        cell,
-        pbc,
-        max_total_cells=max_total_cells,
-    )
+    if cell.ndim == 2:
+        cell = cell[jnp.newaxis, :, :]
+    if pbc.ndim == 1:
+        pbc = pbc[jnp.newaxis, :]
 
-    # Query cell list
-    neighbor_matrix, num_neighbors, neighbor_matrix_shifts = query_cell_list(
-        positions=positions,
-        cutoff=cutoff,
-        cell=cell,
-        pbc=pbc,
-        cells_per_dimension=cells_per_dimension,
-        atom_periodic_shifts=atom_periodic_shifts,
-        atom_to_cell_mapping=atom_to_cell_mapping,
-        atoms_per_cell_count=atoms_per_cell_count,
-        cell_atom_start_indices=cell_atom_start_indices,
-        cell_atom_list=cell_atom_list,
-        neighbor_search_radius=neighbor_search_radius,
-        max_neighbors=max_neighbors,
-    )
+    if max_neighbors is None and (
+        neighbor_matrix is None
+        or neighbor_matrix_shifts is None
+        or num_neighbors is None
+    ):
+        max_neighbors = estimate_max_neighbors(cutoff)
+
+    if max_total_cells is None:
+        max_total_cells, _, neighbor_search_radius_est = estimate_cell_list_sizes(
+            positions, cell, cutoff, pbc
+        )
+        if neighbor_search_radius is None:
+            neighbor_search_radius = neighbor_search_radius_est
+    elif neighbor_search_radius is None:
+        neighbor_search_radius = jnp.ones(3, dtype=jnp.int32)
+
+    if cells_per_dimension is None:
+        cells_per_dimension = jnp.ones(3, dtype=jnp.int32)
+    if atom_periodic_shifts is None:
+        atom_periodic_shifts = jnp.zeros((positions.shape[0], 3), dtype=jnp.int32)
+    if atom_to_cell_mapping is None:
+        atom_to_cell_mapping = jnp.zeros((positions.shape[0], 3), dtype=jnp.int32)
+    if atoms_per_cell_count is None:
+        atoms_per_cell_count = jnp.zeros(max_total_cells, dtype=jnp.int32)
+    elif graph_mode == "none":
+        atoms_per_cell_count = atoms_per_cell_count.at[:].set(jnp.int32(0))
+    if cell_atom_start_indices is None:
+        cell_atom_start_indices = jnp.zeros(max_total_cells, dtype=jnp.int32)
+    if cell_atom_list is None:
+        cell_atom_list = jnp.zeros(positions.shape[0], dtype=jnp.int32)
+    if neighbor_matrix is None:
+        neighbor_matrix = jnp.full(
+            (positions.shape[0], max_neighbors),
+            positions.shape[0],
+            dtype=jnp.int32,
+        )
+    elif graph_mode == "none":
+        neighbor_matrix = neighbor_matrix.at[:].set(jnp.int32(positions.shape[0]))
+    if neighbor_matrix_shifts is None:
+        neighbor_matrix_shifts = jnp.zeros(
+            (positions.shape[0], max_neighbors, 3),
+            dtype=jnp.int32,
+        )
+    elif graph_mode == "none":
+        neighbor_matrix_shifts = neighbor_matrix_shifts.at[:].set(jnp.int32(0))
+    if num_neighbors is None:
+        num_neighbors = jnp.zeros(positions.shape[0], dtype=jnp.int32)
+    elif graph_mode == "none":
+        num_neighbors = num_neighbors.at[:].set(jnp.int32(0))
+
+    if positions.dtype != jnp.float64:
+        positions = positions.astype(jnp.float32)
+    if cell.dtype != positions.dtype:
+        cell = cell.astype(positions.dtype)
+    pbc_1d = pbc.squeeze() if pbc.ndim == 2 else pbc
+    pbc_bool = pbc_1d.astype(jnp.bool_)
+
+    if graph_mode == "warp":
+        graph_cell_list = (
+            _jax_graph_cell_list_f64
+            if positions.dtype == jnp.float64
+            else _jax_graph_cell_list_f32
+        )
+        (
+            cells_per_dimension,
+            atom_periodic_shifts,
+            atom_to_cell_mapping,
+            atoms_per_cell_count,
+            cell_atom_start_indices,
+            cell_atom_list,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            num_neighbors,
+        ) = graph_cell_list(
+            positions,
+            cell,
+            pbc_bool,
+            neighbor_search_radius,
+            cells_per_dimension,
+            atom_periodic_shifts,
+            atom_to_cell_mapping,
+            atoms_per_cell_count,
+            cell_atom_start_indices,
+            cell_atom_list,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            num_neighbors,
+            float(cutoff),
+            int(positions.shape[0]),
+        )
+    else:
+        (
+            cells_per_dimension,
+            atom_periodic_shifts,
+            atom_to_cell_mapping,
+            atoms_per_cell_count,
+            cell_atom_start_indices,
+            cell_atom_list,
+            neighbor_search_radius,
+        ) = build_cell_list(
+            positions,
+            cutoff,
+            cell,
+            pbc,
+            cells_per_dimension=cells_per_dimension,
+            neighbor_search_radius=neighbor_search_radius,
+            atom_periodic_shifts=atom_periodic_shifts,
+            atom_to_cell_mapping=atom_to_cell_mapping,
+            atoms_per_cell_count=atoms_per_cell_count,
+            cell_atom_start_indices=cell_atom_start_indices,
+            cell_atom_list=cell_atom_list,
+            max_total_cells=max_total_cells,
+            graph_mode="none",
+        )
+
+        neighbor_matrix, num_neighbors, neighbor_matrix_shifts = query_cell_list(
+            positions=positions,
+            cutoff=cutoff,
+            cell=cell,
+            pbc=pbc,
+            cells_per_dimension=cells_per_dimension,
+            atom_periodic_shifts=atom_periodic_shifts,
+            atom_to_cell_mapping=atom_to_cell_mapping,
+            atoms_per_cell_count=atoms_per_cell_count,
+            cell_atom_start_indices=cell_atom_start_indices,
+            cell_atom_list=cell_atom_list,
+            neighbor_search_radius=neighbor_search_radius,
+            max_neighbors=max_neighbors,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            num_neighbors=num_neighbors,
+            graph_mode="none",
+        )
 
     if return_neighbor_list:
         neighbor_list, neighbor_ptr, neighbor_list_shifts = (

--- a/nvalchemiops/jax/neighbors/naive.py
+++ b/nvalchemiops/jax/neighbors/naive.py
@@ -25,6 +25,7 @@ import warp as wp
 from warp.jax_experimental import GraphMode, jax_callable, jax_kernel
 
 from nvalchemiops.jax.neighbors.neighbor_utils import (
+    _validate_graph_mode,
     compute_naive_num_shifts,
     get_neighbor_list_from_neighbor_matrix,
 )
@@ -145,13 +146,6 @@ _jax_wrap_positions_single_f64 = jax_kernel(
     in_out_argnames=["positions_wrapped", "per_atom_cell_offsets"],
     enable_backward=False,
 )
-
-
-def _validate_graph_mode(graph_mode: str) -> Literal["none", "warp"]:
-    """Validate the public graph-mode string."""
-    if graph_mode not in {"none", "warp"}:
-        raise ValueError("graph_mode must be one of {'none', 'warp'}")
-    return graph_mode
 
 
 def _reset_graph_neighbor_outputs(
@@ -841,22 +835,29 @@ def naive_neighbor_list(
         neighbor search. Set to False when positions are already
         wrapped (e.g. by a preceding integration step) to save two
         GPU kernel launches per call.
-    inv_cell : jax.Array, shape (1, 3, 3), dtype=float32 or float64, optional
+    inv_cell : jax.Array, shape (1, 3, 3), dtype matches positions, optional
         Inverse cell matrix consumed by the wrap kernel. Only used when
         ``pbc`` is provided and ``wrap_positions=True``. Pass in a
         precomputed value to avoid a per-call ``jnp.linalg.inv`` and to
         keep the input pointer stable for ``graph_mode="warp"`` graph
         replay (omitting it forces cache-miss-per-call on the wrapped
-        path). If None, computed from ``cell`` each call.
+        path). If None, computed from ``cell`` each call. The shape must
+        be exactly ``(1, 3, 3)`` (matching the internally-normalized
+        ``cell``); a ``(3, 3)`` array would silently allocate a different
+        buffer per call and break ``graph_mode="warp"`` cache replay,
+        which is why a mismatched shape now raises ``ValueError``.
     positions_wrapped : jax.Array, shape (total_atoms, 3), dtype matches positions, optional
         Scratch buffer the wrap kernel writes into. Pass in a pre-shaped
         array to keep the buffer pointer stable across ``graph_mode="warp"``
         calls (required for graph-replay cache hits on the wrapped path).
-        If None, allocated fresh each call.
+        If None, allocated fresh each call. A mismatched shape or dtype
+        raises ``ValueError`` to prevent silent graph-replay cache misses.
     per_atom_cell_offsets : jax.Array, shape (total_atoms, 3), dtype=int32, optional
         Scratch buffer the wrap kernel uses to record per-atom cell offsets.
         Pass in a pre-shaped array to keep the buffer pointer stable for
         ``graph_mode="warp"`` replay. If None, allocated fresh each call.
+        A mismatched shape or dtype raises ``ValueError`` to prevent
+        silent graph-replay cache misses.
     graph_mode : {"none", "warp"}, default="none"
         Execution mode for the underlying Warp launches. ``"none"``
         preserves the existing per-kernel ``jax_kernel`` dispatch path.
@@ -999,6 +1000,47 @@ def naive_neighbor_list(
             cell = cell.astype(positions.dtype)
     if pbc is not None:
         pbc = pbc if pbc.ndim == 2 else pbc[jnp.newaxis, :]
+
+    # Validate caller-supplied scratch buffers used by the wrap kernel. Shape
+    # or dtype mismatches would silently break graph_mode="warp" cache replay
+    # by changing input buffer pointers/layouts on every call, so reject them
+    # early with a clear error.
+    if inv_cell is not None:
+        if inv_cell.shape != (1, 3, 3):
+            raise ValueError(
+                f"inv_cell must have shape (1, 3, 3) to match the internal "
+                f"cell layout; got {inv_cell.shape}. A mismatched shape "
+                f"silently breaks graph_mode='warp' cache replay."
+            )
+        if inv_cell.dtype != positions.dtype:
+            raise ValueError(
+                f"inv_cell dtype must match positions dtype "
+                f"({positions.dtype}); got {inv_cell.dtype}."
+            )
+    if positions_wrapped is not None:
+        expected_pw_shape = (positions.shape[0], 3)
+        if positions_wrapped.shape != expected_pw_shape:
+            raise ValueError(
+                f"positions_wrapped must have shape {expected_pw_shape}; "
+                f"got {positions_wrapped.shape}."
+            )
+        if positions_wrapped.dtype != positions.dtype:
+            raise ValueError(
+                f"positions_wrapped dtype must match positions dtype "
+                f"({positions.dtype}); got {positions_wrapped.dtype}."
+            )
+    if per_atom_cell_offsets is not None:
+        expected_off_shape = (positions.shape[0], 3)
+        if per_atom_cell_offsets.shape != expected_off_shape:
+            raise ValueError(
+                f"per_atom_cell_offsets must have shape {expected_off_shape}; "
+                f"got {per_atom_cell_offsets.shape}."
+            )
+        if per_atom_cell_offsets.dtype != jnp.int32:
+            raise ValueError(
+                f"per_atom_cell_offsets dtype must be int32; "
+                f"got {per_atom_cell_offsets.dtype}."
+            )
 
     if max_neighbors is None and (
         neighbor_matrix is None

--- a/nvalchemiops/jax/neighbors/naive.py
+++ b/nvalchemiops/jax/neighbors/naive.py
@@ -17,10 +17,12 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import jax_kernel
+from warp.jax_experimental import GraphMode, jax_callable, jax_kernel
 
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     compute_naive_num_shifts,
@@ -35,6 +37,7 @@ from nvalchemiops.neighbors.naive import (
     _fill_naive_neighbor_matrix_selective_overload,
 )
 from nvalchemiops.neighbors.neighbor_utils import (
+    _selective_zero_num_neighbors_single,
     _wrap_positions_single_overload,
     estimate_max_neighbors,
 )
@@ -144,6 +147,616 @@ _jax_wrap_positions_single_f64 = jax_kernel(
 )
 
 
+def _validate_graph_mode(graph_mode: str) -> Literal["none", "warp"]:
+    """Validate the public graph-mode string."""
+    if graph_mode not in {"none", "warp"}:
+        raise ValueError("graph_mode must be one of {'none', 'warp'}")
+    return graph_mode
+
+
+def _reset_graph_neighbor_outputs(
+    neighbor_matrix,
+    num_neighbors,
+    fill_value,
+    neighbor_matrix_shifts=None,
+) -> None:
+    """Reset neighbor outputs inside the Warp callback to keep buffers stable."""
+    neighbor_matrix.fill_(fill_value)
+    num_neighbors.zero_()
+    if neighbor_matrix_shifts is not None:
+        neighbor_matrix_shifts.zero_()
+
+
+def _run_graph_naive_no_pbc(
+    positions,
+    neighbor_matrix,
+    num_neighbors,
+    cutoff_sq,
+    fill_value,
+    half_fill,
+    fill_kernel,
+    selective_kernel=None,
+    rebuild_flags=None,
+) -> None:
+    """Execute the no-PBC graph-mode body."""
+    total_atoms = positions.shape[0]
+    if rebuild_flags is None:
+        _reset_graph_neighbor_outputs(neighbor_matrix, num_neighbors, fill_value)
+        wp.launch(
+            kernel=fill_kernel,
+            dim=total_atoms,
+            inputs=[positions, cutoff_sq, neighbor_matrix, num_neighbors, half_fill],
+        )
+    else:
+        wp.launch(
+            kernel=_selective_zero_num_neighbors_single,
+            dim=total_atoms,
+            inputs=[num_neighbors, rebuild_flags],
+        )
+        wp.launch(
+            kernel=selective_kernel,
+            dim=total_atoms,
+            inputs=[
+                positions,
+                cutoff_sq,
+                neighbor_matrix,
+                num_neighbors,
+                half_fill,
+                rebuild_flags,
+            ],
+        )
+
+
+def _run_graph_naive_pbc_prewrapped(
+    positions,
+    cell,
+    shift_range,
+    neighbor_matrix,
+    neighbor_matrix_shifts,
+    num_neighbors,
+    cutoff_sq,
+    num_shifts,
+    fill_value,
+    half_fill,
+    fill_kernel,
+    selective_kernel=None,
+    rebuild_flags=None,
+) -> None:
+    """Execute the prewrapped-PBC graph-mode body."""
+    launch_dims = (num_shifts, positions.shape[0])
+    if rebuild_flags is None:
+        _reset_graph_neighbor_outputs(
+            neighbor_matrix,
+            num_neighbors,
+            fill_value,
+            neighbor_matrix_shifts,
+        )
+        wp.launch(
+            kernel=fill_kernel,
+            dim=launch_dims,
+            inputs=[
+                positions,
+                cutoff_sq,
+                cell,
+                shift_range,
+                neighbor_matrix,
+                neighbor_matrix_shifts,
+                num_neighbors,
+                half_fill,
+            ],
+        )
+    else:
+        wp.launch(
+            kernel=_selective_zero_num_neighbors_single,
+            dim=positions.shape[0],
+            inputs=[num_neighbors, rebuild_flags],
+        )
+        wp.launch(
+            kernel=selective_kernel,
+            dim=launch_dims,
+            inputs=[
+                positions,
+                cutoff_sq,
+                cell,
+                shift_range,
+                neighbor_matrix,
+                neighbor_matrix_shifts,
+                num_neighbors,
+                half_fill,
+                rebuild_flags,
+            ],
+        )
+
+
+def _run_graph_naive_pbc_wrapped(
+    positions,
+    cell,
+    inv_cell,
+    shift_range,
+    positions_wrapped,
+    per_atom_cell_offsets,
+    neighbor_matrix,
+    neighbor_matrix_shifts,
+    num_neighbors,
+    cutoff_sq,
+    num_shifts,
+    fill_value,
+    half_fill,
+    wrap_kernel,
+    fill_kernel,
+    selective_kernel=None,
+    rebuild_flags=None,
+) -> None:
+    """Execute the wrapped-PBC graph-mode body."""
+    total_atoms = positions.shape[0]
+    launch_dims = (num_shifts, total_atoms)
+    if rebuild_flags is None:
+        _reset_graph_neighbor_outputs(
+            neighbor_matrix,
+            num_neighbors,
+            fill_value,
+            neighbor_matrix_shifts,
+        )
+    else:
+        wp.launch(
+            kernel=_selective_zero_num_neighbors_single,
+            dim=total_atoms,
+            inputs=[num_neighbors, rebuild_flags],
+        )
+
+    wp.launch(
+        kernel=wrap_kernel,
+        dim=total_atoms,
+        inputs=[positions, cell, inv_cell],
+        outputs=[positions_wrapped, per_atom_cell_offsets],
+    )
+
+    fill_inputs = [
+        positions_wrapped,
+        per_atom_cell_offsets,
+        cutoff_sq,
+        cell,
+        shift_range,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        half_fill,
+    ]
+    if rebuild_flags is not None:
+        fill_inputs.append(rebuild_flags)
+
+    wp.launch(
+        kernel=fill_kernel if rebuild_flags is None else selective_kernel,
+        dim=launch_dims,
+        inputs=fill_inputs,
+    )
+
+
+def _graph_naive_no_pbc_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff_sq: wp.float32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+) -> None:
+    _run_graph_naive_no_pbc(
+        positions,
+        neighbor_matrix,
+        num_neighbors,
+        cutoff_sq,
+        fill_value,
+        half_fill,
+        _fill_naive_neighbor_matrix_overload[wp.float32],
+    )
+
+
+def _graph_naive_no_pbc_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff_sq: wp.float64,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+) -> None:
+    _run_graph_naive_no_pbc(
+        positions,
+        neighbor_matrix,
+        num_neighbors,
+        cutoff_sq,
+        fill_value,
+        half_fill,
+        _fill_naive_neighbor_matrix_overload[wp.float64],
+    )
+
+
+def _graph_naive_no_pbc_selective_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff_sq: wp.float32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+    rebuild_flags: wp.array(dtype=wp.bool),
+) -> None:
+    _run_graph_naive_no_pbc(
+        positions,
+        neighbor_matrix,
+        num_neighbors,
+        cutoff_sq,
+        fill_value,
+        half_fill,
+        _fill_naive_neighbor_matrix_overload[wp.float32],
+        selective_kernel=_fill_naive_neighbor_matrix_selective_overload[wp.float32],
+        rebuild_flags=rebuild_flags,
+    )
+
+
+def _graph_naive_no_pbc_selective_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff_sq: wp.float64,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+    rebuild_flags: wp.array(dtype=wp.bool),
+) -> None:
+    _run_graph_naive_no_pbc(
+        positions,
+        neighbor_matrix,
+        num_neighbors,
+        cutoff_sq,
+        fill_value,
+        half_fill,
+        _fill_naive_neighbor_matrix_overload[wp.float64],
+        selective_kernel=_fill_naive_neighbor_matrix_selective_overload[wp.float64],
+        rebuild_flags=rebuild_flags,
+    )
+
+
+def _graph_naive_pbc_prewrapped_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    cell: wp.array(dtype=wp.mat33f),
+    shift_range: wp.array(dtype=wp.vec3i),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff_sq: wp.float32,
+    num_shifts: wp.int32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+) -> None:
+    _run_graph_naive_pbc_prewrapped(
+        positions,
+        cell,
+        shift_range,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff_sq,
+        num_shifts,
+        fill_value,
+        half_fill,
+        _fill_naive_neighbor_matrix_pbc_prewrapped_overload[wp.float32],
+    )
+
+
+def _graph_naive_pbc_prewrapped_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    cell: wp.array(dtype=wp.mat33d),
+    shift_range: wp.array(dtype=wp.vec3i),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff_sq: wp.float64,
+    num_shifts: wp.int32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+) -> None:
+    _run_graph_naive_pbc_prewrapped(
+        positions,
+        cell,
+        shift_range,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff_sq,
+        num_shifts,
+        fill_value,
+        half_fill,
+        _fill_naive_neighbor_matrix_pbc_prewrapped_overload[wp.float64],
+    )
+
+
+def _graph_naive_pbc_prewrapped_selective_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    cell: wp.array(dtype=wp.mat33f),
+    shift_range: wp.array(dtype=wp.vec3i),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff_sq: wp.float32,
+    num_shifts: wp.int32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+    rebuild_flags: wp.array(dtype=wp.bool),
+) -> None:
+    _run_graph_naive_pbc_prewrapped(
+        positions,
+        cell,
+        shift_range,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff_sq,
+        num_shifts,
+        fill_value,
+        half_fill,
+        _fill_naive_neighbor_matrix_pbc_prewrapped_overload[wp.float32],
+        selective_kernel=_fill_naive_neighbor_matrix_pbc_prewrapped_selective_overload[
+            wp.float32
+        ],
+        rebuild_flags=rebuild_flags,
+    )
+
+
+def _graph_naive_pbc_prewrapped_selective_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    cell: wp.array(dtype=wp.mat33d),
+    shift_range: wp.array(dtype=wp.vec3i),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff_sq: wp.float64,
+    num_shifts: wp.int32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+    rebuild_flags: wp.array(dtype=wp.bool),
+) -> None:
+    _run_graph_naive_pbc_prewrapped(
+        positions,
+        cell,
+        shift_range,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff_sq,
+        num_shifts,
+        fill_value,
+        half_fill,
+        _fill_naive_neighbor_matrix_pbc_prewrapped_overload[wp.float64],
+        selective_kernel=_fill_naive_neighbor_matrix_pbc_prewrapped_selective_overload[
+            wp.float64
+        ],
+        rebuild_flags=rebuild_flags,
+    )
+
+
+def _graph_naive_pbc_wrapped_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    cell: wp.array(dtype=wp.mat33f),
+    inv_cell: wp.array(dtype=wp.mat33f),
+    shift_range: wp.array(dtype=wp.vec3i),
+    positions_wrapped: wp.array(dtype=wp.vec3f),
+    per_atom_cell_offsets: wp.array(dtype=wp.vec3i),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff_sq: wp.float32,
+    num_shifts: wp.int32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+) -> None:
+    _run_graph_naive_pbc_wrapped(
+        positions,
+        cell,
+        inv_cell,
+        shift_range,
+        positions_wrapped,
+        per_atom_cell_offsets,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff_sq,
+        num_shifts,
+        fill_value,
+        half_fill,
+        _wrap_positions_single_overload[wp.float32],
+        _fill_naive_neighbor_matrix_pbc_overload[wp.float32],
+    )
+
+
+def _graph_naive_pbc_wrapped_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    cell: wp.array(dtype=wp.mat33d),
+    inv_cell: wp.array(dtype=wp.mat33d),
+    shift_range: wp.array(dtype=wp.vec3i),
+    positions_wrapped: wp.array(dtype=wp.vec3d),
+    per_atom_cell_offsets: wp.array(dtype=wp.vec3i),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff_sq: wp.float64,
+    num_shifts: wp.int32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+) -> None:
+    _run_graph_naive_pbc_wrapped(
+        positions,
+        cell,
+        inv_cell,
+        shift_range,
+        positions_wrapped,
+        per_atom_cell_offsets,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff_sq,
+        num_shifts,
+        fill_value,
+        half_fill,
+        _wrap_positions_single_overload[wp.float64],
+        _fill_naive_neighbor_matrix_pbc_overload[wp.float64],
+    )
+
+
+def _graph_naive_pbc_wrapped_selective_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    cell: wp.array(dtype=wp.mat33f),
+    inv_cell: wp.array(dtype=wp.mat33f),
+    shift_range: wp.array(dtype=wp.vec3i),
+    positions_wrapped: wp.array(dtype=wp.vec3f),
+    per_atom_cell_offsets: wp.array(dtype=wp.vec3i),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff_sq: wp.float32,
+    num_shifts: wp.int32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+    rebuild_flags: wp.array(dtype=wp.bool),
+) -> None:
+    _run_graph_naive_pbc_wrapped(
+        positions,
+        cell,
+        inv_cell,
+        shift_range,
+        positions_wrapped,
+        per_atom_cell_offsets,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff_sq,
+        num_shifts,
+        fill_value,
+        half_fill,
+        _wrap_positions_single_overload[wp.float32],
+        _fill_naive_neighbor_matrix_pbc_overload[wp.float32],
+        selective_kernel=_fill_naive_neighbor_matrix_pbc_selective_overload[wp.float32],
+        rebuild_flags=rebuild_flags,
+    )
+
+
+def _graph_naive_pbc_wrapped_selective_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    cell: wp.array(dtype=wp.mat33d),
+    inv_cell: wp.array(dtype=wp.mat33d),
+    shift_range: wp.array(dtype=wp.vec3i),
+    positions_wrapped: wp.array(dtype=wp.vec3d),
+    per_atom_cell_offsets: wp.array(dtype=wp.vec3i),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff_sq: wp.float64,
+    num_shifts: wp.int32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+    rebuild_flags: wp.array(dtype=wp.bool),
+) -> None:
+    _run_graph_naive_pbc_wrapped(
+        positions,
+        cell,
+        inv_cell,
+        shift_range,
+        positions_wrapped,
+        per_atom_cell_offsets,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff_sq,
+        num_shifts,
+        fill_value,
+        half_fill,
+        _wrap_positions_single_overload[wp.float64],
+        _fill_naive_neighbor_matrix_pbc_overload[wp.float64],
+        selective_kernel=_fill_naive_neighbor_matrix_pbc_selective_overload[wp.float64],
+        rebuild_flags=rebuild_flags,
+    )
+
+
+_GRAPH_NAIVE_NO_PBC_IN_OUT_ARGS = ("neighbor_matrix", "num_neighbors")
+_GRAPH_NAIVE_PBC_IN_OUT_ARGS = (
+    "neighbor_matrix",
+    "neighbor_matrix_shifts",
+    "num_neighbors",
+)
+_GRAPH_NAIVE_PBC_WRAPPED_IN_OUT_ARGS = (
+    "positions_wrapped",
+    "per_atom_cell_offsets",
+    "neighbor_matrix",
+    "neighbor_matrix_shifts",
+    "num_neighbors",
+)
+_GRAPH_NAIVE_DTYPE_TO_WARP_CALLABLES = {
+    (False, False): {
+        "num_outputs": 2,
+        "in_out_argnames": _GRAPH_NAIVE_NO_PBC_IN_OUT_ARGS,
+        jnp.dtype(jnp.float32): _graph_naive_no_pbc_f32,
+        jnp.dtype(jnp.float64): _graph_naive_no_pbc_f64,
+    },
+    (False, True): {
+        "num_outputs": 2,
+        "in_out_argnames": _GRAPH_NAIVE_NO_PBC_IN_OUT_ARGS,
+        jnp.dtype(jnp.float32): _graph_naive_no_pbc_selective_f32,
+        jnp.dtype(jnp.float64): _graph_naive_no_pbc_selective_f64,
+    },
+    (True, False, False): {
+        "num_outputs": 3,
+        "in_out_argnames": _GRAPH_NAIVE_PBC_IN_OUT_ARGS,
+        jnp.dtype(jnp.float32): _graph_naive_pbc_prewrapped_f32,
+        jnp.dtype(jnp.float64): _graph_naive_pbc_prewrapped_f64,
+    },
+    (True, False, True): {
+        "num_outputs": 3,
+        "in_out_argnames": _GRAPH_NAIVE_PBC_IN_OUT_ARGS,
+        jnp.dtype(jnp.float32): _graph_naive_pbc_prewrapped_selective_f32,
+        jnp.dtype(jnp.float64): _graph_naive_pbc_prewrapped_selective_f64,
+    },
+    (True, True, False): {
+        "num_outputs": 5,
+        "in_out_argnames": _GRAPH_NAIVE_PBC_WRAPPED_IN_OUT_ARGS,
+        jnp.dtype(jnp.float32): _graph_naive_pbc_wrapped_f32,
+        jnp.dtype(jnp.float64): _graph_naive_pbc_wrapped_f64,
+    },
+    (True, True, True): {
+        "num_outputs": 5,
+        "in_out_argnames": _GRAPH_NAIVE_PBC_WRAPPED_IN_OUT_ARGS,
+        jnp.dtype(jnp.float32): _graph_naive_pbc_wrapped_selective_f32,
+        jnp.dtype(jnp.float64): _graph_naive_pbc_wrapped_selective_f64,
+    },
+}
+
+
+def _register_graph_naive_callables() -> dict[
+    tuple[bool, bool, bool, jnp.dtype], object
+]:
+    """Register GraphMode.WARP callables for all naive graph-mode paths."""
+    registered: dict[tuple[bool, bool, bool, jnp.dtype], object] = {}
+
+    for key, spec in _GRAPH_NAIVE_DTYPE_TO_WARP_CALLABLES.items():
+        if len(key) == 2:
+            has_pbc, selective = key
+            wrap_positions_values = (False, True)
+        else:
+            has_pbc, wrap_positions, selective = key
+            wrap_positions_values = (wrap_positions,)
+
+        for dtype in (jnp.dtype(jnp.float32), jnp.dtype(jnp.float64)):
+            callable_obj = jax_callable(
+                spec[dtype],
+                num_outputs=spec["num_outputs"],
+                in_out_argnames=spec["in_out_argnames"],
+                graph_mode=GraphMode.WARP,
+            )
+            for wrap_positions in wrap_positions_values:
+                registered[(has_pbc, wrap_positions, selective, dtype)] = callable_obj
+
+    return registered
+
+
+_GRAPH_NAIVE_WARP_CALLABLES = _register_graph_naive_callables()
+
+
 def naive_neighbor_list(
     positions: jax.Array,
     cutoff: float,
@@ -161,6 +774,10 @@ def naive_neighbor_list(
     max_shifts_per_system: int | None = None,
     rebuild_flags: jax.Array | None = None,
     wrap_positions: bool = True,
+    inv_cell: jax.Array | None = None,
+    positions_wrapped: jax.Array | None = None,
+    per_atom_cell_offsets: jax.Array | None = None,
+    graph_mode: Literal["none", "warp"] = "none",
 ) -> (
     tuple[jax.Array, jax.Array, jax.Array, jax.Array]
     | tuple[jax.Array, jax.Array, jax.Array]
@@ -224,6 +841,28 @@ def naive_neighbor_list(
         neighbor search. Set to False when positions are already
         wrapped (e.g. by a preceding integration step) to save two
         GPU kernel launches per call.
+    inv_cell : jax.Array, shape (1, 3, 3), dtype=float32 or float64, optional
+        Inverse cell matrix consumed by the wrap kernel. Only used when
+        ``pbc`` is provided and ``wrap_positions=True``. Pass in a
+        precomputed value to avoid a per-call ``jnp.linalg.inv`` and to
+        keep the input pointer stable for ``graph_mode="warp"`` graph
+        replay (omitting it forces cache-miss-per-call on the wrapped
+        path). If None, computed from ``cell`` each call.
+    positions_wrapped : jax.Array, shape (total_atoms, 3), dtype matches positions, optional
+        Scratch buffer the wrap kernel writes into. Pass in a pre-shaped
+        array to keep the buffer pointer stable across ``graph_mode="warp"``
+        calls (required for graph-replay cache hits on the wrapped path).
+        If None, allocated fresh each call.
+    per_atom_cell_offsets : jax.Array, shape (total_atoms, 3), dtype=int32, optional
+        Scratch buffer the wrap kernel uses to record per-atom cell offsets.
+        Pass in a pre-shaped array to keep the buffer pointer stable for
+        ``graph_mode="warp"`` replay. If None, allocated fresh each call.
+    graph_mode : {"none", "warp"}, default="none"
+        Execution mode for the underlying Warp launches. ``"none"``
+        preserves the existing per-kernel ``jax_kernel`` dispatch path.
+        ``"warp"`` uses fused ``jax_callable(..., graph_mode=GraphMode.WARP)``
+        callbacks and is intended for ``jax.jit`` call sites that donate
+        reusable output buffers.
 
     Returns
     -------
@@ -290,12 +929,64 @@ def naive_neighbor_list(
     ... )
     >>> source_atoms, target_atoms = neighbor_list[0], neighbor_list[1]
 
+    Warp graph replay with donated buffers (PBC + wrap_positions=True):
+
+    >>> import functools
+    >>> import jax
+    >>> # Pre-allocate the wrap kernel's scratch buffers and inv_cell once.
+    >>> # Capturing them in the closure (rather than donating) keeps their
+    >>> # buffer pointers stable across calls, which is what Warp's graph
+    >>> # cache keys on. Only the buffers naive_neighbor_list returns are
+    >>> # donated, so the in/out arity of the jit'ed step matches.
+    >>> inv_cell = jnp.linalg.inv(cell)
+    >>> positions_wrapped = jnp.zeros_like(positions)
+    >>> per_atom_cell_offsets = jnp.zeros((positions.shape[0], 3), dtype=jnp.int32)
+    >>> @functools.partial(jax.jit, donate_argnums=(1, 2, 3))
+    ... def md_step(positions, neighbor_matrix, num_neighbors, shifts):
+    ...     return naive_neighbor_list(
+    ...         positions,
+    ...         cutoff,
+    ...         cell=cell,
+    ...         pbc=pbc,
+    ...         neighbor_matrix=neighbor_matrix,
+    ...         num_neighbors=num_neighbors,
+    ...         neighbor_matrix_shifts=shifts,
+    ...         inv_cell=inv_cell,
+    ...         positions_wrapped=positions_wrapped,
+    ...         per_atom_cell_offsets=per_atom_cell_offsets,
+    ...         graph_mode="warp",
+    ...     )
+
     See Also
     --------
     nvalchemiops.neighbors.naive.naive_neighbor_matrix : Core warp launcher (no PBC)
     nvalchemiops.neighbors.naive.naive_neighbor_matrix_pbc : Core warp launcher (with PBC)
     cell_list : O(N) cell list method for larger systems
+
+    Notes
+    -----
+    For lower host-side launch overhead on supported GPUs, setting
+    ``XLA_FLAGS=--xla_gpu_enable_command_buffer=CUSTOM_CALL`` before
+    importing JAX can improve the steady-state ``graph_mode="none"`` and
+    ``graph_mode="warp"`` paths. Advanced users can bound Warp's graph
+    cache via ``warp.jax_experimental.set_jax_callable_default_graph_cache_max(...)``.
+
+    For ``graph_mode="warp"`` to actually replay (rather than re-capture
+    every call), every in/out buffer pointer the fused callable sees must
+    be stable across calls. The output buffers (``neighbor_matrix``,
+    ``num_neighbors``, ``neighbor_matrix_shifts`` when applicable) must be
+    user-provided **and** included in ``donate_argnums`` of the enclosing
+    ``jax.jit`` so they round-trip across calls. On the wrapped path
+    (``pbc`` provided + ``wrap_positions=True``), ``inv_cell``,
+    ``positions_wrapped`` and ``per_atom_cell_offsets`` must also be passed
+    in with stable buffer pointers; the simplest way is to pre-allocate them
+    once and capture them in the jit'ed closure (see the example above).
+    Letting any of these allocate fresh inside ``naive_neighbor_list``
+    silently degrades the wrapped path to cold-capture-per-call (correct,
+    but significantly slower than the proposal's measured replay numbers).
     """
+    graph_mode = _validate_graph_mode(graph_mode)
+
     if pbc is None and cell is not None:
         raise ValueError("If cell is provided, pbc must also be provided")
     if pbc is not None and cell is None:
@@ -317,7 +1008,7 @@ def naive_neighbor_list(
         max_neighbors = estimate_max_neighbors(cutoff)
 
     if fill_value is None:
-        fill_value = jnp.int32(positions.shape[0])
+        fill_value = positions.shape[0]
 
     if neighbor_matrix is None:
         neighbor_matrix = jnp.full(
@@ -325,12 +1016,12 @@ def naive_neighbor_list(
             fill_value,
             dtype=jnp.int32,
         )
-    elif rebuild_flags is None:
+    elif rebuild_flags is None and graph_mode == "none":
         neighbor_matrix = neighbor_matrix.at[:].set(fill_value)
 
     if num_neighbors is None:
         num_neighbors = jnp.zeros(positions.shape[0], dtype=jnp.int32)
-    elif rebuild_flags is None:
+    elif rebuild_flags is None and graph_mode == "none":
         num_neighbors = num_neighbors.at[:].set(jnp.int32(0))
 
     if pbc is not None:
@@ -339,7 +1030,7 @@ def naive_neighbor_list(
                 (positions.shape[0], max_neighbors, 3),
                 dtype=jnp.int32,
             )
-        elif rebuild_flags is None:
+        elif rebuild_flags is None and graph_mode == "none":
             neighbor_matrix_shifts = neighbor_matrix_shifts.at[:].set(jnp.int32(0))
         if (
             max_shifts_per_system is None
@@ -351,6 +1042,11 @@ def naive_neighbor_list(
             )
 
     if cutoff <= 0:
+        if rebuild_flags is None and graph_mode == "warp":
+            neighbor_matrix = neighbor_matrix.at[:].set(fill_value)
+            num_neighbors = num_neighbors.at[:].set(jnp.int32(0))
+            if pbc is not None:
+                neighbor_matrix_shifts = neighbor_matrix_shifts.at[:].set(jnp.int32(0))
         if return_neighbor_list:
             if pbc is not None:
                 return (
@@ -399,8 +1095,129 @@ def naive_neighbor_list(
         positions = positions.astype(jnp.float32)
 
     total_atoms = positions.shape[0]
+    cutoff_sq = float(cutoff * cutoff)
 
-    if pbc is None:
+    if graph_mode == "warp":
+        has_pbc = pbc is not None
+        is_selective = rebuild_flags is not None
+        graph_callable = _GRAPH_NAIVE_WARP_CALLABLES[
+            (has_pbc, wrap_positions, is_selective, positions.dtype)
+        ]
+        fill_value_i32 = int(fill_value)
+        rf = None
+        if is_selective:
+            rf = rebuild_flags.flatten()[:1].astype(jnp.bool_)
+
+        if not has_pbc:
+            if is_selective:
+                neighbor_matrix, num_neighbors = graph_callable(
+                    positions,
+                    neighbor_matrix,
+                    num_neighbors,
+                    cutoff_sq,
+                    fill_value_i32,
+                    half_fill,
+                    rf,
+                )
+            else:
+                neighbor_matrix, num_neighbors = graph_callable(
+                    positions,
+                    neighbor_matrix,
+                    num_neighbors,
+                    cutoff_sq,
+                    fill_value_i32,
+                    half_fill,
+                )
+        else:
+            if cell.dtype != positions.dtype:
+                cell = cell.astype(positions.dtype)
+
+            num_shifts = int(max_shifts_per_system)
+            if wrap_positions:
+                if inv_cell is None:
+                    inv_cell = jnp.linalg.inv(cell)
+                if positions_wrapped is None:
+                    positions_wrapped = jnp.zeros_like(positions)
+                if per_atom_cell_offsets is None:
+                    per_atom_cell_offsets = jnp.zeros((total_atoms, 3), dtype=jnp.int32)
+                if is_selective:
+                    (
+                        positions_wrapped,
+                        per_atom_cell_offsets,
+                        neighbor_matrix,
+                        neighbor_matrix_shifts,
+                        num_neighbors,
+                    ) = graph_callable(
+                        positions,
+                        cell,
+                        inv_cell,
+                        shift_range_per_dimension,
+                        positions_wrapped,
+                        per_atom_cell_offsets,
+                        neighbor_matrix,
+                        neighbor_matrix_shifts,
+                        num_neighbors,
+                        cutoff_sq,
+                        num_shifts,
+                        fill_value_i32,
+                        half_fill,
+                        rf,
+                    )
+                else:
+                    (
+                        positions_wrapped,
+                        per_atom_cell_offsets,
+                        neighbor_matrix,
+                        neighbor_matrix_shifts,
+                        num_neighbors,
+                    ) = graph_callable(
+                        positions,
+                        cell,
+                        inv_cell,
+                        shift_range_per_dimension,
+                        positions_wrapped,
+                        per_atom_cell_offsets,
+                        neighbor_matrix,
+                        neighbor_matrix_shifts,
+                        num_neighbors,
+                        cutoff_sq,
+                        num_shifts,
+                        fill_value_i32,
+                        half_fill,
+                    )
+            else:
+                if is_selective:
+                    neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
+                        graph_callable(
+                            positions,
+                            cell,
+                            shift_range_per_dimension,
+                            neighbor_matrix,
+                            neighbor_matrix_shifts,
+                            num_neighbors,
+                            cutoff_sq,
+                            num_shifts,
+                            fill_value_i32,
+                            half_fill,
+                            rf,
+                        )
+                    )
+                else:
+                    neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
+                        graph_callable(
+                            positions,
+                            cell,
+                            shift_range_per_dimension,
+                            neighbor_matrix,
+                            neighbor_matrix_shifts,
+                            num_neighbors,
+                            cutoff_sq,
+                            num_shifts,
+                            fill_value_i32,
+                            half_fill,
+                        )
+                    )
+    elif pbc is None:
         # No PBC case
         if rebuild_flags is not None:
             rf = rebuild_flags.flatten()[:1].astype(jnp.bool_)
@@ -409,7 +1226,7 @@ def naive_neighbor_list(
             )
             neighbor_matrix, num_neighbors = _jax_fill_selective(
                 positions,
-                float(cutoff * cutoff),
+                cutoff_sq,
                 neighbor_matrix,
                 num_neighbors,
                 half_fill,
@@ -419,7 +1236,7 @@ def naive_neighbor_list(
         else:
             neighbor_matrix, num_neighbors = _jax_fill(
                 positions,
-                float(cutoff * cutoff),
+                cutoff_sq,
                 neighbor_matrix,
                 num_neighbors,
                 half_fill,
@@ -430,9 +1247,12 @@ def naive_neighbor_list(
             cell = cell.astype(positions.dtype)
 
         if wrap_positions:
-            inv_cell = jnp.linalg.inv(cell)
-            positions_wrapped = jnp.zeros_like(positions)
-            per_atom_cell_offsets = jnp.zeros((total_atoms, 3), dtype=jnp.int32)
+            if inv_cell is None:
+                inv_cell = jnp.linalg.inv(cell)
+            if positions_wrapped is None:
+                positions_wrapped = jnp.zeros_like(positions)
+            if per_atom_cell_offsets is None:
+                per_atom_cell_offsets = jnp.zeros((total_atoms, 3), dtype=jnp.int32)
             positions_wrapped, per_atom_cell_offsets = _jax_wrap_single(
                 positions,
                 cell,
@@ -451,7 +1271,7 @@ def naive_neighbor_list(
                     _jax_fill_pbc_selective(
                         positions_wrapped,
                         per_atom_cell_offsets,
-                        float(cutoff * cutoff),
+                        cutoff_sq,
                         cell,
                         shift_range_per_dimension,
                         neighbor_matrix,
@@ -466,7 +1286,7 @@ def naive_neighbor_list(
                 neighbor_matrix, neighbor_matrix_shifts, num_neighbors = _jax_fill_pbc(
                     positions_wrapped,
                     per_atom_cell_offsets,
-                    float(cutoff * cutoff),
+                    cutoff_sq,
                     cell,
                     shift_range_per_dimension,
                     neighbor_matrix,
@@ -484,7 +1304,7 @@ def naive_neighbor_list(
                 neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
                     _jax_fill_pbc_prewrapped_selective(
                         positions,
-                        float(cutoff * cutoff),
+                        cutoff_sq,
                         cell,
                         shift_range_per_dimension,
                         neighbor_matrix,
@@ -499,7 +1319,7 @@ def naive_neighbor_list(
                 neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
                     _jax_fill_pbc_prewrapped(
                         positions,
-                        float(cutoff * cutoff),
+                        cutoff_sq,
                         cell,
                         shift_range_per_dimension,
                         neighbor_matrix,

--- a/nvalchemiops/jax/neighbors/naive.py
+++ b/nvalchemiops/jax/neighbors/naive.py
@@ -907,7 +907,7 @@ def naive_neighbor_list(
     Basic usage without periodic boundary conditions:
 
     >>> import jax.numpy as jnp
-    >>> from nvalchemiops.jax.neighbors import naive_neighbor_list
+    >>> from nvalchemiops.jax.neighbors import compute_naive_num_shifts, naive_neighbor_list
     >>> positions = jnp.zeros((100, 3), dtype=jnp.float32)
     >>> cutoff = 2.5
     >>> max_neighbors = 50
@@ -942,6 +942,9 @@ def naive_neighbor_list(
     >>> inv_cell = jnp.linalg.inv(cell)
     >>> positions_wrapped = jnp.zeros_like(positions)
     >>> per_atom_cell_offsets = jnp.zeros((positions.shape[0], 3), dtype=jnp.int32)
+    >>> shift_range, num_shifts_per_system, max_shifts_per_system = (
+    ...     compute_naive_num_shifts(cell, cutoff, pbc)
+    ... )
     >>> @functools.partial(jax.jit, donate_argnums=(1, 2, 3))
     ... def md_step(positions, neighbor_matrix, num_neighbors, shifts):
     ...     return naive_neighbor_list(
@@ -955,6 +958,9 @@ def naive_neighbor_list(
     ...         inv_cell=inv_cell,
     ...         positions_wrapped=positions_wrapped,
     ...         per_atom_cell_offsets=per_atom_cell_offsets,
+    ...         shift_range_per_dimension=shift_range,
+    ...         num_shifts_per_system=num_shifts_per_system,
+    ...         max_shifts_per_system=max_shifts_per_system,
     ...         graph_mode="warp",
     ...     )
 

--- a/nvalchemiops/jax/neighbors/neighbor_utils.py
+++ b/nvalchemiops/jax/neighbors/neighbor_utils.py
@@ -20,6 +20,8 @@ This module contains JAX-specific helper functions for neighbor list operations.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import jax
 import jax.numpy as jnp
 import warp as wp
@@ -39,6 +41,30 @@ __all__ = [
     "estimate_max_neighbors",
     "NeighborOverflowError",
 ]
+
+
+def _validate_graph_mode(graph_mode: str) -> Literal["none", "warp"]:
+    """Validate the public ``graph_mode`` argument used by neighbor-list APIs.
+
+    Parameters
+    ----------
+    graph_mode : str
+        User-supplied mode string. Must be one of ``{"none", "warp"}``.
+
+    Returns
+    -------
+    Literal["none", "warp"]
+        The validated mode.
+
+    Raises
+    ------
+    ValueError
+        If ``graph_mode`` is not a recognized mode.
+    """
+    if graph_mode not in {"none", "warp"}:
+        raise ValueError("graph_mode must be one of {'none', 'warp'}")
+    return graph_mode
+
 
 # ==============================================================================
 # JAX Kernel Wrappers

--- a/nvalchemiops/neighborlist/__init__.py
+++ b/nvalchemiops/neighborlist/__init__.py
@@ -81,9 +81,6 @@ from nvalchemiops.neighbors import (
 from nvalchemiops.neighbors import (
     query_cell_list as wp_query_cell_list,
 )
-from nvalchemiops.neighbors import (
-    zero_array as wp_zero_array,
-)
 
 # Emit deprecation warning on first import of this module
 warnings.warn(
@@ -179,7 +176,6 @@ __all__ = [
     "wp_check_cell_list_rebuild",
     "wp_check_neighbor_list_rebuild",
     "wp_compute_naive_num_shifts",
-    "wp_zero_array",
     "estimate_max_neighbors",
     "neighbor_list",
     # Submodules for backwards compatibility

--- a/nvalchemiops/neighbors/__init__.py
+++ b/nvalchemiops/neighbors/__init__.py
@@ -65,7 +65,6 @@ from nvalchemiops.neighbors.neighbor_utils import (
     NeighborOverflowError,
     compute_naive_num_shifts,
     estimate_max_neighbors,
-    zero_array,
 )
 
 # Warp launchers from rebuild_detection
@@ -138,7 +137,6 @@ __all__ = [
     "check_batch_neighbor_list_rebuild",
     "check_batch_cell_list_rebuild",
     "compute_naive_num_shifts",
-    "zero_array",
     "estimate_max_neighbors",
     "neighbor_list",
 ]

--- a/nvalchemiops/neighbors/batch_cell_list.py
+++ b/nvalchemiops/neighbors/batch_cell_list.py
@@ -27,7 +27,6 @@ from nvalchemiops.math import wpdivmod
 from nvalchemiops.neighbors.neighbor_utils import (
     _update_neighbor_matrix_pbc,
     selective_zero_num_neighbors,
-    zero_array,
 )
 
 __all__ = [
@@ -1001,7 +1000,7 @@ def batch_build_cell_list(
     wp.utils.array_scan(atoms_per_cell_count, cell_atom_start_indices, inclusive=False)
 
     # Zero counts before binning atoms (second pass needs fresh counts)
-    zero_array(atoms_per_cell_count, device)
+    atoms_per_cell_count.zero_()
 
     # Bin atoms (expects atoms_per_cell_count to be zeroed)
     wp.launch(

--- a/nvalchemiops/neighbors/cell_list.py
+++ b/nvalchemiops/neighbors/cell_list.py
@@ -26,7 +26,6 @@ import warp as wp
 from nvalchemiops.math import wpdivmod
 from nvalchemiops.neighbors.neighbor_utils import (
     _update_neighbor_matrix_pbc,
-    zero_array,
 )
 
 __all__ = [
@@ -869,7 +868,7 @@ def build_cell_list(
     wp.utils.array_scan(atoms_per_cell_count, cell_atom_start_indices, inclusive=False)
 
     # Zero counts before binning atoms (second pass needs fresh counts)
-    zero_array(atoms_per_cell_count, device)
+    atoms_per_cell_count.zero_()
 
     # Bin atoms (expects atoms_per_cell_count to be zeroed)
     wp.launch(

--- a/nvalchemiops/neighbors/neighbor_utils.py
+++ b/nvalchemiops/neighbors/neighbor_utils.py
@@ -390,7 +390,7 @@ def zero_array(
     """Core warp launcher for zeroing an array.
 
     .. deprecated::
-        Use ``array.zero_()`` (Warp's built-in in-place zero) instead. 
+        Use ``array.zero_()`` (Warp's built-in in-place zero) instead.
 
     Zeros all elements of an array in parallel using pure warp operations.
 

--- a/nvalchemiops/neighbors/neighbor_utils.py
+++ b/nvalchemiops/neighbors/neighbor_utils.py
@@ -20,6 +20,7 @@ See `nvalchemiops.torch.neighbors` for PyTorch bindings.
 """
 
 import math
+import warnings
 from typing import Any
 
 import warp as wp
@@ -53,7 +54,6 @@ __all__ = [
     "NeighborOverflowError",
     "compute_naive_num_shifts",
     "compute_inv_cells",
-    "zero_array",
     "selective_zero_num_neighbors",
     "selective_zero_num_neighbors_single",
     "estimate_max_neighbors",
@@ -389,6 +389,9 @@ def zero_array(
 ) -> None:
     """Core warp launcher for zeroing an array.
 
+    .. deprecated::
+        Use ``array.zero_()`` (Warp's built-in in-place zero) instead. 
+
     Zeros all elements of an array in parallel using pure warp operations.
 
     Parameters
@@ -400,13 +403,21 @@ def zero_array(
 
     Notes
     -----
-    - This is a low-level warp interface.
+    - This is a low-level warp interface kept for backwards compatibility.
     - Operates on arrays of any dtype.
 
     See Also
     --------
     _zero_array_kernel : Kernel that performs the zeroing
+    warp.array.zero_ : Recommended in-place replacement
     """
+    warnings.warn(
+        "nvalchemiops.neighbors.neighbor_utils.zero_array is deprecated; "
+        "use the Warp built-in `array.zero_()` instead "
+        "(e.g. `my_array.zero_()`).",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     n = array.shape[0]
 
     wp.launch(

--- a/test/neighbors/bindings/jax/test_cell_list.py
+++ b/test/neighbors/bindings/jax/test_cell_list.py
@@ -22,7 +22,12 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from nvalchemiops.jax.neighbors.cell_list import cell_list, estimate_cell_list_sizes
+from nvalchemiops.jax.neighbors.cell_list import (
+    build_cell_list,
+    cell_list,
+    estimate_cell_list_sizes,
+    query_cell_list,
+)
 
 from .conftest import requires_gpu, requires_vesin
 
@@ -589,3 +594,225 @@ class TestCellListSelectiveRebuildFlags:
         assert jnp.all(nn2 == nn_ref), (
             "num_neighbors should match full rebuild when flag=True"
         )
+
+
+def _assert_arrays_equal(lhs, rhs) -> None:
+    """Assert two tuples of JAX arrays are exactly equal."""
+    assert len(lhs) == len(rhs)
+    for left, right in zip(lhs, rhs, strict=True):
+        assert left.shape == right.shape
+        assert left.dtype == right.dtype
+        assert jnp.array_equal(left, right)
+
+
+def _make_cell_list_inputs(dtype):
+    """Create a small periodic system for cell-list graph-mode tests."""
+    positions = jnp.array(
+        [
+            [0.1, 0.0, 0.0],
+            [1.8, 0.0, 0.0],
+            [0.0, 1.7, 0.0],
+            [1.7, 1.7, 0.0],
+            [0.0, 0.0, 1.8],
+        ],
+        dtype=dtype,
+    )
+    cell = jnp.eye(3, dtype=dtype).reshape(1, 3, 3) * 4.0
+    pbc = jnp.array([[True, True, True]])
+    cutoff = 2.2
+    max_neighbors = 16
+    max_total_cells, _, neighbor_search_radius = estimate_cell_list_sizes(
+        positions,
+        cell,
+        cutoff,
+        pbc,
+    )
+    return (
+        positions,
+        cell,
+        pbc,
+        cutoff,
+        max_neighbors,
+        int(max_total_cells),
+        neighbor_search_radius,
+    )
+
+
+class TestCellListGraphMode:
+    """Graph-mode coverage for JAX cell-list bindings."""
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    def test_build_matches_default(self, dtype):
+        """Cell-list build graph mode should match the default path."""
+        (
+            positions,
+            cell,
+            pbc,
+            cutoff,
+            _max_neighbors,
+            max_total_cells,
+            neighbor_search_radius,
+        ) = _make_cell_list_inputs(dtype)
+
+        common = {
+            "cells_per_dimension": jnp.full((3,), -1, dtype=jnp.int32),
+            "neighbor_search_radius": neighbor_search_radius,
+            "atom_periodic_shifts": jnp.full(
+                (positions.shape[0], 3), -1, dtype=jnp.int32
+            ),
+            "atom_to_cell_mapping": jnp.full(
+                (positions.shape[0], 3), -1, dtype=jnp.int32
+            ),
+            "atoms_per_cell_count": jnp.full((max_total_cells,), 9, dtype=jnp.int32),
+            "cell_atom_start_indices": jnp.full(
+                (max_total_cells,), -1, dtype=jnp.int32
+            ),
+            "cell_atom_list": jnp.full((positions.shape[0],), -1, dtype=jnp.int32),
+            "max_total_cells": max_total_cells,
+        }
+
+        none_result = build_cell_list(
+            positions,
+            cutoff,
+            cell,
+            pbc,
+            graph_mode="none",
+            **common,
+        )
+        warp_result = build_cell_list(
+            positions,
+            cutoff,
+            cell,
+            pbc,
+            graph_mode="warp",
+            **common,
+        )
+
+        _assert_arrays_equal(none_result, warp_result)
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    @pytest.mark.parametrize("selective_flag", [None, False, True])
+    def test_query_matches_default(self, dtype, selective_flag):
+        """Cell-list query graph mode should match the default path."""
+        (
+            positions,
+            cell,
+            pbc,
+            cutoff,
+            max_neighbors,
+            max_total_cells,
+            neighbor_search_radius,
+        ) = _make_cell_list_inputs(dtype)
+
+        build_result = build_cell_list(
+            positions,
+            cutoff,
+            cell,
+            pbc,
+            max_total_cells=max_total_cells,
+            neighbor_search_radius=neighbor_search_radius,
+            graph_mode="none",
+        )
+        rebuild_flags = (
+            None
+            if selective_flag is None
+            else jnp.array([selective_flag], dtype=jnp.bool_)
+        )
+
+        common = {
+            "positions": positions,
+            "cutoff": cutoff,
+            "cell": cell,
+            "pbc": pbc,
+            "cells_per_dimension": build_result[0],
+            "atom_periodic_shifts": build_result[1],
+            "atom_to_cell_mapping": build_result[2],
+            "atoms_per_cell_count": build_result[3],
+            "cell_atom_start_indices": build_result[4],
+            "cell_atom_list": build_result[5],
+            "neighbor_search_radius": build_result[6],
+            "max_neighbors": max_neighbors,
+            "neighbor_matrix": jnp.full(
+                (positions.shape[0], max_neighbors),
+                42,
+                dtype=jnp.int32,
+            ),
+            "neighbor_matrix_shifts": jnp.full(
+                (positions.shape[0], max_neighbors, 3),
+                -4,
+                dtype=jnp.int32,
+            ),
+            "num_neighbors": jnp.full((positions.shape[0],), 42, dtype=jnp.int32),
+            "rebuild_flags": rebuild_flags,
+        }
+
+        none_result = query_cell_list(graph_mode="none", **common)
+        warp_result = query_cell_list(graph_mode="warp", **common)
+        _assert_arrays_equal(none_result, warp_result)
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    @pytest.mark.parametrize("return_neighbor_list", [False, True])
+    def test_top_level_matches_default(self, dtype, return_neighbor_list: bool):
+        """Top-level cell_list graph mode should match the default path."""
+        (
+            positions,
+            cell,
+            pbc,
+            cutoff,
+            max_neighbors,
+            max_total_cells,
+            neighbor_search_radius,
+        ) = _make_cell_list_inputs(dtype)
+
+        common = {
+            "positions": positions,
+            "cutoff": cutoff,
+            "cell": cell,
+            "pbc": pbc,
+            "max_neighbors": max_neighbors,
+            "max_total_cells": max_total_cells,
+            "return_neighbor_list": return_neighbor_list,
+            "cells_per_dimension": jnp.full((3,), -1, dtype=jnp.int32),
+            "neighbor_search_radius": neighbor_search_radius,
+            "atom_periodic_shifts": jnp.full(
+                (positions.shape[0], 3), -1, dtype=jnp.int32
+            ),
+            "atom_to_cell_mapping": jnp.full(
+                (positions.shape[0], 3), -1, dtype=jnp.int32
+            ),
+            "atoms_per_cell_count": jnp.full((max_total_cells,), 7, dtype=jnp.int32),
+            "cell_atom_start_indices": jnp.full(
+                (max_total_cells,), -1, dtype=jnp.int32
+            ),
+            "cell_atom_list": jnp.full((positions.shape[0],), -1, dtype=jnp.int32),
+            "neighbor_matrix": jnp.full(
+                (positions.shape[0], max_neighbors),
+                88,
+                dtype=jnp.int32,
+            ),
+            "neighbor_matrix_shifts": jnp.full(
+                (positions.shape[0], max_neighbors, 3),
+                -8,
+                dtype=jnp.int32,
+            ),
+            "num_neighbors": jnp.full((positions.shape[0],), 88, dtype=jnp.int32),
+        }
+
+        none_result = cell_list(graph_mode="none", **common)
+        warp_result = cell_list(graph_mode="warp", **common)
+        _assert_arrays_equal(none_result, warp_result)
+
+    def test_invalid_value(self):
+        """Invalid graph_mode values should raise for cell-list APIs."""
+        positions = jnp.zeros((2, 3), dtype=jnp.float32)
+        cell = jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3)
+        pbc = jnp.ones((1, 3), dtype=jnp.bool_)
+        with pytest.raises(ValueError, match="graph_mode"):
+            build_cell_list(
+                positions,
+                1.0,
+                cell,
+                pbc,
+                max_total_cells=8,
+                graph_mode="bad",
+            )

--- a/test/neighbors/bindings/jax/test_naive.py
+++ b/test/neighbors/bindings/jax/test_naive.py
@@ -17,11 +17,14 @@
 
 from __future__ import annotations
 
+import functools
+
 import jax
 import jax.numpy as jnp
 import pytest
 
 from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
+from nvalchemiops.jax.neighbors.neighbor_utils import compute_naive_num_shifts
 
 from .conftest import requires_gpu
 
@@ -466,3 +469,280 @@ class TestNaiveSelectiveRebuildFlags:
         assert jnp.all(nn2 == nn_ref), (
             "num_neighbors should match full rebuild when flag=True"
         )
+
+
+def _assert_arrays_equal(lhs, rhs) -> None:
+    """Assert two tuples of JAX arrays are exactly equal."""
+    assert len(lhs) == len(rhs)
+    for left, right in zip(lhs, rhs, strict=True):
+        assert left.shape == right.shape
+        assert left.dtype == right.dtype
+        assert jnp.array_equal(left, right)
+
+
+def _make_naive_inputs(dtype, *, pbc_enabled: bool, wrap_positions: bool):
+    """Create a small but nontrivial naive neighbor-list test system."""
+    if pbc_enabled and wrap_positions:
+        positions = jnp.array(
+            [
+                [0.1, 0.0, 0.0],
+                [9.8, 0.0, 0.0],
+                [10.4, 0.1, 0.0],
+                [-0.2, 0.2, 0.0],
+            ],
+            dtype=dtype,
+        )
+    else:
+        positions = jnp.array(
+            [
+                [0.1, 0.0, 0.0],
+                [0.8, 0.0, 0.0],
+                [0.1, 0.8, 0.0],
+                [0.8, 0.8, 0.0],
+            ],
+            dtype=dtype,
+        )
+
+    cutoff = 1.1
+    max_neighbors = 12
+    if pbc_enabled:
+        cell = jnp.eye(3, dtype=dtype).reshape(1, 3, 3) * 10.0
+        pbc = jnp.array([[True, True, True]])
+    else:
+        cell = None
+        pbc = None
+
+    return positions, cutoff, cell, pbc, max_neighbors
+
+
+def _make_naive_stale_inputs(
+    positions,
+    cutoff,
+    cell,
+    pbc,
+    max_neighbors,
+    *,
+    wrap_positions: bool,
+):
+    """Create stale outputs to verify graph-mode reset behavior.
+
+    For PBC + ``wrap_positions=True``, also seeds stale ``positions_wrapped`` and
+    ``per_atom_cell_offsets`` scratch buffers (the wrap kernel always overwrites
+    them, so any prior contents must be irrelevant to the final result on both
+    ``graph_mode`` paths).
+    """
+    base = naive_neighbor_list(
+        positions,
+        cutoff,
+        cell=cell,
+        pbc=pbc,
+        max_neighbors=max_neighbors,
+        wrap_positions=wrap_positions,
+        graph_mode="none",
+    )
+    stale_inputs = {
+        "neighbor_matrix": jnp.full_like(base[0], 77),
+        "num_neighbors": jnp.full_like(base[1], 33),
+    }
+    if pbc is not None:
+        stale_inputs["neighbor_matrix_shifts"] = jnp.full_like(base[2], -5)
+    if pbc is not None and wrap_positions:
+        stale_inputs["positions_wrapped"] = jnp.full_like(positions, 1234.5)
+        stale_inputs["per_atom_cell_offsets"] = jnp.full(
+            (positions.shape[0], 3), -7, dtype=jnp.int32
+        )
+    return stale_inputs
+
+
+class TestNaiveGraphMode:
+    """Graph-mode coverage for JAX naive neighbor lists."""
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    @pytest.mark.parametrize(
+        ("pbc_enabled", "wrap_positions"),
+        [
+            (False, True),
+            (True, True),
+            (True, False),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "selective",
+        [None, False, True],
+        ids=["norebuild", "rebuild_false", "rebuild_true"],
+    )
+    def test_matches_default(
+        self,
+        dtype,
+        pbc_enabled: bool,
+        wrap_positions: bool,
+        selective: bool | None,
+    ):
+        """`graph_mode="warp"` should match the default path for legal naive cases."""
+        positions, cutoff, cell, pbc, max_neighbors = _make_naive_inputs(
+            dtype,
+            pbc_enabled=pbc_enabled,
+            wrap_positions=wrap_positions,
+        )
+        rebuild_flags = (
+            None if selective is None else jnp.array([selective], dtype=jnp.bool_)
+        )
+        stale_inputs = _make_naive_stale_inputs(
+            positions,
+            cutoff,
+            cell,
+            pbc,
+            max_neighbors,
+            wrap_positions=wrap_positions,
+        )
+
+        none_result = naive_neighbor_list(
+            positions,
+            cutoff,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=max_neighbors,
+            wrap_positions=wrap_positions,
+            rebuild_flags=rebuild_flags,
+            graph_mode="none",
+            **stale_inputs,
+        )
+        warp_result = naive_neighbor_list(
+            positions,
+            cutoff,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=max_neighbors,
+            wrap_positions=wrap_positions,
+            rebuild_flags=rebuild_flags,
+            graph_mode="warp",
+            **stale_inputs,
+        )
+
+        _assert_arrays_equal(none_result, warp_result)
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    def test_return_neighbor_list(self, dtype):
+        """COO conversion should work around the Warp graph callback."""
+        positions, cutoff, cell, pbc, max_neighbors = _make_naive_inputs(
+            dtype,
+            pbc_enabled=True,
+            wrap_positions=True,
+        )
+        stale_neighbor_matrix = jnp.full(
+            (positions.shape[0], max_neighbors),
+            99,
+            dtype=jnp.int32,
+        )
+        stale_num_neighbors = jnp.full((positions.shape[0],), 99, dtype=jnp.int32)
+        stale_shifts = jnp.full(
+            (positions.shape[0], max_neighbors, 3),
+            -9,
+            dtype=jnp.int32,
+        )
+
+        none_result = naive_neighbor_list(
+            positions,
+            cutoff,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=max_neighbors,
+            wrap_positions=True,
+            return_neighbor_list=True,
+            neighbor_matrix=stale_neighbor_matrix,
+            num_neighbors=stale_num_neighbors,
+            neighbor_matrix_shifts=stale_shifts,
+            graph_mode="none",
+        )
+        warp_result = naive_neighbor_list(
+            positions,
+            cutoff,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=max_neighbors,
+            wrap_positions=True,
+            return_neighbor_list=True,
+            neighbor_matrix=stale_neighbor_matrix,
+            num_neighbors=stale_num_neighbors,
+            neighbor_matrix_shifts=stale_shifts,
+            graph_mode="warp",
+        )
+
+        _assert_arrays_equal(none_result, warp_result)
+
+    def test_invalid_value(self):
+        """Invalid graph_mode values should raise a ValueError."""
+        positions = jnp.zeros((2, 3), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="graph_mode"):
+            naive_neighbor_list(positions, 1.0, max_neighbors=4, graph_mode="bad")
+
+    def test_wrapped_warp_replay_stable_pointers(self):
+        """Donation contract from the docstring example should produce stable results.
+
+        Functional smoke test: jit-compile the wrapped warp step exactly like the
+        docstring example (donating the returned buffers, capturing ``inv_cell`` /
+        ``positions_wrapped`` / ``per_atom_cell_offsets`` in the closure so their
+        buffer pointers stay stable across calls), run it 5 times, and assert each
+        call's outputs match a fresh ``graph_mode="none"`` reference. This guards
+        the contract that lets Warp's graph cache hit on the wrapped path; we
+        deliberately avoid timing assertions because perf tests are flaky.
+        """
+        dtype = jnp.float32
+        positions, cutoff, cell, pbc, max_neighbors = _make_naive_inputs(
+            dtype,
+            pbc_enabled=True,
+            wrap_positions=True,
+        )
+        n_atoms = positions.shape[0]
+        fill_value = n_atoms
+        inv_cell = jnp.linalg.inv(cell)
+        positions_wrapped = jnp.zeros((n_atoms, 3), dtype=dtype)
+        per_atom_cell_offsets = jnp.zeros((n_atoms, 3), dtype=jnp.int32)
+        shift_range, num_shifts_per_system, max_shifts_per_system = (
+            compute_naive_num_shifts(cell, cutoff, pbc)
+        )
+
+        @functools.partial(jax.jit, donate_argnums=(1, 2, 3))
+        def md_step(pos, neighbor_matrix, num_neighbors, shifts):
+            return naive_neighbor_list(
+                pos,
+                cutoff,
+                cell=cell,
+                pbc=pbc,
+                neighbor_matrix=neighbor_matrix,
+                num_neighbors=num_neighbors,
+                neighbor_matrix_shifts=shifts,
+                inv_cell=inv_cell,
+                positions_wrapped=positions_wrapped,
+                per_atom_cell_offsets=per_atom_cell_offsets,
+                shift_range_per_dimension=shift_range,
+                num_shifts_per_system=num_shifts_per_system,
+                max_shifts_per_system=max_shifts_per_system,
+                graph_mode="warp",
+            )
+
+        reference = naive_neighbor_list(
+            positions,
+            cutoff,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=max_neighbors,
+            wrap_positions=True,
+            graph_mode="none",
+        )
+
+        neighbor_matrix = jnp.full(
+            (n_atoms, max_neighbors), fill_value, dtype=jnp.int32
+        )
+        num_neighbors = jnp.zeros((n_atoms,), dtype=jnp.int32)
+        shifts = jnp.zeros((n_atoms, max_neighbors, 3), dtype=jnp.int32)
+
+        for _ in range(5):
+            out_nm, out_nn, out_shifts = md_step(
+                positions,
+                neighbor_matrix,
+                num_neighbors,
+                shifts,
+            )
+            neighbor_matrix, num_neighbors, shifts = out_nm, out_nn, out_shifts
+            _assert_arrays_equal(reference, (out_nm, out_nn, out_shifts))

--- a/test/neighbors/test_neighbor_utils_kernels.py
+++ b/test/neighbors/test_neighbor_utils_kernels.py
@@ -22,7 +22,6 @@ import warp as wp
 
 from nvalchemiops.neighbors.neighbor_utils import (
     compute_naive_num_shifts,
-    zero_array,
 )
 from nvalchemiops.torch.types import get_wp_dtype, get_wp_mat_dtype
 
@@ -75,29 +74,3 @@ class TestNeighborUtilsWpLaunchers:
             "Shift ranges should be non-negative"
         )
         assert num_shifts.item() > 0, "Should have at least one shift"
-
-    def test_zero_array(self, device):
-        """Test zero_array launcher."""
-        # Test data with non-zero values
-        test_array = torch.full((100,), 42, dtype=torch.int32, device=device)
-
-        # Convert to warp array
-        wp_array = wp.from_torch(test_array, dtype=wp.int32)
-
-        # Call launcher
-        zero_array(wp_array, device)
-
-        # Should be all zeros
-        assert torch.all(test_array == 0), "Array should be zeroed"
-
-    def test_zero_array_empty(self, device):
-        """Test zero_array with empty array."""
-        test_array = torch.empty(0, dtype=torch.int32, device=device)
-
-        # Convert to warp array
-        wp_array = wp.from_torch(test_array, dtype=wp.int32)
-
-        # Call launcher - should handle gracefully
-        zero_array(wp_array, device)
-
-        assert test_array.shape == (0,)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Adds an opt-in `graph_mode={"none","warp"}` kwarg to the JAX naive and cell-list neighbor-list APIs so the underlying Warp kernels can be fused into a single CUDA-graph capture+replay via `jax_callable(..., graph_mode=GraphMode.WARP)` instead of N separate `jax_kernel` launches. To make the wrapped-PBC naive path graph-cacheable, `naive_neighbor_list` also accepts pre-allocated `inv_cell`, `positions_wrapped`, and `per_atom_cell_offsets` buffers (closure-captured by the caller so the buffer pointers stay stable across calls). Also deprecates the legacy `zero_array` helper in favor of Warp's built-in `wp.array.zero_()`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

- Added `graph_mode: Literal["none", "warp"] = "none"` to `naive_neighbor_list`, `build_cell_list`, `query_cell_list`, and `cell_list` in `nvalchemiops/jax/neighbors/{naive,cell_list}.py`. The `"warp"` path registers a fused `jax_callable(..., graph_mode=GraphMode.WARP)` per (dtype, selective-rebuild, return-mode) variant so steady-state calls become a CUDA-graph replay.
- Extended `naive_neighbor_list` with optional `inv_cell`, `positions_wrapped`, and `per_atom_cell_offsets` kwargs so callers can pre-allocate the wrap-kernel scratch buffers and keep their pointers stable across `graph_mode="warp"` replays. The new docstring example shows the closure-capture + `donate_argnums` pattern.
- Deprecated `nvalchemiops.neighbors.neighbor_utils.zero_array`: it now emits a `DeprecationWarning` pointing at `wp.array.zero_()`, and the symbol was dropped from the `nvalchemiops.neighbors.__init__` and `nvalchemiops.neighborlist.__init__` re-exports so new code is steered to the built-in. The function itself is still importable from `nvalchemiops.neighbors.neighbor_utils` for backwards compatibility. Internal call sites in `nvalchemiops/neighbors/{cell_list,batch_cell_list}.py` and `benchmarks/dynamics/shared_utils.py` switched to `array.zero_()`.
- Added `TestNaiveGraphMode` (22 parameterized cases incl. parity with the default path, `return_neighbor_list=True`, the donation/closure contract via `test_wrapped_warp_replay_stable_pointers`, and `ValueError` on invalid values) to `test/neighbors/bindings/jax/test_naive.py`.
- Added `TestCellListGraphMode` (13 cases across `build_cell_list` / `query_cell_list` / `cell_list` parity and invalid-value handling) to `test/neighbors/bindings/jax/test_cell_list.py`.
- Removed the no-longer-needed `test_zero_array` / `test_zero_array_empty` cases from `test/neighbors/test_neighbor_utils_kernels.py`.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?


Latency benchmark on a single GPU with 200 atoms (median single-call wall-clock, ms; lower is better; JAX 0.9.0.1, Warp 1.11.0, RTX A6000 Ada). The "Warp-kernel share" column is the pure CUDA-kernel time (CUDA-event floor) divided by the measured wall, i.e. the fraction of each call that is actually GPU work; the remainder is host-side dispatch overhead.

| Public API path                     | `graph_mode="none"` | `graph_mode="warp"` (replay) | Speedup | Warp-kernel share (none → warp) |
| ----------------------------------- | ------------------: | ---------------------------: | ------: | ------------------------------: |
| `naive_neighbor_list` (no PBC wrap) | 0.160 ms            | 0.139 ms                     | 1.15x   | 59% → 80%                       |
| `naive_neighbor_list` (PBC wrap)    | 0.234 ms            | 0.143 ms                     | 1.64x   | 47% → 84%                       |
| `build_cell_list`                   | 0.158 ms            | 0.063 ms                     | 2.52x   | 34% → 87%                       |
| `query_cell_list`                   | 0.213 ms            | 0.192 ms                     | 1.11x   | 64% → 71%                       |

Reference (lower bound): the hand-fused prototype `jax_callable_wrap_and_fill_graphwarp_replay` reaches 0.131 ms on the wrapped-naive path; the public `naive_neighbor_list(..., graph_mode="warp", wrap_positions=True)` lands at 0.143 ms (~9% off the prototype). The rising Warp-kernel share confirms the host-dispatch overhead is what's being eliminated rather than any GPU-side speedup. The wrapped-PBC replay required closure-capturing the `inv_cell` / `positions_wrapped` / `per_atom_cell_offsets` scratch buffers so their pointers stay stable across calls; without that fix, the Warp graph cache misses every step and replay regresses to ~0.185 ms.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

`graph_mode` defaults to `"none"`, so this is a purely opt-in addition with no behavior change for existing callers. `zero_array` is still importable from `nvalchemiops.neighbors.neighbor_utils` (now emits a `DeprecationWarning`) so existing user code keeps working; downstream callers should migrate to the Warp built-in `wp.array.zero_()` (one-liner: `my_array.zero_()`, no `device` arg needed since the array already knows its device, and faster because there's no Python-side kernel dispatch). The closure-capture requirement for `inv_cell` / `positions_wrapped` / `per_atom_cell_offsets` is explicitly documented in `naive_neighbor_list`'s docstring under "Notes" and demonstrated in the docstring example, mirroring the `_make_public_naive_stateful` helper in the new latency benchmark.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
