### PR TITLE
Draft: optimized DFTD3 kernels  — one thread block per atom with tile API for reduction

### DIFF
--- a/benchmarks/interactions/dispersion/benchmark_dftd3.py
+++ b/benchmarks/interactions/dispersion/benchmark_dftd3.py
@@ -672,7 +672,7 @@ def run_dftd3_nvalchemiops_benchmark(
         if return_neighbor_list:
             neighbor_list_data = system_data["neighbor_data"]  # (2, num_pairs)
             neighbor_ptr = system_data["num_neighbor_data"]  # (N+1,)
-            unit_shifts = system_data["unit_shifts"]
+            unit_shifts = system_data["unit_shifts"] if compute_virial else None
 
             def dftd3_call():
                 return torch_dftd3(
@@ -682,7 +682,7 @@ def run_dftd3_nvalchemiops_benchmark(
                     neighbor_list=neighbor_list_data,
                     neighbor_ptr=neighbor_ptr,
                     unit_shifts=unit_shifts,
-                    cell=cell,
+                    cell=cell if compute_virial else None,
                     a1=dftd3_config["a1"],
                     a2=dftd3_config["a2"],
                     s6=dftd3_config["s6"],
@@ -697,7 +697,7 @@ def run_dftd3_nvalchemiops_benchmark(
                 )
         else:
             neighbor_matrix = system_data["neighbor_data"]
-            neighbor_matrix_shifts = system_data["unit_shifts"]
+            neighbor_matrix_shifts = system_data["unit_shifts"] if compute_virial else None
 
             def dftd3_call():
                 return torch_dftd3(
@@ -707,7 +707,7 @@ def run_dftd3_nvalchemiops_benchmark(
                     neighbor_matrix=neighbor_matrix,
                     neighbor_matrix_shifts=neighbor_matrix_shifts,
                     fill_value=total_atoms,
-                    cell=cell,
+                    cell=cell if compute_virial else None,
                     a1=dftd3_config["a1"],
                     a2=dftd3_config["a2"],
                     s6=dftd3_config["s6"],

--- a/benchmarks/interactions/dispersion/benchmark_dftd3.py
+++ b/benchmarks/interactions/dispersion/benchmark_dftd3.py
@@ -697,7 +697,9 @@ def run_dftd3_nvalchemiops_benchmark(
                 )
         else:
             neighbor_matrix = system_data["neighbor_data"]
-            neighbor_matrix_shifts = system_data["unit_shifts"] if compute_virial else None
+            neighbor_matrix_shifts = (
+                system_data["unit_shifts"] if compute_virial else None
+            )
 
             def dftd3_call():
                 return torch_dftd3(

--- a/benchmarks/interactions/dispersion/benchmark_dftd3.py
+++ b/benchmarks/interactions/dispersion/benchmark_dftd3.py
@@ -673,6 +673,11 @@ def run_dftd3_nvalchemiops_benchmark(
             neighbor_list_data = system_data["neighbor_data"]  # (2, num_pairs)
             neighbor_ptr = system_data["num_neighbor_data"]  # (N+1,)
             unit_shifts = system_data["unit_shifts"] if compute_virial else None
+            if unit_shifts is not None and unit_shifts.ndim != 2:
+                raise ValueError(
+                    "unit_shifts must be [num_pairs, 3] for the neighbor list path; "
+                    "got a 3-D tensor, which indicates return_neighbor_list=False data was used here"
+                )
 
             def dftd3_call():
                 return torch_dftd3(
@@ -700,6 +705,11 @@ def run_dftd3_nvalchemiops_benchmark(
             neighbor_matrix_shifts = (
                 system_data["unit_shifts"] if compute_virial else None
             )
+            if neighbor_matrix_shifts is not None and neighbor_matrix_shifts.ndim != 3:
+                raise ValueError(
+                    "unit_shifts must be [num_atoms, max_neighbors, 3] for the matrix path; "
+                    "got a 2-D tensor, which indicates return_neighbor_list=True data was used here"
+                )
 
             def dftd3_call():
                 return torch_dftd3(

--- a/benchmarks/interactions/dispersion/benchmark_dftd3.py
+++ b/benchmarks/interactions/dispersion/benchmark_dftd3.py
@@ -670,8 +670,8 @@ def run_dftd3_nvalchemiops_benchmark(
 
         # Define the function to benchmark
         if return_neighbor_list:
-            neighbor_list_data = system_data["neighbor_data"]   # (2, num_pairs)
-            neighbor_ptr = system_data["num_neighbor_data"]     # (N+1,)
+            neighbor_list_data = system_data["neighbor_data"]  # (2, num_pairs)
+            neighbor_ptr = system_data["num_neighbor_data"]  # (N+1,)
             unit_shifts = system_data["unit_shifts"]
 
             def dftd3_call():

--- a/benchmarks/interactions/dispersion/benchmark_dftd3.py
+++ b/benchmarks/interactions/dispersion/benchmark_dftd3.py
@@ -568,7 +568,7 @@ def prepare_system_and_neighborlist(
     backend_data = convert_to_backend(np_data, "torch", device, dtype_str)
 
     # Step 3: Compute neighbor list
-    neighbor_data, num_neighbor_data, _ = compute_neighbor_list(
+    neighbor_data, num_neighbor_data, unit_shifts = compute_neighbor_list(
         backend_data, "torch", cutoff, max_neighbors, return_neighbor_list
     )
 
@@ -588,6 +588,7 @@ def prepare_system_and_neighborlist(
         "pbc": backend_data["pbc"],
         "neighbor_data": neighbor_data,
         "num_neighbor_data": num_neighbor_data,
+        "unit_shifts": unit_shifts,
         "batch_idx": backend_data["batch_idx"],
         "batch_ptr": backend_data["batch_ptr"],
         "total_atoms": backend_data["total_atoms"],
@@ -645,10 +646,11 @@ def run_dftd3_nvalchemiops_benchmark(
     device: str,
     dtype: "torch.dtype",
     batch_size: int = 1,
+    return_neighbor_list: bool = False,
+    compute_virial: bool = False,
 ) -> dict:
     """Run DFT-D3 benchmark using nvalchemiops backend (single or batched)."""
     try:
-        # Prepare system and neighbor list (matrix format for nvalchemiops)
         system_data = prepare_system_and_neighborlist(
             supercell_size,
             cutoff,
@@ -656,35 +658,68 @@ def run_dftd3_nvalchemiops_benchmark(
             device,
             dtype,
             batch_size,
-            return_neighbor_list=False,
+            return_neighbor_list=return_neighbor_list,
         )
 
         positions = system_data["positions"]
         numbers = system_data["numbers"]
-        neighbor_matrix = system_data["neighbor_data"]
         total_atoms = system_data["total_atoms"]
         total_neighbors = system_data["total_neighbors"]
         batch_idx = system_data["batch_idx"]
+        cell = system_data["cell"]
 
         # Define the function to benchmark
-        def dftd3_call():
-            return torch_dftd3(
-                positions=positions,
-                numbers=numbers,
-                d3_params=d3_params,
-                neighbor_matrix=neighbor_matrix,
-                fill_value=total_atoms,
-                a1=dftd3_config["a1"],
-                a2=dftd3_config["a2"],
-                s6=dftd3_config["s6"],
-                s8=dftd3_config["s8"],
-                k1=dftd3_config["k1"],
-                k3=dftd3_config["k3"],
-                batch_idx=batch_idx,
-                s5_smoothing_on=dftd3_config["s5_smoothing_on"],
-                s5_smoothing_off=dftd3_config["s5_smoothing_off"],
-                device=device,
-            )
+        if return_neighbor_list:
+            neighbor_list_data = system_data["neighbor_data"]   # (2, num_pairs)
+            neighbor_ptr = system_data["num_neighbor_data"]     # (N+1,)
+            unit_shifts = system_data["unit_shifts"]
+
+            def dftd3_call():
+                return torch_dftd3(
+                    positions=positions,
+                    numbers=numbers,
+                    d3_params=d3_params,
+                    neighbor_list=neighbor_list_data,
+                    neighbor_ptr=neighbor_ptr,
+                    unit_shifts=unit_shifts,
+                    cell=cell,
+                    a1=dftd3_config["a1"],
+                    a2=dftd3_config["a2"],
+                    s6=dftd3_config["s6"],
+                    s8=dftd3_config["s8"],
+                    k1=dftd3_config["k1"],
+                    k3=dftd3_config["k3"],
+                    batch_idx=batch_idx,
+                    s5_smoothing_on=dftd3_config["s5_smoothing_on"],
+                    s5_smoothing_off=dftd3_config["s5_smoothing_off"],
+                    compute_virial=compute_virial,
+                    device=device,
+                )
+        else:
+            neighbor_matrix = system_data["neighbor_data"]
+            neighbor_matrix_shifts = system_data["unit_shifts"]
+
+            def dftd3_call():
+                return torch_dftd3(
+                    positions=positions,
+                    numbers=numbers,
+                    d3_params=d3_params,
+                    neighbor_matrix=neighbor_matrix,
+                    neighbor_matrix_shifts=neighbor_matrix_shifts,
+                    fill_value=total_atoms,
+                    cell=cell,
+                    a1=dftd3_config["a1"],
+                    a2=dftd3_config["a2"],
+                    s6=dftd3_config["s6"],
+                    s8=dftd3_config["s8"],
+                    k1=dftd3_config["k1"],
+                    k3=dftd3_config["k3"],
+                    batch_idx=batch_idx,
+                    s5_smoothing_on=dftd3_config["s5_smoothing_on"],
+                    s5_smoothing_off=dftd3_config["s5_smoothing_off"],
+                    compute_virial=compute_virial,
+                    device=device,
+                )
 
         # Time the function
         timing_results = timer.time_function(dftd3_call)
@@ -1104,6 +1139,18 @@ def main():
         help="Override GPU SKU name for output files (default: auto-detect)",
     )
     parser.add_argument(
+        "--neighbor-format",
+        type=str,
+        choices=["matrix", "list"],
+        default="matrix",
+        help="Neighbor representation format for dftd3 kernel (default: matrix)",
+    )
+    parser.add_argument(
+        "--virial",
+        action="store_true",
+        help="Enable virial computation (requires PBC; passes cell and shifts to dftd3)",
+    )
+    parser.add_argument(
         "--jax-allocator",
         type=str,
         choices=["throughput", "memory"],
@@ -1250,6 +1297,8 @@ def main():
                             device,
                             dtype,
                             batch_size,
+                            return_neighbor_list=(args.neighbor_format == "list"),
+                            compute_virial=args.virial,
                         )
                     case "jax":
                         result = run_dftd3_nvalchemiops_jax_benchmark(

--- a/nvalchemiops/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/interactions/dispersion/_dftd3.py
@@ -247,6 +247,10 @@ __all__ = [
     "_cn_forces_contrib_kernel_overload",
 ]
 
+# Threads per atom (CUDA block size) for tile-based _direct_forces_and_dE_dCN_kernel_matrix.
+# One warp per atom: all reductions use warp shuffles with no shared memory.
+DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE = 32
+
 # ==============================================================================
 # Helper Functions
 # ==============================================================================
@@ -744,6 +748,7 @@ def _compute_cartesian_shifts_matrix(
     )
 
 
+
 @wp.kernel(enable_backward=False)
 def _cn_kernel_matrix(
     positions: wp.array(dtype=Any),
@@ -855,7 +860,7 @@ def _cn_kernel_matrix(
     coord_num[atom_i] = cn_acc
 
 
-@wp.kernel(enable_backward=False)
+@wp.kernel(enable_backward=False, launch_bounds=(32, 24))
 def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
     positions: wp.array(dtype=Any),
     numbers: wp.array(dtype=wp.int32),
@@ -874,6 +879,7 @@ def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
     s5_smoothing_off: wp.float32,
     inv_w: wp.float32,
     fill_value: wp.int32,
+    block_stride: wp.int32,
     periodic: bool,
     batch_idx: wp.array(dtype=wp.int32),
     compute_virial: bool,
@@ -932,8 +938,9 @@ def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
 
     Notes
     -----
-    - Launch with dim=num_atoms (one thread per atom)
-    - Each thread iterates over all neighbors and accumulates results in local registers
+    - Launch with dim=(num_atoms, DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE), block_dim=DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE
+    - One warp per atom; threads stride over the neighbor list BLOCK_SIZE apart
+    - Tile reduction (warp shuffles) eliminates atomics for forces and dE/dCN
     - Direct forces are F = :math:`-(\\partial E/\\partial r)|_\text{CN}`, without chain rule term
     - dE_dCN[i] = :math:`\\sum_j \\partial E_{ij}/\\partial \text{CN}_i` accumulated over all pairs containing atom i
     - Neighbor entries with j >= fill_value are padding and are skipped
@@ -947,10 +954,11 @@ def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
     :func:`_s5_switch` : Called for cutoff smoothing
     :func:`dftd3` : High-level wrapper that orchestrates all passes
     """
-    atom_i = wp.tid()
+    # One warp per atom: atom_i owns the block, thread_in_block indexes within the warp
+    atom_i, thread_in_block = wp.tid()
     if atom_i >= numbers.shape[0]:
         return
-    # skip padding atoms
+    # skip padding atoms (uniform across block — all threads share atom_i)
     if numbers[atom_i] == 0:
         return
 
@@ -960,89 +968,107 @@ def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
     z_i = numbers[atom_i]
     r4r2_i = r4r2[z_i]
 
-    # Accumulate in local registers (using float64 for better precision)
-    F_acc = wp.vec3d()  # NOSONAR (S117) "math formula"
+    # Thread-local partial accumulators (float64 for precision)
+    F_acc_x = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_acc_y = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_acc_z = wp.float64(0.0)  # NOSONAR (S117) "math formula"
     dE_dCN_acc = wp.float32(0.0)  # NOSONAR (S117) "math formula"
     energy_acc = wp.float64(0.0)
 
-    # Initialize virial accumulator
     if compute_virial:
         virial_acc = wp.mat33d()
 
-    for neighbor_idx in range(max_neighbors):
+    # Stride loop: each thread covers neighbors at thread_in_block, +BLOCK_SIZE, +2*BLOCK_SIZE, ...
+    neighbor_idx = thread_in_block
+    while neighbor_idx < max_neighbors:
         atom_j = neighbor_matrix[atom_i, neighbor_idx]
-        if atom_j >= fill_value:
-            continue
-        # skip padding atoms
-        if numbers[atom_j] == 0:
-            continue
+        if atom_j < fill_value and numbers[atom_j] != 0:
+            # Geometry
+            r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
+                pos_i,
+                positions[atom_j],
+                cartesian_shifts[atom_i, neighbor_idx],
+                periodic,
+                True,
+            )
+            if r >= wp.float32(1e-12):
+                cn_j = coord_num[atom_j]
+                z_j = numbers[atom_j]
 
-        # Geometry
-        r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
-            pos_i,
-            positions[atom_j],
-            cartesian_shifts[atom_i, neighbor_idx],
-            periodic,
-            True,
-        )
-        if r < 1e-12:
-            continue
+                # C6 interpolation
+                c6ab_mat = c6_reference[z_i, z_j]
+                cnref_i_mat = coord_num_ref[z_i, z_j]
+                cnref_j_mat = coord_num_ref[z_j, z_i]
 
-        cn_j = coord_num[atom_j]
-        z_j = numbers[atom_j]
+                c6_ij, dC6_dCNi, dC6_dCNj = _c6ab_interpolate(  # NOSONAR (S125) "math formula"
+                    cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
+                )
+                if c6_ij >= wp.float32(1e-12):
+                    # BJ damping
+                    damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv = _bj_damping(
+                        r, r4r2_i, r4r2[z_j], a1, a2, s6, s8
+                    )
 
-        # C6 interpolation
-        c6ab_mat = c6_reference[z_i, z_j]
-        cnref_i_mat = coord_num_ref[z_i, z_j]
-        cnref_j_mat = coord_num_ref[z_j, z_i]
+                    # Energy and direct force
+                    e_ij_sw, F_direct = _dispersion_energy_force(
+                        c6_ij,
+                        r,
+                        r_hat,
+                        damp_sum,
+                        r4r2_ij,
+                        r6,
+                        r4,
+                        den6_inv,
+                        den8_inv,
+                        s6,
+                        s8,
+                        s5_smoothing_on,
+                        s5_smoothing_off,
+                        inv_w,
+                    )
 
-        c6_ij, dC6_dCNi, dC6_dCNj = _c6ab_interpolate(  # NOSONAR (S125) "math formula"
-            cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
-        )
-        if c6_ij < 1e-12:
-            continue
+                    # Accumulate in thread-local registers
+                    F_direct_d = wp.vec3d(F_direct)
+                    F_acc_x += F_direct_d[0]  # NOSONAR (S117) "math formula"
+                    F_acc_y += F_direct_d[1]  # NOSONAR (S117) "math formula"
+                    F_acc_z += F_direct_d[2]  # NOSONAR (S117) "math formula"
+                    energy_acc += wp.float64(e_ij_sw)
+                    dE_dCN_acc += -damp_sum * dC6_dCNi  # NOSONAR (S117) "math formula"
 
-        # BJ damping
-        damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv = _bj_damping(
-            r, r4r2_i, r4r2[z_j], a1, a2, s6, s8
-        )
+                    if compute_virial:
+                        virial_acc += wp.mat33d(wp.outer(F_direct, r_ij))
 
-        # Energy and direct force
-        e_ij_sw, F_direct = _dispersion_energy_force(
-            c6_ij,
-            r,
-            r_hat,
-            damp_sum,
-            r4r2_ij,
-            r6,
-            r4,
-            den6_inv,
-            den8_inv,
-            s6,
-            s8,
-            s5_smoothing_on,
-            s5_smoothing_off,
-            inv_w,
-        )
+        neighbor_idx += block_stride
 
-        # Accumulate in registers
-        F_acc += wp.vec3d(F_direct)  # NOSONAR (S117) "math formula"
-        energy_acc += wp.float64(e_ij_sw)
-        dE_dCN_acc += -damp_sum * dC6_dCNi  # NOSONAR (S117) "math formula"
+    # Block-level tile reductions via warp shuffles (BLOCK_SIZE=32 → no shared memory)
+    sum_fx     = wp.tile_sum(wp.tile(F_acc_x))[0]
+    sum_fy     = wp.tile_sum(wp.tile(F_acc_y))[0]
+    sum_fz     = wp.tile_sum(wp.tile(F_acc_z))[0]
+    sum_dEdCN  = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
+    sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
 
-        # Accumulate virial if requested
-        if compute_virial:
-            virial_acc += wp.mat33d(wp.outer(F_direct, r_ij))
+    # Thread 0 writes atom-level results without atomics
+    if thread_in_block == 0:
+        forces[atom_i] = wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+        dE_dCN[atom_i] = sum_dEdCN
+        wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
 
-    # Write final results once (atomic only for shared batch array)
-    # Convert from float64 accumulation to float32 output
-    forces[atom_i] = wp.vec3f(F_acc)
-    dE_dCN[atom_i] = dE_dCN_acc
-    wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(energy_acc))
-
-    # Add virial contribution with -0.5 scaling for correct sign and double counting
     if compute_virial:
-        wp.atomic_add(virial, batch_idx[atom_i], -0.5 * wp.mat33f(virial_acc))
+        sum_v00 = wp.tile_sum(wp.tile(virial_acc[0, 0]))[0]  # NOSONAR (S117)
+        sum_v01 = wp.tile_sum(wp.tile(virial_acc[0, 1]))[0]
+        sum_v02 = wp.tile_sum(wp.tile(virial_acc[0, 2]))[0]
+        sum_v10 = wp.tile_sum(wp.tile(virial_acc[1, 0]))[0]
+        sum_v11 = wp.tile_sum(wp.tile(virial_acc[1, 1]))[0]
+        sum_v12 = wp.tile_sum(wp.tile(virial_acc[1, 2]))[0]
+        sum_v20 = wp.tile_sum(wp.tile(virial_acc[2, 0]))[0]
+        sum_v21 = wp.tile_sum(wp.tile(virial_acc[2, 1]))[0]
+        sum_v22 = wp.tile_sum(wp.tile(virial_acc[2, 2]))[0]
+        if thread_in_block == 0:
+            wp.atomic_add(virial, batch_idx[atom_i], wp.float32(-0.5) * wp.mat33f(wp.matrix_from_rows(
+                wp.vec3d(sum_v00, sum_v01, sum_v02),
+                wp.vec3d(sum_v10, sum_v11, sum_v12),
+                wp.vec3d(sum_v20, sum_v21, sum_v22),
+            )))
 
 
 @wp.kernel(enable_backward=False)
@@ -1600,6 +1626,7 @@ for t, v, m in zip(T, V, M):
             wp.float32,
             wp.float32,
             wp.int32,
+            wp.int32,    # block_stride
             wp.bool,
             wp.array(dtype=wp.int32),
             wp.bool,
@@ -1871,9 +1898,11 @@ def dftd3_matrix(
 
     # Pass 2: Compute direct forces, energy, and accumulate dE/dCN
     # compute_virial=False for non-periodic systems
+    _block_size = DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE if "cuda" in device else 1
     wp.launch(
         kernel=_direct_forces_and_dE_dCN_kernel_matrix_overload[wp_dtype],
-        dim=num_atoms,
+        dim=(num_atoms, _block_size),
+        block_dim=_block_size,
         inputs=[
             positions,
             numbers,
@@ -1892,6 +1921,7 @@ def dftd3_matrix(
             wp.float32(s5_smoothing_off),
             wp.float32(inv_w),
             wp.int32(fill_value),
+            wp.int32(_block_size),
             periodic,
             batch_idx,
             False,  # compute_virial=False for non-periodic
@@ -2113,9 +2143,11 @@ def dftd3_matrix_pbc(
     )
 
     # Pass 2: Compute direct forces, energy, and accumulate dE/dCN
+    _block_size = DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE if "cuda" in device else 1
     wp.launch(
         kernel=_direct_forces_and_dE_dCN_kernel_matrix_overload[wp_dtype],
-        dim=num_atoms,
+        dim=(num_atoms, _block_size),
+        block_dim=_block_size,
         inputs=[
             positions,
             numbers,
@@ -2134,6 +2166,7 @@ def dftd3_matrix_pbc(
             wp.float32(s5_smoothing_off),
             wp.float32(inv_w),
             wp.int32(fill_value),
+            wp.int32(_block_size),
             periodic,
             batch_idx,
             compute_virial,

--- a/nvalchemiops/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/interactions/dispersion/_dftd3.py
@@ -1467,7 +1467,9 @@ def _compute_cartesian_shifts(
 
     edge_idx = j_range_start + thread_in_block
     while edge_idx < j_range_end:
-        cartesian_shifts[edge_idx] = _unit_shift_to_cartesian(unit_shifts[edge_idx], cell_mat)
+        cartesian_shifts[edge_idx] = _unit_shift_to_cartesian(
+            unit_shifts[edge_idx], cell_mat
+        )
         edge_idx += block_stride
 
 
@@ -2614,8 +2616,6 @@ def dftd3_matrix_pbc(
     """
     # Get number of atoms from positions array
     num_atoms = positions.shape[0]
-    max_neighbors = neighbor_matrix.shape[1] if num_atoms > 0 else 0
-
     # Set fill_value if not provided
     if fill_value is None:
         fill_value = num_atoms

--- a/nvalchemiops/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/interactions/dispersion/_dftd3.py
@@ -240,7 +240,9 @@ __all__ = [
     "_compute_cartesian_shifts_matrix_overload",
     "_cn_kernel_matrix_overload",
     "_direct_forces_and_dE_dCN_kernel_matrix_overload",
+    "_direct_forces_and_dE_dCN_kernel_matrix_virial_overload",
     "_cn_forces_contrib_kernel_matrix_overload",
+    "_cn_forces_contrib_kernel_matrix_virial_overload",
     "_compute_cartesian_shifts_overload",
     "_cn_kernel_overload",
     "_direct_forces_and_dE_dCN_kernel_overload",
@@ -881,11 +883,9 @@ def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
     block_stride: wp.int32,
     periodic: bool,
     batch_idx: wp.array(dtype=wp.int32),
-    compute_virial: bool,
     dE_dCN: wp.array(dtype=wp.float32),  # NOSONAR (S125) "math formula"
     forces: wp.array(dtype=wp.vec3f),
     energy: wp.array(dtype=wp.float32),
-    virial: wp.array(dtype=Any),
 ):
     """
     Pass 2: Compute direct forces, energy, and accumulate dE/dCN per atom.
@@ -974,9 +974,6 @@ def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
     dE_dCN_acc = wp.float32(0.0)  # NOSONAR (S117) "math formula"
     energy_acc = wp.float64(0.0)
 
-    if compute_virial:
-        virial_acc = wp.mat33d()
-
     # Stride loop: each thread covers neighbors at thread_in_block, +BLOCK_SIZE, +2*BLOCK_SIZE, ...
     neighbor_idx = thread_in_block
     while neighbor_idx < max_neighbors:
@@ -1034,9 +1031,6 @@ def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
                     energy_acc += wp.float64(e_ij_sw)
                     dE_dCN_acc += -damp_sum * dC6_dCNi  # NOSONAR (S117) "math formula"
 
-                    if compute_virial:
-                        virial_acc += wp.mat33d(wp.outer(F_direct, r_ij))
-
         neighbor_idx += block_stride
 
     # Block-level tile reductions via warp shuffles (BLOCK_SIZE=32 → no shared memory)
@@ -1052,22 +1046,129 @@ def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
         dE_dCN[atom_i] = sum_dEdCN
         wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
 
-    if compute_virial:
-        sum_v00 = wp.tile_sum(wp.tile(virial_acc[0, 0]))[0]  # NOSONAR (S117)
-        sum_v01 = wp.tile_sum(wp.tile(virial_acc[0, 1]))[0]
-        sum_v02 = wp.tile_sum(wp.tile(virial_acc[0, 2]))[0]
-        sum_v10 = wp.tile_sum(wp.tile(virial_acc[1, 0]))[0]
-        sum_v11 = wp.tile_sum(wp.tile(virial_acc[1, 1]))[0]
-        sum_v12 = wp.tile_sum(wp.tile(virial_acc[1, 2]))[0]
-        sum_v20 = wp.tile_sum(wp.tile(virial_acc[2, 0]))[0]
-        sum_v21 = wp.tile_sum(wp.tile(virial_acc[2, 1]))[0]
-        sum_v22 = wp.tile_sum(wp.tile(virial_acc[2, 2]))[0]
-        if thread_in_block == 0:
-            wp.atomic_add(virial, batch_idx[atom_i], wp.float32(-0.5) * wp.mat33f(wp.matrix_from_rows(
-                wp.vec3d(sum_v00, sum_v01, sum_v02),
-                wp.vec3d(sum_v10, sum_v11, sum_v12),
-                wp.vec3d(sum_v20, sum_v21, sum_v22),
-            )))
+
+@wp.kernel(enable_backward=False, launch_bounds=(32, 24))
+def _direct_forces_and_dE_dCN_kernel_matrix_virial(  # NOSONAR (S1542) "math formula"
+    positions: wp.array(dtype=Any),
+    numbers: wp.array(dtype=wp.int32),
+    neighbor_matrix: wp.array2d(dtype=wp.int32),
+    cartesian_shifts: wp.array2d(dtype=Any),
+    coord_num: wp.array(dtype=wp.float32),
+    r4r2: wp.array(dtype=wp.float32),
+    c6_reference: wp.array4d(dtype=wp.float32),
+    coord_num_ref: wp.array4d(dtype=wp.float32),
+    k3: wp.float32,
+    a1: wp.float32,
+    a2: wp.float32,
+    s6: wp.float32,
+    s8: wp.float32,
+    s5_smoothing_on: wp.float32,
+    s5_smoothing_off: wp.float32,
+    inv_w: wp.float32,
+    fill_value: wp.int32,
+    block_stride: wp.int32,
+    periodic: bool,
+    batch_idx: wp.array(dtype=wp.int32),
+    dE_dCN: wp.array(dtype=wp.float32),  # NOSONAR (S125) "math formula"
+    forces: wp.array(dtype=wp.vec3f),
+    energy: wp.array(dtype=wp.float32),
+    virial: wp.array(dtype=Any),
+):
+    """Pass 2 with virial. See _direct_forces_and_dE_dCN_kernel_matrix for full docs."""
+    atom_i, thread_in_block = wp.tid()
+    if atom_i >= numbers.shape[0]:
+        return
+    if numbers[atom_i] == 0:
+        return
+
+    max_neighbors = neighbor_matrix.shape[1]
+    pos_i = positions[atom_i]
+    cn_i = coord_num[atom_i]
+    z_i = numbers[atom_i]
+    r4r2_i = r4r2[z_i]
+
+    F_acc_x = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_acc_y = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_acc_z = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    dE_dCN_acc = wp.float32(0.0)  # NOSONAR (S117) "math formula"
+    energy_acc = wp.float64(0.0)
+    virial_acc = wp.mat33d()
+
+    neighbor_idx = thread_in_block
+    while neighbor_idx < max_neighbors:
+        atom_j = neighbor_matrix[atom_i, neighbor_idx]
+        if atom_j < fill_value and numbers[atom_j] != 0:
+            r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
+                pos_i,
+                positions[atom_j],
+                cartesian_shifts[atom_i, neighbor_idx],
+                periodic,
+                True,
+            )
+            if r >= wp.float32(1e-12):
+                cn_j = coord_num[atom_j]
+                z_j = numbers[atom_j]
+                c6ab_mat = c6_reference[z_i, z_j]
+                cnref_i_mat = coord_num_ref[z_i, z_j]
+                cnref_j_mat = coord_num_ref[z_j, z_i]
+                c6_ij, dC6_dCNi, dC6_dCNj = _c6ab_interpolate(  # NOSONAR (S125) "math formula"
+                    cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
+                )
+                if c6_ij >= wp.float32(1e-12):
+                    damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv = _bj_damping(
+                        r, r4r2_i, r4r2[z_j], a1, a2, s6, s8
+                    )
+                    e_ij_sw, F_direct = _dispersion_energy_force(
+                        c6_ij,
+                        r,
+                        r_hat,
+                        damp_sum,
+                        r4r2_ij,
+                        r6,
+                        r4,
+                        den6_inv,
+                        den8_inv,
+                        s6,
+                        s8,
+                        s5_smoothing_on,
+                        s5_smoothing_off,
+                        inv_w,
+                    )
+                    F_direct_d = wp.vec3d(F_direct)
+                    F_acc_x += F_direct_d[0]  # NOSONAR (S117) "math formula"
+                    F_acc_y += F_direct_d[1]  # NOSONAR (S117) "math formula"
+                    F_acc_z += F_direct_d[2]  # NOSONAR (S117) "math formula"
+                    energy_acc += wp.float64(e_ij_sw)
+                    dE_dCN_acc += -damp_sum * dC6_dCNi  # NOSONAR (S117) "math formula"
+                    virial_acc += wp.mat33d(wp.outer(F_direct, r_ij))
+        neighbor_idx += block_stride
+
+    sum_fx     = wp.tile_sum(wp.tile(F_acc_x))[0]
+    sum_fy     = wp.tile_sum(wp.tile(F_acc_y))[0]
+    sum_fz     = wp.tile_sum(wp.tile(F_acc_z))[0]
+    sum_dEdCN  = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
+    sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
+
+    if thread_in_block == 0:
+        forces[atom_i] = wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+        dE_dCN[atom_i] = sum_dEdCN
+        wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
+
+    sum_v00 = wp.tile_sum(wp.tile(virial_acc[0, 0]))[0]  # NOSONAR (S117)
+    sum_v01 = wp.tile_sum(wp.tile(virial_acc[0, 1]))[0]
+    sum_v02 = wp.tile_sum(wp.tile(virial_acc[0, 2]))[0]
+    sum_v10 = wp.tile_sum(wp.tile(virial_acc[1, 0]))[0]
+    sum_v11 = wp.tile_sum(wp.tile(virial_acc[1, 1]))[0]
+    sum_v12 = wp.tile_sum(wp.tile(virial_acc[1, 2]))[0]
+    sum_v20 = wp.tile_sum(wp.tile(virial_acc[2, 0]))[0]
+    sum_v21 = wp.tile_sum(wp.tile(virial_acc[2, 1]))[0]
+    sum_v22 = wp.tile_sum(wp.tile(virial_acc[2, 2]))[0]
+    if thread_in_block == 0:
+        wp.atomic_add(virial, batch_idx[atom_i], wp.float32(-0.5) * wp.mat33f(wp.matrix_from_rows(
+            wp.vec3d(sum_v00, sum_v01, sum_v02),
+            wp.vec3d(sum_v10, sum_v11, sum_v12),
+            wp.vec3d(sum_v20, sum_v21, sum_v22),
+        )))
 
 
 @wp.kernel(enable_backward=False, launch_bounds=(32, 24))
@@ -1082,10 +1183,7 @@ def _cn_forces_contrib_kernel_matrix(
     fill_value: wp.int32,
     block_stride: wp.int32,
     periodic: bool,
-    batch_idx: wp.array(dtype=wp.int32),
-    compute_virial: bool,
     forces: wp.array(dtype=wp.vec3f),
-    virial: wp.array(dtype=Any),
 ):
     """
     Pass 3: Add CN-dependent force contribution.
@@ -1122,7 +1220,7 @@ def _cn_forces_contrib_kernel_matrix(
     -----
     - Launch with dim=(num_atoms, DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE), block_dim=DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE
     - One warp per atom; threads stride over the neighbor list block_stride apart
-    - Block-level tile_sum reduction; thread 0 writes force and virial contributions
+    - Block-level tile_sum reduction; thread 0 writes force contributions
     - Skips C6 interpolation and damping calculations
     - Uses precomputed dE_dCN[i] = :math:`\\sum_k \\partial E_{ik}/\\partial \text{CN}_i` from all pairs
     - Neighbor entries with j >= fill_value are padding and are skipped
@@ -1148,8 +1246,68 @@ def _cn_forces_contrib_kernel_matrix(
     F_chain_acc_y = wp.float64(0.0)  # NOSONAR (S117) "math formula"
     F_chain_acc_z = wp.float64(0.0)  # NOSONAR (S117) "math formula"
 
-    if compute_virial:
-        virial_chain_acc = wp.mat33d()
+    neighbor_idx = thread_in_block
+    while neighbor_idx < max_neighbors:
+        atom_j = neighbor_matrix[atom_i, neighbor_idx]
+        if atom_j < fill_value and numbers[atom_j] != 0:
+            r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
+                pos_i,
+                positions[atom_j],
+                cartesian_shifts[atom_i, neighbor_idx],
+                periodic,
+                True,
+            )
+            if r >= wp.float32(1e-12):
+                f_cn, dCN_dr = _cn_counting(
+                    r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, True
+                )
+                dE_dCN_j = dE_dCN[atom_j]  # NOSONAR (S125) "math formula"
+                dE_dr_chain = (dE_dCN_i + dE_dCN_j) * dCN_dr  # NOSONAR (S125) "math formula"
+                F_chain = dE_dr_chain * r_hat  # NOSONAR (S125) "math formula"
+                F_chain_acc_x += wp.float64(F_chain[0])  # NOSONAR (S117) "math formula"
+                F_chain_acc_y += wp.float64(F_chain[1])  # NOSONAR (S117) "math formula"
+                F_chain_acc_z += wp.float64(F_chain[2])  # NOSONAR (S117) "math formula"
+        neighbor_idx += block_stride
+
+    sum_fx = wp.tile_sum(wp.tile(F_chain_acc_x))[0]  # NOSONAR (S117) "math formula"
+    sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
+    sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
+    if thread_in_block == 0:
+        forces[atom_i] = forces[atom_i] + wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+
+
+@wp.kernel(enable_backward=False, launch_bounds=(32, 24))
+def _cn_forces_contrib_kernel_matrix_virial(
+    positions: wp.array(dtype=Any),
+    numbers: wp.array(dtype=wp.int32),
+    neighbor_matrix: wp.array2d(dtype=wp.int32),
+    cartesian_shifts: wp.array2d(dtype=Any),
+    covalent_radii: wp.array(dtype=wp.float32),
+    dE_dCN: wp.array(dtype=wp.float32),  # NOSONAR (S125) "math formula"
+    k1: wp.float32,
+    fill_value: wp.int32,
+    block_stride: wp.int32,
+    periodic: bool,
+    batch_idx: wp.array(dtype=wp.int32),
+    forces: wp.array(dtype=wp.vec3f),
+    virial: wp.array(dtype=Any),
+):
+    """Pass 3 with virial. See _cn_forces_contrib_kernel_matrix for full docs."""
+    atom_i, thread_in_block = wp.tid()
+    if atom_i >= numbers.shape[0]:
+        return
+    if numbers[atom_i] == 0:
+        return
+
+    max_neighbors = neighbor_matrix.shape[1]
+    dE_dCN_i = dE_dCN[atom_i]  # NOSONAR (S125) "math formula"
+    pos_i = positions[atom_i]
+    rcov_i = covalent_radii[numbers[atom_i]]
+
+    F_chain_acc_x = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_chain_acc_y = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_chain_acc_z = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    virial_chain_acc = wp.mat33d()
 
     neighbor_idx = thread_in_block
     while neighbor_idx < max_neighbors:
@@ -1172,8 +1330,7 @@ def _cn_forces_contrib_kernel_matrix(
                 F_chain_acc_x += wp.float64(F_chain[0])  # NOSONAR (S117) "math formula"
                 F_chain_acc_y += wp.float64(F_chain[1])  # NOSONAR (S117) "math formula"
                 F_chain_acc_z += wp.float64(F_chain[2])  # NOSONAR (S117) "math formula"
-                if compute_virial:
-                    virial_chain_acc += wp.mat33d(wp.outer(F_chain, r_ij))
+                virial_chain_acc += wp.mat33d(wp.outer(F_chain, r_ij))
         neighbor_idx += block_stride
 
     sum_fx = wp.tile_sum(wp.tile(F_chain_acc_x))[0]  # NOSONAR (S117) "math formula"
@@ -1182,22 +1339,21 @@ def _cn_forces_contrib_kernel_matrix(
     if thread_in_block == 0:
         forces[atom_i] = forces[atom_i] + wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
 
-    if compute_virial:
-        sum_v00 = wp.tile_sum(wp.tile(virial_chain_acc[0, 0]))[0]  # NOSONAR (S117)
-        sum_v01 = wp.tile_sum(wp.tile(virial_chain_acc[0, 1]))[0]
-        sum_v02 = wp.tile_sum(wp.tile(virial_chain_acc[0, 2]))[0]
-        sum_v10 = wp.tile_sum(wp.tile(virial_chain_acc[1, 0]))[0]
-        sum_v11 = wp.tile_sum(wp.tile(virial_chain_acc[1, 1]))[0]
-        sum_v12 = wp.tile_sum(wp.tile(virial_chain_acc[1, 2]))[0]
-        sum_v20 = wp.tile_sum(wp.tile(virial_chain_acc[2, 0]))[0]
-        sum_v21 = wp.tile_sum(wp.tile(virial_chain_acc[2, 1]))[0]
-        sum_v22 = wp.tile_sum(wp.tile(virial_chain_acc[2, 2]))[0]
-        if thread_in_block == 0:
-            wp.atomic_add(virial, batch_idx[atom_i], wp.float32(-0.5) * wp.mat33f(wp.matrix_from_rows(
-                wp.vec3d(sum_v00, sum_v01, sum_v02),
-                wp.vec3d(sum_v10, sum_v11, sum_v12),
-                wp.vec3d(sum_v20, sum_v21, sum_v22),
-            )))
+    sum_v00 = wp.tile_sum(wp.tile(virial_chain_acc[0, 0]))[0]  # NOSONAR (S117)
+    sum_v01 = wp.tile_sum(wp.tile(virial_chain_acc[0, 1]))[0]
+    sum_v02 = wp.tile_sum(wp.tile(virial_chain_acc[0, 2]))[0]
+    sum_v10 = wp.tile_sum(wp.tile(virial_chain_acc[1, 0]))[0]
+    sum_v11 = wp.tile_sum(wp.tile(virial_chain_acc[1, 1]))[0]
+    sum_v12 = wp.tile_sum(wp.tile(virial_chain_acc[1, 2]))[0]
+    sum_v20 = wp.tile_sum(wp.tile(virial_chain_acc[2, 0]))[0]
+    sum_v21 = wp.tile_sum(wp.tile(virial_chain_acc[2, 1]))[0]
+    sum_v22 = wp.tile_sum(wp.tile(virial_chain_acc[2, 2]))[0]
+    if thread_in_block == 0:
+        wp.atomic_add(virial, batch_idx[atom_i], wp.float32(-0.5) * wp.mat33f(wp.matrix_from_rows(
+            wp.vec3d(sum_v00, sum_v01, sum_v02),
+            wp.vec3d(sum_v10, sum_v11, sum_v12),
+            wp.vec3d(sum_v20, sum_v21, sum_v22),
+        )))
 
 
 # ==============================================================================
@@ -1576,7 +1732,9 @@ M = [wp.mat33f, wp.mat33d]
 _compute_cartesian_shifts_matrix_overload = {}
 _cn_kernel_matrix_overload = {}
 _direct_forces_and_dE_dCN_kernel_matrix_overload = {}
+_direct_forces_and_dE_dCN_kernel_matrix_virial_overload = {}
 _cn_forces_contrib_kernel_matrix_overload = {}
+_cn_forces_contrib_kernel_matrix_virial_overload = {}
 
 # Neighbor list kernel overload dictionaries (CSR format) - default naming convention
 _compute_cartesian_shifts_overload = {}
@@ -1636,7 +1794,34 @@ for t, v, m in zip(T, V, M):
             wp.int32,    # block_stride
             wp.bool,
             wp.array(dtype=wp.int32),
+            wp.array(dtype=wp.float32),
+            wp.array(dtype=wp.vec3f),
+            wp.array(dtype=wp.float32),
+        ],
+    )
+    _direct_forces_and_dE_dCN_kernel_matrix_virial_overload[t] = wp.overload(
+        _direct_forces_and_dE_dCN_kernel_matrix_virial,
+        [
+            wp.array(dtype=v),
+            wp.array(dtype=wp.int32),
+            wp.array2d(dtype=wp.int32),
+            wp.array2d(dtype=v),
+            wp.array(dtype=wp.float32),
+            wp.array(dtype=wp.float32),
+            wp.array4d(dtype=wp.float32),
+            wp.array4d(dtype=wp.float32),
+            wp.float32,
+            wp.float32,
+            wp.float32,
+            wp.float32,
+            wp.float32,
+            wp.float32,
+            wp.float32,
+            wp.float32,
+            wp.int32,
+            wp.int32,    # block_stride
             wp.bool,
+            wp.array(dtype=wp.int32),
             wp.array(dtype=wp.float32),
             wp.array(dtype=wp.vec3f),
             wp.array(dtype=wp.float32),
@@ -1656,8 +1841,23 @@ for t, v, m in zip(T, V, M):
             wp.int32,
             wp.int32,          # block_stride
             wp.bool,
+            wp.array(dtype=wp.vec3f),
+        ],
+    )
+    _cn_forces_contrib_kernel_matrix_virial_overload[t] = wp.overload(
+        _cn_forces_contrib_kernel_matrix_virial,
+        [
+            wp.array(dtype=v),
             wp.array(dtype=wp.int32),
+            wp.array2d(dtype=wp.int32),
+            wp.array2d(dtype=v),
+            wp.array(dtype=wp.float32),
+            wp.array(dtype=wp.float32),
+            wp.float32,
+            wp.int32,
+            wp.int32,          # block_stride
             wp.bool,
+            wp.array(dtype=wp.int32),
             wp.array(dtype=wp.vec3f),
             wp.array(dtype=wp.mat33f),
         ],
@@ -1910,7 +2110,6 @@ def dftd3_matrix(
     )
 
     # Pass 2: Compute direct forces, energy, and accumulate dE/dCN
-    # compute_virial=False for non-periodic systems
     wp.launch(
         kernel=_direct_forces_and_dE_dCN_kernel_matrix_overload[wp_dtype],
         dim=(num_atoms, _block_size),
@@ -1936,9 +2135,8 @@ def dftd3_matrix(
             wp.int32(_block_size),
             periodic,
             batch_idx,
-            False,  # compute_virial=False for non-periodic
         ],
-        outputs=[dE_dCN, forces, energy, virial],
+        outputs=[dE_dCN, forces, energy],
         device=device,
     )
 
@@ -1958,10 +2156,8 @@ def dftd3_matrix(
             wp.int32(fill_value),
             wp.int32(_block_size),
             periodic,
-            batch_idx,
-            False,  # compute_virial=False for non-periodic
         ],
-        outputs=[forces, virial],
+        outputs=[forces],
         device=device,
     )
 
@@ -2162,59 +2358,109 @@ def dftd3_matrix_pbc(
     )
 
     # Pass 2: Compute direct forces, energy, and accumulate dE/dCN
-    wp.launch(
-        kernel=_direct_forces_and_dE_dCN_kernel_matrix_overload[wp_dtype],
-        dim=(num_atoms, _block_size),
-        block_dim=_block_size,
-        inputs=[
-            positions,
-            numbers,
-            neighbor_matrix,
-            cartesian_shifts,
-            coord_num,
-            r4r2,
-            c6_reference,
-            coord_num_ref,
-            wp.float32(k3),
-            wp.float32(a1),
-            wp.float32(a2),
-            wp.float32(s6),
-            wp.float32(s8),
-            wp.float32(s5_smoothing_on),
-            wp.float32(s5_smoothing_off),
-            wp.float32(inv_w),
-            wp.int32(fill_value),
-            wp.int32(_block_size),
-            periodic,
-            batch_idx,
-            compute_virial,
-        ],
-        outputs=[dE_dCN, forces, energy, virial],
-        device=device,
-    )
+    if compute_virial:
+        wp.launch(
+            kernel=_direct_forces_and_dE_dCN_kernel_matrix_virial_overload[wp_dtype],
+            dim=(num_atoms, _block_size),
+            block_dim=_block_size,
+            inputs=[
+                positions,
+                numbers,
+                neighbor_matrix,
+                cartesian_shifts,
+                coord_num,
+                r4r2,
+                c6_reference,
+                coord_num_ref,
+                wp.float32(k3),
+                wp.float32(a1),
+                wp.float32(a2),
+                wp.float32(s6),
+                wp.float32(s8),
+                wp.float32(s5_smoothing_on),
+                wp.float32(s5_smoothing_off),
+                wp.float32(inv_w),
+                wp.int32(fill_value),
+                wp.int32(_block_size),
+                periodic,
+                batch_idx,
+            ],
+            outputs=[dE_dCN, forces, energy, virial],
+            device=device,
+        )
+    else:
+        wp.launch(
+            kernel=_direct_forces_and_dE_dCN_kernel_matrix_overload[wp_dtype],
+            dim=(num_atoms, _block_size),
+            block_dim=_block_size,
+            inputs=[
+                positions,
+                numbers,
+                neighbor_matrix,
+                cartesian_shifts,
+                coord_num,
+                r4r2,
+                c6_reference,
+                coord_num_ref,
+                wp.float32(k3),
+                wp.float32(a1),
+                wp.float32(a2),
+                wp.float32(s6),
+                wp.float32(s8),
+                wp.float32(s5_smoothing_on),
+                wp.float32(s5_smoothing_off),
+                wp.float32(inv_w),
+                wp.int32(fill_value),
+                wp.int32(_block_size),
+                periodic,
+                batch_idx,
+            ],
+            outputs=[dE_dCN, forces, energy],
+            device=device,
+        )
 
     # Pass 3: Add CN-dependent force contribution
-    wp.launch(
-        kernel=_cn_forces_contrib_kernel_matrix_overload[wp_dtype],
-        dim=(num_atoms, _block_size),
-        block_dim=_block_size,
-        inputs=[
-            positions,
-            numbers,
-            neighbor_matrix,
-            cartesian_shifts,
-            covalent_radii,
-            dE_dCN,
-            wp.float32(k1),
-            wp.int32(fill_value),
-            wp.int32(_block_size),
-            periodic,
-            batch_idx,
-            compute_virial,
-        ],
-        outputs=[forces, virial],
-        device=device,
-    )
+    if compute_virial:
+        wp.launch(
+            kernel=_cn_forces_contrib_kernel_matrix_virial_overload[wp_dtype],
+            dim=(num_atoms, _block_size),
+            block_dim=_block_size,
+            inputs=[
+                positions,
+                numbers,
+                neighbor_matrix,
+                cartesian_shifts,
+                covalent_radii,
+                dE_dCN,
+                wp.float32(k1),
+                wp.int32(fill_value),
+                wp.int32(_block_size),
+                periodic,
+                batch_idx,
+            ],
+            outputs=[forces, virial],
+            device=device,
+        )
+    else:
+        wp.launch(
+            kernel=_cn_forces_contrib_kernel_matrix_overload[wp_dtype],
+            dim=(num_atoms, _block_size),
+            block_dim=_block_size,
+            inputs=[
+                positions,
+                numbers,
+                neighbor_matrix,
+                cartesian_shifts,
+                covalent_radii,
+                dE_dCN,
+                wp.float32(k1),
+                wp.int32(fill_value),
+                wp.int32(_block_size),
+                periodic,
+            ],
+            outputs=[forces],
+            device=device,
+        )
 
 
 def dftd3(

--- a/nvalchemiops/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/interactions/dispersion/_dftd3.py
@@ -246,7 +246,9 @@ __all__ = [
     "_compute_cartesian_shifts_overload",
     "_cn_kernel_overload",
     "_direct_forces_and_dE_dCN_kernel_overload",
+    "_direct_forces_and_dE_dCN_kernel_virial_overload",
     "_cn_forces_contrib_kernel_overload",
+    "_cn_forces_contrib_kernel_virial_overload",
 ]
 
 # Threads per atom for _direct_forces_and_dE_dCN_kernel_matrix (matrix and NL).
@@ -729,7 +731,7 @@ def _compute_cartesian_shifts_matrix(
 
     Launch with dim=(num_atoms, DFTD3_MATRIX_CARTESIAN_SHIFTS_BLOCK_SIZE),
     block_dim=DFTD3_MATRIX_CARTESIAN_SHIFTS_BLOCK_SIZE. One block per atom;
-    all threads in the block stride through the neighbor list with step=block_stride. 
+    all threads in the block stride through the neighbor list with step=block_stride.
     Each thread writes its own cartesian_shifts entries independently.
 
     See Also
@@ -1159,16 +1161,6 @@ def _direct_forces_and_dE_dCN_kernel_matrix_virial(  # NOSONAR (S1542) "math for
     sum_fz = wp.tile_sum(wp.tile(F_acc_z))[0]
     sum_dEdCN = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
     sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
-
-    # Write final results once (atomic only for shared batch array)
-    if thread_in_block == 0:
-        # Convert from float64 accumulation to float32 output
-        forces[atom_i] = wp.vec3f(
-            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
-        )
-        dE_dCN[atom_i] = sum_dEdCN
-        wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
-
     sum_v00 = wp.tile_sum(wp.tile(virial_acc[0, 0]))[0]  # NOSONAR (S117)
     sum_v01 = wp.tile_sum(wp.tile(virial_acc[0, 1]))[0]
     sum_v02 = wp.tile_sum(wp.tile(virial_acc[0, 2]))[0]
@@ -1178,8 +1170,16 @@ def _direct_forces_and_dE_dCN_kernel_matrix_virial(  # NOSONAR (S1542) "math for
     sum_v20 = wp.tile_sum(wp.tile(virial_acc[2, 0]))[0]
     sum_v21 = wp.tile_sum(wp.tile(virial_acc[2, 1]))[0]
     sum_v22 = wp.tile_sum(wp.tile(virial_acc[2, 2]))[0]
-    # Add virial contribution with -0.5 scaling for correct sign and double counting
+
+    # Write final results once (atomic only for shared batch array)
     if thread_in_block == 0:
+        # Convert from float64 accumulation to float32 output
+        forces[atom_i] = wp.vec3f(
+            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
+        )
+        dE_dCN[atom_i] = sum_dEdCN
+        wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
+        # Add virial contribution with -0.5 scaling for correct sign and double counting
         wp.atomic_add(
             virial,
             batch_idx[atom_i],
@@ -1367,11 +1367,6 @@ def _cn_forces_contrib_kernel_matrix_virial(
     sum_fx = wp.tile_sum(wp.tile(F_chain_acc_x))[0]  # NOSONAR (S117) "math formula"
     sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
     sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
-    if thread_in_block == 0:
-        forces[atom_i] = forces[atom_i] + wp.vec3f(
-            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
-        )
-
     sum_v00 = wp.tile_sum(wp.tile(virial_chain_acc[0, 0]))[0]  # NOSONAR (S117)
     sum_v01 = wp.tile_sum(wp.tile(virial_chain_acc[0, 1]))[0]
     sum_v02 = wp.tile_sum(wp.tile(virial_chain_acc[0, 2]))[0]
@@ -1381,8 +1376,12 @@ def _cn_forces_contrib_kernel_matrix_virial(
     sum_v20 = wp.tile_sum(wp.tile(virial_chain_acc[2, 0]))[0]
     sum_v21 = wp.tile_sum(wp.tile(virial_chain_acc[2, 1]))[0]
     sum_v22 = wp.tile_sum(wp.tile(virial_chain_acc[2, 2]))[0]
-    # Add virial contribution with -0.5 scaling for correct sign and double counting
+
     if thread_in_block == 0:
+        forces[atom_i] = forces[atom_i] + wp.vec3f(
+            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
+        )
+        # Add virial contribution with -0.5 scaling for correct sign and double counting
         wp.atomic_add(
             virial,
             batch_idx[atom_i],
@@ -1436,7 +1435,7 @@ def _compute_cartesian_shifts(
     -----
     Launch with dim=(num_atoms, DFTD3_NL_CARTESIAN_SHIFTS_BLOCK_SIZE),
     block_dim=DFTD3_NL_CARTESIAN_SHIFTS_BLOCK_SIZE. One block per atom; all threads
-    stride through the atom's CSR edge range with step=block_stride. Each thread 
+    stride through the atom's CSR edge range with step=block_stride. Each thread
     writes its own cartesian_shifts entries independently..
 
     See Also
@@ -1770,16 +1769,6 @@ def _direct_forces_and_dE_dCN_kernel_virial(  # NOSONAR (S1542) "math formula"
     sum_fz = wp.tile_sum(wp.tile(F_acc_z))[0]
     sum_dEdCN = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
     sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
-
-    # Write final results once (atomic only for shared batch array)
-    if thread_in_block == 0:
-        # Convert from float64 accumulation to float32 output
-        forces[atom_i] = wp.vec3f(
-            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
-        )
-        dE_dCN[atom_i] = sum_dEdCN
-        wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
-
     sum_v00 = wp.tile_sum(wp.tile(virial_acc[0, 0]))[0]  # NOSONAR (S117)
     sum_v01 = wp.tile_sum(wp.tile(virial_acc[0, 1]))[0]
     sum_v02 = wp.tile_sum(wp.tile(virial_acc[0, 2]))[0]
@@ -1789,8 +1778,16 @@ def _direct_forces_and_dE_dCN_kernel_virial(  # NOSONAR (S1542) "math formula"
     sum_v20 = wp.tile_sum(wp.tile(virial_acc[2, 0]))[0]
     sum_v21 = wp.tile_sum(wp.tile(virial_acc[2, 1]))[0]
     sum_v22 = wp.tile_sum(wp.tile(virial_acc[2, 2]))[0]
-    # Add virial contribution with -0.5 scaling for correct sign and double counting
+
+    # Write final results once (atomic only for shared batch array)
     if thread_in_block == 0:
+        # Convert from float64 accumulation to float32 output
+        forces[atom_i] = wp.vec3f(
+            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
+        )
+        dE_dCN[atom_i] = sum_dEdCN
+        wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
+        # Add virial contribution with -0.5 scaling for correct sign and double counting
         wp.atomic_add(
             virial,
             batch_idx[atom_i],
@@ -1943,13 +1940,6 @@ def _cn_forces_contrib_kernel_virial(
     sum_fx = wp.tile_sum(wp.tile(F_chain_acc_x))[0]  # NOSONAR (S117) "math formula"
     sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
     sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
-    # Write final results once (atomic only for shared batch array)
-    if thread_in_block == 0:
-        # Convert from float64 accumulation to float32 output
-        forces[atom_i] = forces[atom_i] + wp.vec3f(
-            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
-        )
-
     sum_v00 = wp.tile_sum(wp.tile(virial_chain_acc[0, 0]))[0]  # NOSONAR (S117)
     sum_v01 = wp.tile_sum(wp.tile(virial_chain_acc[0, 1]))[0]
     sum_v02 = wp.tile_sum(wp.tile(virial_chain_acc[0, 2]))[0]
@@ -1959,8 +1949,14 @@ def _cn_forces_contrib_kernel_virial(
     sum_v20 = wp.tile_sum(wp.tile(virial_chain_acc[2, 0]))[0]
     sum_v21 = wp.tile_sum(wp.tile(virial_chain_acc[2, 1]))[0]
     sum_v22 = wp.tile_sum(wp.tile(virial_chain_acc[2, 2]))[0]
-    # Add virial contribution with -0.5 scaling for correct sign and double counting
+
+    # Write final results once (atomic only for shared batch array)
     if thread_in_block == 0:
+        # Convert from float64 accumulation to float32 output
+        forces[atom_i] = forces[atom_i] + wp.vec3f(
+            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
+        )
+        # Add virial contribution with -0.5 scaling for correct sign and double counting
         wp.atomic_add(
             virial,
             batch_idx[atom_i],

--- a/nvalchemiops/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/interactions/dispersion/_dftd3.py
@@ -1046,8 +1046,9 @@ def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
     sum_dEdCN = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
     sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
 
-    # Thread 0 writes atom-level results without atomics
+    # Write final results once (atomic only for shared batch array)
     if thread_in_block == 0:
+        # Convert from float64 accumulation to float32 output
         forces[atom_i] = wp.vec3f(
             wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
         )
@@ -1159,7 +1160,9 @@ def _direct_forces_and_dE_dCN_kernel_matrix_virial(  # NOSONAR (S1542) "math for
     sum_dEdCN = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
     sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
 
+    # Write final results once (atomic only for shared batch array)
     if thread_in_block == 0:
+        # Convert from float64 accumulation to float32 output
         forces[atom_i] = wp.vec3f(
             wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
         )
@@ -1175,6 +1178,7 @@ def _direct_forces_and_dE_dCN_kernel_matrix_virial(  # NOSONAR (S1542) "math for
     sum_v20 = wp.tile_sum(wp.tile(virial_acc[2, 0]))[0]
     sum_v21 = wp.tile_sum(wp.tile(virial_acc[2, 1]))[0]
     sum_v22 = wp.tile_sum(wp.tile(virial_acc[2, 2]))[0]
+    # Add virial contribution with -0.5 scaling for correct sign and double counting
     if thread_in_block == 0:
         wp.atomic_add(
             virial,
@@ -1293,7 +1297,9 @@ def _cn_forces_contrib_kernel_matrix(
     sum_fx = wp.tile_sum(wp.tile(F_chain_acc_x))[0]  # NOSONAR (S117) "math formula"
     sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
     sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
+    # Write final results once (atomic only for shared batch array)
     if thread_in_block == 0:
+        # Convert from float64 accumulation to float32 output
         forces[atom_i] = forces[atom_i] + wp.vec3f(
             wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
         )
@@ -1375,6 +1381,7 @@ def _cn_forces_contrib_kernel_matrix_virial(
     sum_v20 = wp.tile_sum(wp.tile(virial_chain_acc[2, 0]))[0]
     sum_v21 = wp.tile_sum(wp.tile(virial_chain_acc[2, 1]))[0]
     sum_v22 = wp.tile_sum(wp.tile(virial_chain_acc[2, 2]))[0]
+    # Add virial contribution with -0.5 scaling for correct sign and double counting
     if thread_in_block == 0:
         wp.atomic_add(
             virial,
@@ -1646,7 +1653,9 @@ def _direct_forces_and_dE_dCN_kernel(  # NOSONAR (S1542) "math formula"
     sum_dEdCN = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
     sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
 
+    # Write final results once (atomic only for shared batch array)
     if thread_in_block == 0:
+        # Convert from float64 accumulation to float32 output
         forces[atom_i] = wp.vec3f(
             wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
         )
@@ -1759,7 +1768,9 @@ def _direct_forces_and_dE_dCN_kernel_virial(  # NOSONAR (S1542) "math formula"
     sum_dEdCN = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
     sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
 
+    # Write final results once (atomic only for shared batch array)
     if thread_in_block == 0:
+        # Convert from float64 accumulation to float32 output
         forces[atom_i] = wp.vec3f(
             wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
         )
@@ -1775,6 +1786,7 @@ def _direct_forces_and_dE_dCN_kernel_virial(  # NOSONAR (S1542) "math formula"
     sum_v20 = wp.tile_sum(wp.tile(virial_acc[2, 0]))[0]
     sum_v21 = wp.tile_sum(wp.tile(virial_acc[2, 1]))[0]
     sum_v22 = wp.tile_sum(wp.tile(virial_acc[2, 2]))[0]
+    # Add virial contribution with -0.5 scaling for correct sign and double counting
     if thread_in_block == 0:
         wp.atomic_add(
             virial,
@@ -1857,7 +1869,9 @@ def _cn_forces_contrib_kernel(
     sum_fx = wp.tile_sum(wp.tile(F_chain_acc_x))[0]  # NOSONAR (S117) "math formula"
     sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
     sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
+    # Write final results once (atomic only for shared batch array)
     if thread_in_block == 0:
+        # Convert from float64 accumulation to float32 output
         forces[atom_i] = forces[atom_i] + wp.vec3f(
             wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
         )
@@ -1926,7 +1940,9 @@ def _cn_forces_contrib_kernel_virial(
     sum_fx = wp.tile_sum(wp.tile(F_chain_acc_x))[0]  # NOSONAR (S117) "math formula"
     sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
     sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
+    # Write final results once (atomic only for shared batch array)
     if thread_in_block == 0:
+        # Convert from float64 accumulation to float32 output
         forces[atom_i] = forces[atom_i] + wp.vec3f(
             wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
         )
@@ -1940,6 +1956,7 @@ def _cn_forces_contrib_kernel_virial(
     sum_v20 = wp.tile_sum(wp.tile(virial_chain_acc[2, 0]))[0]
     sum_v21 = wp.tile_sum(wp.tile(virial_chain_acc[2, 1]))[0]
     sum_v22 = wp.tile_sum(wp.tile(virial_chain_acc[2, 2]))[0]
+    # Add virial contribution with -0.5 scaling for correct sign and double counting
     if thread_in_block == 0:
         wp.atomic_add(
             virial,

--- a/nvalchemiops/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/interactions/dispersion/_dftd3.py
@@ -251,6 +251,11 @@ __all__ = [
 # One warp per atom: all reductions use warp shuffles with no shared memory.
 DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE = 32
 
+# Threads per atom for tile-based _cn_kernel_matrix.
+# Two warps per atom (64 threads): with H100 max 32 blocks/SM → 64 warps/SM = 100% warp occupancy.
+# The CN kernel is register-light; launch_bounds=(64, 32) keeps registers ≤32/thread.
+DFTD3_MATRIX_CN_BLOCK_SIZE = 64
+
 # ==============================================================================
 # Helper Functions
 # ==============================================================================
@@ -749,7 +754,7 @@ def _compute_cartesian_shifts_matrix(
 
 
 
-@wp.kernel(enable_backward=False)
+@wp.kernel(enable_backward=False, launch_bounds=(64, 32))
 def _cn_kernel_matrix(
     positions: wp.array(dtype=Any),
     numbers: wp.array(dtype=wp.int32),
@@ -758,6 +763,7 @@ def _cn_kernel_matrix(
     covalent_radii: wp.array(dtype=wp.float32),
     k1: wp.float32,
     fill_value: wp.int32,
+    block_stride: wp.int32,
     periodic: bool,
     coord_num: wp.array(dtype=wp.float32),
 ):
@@ -805,8 +811,9 @@ def _cn_kernel_matrix(
 
     Notes
     -----
-    - Launch with dim=num_atoms (one thread per atom)
-    - Each thread iterates over all neighbors and accumulates CN in a local register
+    - Launch with dim=(num_atoms, DFTD3_MATRIX_CN_BLOCK_SIZE), block_dim=DFTD3_MATRIX_CN_BLOCK_SIZE
+    - Two warps per atom (64 threads); 32 blocks/SM on H100 → 100% warp occupancy
+    - Block-level tile_sum reduction; thread 0 writes coord_num[atom_i]
     - Padding atoms indicated by numbers[i] == 0 are skipped
     - Neighbor entries with j >= fill_value are padding and are skipped
 
@@ -817,10 +824,9 @@ def _cn_kernel_matrix(
     computed here
     :func:`dftd3` : High-level wrapper that orchestrates all passes
     """
-    atom_i = wp.tid()
+    atom_i, thread_in_block = wp.tid()
     if atom_i >= numbers.shape[0]:
         return
-    # skip padding atoms
     if numbers[atom_i] == 0:
         return
 
@@ -828,36 +834,29 @@ def _cn_kernel_matrix(
     pos_i = positions[atom_i]
     rcov_i = covalent_radii[numbers[atom_i]]
 
-    # Accumulate coordination number in local register
     cn_acc = wp.float32(0.0)
 
-    for neighbor_idx in range(max_neighbors):
+    neighbor_idx = thread_in_block
+    while neighbor_idx < max_neighbors:
         atom_j = neighbor_matrix[atom_i, neighbor_idx]
-        if atom_j >= fill_value:
-            continue
-        # skip padding
-        if numbers[atom_j] == 0:
-            continue
+        if atom_j < fill_value and numbers[atom_j] != 0:
+            r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
+                pos_i,
+                positions[atom_j],
+                cartesian_shifts[atom_i, neighbor_idx],
+                periodic,
+                False,
+            )
+            if r >= wp.float32(1e-12):
+                f_cn, dCN_dr = _cn_counting(
+                    r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, False
+                )
+                cn_acc += f_cn
+        neighbor_idx += block_stride
 
-        # Compute distance with optional PBC shift
-        r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
-            pos_i,
-            positions[atom_j],
-            cartesian_shifts[atom_i, neighbor_idx],
-            periodic,
-            False,
-        )
-        if r < 1e-12:
-            continue
-
-        # Compute coordination number contribution
-        f_cn, dCN_dr = _cn_counting(
-            r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, False
-        )
-        cn_acc += f_cn
-
-    # Write final coordination number once
-    coord_num[atom_i] = cn_acc
+    sum_cn = wp.tile_sum(wp.tile(cn_acc))[0]
+    if thread_in_block == 0:
+        coord_num[atom_i] = sum_cn
 
 
 @wp.kernel(enable_backward=False, launch_bounds=(32, 24))
@@ -1071,7 +1070,7 @@ def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
             )))
 
 
-@wp.kernel(enable_backward=False)
+@wp.kernel(enable_backward=False, launch_bounds=(32, 24))
 def _cn_forces_contrib_kernel_matrix(
     positions: wp.array(dtype=Any),
     numbers: wp.array(dtype=wp.int32),
@@ -1081,6 +1080,7 @@ def _cn_forces_contrib_kernel_matrix(
     dE_dCN: wp.array(dtype=wp.float32),  # NOSONAR (S125) "math formula"
     k1: wp.float32,
     fill_value: wp.int32,
+    block_stride: wp.int32,
     periodic: bool,
     batch_idx: wp.array(dtype=wp.int32),
     compute_virial: bool,
@@ -1120,8 +1120,9 @@ def _cn_forces_contrib_kernel_matrix(
 
     Notes
     -----
-    - Launch with dim=num_atoms (one thread per atom)
-    - Each thread iterates over all neighbors and accumulates results in local registers
+    - Launch with dim=(num_atoms, DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE), block_dim=DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE
+    - One warp per atom; threads stride over the neighbor list block_stride apart
+    - Block-level tile_sum reduction; thread 0 writes force and virial contributions
     - Skips C6 interpolation and damping calculations
     - Uses precomputed dE_dCN[i] = :math:`\\sum_k \\partial E_{ik}/\\partial \text{CN}_i` from all pairs
     - Neighbor entries with j >= fill_value are padding and are skipped
@@ -1132,10 +1133,9 @@ def _cn_forces_contrib_kernel_matrix(
     :func:`_direct_forces_and_dE_dCN_kernel_matrix` : Pass 2 - Computes dE/dCN values used here
     :func:`dftd3` : High-level wrapper that orchestrates all passes
     """
-    atom_i = wp.tid()
+    atom_i, thread_in_block = wp.tid()
     if atom_i >= numbers.shape[0]:
         return
-    # skip padding atoms
     if numbers[atom_i] == 0:
         return
 
@@ -1144,54 +1144,60 @@ def _cn_forces_contrib_kernel_matrix(
     pos_i = positions[atom_i]
     rcov_i = covalent_radii[numbers[atom_i]]
 
-    # Accumulate force in local register (using float64 for better precision)
-    F_chain_acc = wp.vec3d()  # NOSONAR (S117) "math formula"
+    F_chain_acc_x = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_chain_acc_y = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_chain_acc_z = wp.float64(0.0)  # NOSONAR (S117) "math formula"
 
-    # Initialize virial accumulator
     if compute_virial:
         virial_chain_acc = wp.mat33d()
 
-    for neighbor_idx in range(max_neighbors):
+    neighbor_idx = thread_in_block
+    while neighbor_idx < max_neighbors:
         atom_j = neighbor_matrix[atom_i, neighbor_idx]
-        if atom_j >= fill_value:
-            continue
-        if numbers[atom_j] == 0:
-            continue
+        if atom_j < fill_value and numbers[atom_j] != 0:
+            r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
+                pos_i,
+                positions[atom_j],
+                cartesian_shifts[atom_i, neighbor_idx],
+                periodic,
+                True,
+            )
+            if r >= wp.float32(1e-12):
+                f_cn, dCN_dr = _cn_counting(
+                    r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, True
+                )
+                dE_dCN_j = dE_dCN[atom_j]  # NOSONAR (S125) "math formula"
+                dE_dr_chain = (dE_dCN_i + dE_dCN_j) * dCN_dr  # NOSONAR (S125) "math formula"
+                F_chain = dE_dr_chain * r_hat  # NOSONAR (S125) "math formula"
+                F_chain_acc_x += wp.float64(F_chain[0])  # NOSONAR (S117) "math formula"
+                F_chain_acc_y += wp.float64(F_chain[1])  # NOSONAR (S117) "math formula"
+                F_chain_acc_z += wp.float64(F_chain[2])  # NOSONAR (S117) "math formula"
+                if compute_virial:
+                    virial_chain_acc += wp.mat33d(wp.outer(F_chain, r_ij))
+        neighbor_idx += block_stride
 
-        # Distance
-        r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
-            pos_i,
-            positions[atom_j],
-            cartesian_shifts[atom_i, neighbor_idx],
-            periodic,
-            True,
-        )
-        if r < 1e-12:
-            continue
+    sum_fx = wp.tile_sum(wp.tile(F_chain_acc_x))[0]  # NOSONAR (S117) "math formula"
+    sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
+    sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
+    if thread_in_block == 0:
+        forces[atom_i] = forces[atom_i] + wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
 
-        # CN derivative
-        f_cn, dCN_dr = _cn_counting(
-            r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, True
-        )
-
-        # CN-dependent force contribution
-        dE_dCN_j = dE_dCN[atom_j]  # NOSONAR (S125) "math formula"
-        dE_dr_chain = (dE_dCN_i + dE_dCN_j) * dCN_dr  # NOSONAR (S125) "math formula"
-        F_chain = dE_dr_chain * r_hat  # NOSONAR (S125) "math formula"
-
-        F_chain_acc += wp.vec3d(F_chain)
-
-        # Accumulate virial if requested
-        if compute_virial:
-            virial_chain_acc += wp.mat33d(wp.outer(F_chain, r_ij))
-
-    # Add accumulated force to existing forces (direct read-modify-write)
-    # Convert from float64 accumulation to float32 output
-    forces[atom_i] = forces[atom_i] + wp.vec3f(F_chain_acc)
-
-    # Add virial contribution with -0.5 scaling for correct sign and double counting
     if compute_virial:
-        wp.atomic_add(virial, batch_idx[atom_i], -0.5 * wp.mat33f(virial_chain_acc))
+        sum_v00 = wp.tile_sum(wp.tile(virial_chain_acc[0, 0]))[0]  # NOSONAR (S117)
+        sum_v01 = wp.tile_sum(wp.tile(virial_chain_acc[0, 1]))[0]
+        sum_v02 = wp.tile_sum(wp.tile(virial_chain_acc[0, 2]))[0]
+        sum_v10 = wp.tile_sum(wp.tile(virial_chain_acc[1, 0]))[0]
+        sum_v11 = wp.tile_sum(wp.tile(virial_chain_acc[1, 1]))[0]
+        sum_v12 = wp.tile_sum(wp.tile(virial_chain_acc[1, 2]))[0]
+        sum_v20 = wp.tile_sum(wp.tile(virial_chain_acc[2, 0]))[0]
+        sum_v21 = wp.tile_sum(wp.tile(virial_chain_acc[2, 1]))[0]
+        sum_v22 = wp.tile_sum(wp.tile(virial_chain_acc[2, 2]))[0]
+        if thread_in_block == 0:
+            wp.atomic_add(virial, batch_idx[atom_i], wp.float32(-0.5) * wp.mat33f(wp.matrix_from_rows(
+                wp.vec3d(sum_v00, sum_v01, sum_v02),
+                wp.vec3d(sum_v10, sum_v11, sum_v12),
+                wp.vec3d(sum_v20, sum_v21, sum_v22),
+            )))
 
 
 # ==============================================================================
@@ -1602,6 +1608,7 @@ for t, v, m in zip(T, V, M):
             wp.array(dtype=wp.float32),
             wp.float32,
             wp.int32,
+            wp.int32,          # block_stride
             wp.bool,
             wp.array(dtype=wp.float32),
         ],
@@ -1647,6 +1654,7 @@ for t, v, m in zip(T, V, M):
             wp.array(dtype=wp.float32),
             wp.float32,
             wp.int32,
+            wp.int32,          # block_stride
             wp.bool,
             wp.array(dtype=wp.int32),
             wp.bool,
@@ -1878,10 +1886,14 @@ def dftd3_matrix(
 
     periodic = False
 
+    _block_size = DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE if "cuda" in device else 1
+    _cn_block_size = DFTD3_MATRIX_CN_BLOCK_SIZE if "cuda" in device else 1
+
     # Pass 1: Compute coordination numbers
     wp.launch(
         kernel=_cn_kernel_matrix_overload[wp_dtype],
-        dim=num_atoms,
+        dim=(num_atoms, _cn_block_size),
+        block_dim=_cn_block_size,
         inputs=[
             positions,
             numbers,
@@ -1890,6 +1902,7 @@ def dftd3_matrix(
             covalent_radii,
             wp.float32(k1),
             wp.int32(fill_value),
+            wp.int32(_cn_block_size),
             periodic,
         ],
         outputs=[coord_num],
@@ -1898,7 +1911,6 @@ def dftd3_matrix(
 
     # Pass 2: Compute direct forces, energy, and accumulate dE/dCN
     # compute_virial=False for non-periodic systems
-    _block_size = DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE if "cuda" in device else 1
     wp.launch(
         kernel=_direct_forces_and_dE_dCN_kernel_matrix_overload[wp_dtype],
         dim=(num_atoms, _block_size),
@@ -1933,7 +1945,8 @@ def dftd3_matrix(
     # Pass 3: Add CN-dependent force contribution
     wp.launch(
         kernel=_cn_forces_contrib_kernel_matrix_overload[wp_dtype],
-        dim=num_atoms,
+        dim=(num_atoms, _block_size),
+        block_dim=_block_size,
         inputs=[
             positions,
             numbers,
@@ -1943,6 +1956,7 @@ def dftd3_matrix(
             dE_dCN,
             wp.float32(k1),
             wp.int32(fill_value),
+            wp.int32(_block_size),
             periodic,
             batch_idx,
             False,  # compute_virial=False for non-periodic
@@ -2124,10 +2138,14 @@ def dftd3_matrix_pbc(
         device=device,
     )
 
+    _block_size = DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE if "cuda" in device else 1
+    _cn_block_size = DFTD3_MATRIX_CN_BLOCK_SIZE if "cuda" in device else 1
+
     # Pass 1: Compute coordination numbers
     wp.launch(
         kernel=_cn_kernel_matrix_overload[wp_dtype],
-        dim=num_atoms,
+        dim=(num_atoms, _cn_block_size),
+        block_dim=_cn_block_size,
         inputs=[
             positions,
             numbers,
@@ -2136,6 +2154,7 @@ def dftd3_matrix_pbc(
             covalent_radii,
             wp.float32(k1),
             wp.int32(fill_value),
+            wp.int32(_cn_block_size),
             periodic,
         ],
         outputs=[coord_num],
@@ -2143,7 +2162,6 @@ def dftd3_matrix_pbc(
     )
 
     # Pass 2: Compute direct forces, energy, and accumulate dE/dCN
-    _block_size = DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE if "cuda" in device else 1
     wp.launch(
         kernel=_direct_forces_and_dE_dCN_kernel_matrix_overload[wp_dtype],
         dim=(num_atoms, _block_size),
@@ -2178,7 +2196,8 @@ def dftd3_matrix_pbc(
     # Pass 3: Add CN-dependent force contribution
     wp.launch(
         kernel=_cn_forces_contrib_kernel_matrix_overload[wp_dtype],
-        dim=num_atoms,
+        dim=(num_atoms, _block_size),
+        block_dim=_block_size,
         inputs=[
             positions,
             numbers,
@@ -2188,6 +2207,7 @@ def dftd3_matrix_pbc(
             dE_dCN,
             wp.float32(k1),
             wp.int32(fill_value),
+            wp.int32(_block_size),
             periodic,
             batch_idx,
             compute_virial,

--- a/nvalchemiops/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/interactions/dispersion/_dftd3.py
@@ -760,7 +760,6 @@ def _compute_cartesian_shifts_matrix(
     )
 
 
-
 @wp.kernel(enable_backward=False, launch_bounds=(64, 32))
 def _cn_kernel_matrix(
     positions: wp.array(dtype=Any),
@@ -1001,8 +1000,10 @@ def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
                 cnref_i_mat = coord_num_ref[z_i, z_j]
                 cnref_j_mat = coord_num_ref[z_j, z_i]
 
-                c6_ij, dC6_dCNi, dC6_dCNj = _c6ab_interpolate(  # NOSONAR (S125) "math formula"
-                    cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
+                c6_ij, dC6_dCNi, dC6_dCNj = (
+                    _c6ab_interpolate(  # NOSONAR (S125) "math formula"
+                        cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
+                    )
                 )
                 if c6_ij >= wp.float32(1e-12):
                     # BJ damping
@@ -1039,15 +1040,17 @@ def _direct_forces_and_dE_dCN_kernel_matrix(  # NOSONAR (S1542) "math formula"
         neighbor_idx += block_stride
 
     # Block-level tile reductions via warp shuffles (BLOCK_SIZE=32 → no shared memory)
-    sum_fx     = wp.tile_sum(wp.tile(F_acc_x))[0]
-    sum_fy     = wp.tile_sum(wp.tile(F_acc_y))[0]
-    sum_fz     = wp.tile_sum(wp.tile(F_acc_z))[0]
-    sum_dEdCN  = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
+    sum_fx = wp.tile_sum(wp.tile(F_acc_x))[0]
+    sum_fy = wp.tile_sum(wp.tile(F_acc_y))[0]
+    sum_fz = wp.tile_sum(wp.tile(F_acc_z))[0]
+    sum_dEdCN = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
     sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
 
     # Thread 0 writes atom-level results without atomics
     if thread_in_block == 0:
-        forces[atom_i] = wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+        forces[atom_i] = wp.vec3f(
+            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
+        )
         dE_dCN[atom_i] = sum_dEdCN
         wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
 
@@ -1116,8 +1119,10 @@ def _direct_forces_and_dE_dCN_kernel_matrix_virial(  # NOSONAR (S1542) "math for
                 c6ab_mat = c6_reference[z_i, z_j]
                 cnref_i_mat = coord_num_ref[z_i, z_j]
                 cnref_j_mat = coord_num_ref[z_j, z_i]
-                c6_ij, dC6_dCNi, dC6_dCNj = _c6ab_interpolate(  # NOSONAR (S125) "math formula"
-                    cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
+                c6_ij, dC6_dCNi, dC6_dCNj = (
+                    _c6ab_interpolate(  # NOSONAR (S125) "math formula"
+                        cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
+                    )
                 )
                 if c6_ij >= wp.float32(1e-12):
                     damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv = _bj_damping(
@@ -1148,14 +1153,16 @@ def _direct_forces_and_dE_dCN_kernel_matrix_virial(  # NOSONAR (S1542) "math for
                     virial_acc += wp.mat33d(wp.outer(F_direct, r_ij))
         neighbor_idx += block_stride
 
-    sum_fx     = wp.tile_sum(wp.tile(F_acc_x))[0]
-    sum_fy     = wp.tile_sum(wp.tile(F_acc_y))[0]
-    sum_fz     = wp.tile_sum(wp.tile(F_acc_z))[0]
-    sum_dEdCN  = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
+    sum_fx = wp.tile_sum(wp.tile(F_acc_x))[0]
+    sum_fy = wp.tile_sum(wp.tile(F_acc_y))[0]
+    sum_fz = wp.tile_sum(wp.tile(F_acc_z))[0]
+    sum_dEdCN = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
     sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
 
     if thread_in_block == 0:
-        forces[atom_i] = wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+        forces[atom_i] = wp.vec3f(
+            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
+        )
         dE_dCN[atom_i] = sum_dEdCN
         wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
 
@@ -1169,11 +1176,18 @@ def _direct_forces_and_dE_dCN_kernel_matrix_virial(  # NOSONAR (S1542) "math for
     sum_v21 = wp.tile_sum(wp.tile(virial_acc[2, 1]))[0]
     sum_v22 = wp.tile_sum(wp.tile(virial_acc[2, 2]))[0]
     if thread_in_block == 0:
-        wp.atomic_add(virial, batch_idx[atom_i], wp.float32(-0.5) * wp.mat33f(wp.matrix_from_rows(
-            wp.vec3d(sum_v00, sum_v01, sum_v02),
-            wp.vec3d(sum_v10, sum_v11, sum_v12),
-            wp.vec3d(sum_v20, sum_v21, sum_v22),
-        )))
+        wp.atomic_add(
+            virial,
+            batch_idx[atom_i],
+            wp.float32(-0.5)
+            * wp.mat33f(
+                wp.matrix_from_rows(
+                    wp.vec3d(sum_v00, sum_v01, sum_v02),
+                    wp.vec3d(sum_v10, sum_v11, sum_v12),
+                    wp.vec3d(sum_v20, sum_v21, sum_v22),
+                )
+            ),
+        )
 
 
 @wp.kernel(enable_backward=False, launch_bounds=(32, 24))
@@ -1267,7 +1281,9 @@ def _cn_forces_contrib_kernel_matrix(
                     r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, True
                 )
                 dE_dCN_j = dE_dCN[atom_j]  # NOSONAR (S125) "math formula"
-                dE_dr_chain = (dE_dCN_i + dE_dCN_j) * dCN_dr  # NOSONAR (S125) "math formula"
+                dE_dr_chain = (
+                    dE_dCN_i + dE_dCN_j
+                ) * dCN_dr  # NOSONAR (S125) "math formula"
                 F_chain = dE_dr_chain * r_hat  # NOSONAR (S125) "math formula"
                 F_chain_acc_x += wp.float64(F_chain[0])  # NOSONAR (S117) "math formula"
                 F_chain_acc_y += wp.float64(F_chain[1])  # NOSONAR (S117) "math formula"
@@ -1278,7 +1294,9 @@ def _cn_forces_contrib_kernel_matrix(
     sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
     sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
     if thread_in_block == 0:
-        forces[atom_i] = forces[atom_i] + wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+        forces[atom_i] = forces[atom_i] + wp.vec3f(
+            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
+        )
 
 
 @wp.kernel(enable_backward=False, launch_bounds=(32, 24))
@@ -1330,7 +1348,9 @@ def _cn_forces_contrib_kernel_matrix_virial(
                     r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, True
                 )
                 dE_dCN_j = dE_dCN[atom_j]  # NOSONAR (S125) "math formula"
-                dE_dr_chain = (dE_dCN_i + dE_dCN_j) * dCN_dr  # NOSONAR (S125) "math formula"
+                dE_dr_chain = (
+                    dE_dCN_i + dE_dCN_j
+                ) * dCN_dr  # NOSONAR (S125) "math formula"
                 F_chain = dE_dr_chain * r_hat  # NOSONAR (S125) "math formula"
                 F_chain_acc_x += wp.float64(F_chain[0])  # NOSONAR (S117) "math formula"
                 F_chain_acc_y += wp.float64(F_chain[1])  # NOSONAR (S117) "math formula"
@@ -1342,7 +1362,9 @@ def _cn_forces_contrib_kernel_matrix_virial(
     sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
     sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
     if thread_in_block == 0:
-        forces[atom_i] = forces[atom_i] + wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+        forces[atom_i] = forces[atom_i] + wp.vec3f(
+            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
+        )
 
     sum_v00 = wp.tile_sum(wp.tile(virial_chain_acc[0, 0]))[0]  # NOSONAR (S117)
     sum_v01 = wp.tile_sum(wp.tile(virial_chain_acc[0, 1]))[0]
@@ -1354,11 +1376,18 @@ def _cn_forces_contrib_kernel_matrix_virial(
     sum_v21 = wp.tile_sum(wp.tile(virial_chain_acc[2, 1]))[0]
     sum_v22 = wp.tile_sum(wp.tile(virial_chain_acc[2, 2]))[0]
     if thread_in_block == 0:
-        wp.atomic_add(virial, batch_idx[atom_i], wp.float32(-0.5) * wp.mat33f(wp.matrix_from_rows(
-            wp.vec3d(sum_v00, sum_v01, sum_v02),
-            wp.vec3d(sum_v10, sum_v11, sum_v12),
-            wp.vec3d(sum_v20, sum_v21, sum_v22),
-        )))
+        wp.atomic_add(
+            virial,
+            batch_idx[atom_i],
+            wp.float32(-0.5)
+            * wp.mat33f(
+                wp.matrix_from_rows(
+                    wp.vec3d(sum_v00, sum_v01, sum_v02),
+                    wp.vec3d(sum_v10, sum_v11, sum_v12),
+                    wp.vec3d(sum_v20, sum_v21, sum_v22),
+                )
+            ),
+        )
 
 
 # ==============================================================================
@@ -1577,16 +1606,30 @@ def _direct_forces_and_dE_dCN_kernel(  # NOSONAR (S1542) "math formula"
                 c6ab_mat = c6_reference[z_i, z_j]
                 cnref_i_mat = coord_num_ref[z_i, z_j]
                 cnref_j_mat = coord_num_ref[z_j, z_i]
-                c6_ij, dC6_dCNi, dC6_dCNj = _c6ab_interpolate(  # NOSONAR (S125) "math formula"
-                    cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
+                c6_ij, dC6_dCNi, dC6_dCNj = (
+                    _c6ab_interpolate(  # NOSONAR (S125) "math formula"
+                        cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
+                    )
                 )
                 if c6_ij >= wp.float32(1e-12):
                     damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv = _bj_damping(
                         r, r4r2_i, r4r2[z_j], a1, a2, s6, s8
                     )
                     e_ij_sw, F_direct = _dispersion_energy_force(
-                        c6_ij, r, r_hat, damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv,
-                        s6, s8, s5_smoothing_on, s5_smoothing_off, inv_w,
+                        c6_ij,
+                        r,
+                        r_hat,
+                        damp_sum,
+                        r4r2_ij,
+                        r6,
+                        r4,
+                        den6_inv,
+                        den8_inv,
+                        s6,
+                        s8,
+                        s5_smoothing_on,
+                        s5_smoothing_off,
+                        inv_w,
                     )
                     F_direct_d = wp.vec3d(F_direct)
                     F_acc_x += F_direct_d[0]  # NOSONAR (S117) "math formula"
@@ -1597,14 +1640,16 @@ def _direct_forces_and_dE_dCN_kernel(  # NOSONAR (S1542) "math formula"
 
         edge_idx += block_stride
 
-    sum_fx     = wp.tile_sum(wp.tile(F_acc_x))[0]
-    sum_fy     = wp.tile_sum(wp.tile(F_acc_y))[0]
-    sum_fz     = wp.tile_sum(wp.tile(F_acc_z))[0]
-    sum_dEdCN  = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
+    sum_fx = wp.tile_sum(wp.tile(F_acc_x))[0]
+    sum_fy = wp.tile_sum(wp.tile(F_acc_y))[0]
+    sum_fz = wp.tile_sum(wp.tile(F_acc_z))[0]
+    sum_dEdCN = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
     sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
 
     if thread_in_block == 0:
-        forces[atom_i] = wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+        forces[atom_i] = wp.vec3f(
+            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
+        )
         dE_dCN[atom_i] = sum_dEdCN
         wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
 
@@ -1673,16 +1718,30 @@ def _direct_forces_and_dE_dCN_kernel_virial(  # NOSONAR (S1542) "math formula"
                 c6ab_mat = c6_reference[z_i, z_j]
                 cnref_i_mat = coord_num_ref[z_i, z_j]
                 cnref_j_mat = coord_num_ref[z_j, z_i]
-                c6_ij, dC6_dCNi, dC6_dCNj = _c6ab_interpolate(  # NOSONAR (S125) "math formula"
-                    cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
+                c6_ij, dC6_dCNi, dC6_dCNj = (
+                    _c6ab_interpolate(  # NOSONAR (S125) "math formula"
+                        cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
+                    )
                 )
                 if c6_ij >= wp.float32(1e-12):
                     damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv = _bj_damping(
                         r, r4r2_i, r4r2[z_j], a1, a2, s6, s8
                     )
                     e_ij_sw, F_direct = _dispersion_energy_force(
-                        c6_ij, r, r_hat, damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv,
-                        s6, s8, s5_smoothing_on, s5_smoothing_off, inv_w,
+                        c6_ij,
+                        r,
+                        r_hat,
+                        damp_sum,
+                        r4r2_ij,
+                        r6,
+                        r4,
+                        den6_inv,
+                        den8_inv,
+                        s6,
+                        s8,
+                        s5_smoothing_on,
+                        s5_smoothing_off,
+                        inv_w,
                     )
                     F_direct_d = wp.vec3d(F_direct)
                     F_acc_x += F_direct_d[0]  # NOSONAR (S117) "math formula"
@@ -1694,14 +1753,16 @@ def _direct_forces_and_dE_dCN_kernel_virial(  # NOSONAR (S1542) "math formula"
 
         edge_idx += block_stride
 
-    sum_fx     = wp.tile_sum(wp.tile(F_acc_x))[0]
-    sum_fy     = wp.tile_sum(wp.tile(F_acc_y))[0]
-    sum_fz     = wp.tile_sum(wp.tile(F_acc_z))[0]
-    sum_dEdCN  = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
+    sum_fx = wp.tile_sum(wp.tile(F_acc_x))[0]
+    sum_fy = wp.tile_sum(wp.tile(F_acc_y))[0]
+    sum_fz = wp.tile_sum(wp.tile(F_acc_z))[0]
+    sum_dEdCN = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
     sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
 
     if thread_in_block == 0:
-        forces[atom_i] = wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+        forces[atom_i] = wp.vec3f(
+            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
+        )
         dE_dCN[atom_i] = sum_dEdCN
         wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
 
@@ -1715,11 +1776,18 @@ def _direct_forces_and_dE_dCN_kernel_virial(  # NOSONAR (S1542) "math formula"
     sum_v21 = wp.tile_sum(wp.tile(virial_acc[2, 1]))[0]
     sum_v22 = wp.tile_sum(wp.tile(virial_acc[2, 2]))[0]
     if thread_in_block == 0:
-        wp.atomic_add(virial, batch_idx[atom_i], wp.float32(-0.5) * wp.mat33f(wp.matrix_from_rows(
-            wp.vec3d(sum_v00, sum_v01, sum_v02),
-            wp.vec3d(sum_v10, sum_v11, sum_v12),
-            wp.vec3d(sum_v20, sum_v21, sum_v22),
-        )))
+        wp.atomic_add(
+            virial,
+            batch_idx[atom_i],
+            wp.float32(-0.5)
+            * wp.mat33f(
+                wp.matrix_from_rows(
+                    wp.vec3d(sum_v00, sum_v01, sum_v02),
+                    wp.vec3d(sum_v10, sum_v11, sum_v12),
+                    wp.vec3d(sum_v20, sum_v21, sum_v22),
+                )
+            ),
+        )
 
 
 @wp.kernel(enable_backward=False, launch_bounds=(32, 24))
@@ -1776,7 +1844,9 @@ def _cn_forces_contrib_kernel(
                     r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, True
                 )
                 dE_dCN_j = dE_dCN[atom_j]  # NOSONAR (S125) "math formula"
-                dE_dr_chain = (dE_dCN_i + dE_dCN_j) * dCN_dr  # NOSONAR (S125) "math formula"
+                dE_dr_chain = (
+                    dE_dCN_i + dE_dCN_j
+                ) * dCN_dr  # NOSONAR (S125) "math formula"
                 F_chain = dE_dr_chain * r_hat  # NOSONAR (S125) "math formula"
                 F_chain_acc_x += wp.float64(F_chain[0])  # NOSONAR (S117) "math formula"
                 F_chain_acc_y += wp.float64(F_chain[1])  # NOSONAR (S117) "math formula"
@@ -1788,7 +1858,9 @@ def _cn_forces_contrib_kernel(
     sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
     sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
     if thread_in_block == 0:
-        forces[atom_i] = forces[atom_i] + wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+        forces[atom_i] = forces[atom_i] + wp.vec3f(
+            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
+        )
 
 
 @wp.kernel(enable_backward=False, launch_bounds=(32, 24))
@@ -1840,7 +1912,9 @@ def _cn_forces_contrib_kernel_virial(
                     r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, True
                 )
                 dE_dCN_j = dE_dCN[atom_j]  # NOSONAR (S125) "math formula"
-                dE_dr_chain = (dE_dCN_i + dE_dCN_j) * dCN_dr  # NOSONAR (S125) "math formula"
+                dE_dr_chain = (
+                    dE_dCN_i + dE_dCN_j
+                ) * dCN_dr  # NOSONAR (S125) "math formula"
                 F_chain = dE_dr_chain * r_hat  # NOSONAR (S125) "math formula"
                 F_chain_acc_x += wp.float64(F_chain[0])  # NOSONAR (S117) "math formula"
                 F_chain_acc_y += wp.float64(F_chain[1])  # NOSONAR (S117) "math formula"
@@ -1853,7 +1927,9 @@ def _cn_forces_contrib_kernel_virial(
     sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
     sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
     if thread_in_block == 0:
-        forces[atom_i] = forces[atom_i] + wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+        forces[atom_i] = forces[atom_i] + wp.vec3f(
+            wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz)
+        )
 
     sum_v00 = wp.tile_sum(wp.tile(virial_chain_acc[0, 0]))[0]  # NOSONAR (S117)
     sum_v01 = wp.tile_sum(wp.tile(virial_chain_acc[0, 1]))[0]
@@ -1865,11 +1941,18 @@ def _cn_forces_contrib_kernel_virial(
     sum_v21 = wp.tile_sum(wp.tile(virial_chain_acc[2, 1]))[0]
     sum_v22 = wp.tile_sum(wp.tile(virial_chain_acc[2, 2]))[0]
     if thread_in_block == 0:
-        wp.atomic_add(virial, batch_idx[atom_i], wp.float32(-0.5) * wp.mat33f(wp.matrix_from_rows(
-            wp.vec3d(sum_v00, sum_v01, sum_v02),
-            wp.vec3d(sum_v10, sum_v11, sum_v12),
-            wp.vec3d(sum_v20, sum_v21, sum_v22),
-        )))
+        wp.atomic_add(
+            virial,
+            batch_idx[atom_i],
+            wp.float32(-0.5)
+            * wp.mat33f(
+                wp.matrix_from_rows(
+                    wp.vec3d(sum_v00, sum_v01, sum_v02),
+                    wp.vec3d(sum_v10, sum_v11, sum_v12),
+                    wp.vec3d(sum_v20, sum_v21, sum_v22),
+                )
+            ),
+        )
 
 
 # ==============================================================================
@@ -1922,7 +2005,7 @@ for t, v, m in zip(T, V, M):
             wp.array(dtype=wp.float32),
             wp.float32,
             wp.int32,
-            wp.int32,          # block_stride
+            wp.int32,  # block_stride
             wp.bool,
             wp.array(dtype=wp.float32),
         ],
@@ -1947,7 +2030,7 @@ for t, v, m in zip(T, V, M):
             wp.float32,
             wp.float32,
             wp.int32,
-            wp.int32,    # block_stride
+            wp.int32,  # block_stride
             wp.bool,
             wp.array(dtype=wp.int32),
             wp.array(dtype=wp.float32),
@@ -1975,7 +2058,7 @@ for t, v, m in zip(T, V, M):
             wp.float32,
             wp.float32,
             wp.int32,
-            wp.int32,    # block_stride
+            wp.int32,  # block_stride
             wp.bool,
             wp.array(dtype=wp.int32),
             wp.array(dtype=wp.float32),
@@ -1995,7 +2078,7 @@ for t, v, m in zip(T, V, M):
             wp.array(dtype=wp.float32),
             wp.float32,
             wp.int32,
-            wp.int32,          # block_stride
+            wp.int32,  # block_stride
             wp.bool,
             wp.array(dtype=wp.vec3f),
         ],
@@ -2011,7 +2094,7 @@ for t, v, m in zip(T, V, M):
             wp.array(dtype=wp.float32),
             wp.float32,
             wp.int32,
-            wp.int32,          # block_stride
+            wp.int32,  # block_stride
             wp.bool,
             wp.array(dtype=wp.int32),
             wp.array(dtype=wp.vec3f),
@@ -2039,7 +2122,7 @@ for t, v, m in zip(T, V, M):
             wp.array(dtype=v),
             wp.array(dtype=wp.float32),
             wp.float32,
-            wp.int32,              # block_stride
+            wp.int32,  # block_stride
             wp.bool,
             wp.array(dtype=wp.float32),
         ],
@@ -2064,7 +2147,7 @@ for t, v, m in zip(T, V, M):
             wp.float32,
             wp.float32,
             wp.float32,
-            wp.int32,              # block_stride
+            wp.int32,  # block_stride
             wp.bool,
             wp.array(dtype=wp.int32),
             wp.array(dtype=wp.float32),
@@ -2092,7 +2175,7 @@ for t, v, m in zip(T, V, M):
             wp.float32,
             wp.float32,
             wp.float32,
-            wp.int32,              # block_stride
+            wp.int32,  # block_stride
             wp.bool,
             wp.array(dtype=wp.int32),
             wp.array(dtype=wp.float32),
@@ -2112,7 +2195,7 @@ for t, v, m in zip(T, V, M):
             wp.array(dtype=wp.float32),
             wp.array(dtype=wp.float32),
             wp.float32,
-            wp.int32,              # block_stride
+            wp.int32,  # block_stride
             wp.bool,
             wp.array(dtype=wp.vec3f),
         ],
@@ -2128,7 +2211,7 @@ for t, v, m in zip(T, V, M):
             wp.array(dtype=wp.float32),
             wp.array(dtype=wp.float32),
             wp.float32,
-            wp.int32,              # block_stride
+            wp.int32,  # block_stride
             wp.bool,
             wp.array(dtype=wp.int32),
             wp.array(dtype=wp.vec3f),

--- a/nvalchemiops/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/interactions/dispersion/_dftd3.py
@@ -258,8 +258,14 @@ DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE = 32
 # The CN kernel is register-light; launch_bounds=(64, 32) keeps registers ≤32/thread.
 DFTD3_MATRIX_CN_BLOCK_SIZE = 64
 
+# Threads per atom for tile-based _compute_cartesian_shifts_matrix.
+# Same occupancy rationale as _cn_kernel_matrix: 2 warps per atom, 32 blocks/SM → 100% warp occupancy.
+# The cartesian-shifts kernel is register-light (just a matrix-vector multiply per entry).
+DFTD3_MATRIX_CARTESIAN_SHIFTS_BLOCK_SIZE = 64
+
 # Threads per atom (CUDA block size) for tile-based NL (CSR) kernels.
 # Mirror the matrix kernel block sizes: same occupancy rationale applies.
+DFTD3_NL_CARTESIAN_SHIFTS_BLOCK_SIZE = 64
 DFTD3_NL_DIRECT_FORCES_BLOCK_SIZE = 32
 DFTD3_NL_CN_BLOCK_SIZE = 64
 
@@ -680,13 +686,14 @@ def _unit_shift_to_cartesian(
 # ==============================================================================
 
 
-@wp.kernel(enable_backward=False)
+@wp.kernel(enable_backward=False, launch_bounds=(64, 32))
 def _compute_cartesian_shifts_matrix(
     cell: wp.array(dtype=Any),
     unit_shifts: wp.array2d(dtype=wp.vec3i),
     neighbor_matrix: wp.array2d(dtype=wp.int32),
     batch_idx: wp.array(dtype=wp.int32),
     fill_value: wp.int32,
+    block_stride: wp.int32,
     cartesian_shifts: wp.array2d(dtype=Any),
 ):
     """
@@ -727,7 +734,11 @@ def _compute_cartesian_shifts_matrix(
     and :math:`n_a, n_b, n_c` are integer shifts. The system ID is obtained
     from atom i's batch index.
 
-    Launch with dim=(num_atoms, max_neighbors) (one thread per atom-neighbor pair).
+    Launch with dim=(num_atoms, DFTD3_MATRIX_CARTESIAN_SHIFTS_BLOCK_SIZE),
+    block_dim=DFTD3_MATRIX_CARTESIAN_SHIFTS_BLOCK_SIZE. One block per atom;
+    all threads in the block share the same cell matrix (loaded once into L1)
+    and stride through the neighbor list with step=block_stride. Each thread
+    writes its own cartesian_shifts entries independently (no reduction needed).
 
     See Also
     --------
@@ -741,23 +752,20 @@ def _compute_cartesian_shifts_matrix(
     :func:`_cn_forces_contrib_kernel` : Pass 3 - Uses computed Cartesian shifts for PBC (neighbor list)
     :func:`dftd3` : High-level wrapper that orchestrates all passes
     """
-    atom_i, neighbor_idx = wp.tid()
+    atom_i, thread_in_block = wp.tid()
     max_neighbors = neighbor_matrix.shape[1]
 
-    if neighbor_idx >= max_neighbors:
-        return
-
-    atom_j = neighbor_matrix[atom_i, neighbor_idx]
-    if atom_j >= fill_value:
-        return
-
     system_id = batch_idx[atom_i]
-
     cell_mat = cell[system_id]
-    unit_shift = unit_shifts[atom_i, neighbor_idx]
-    cartesian_shifts[atom_i, neighbor_idx] = _unit_shift_to_cartesian(
-        unit_shift, cell_mat
-    )
+
+    neighbor_idx = thread_in_block
+    while neighbor_idx < max_neighbors:
+        atom_j = neighbor_matrix[atom_i, neighbor_idx]
+        if atom_j < fill_value:
+            cartesian_shifts[atom_i, neighbor_idx] = _unit_shift_to_cartesian(
+                unit_shifts[atom_i, neighbor_idx], cell_mat
+            )
+        neighbor_idx += block_stride
 
 
 @wp.kernel(enable_backward=False, launch_bounds=(64, 32))
@@ -1402,12 +1410,13 @@ def _cn_forces_contrib_kernel_matrix_virial(
 # ==============================================================================
 
 
-@wp.kernel(enable_backward=False)
+@wp.kernel(enable_backward=False, launch_bounds=(64, 32))
 def _compute_cartesian_shifts(
     cell: wp.array(dtype=Any),
     unit_shifts: wp.array(dtype=wp.vec3i),
     neighbor_ptr: wp.array(dtype=wp.int32),
     batch_idx: wp.array(dtype=wp.int32),
+    block_stride: wp.int32,
     cartesian_shifts: wp.array(dtype=Any),
 ):
     """
@@ -1433,8 +1442,11 @@ def _compute_cartesian_shifts(
 
     Notes
     -----
-    Launch with dim=num_atoms (one thread per atom). Each thread processes all edges
-    for that atom using the CSR pointers.
+    Launch with dim=(num_atoms, DFTD3_NL_CARTESIAN_SHIFTS_BLOCK_SIZE),
+    block_dim=DFTD3_NL_CARTESIAN_SHIFTS_BLOCK_SIZE. One block per atom; all threads
+    share the same cell matrix (loaded once into L1) and stride through the atom's
+    CSR edge range with step=block_stride. Each thread writes its own cartesian_shifts
+    entries independently (no reduction needed).
 
     See Also
     --------
@@ -1442,23 +1454,21 @@ def _compute_cartesian_shifts(
     :func:`_direct_forces_and_dE_dCN_kernel` : Uses computed Cartesian shifts for PBC
     :func:`_cn_forces_contrib_kernel` : Uses computed Cartesian shifts for PBC
     """
-    atom_i = wp.tid()
+    atom_i, thread_in_block = wp.tid()
 
-    # Get number of atoms from batch_idx size
     if atom_i >= batch_idx.shape[0]:
         return
 
     system_id = batch_idx[atom_i]
     cell_mat = cell[system_id]
 
-    # Get range of edges for this atom
     j_range_start = neighbor_ptr[atom_i]
     j_range_end = neighbor_ptr[atom_i + 1]
 
-    # Convert all unit shifts for this atom's neighbors to Cartesian
-    for edge_idx in range(j_range_start, j_range_end):
-        unit_shift = unit_shifts[edge_idx]
-        cartesian_shifts[edge_idx] = _unit_shift_to_cartesian(unit_shift, cell_mat)
+    edge_idx = j_range_start + thread_in_block
+    while edge_idx < j_range_end:
+        cartesian_shifts[edge_idx] = _unit_shift_to_cartesian(unit_shifts[edge_idx], cell_mat)
+        edge_idx += block_stride
 
 
 @wp.kernel(enable_backward=False, launch_bounds=(64, 32))
@@ -2009,6 +2019,7 @@ for t, v, m in zip(T, V, M):
             wp.array2d(dtype=wp.int32),
             wp.array(dtype=wp.int32),
             wp.int32,
+            wp.int32,
             wp.array2d(dtype=v),
         ],
     )
@@ -2126,6 +2137,7 @@ for t, v, m in zip(T, V, M):
             wp.array(dtype=wp.vec3i),
             wp.array(dtype=wp.int32),
             wp.array(dtype=wp.int32),
+            wp.int32,
             wp.array(dtype=v),
         ],
     )
@@ -2621,15 +2633,18 @@ def dftd3_matrix_pbc(
     # Pass 0: Compute cartesian shifts from unit cell shifts
     periodic = True
 
+    _cs_block_size = DFTD3_MATRIX_CARTESIAN_SHIFTS_BLOCK_SIZE if "cuda" in device else 1
     wp.launch(
         kernel=_compute_cartesian_shifts_matrix_overload[wp_dtype],
-        dim=(num_atoms, max_neighbors),
+        dim=(num_atoms, _cs_block_size),
+        block_dim=_cs_block_size,
         inputs=[
             cell,
             neighbor_matrix_shifts,
             neighbor_matrix,
             batch_idx,
             wp.int32(fill_value),
+            wp.int32(_cs_block_size),
         ],
         outputs=[cartesian_shifts],
         device=device,
@@ -3141,17 +3156,20 @@ def dftd3_pbc(
     # Pass 0: Compute cartesian shifts from unit cell shifts
     periodic = True
 
+    _cs_block_size = DFTD3_NL_CARTESIAN_SHIFTS_BLOCK_SIZE if "cuda" in device else 1
     _block_size = DFTD3_NL_DIRECT_FORCES_BLOCK_SIZE if "cuda" in device else 1
     _cn_block_size = DFTD3_NL_CN_BLOCK_SIZE if "cuda" in device else 1
 
     wp.launch(
         kernel=_compute_cartesian_shifts_overload[wp_dtype],
-        dim=num_atoms,
+        dim=(num_atoms, _cs_block_size),
+        block_dim=_cs_block_size,
         inputs=[
             cell,
             unit_shifts,
             neighbor_ptr,
             batch_idx,
+            wp.int32(_cs_block_size),
         ],
         outputs=[cartesian_shifts],
         device=device,

--- a/nvalchemiops/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/interactions/dispersion/_dftd3.py
@@ -258,6 +258,11 @@ DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE = 32
 # The CN kernel is register-light; launch_bounds=(64, 32) keeps registers ≤32/thread.
 DFTD3_MATRIX_CN_BLOCK_SIZE = 64
 
+# Threads per atom (CUDA block size) for tile-based NL (CSR) kernels.
+# Mirror the matrix kernel block sizes: same occupancy rationale applies.
+DFTD3_NL_DIRECT_FORCES_BLOCK_SIZE = 32
+DFTD3_NL_CN_BLOCK_SIZE = 64
+
 # ==============================================================================
 # Helper Functions
 # ==============================================================================
@@ -1420,7 +1425,7 @@ def _compute_cartesian_shifts(
         cartesian_shifts[edge_idx] = _unit_shift_to_cartesian(unit_shift, cell_mat)
 
 
-@wp.kernel(enable_backward=False)
+@wp.kernel(enable_backward=False, launch_bounds=(64, 32))
 def _cn_kernel(
     positions: wp.array(dtype=Any),
     numbers: wp.array(dtype=wp.int32),
@@ -1429,6 +1434,7 @@ def _cn_kernel(
     cartesian_shifts: wp.array(dtype=Any),
     covalent_radii: wp.array(dtype=wp.float32),
     k1: wp.float32,
+    block_stride: wp.int32,
     periodic: bool,
     coord_num: wp.array(dtype=wp.float32),
 ):
@@ -1451,6 +1457,8 @@ def _cn_kernel(
         Covalent radii [max_Z+1] indexed by atomic number
     k1 : float32
         Steepness parameter for counting function
+    block_stride : int32
+        Thread stride within block (equals DFTD3_NL_CN_BLOCK_SIZE on CUDA, 1 on CPU)
     periodic : bool
         If True, apply PBC using cartesian_shifts
     coord_num : wp.array(dtype=float32)
@@ -1458,9 +1466,11 @@ def _cn_kernel(
 
     Notes
     -----
-    Launch with dim=num_atoms (one thread per atom).
+    Launch with dim=(num_atoms, DFTD3_NL_CN_BLOCK_SIZE), block_dim=DFTD3_NL_CN_BLOCK_SIZE.
+    Two warps per atom; threads stride over CSR edges block_stride apart.
+    Tile reduction (warp shuffles); thread 0 writes coord_num[atom_i].
     """
-    atom_i = wp.tid()
+    atom_i, thread_in_block = wp.tid()
     if atom_i >= numbers.shape[0]:
         return
 
@@ -1471,38 +1481,33 @@ def _cn_kernel(
     pos_i = positions[atom_i]
     rcov_i = covalent_radii[numbers[atom_i]]
 
-    # Accumulate coordination number in local register
     cn_acc = wp.float32(0.0)
 
-    # Iterate over neighbors using CSR pointers
     j_range_start = neighbor_ptr[atom_i]
     j_range_end = neighbor_ptr[atom_i + 1]
 
-    for edge_idx in range(j_range_start, j_range_end):
+    edge_idx = j_range_start + thread_in_block
+    while edge_idx < j_range_end:
         atom_j = idx_j[edge_idx]
 
-        # skip padding atoms
-        if numbers[atom_j] == 0:
-            continue
+        if numbers[atom_j] != 0:
+            r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
+                pos_i, positions[atom_j], cartesian_shifts[edge_idx], periodic, False
+            )
+            if r >= wp.float32(1e-12):
+                f_cn, dCN_dr = _cn_counting(
+                    r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, False
+                )
+                cn_acc += f_cn
 
-        # Compute distance with optional PBC shift
-        r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
-            pos_i, positions[atom_j], cartesian_shifts[edge_idx], periodic, False
-        )
-        if r < 1e-12:
-            continue
+        edge_idx += block_stride
 
-        # Compute coordination number contribution
-        f_cn, dCN_dr = _cn_counting(
-            r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, False
-        )
-        cn_acc += f_cn
-
-    # Write final coordination number once
-    coord_num[atom_i] = cn_acc
+    sum_cn = wp.tile_sum(wp.tile(cn_acc))[0]
+    if thread_in_block == 0:
+        coord_num[atom_i] = sum_cn
 
 
-@wp.kernel(enable_backward=False)
+@wp.kernel(enable_backward=False, launch_bounds=(32, 24))
 def _direct_forces_and_dE_dCN_kernel(  # NOSONAR (S1542) "math formula"
     positions: wp.array(dtype=Any),
     numbers: wp.array(dtype=wp.int32),
@@ -1521,27 +1526,26 @@ def _direct_forces_and_dE_dCN_kernel(  # NOSONAR (S1542) "math formula"
     s5_smoothing_on: wp.float32,
     s5_smoothing_off: wp.float32,
     inv_w: wp.float32,
+    block_stride: wp.int32,
     periodic: bool,
     batch_idx: wp.array(dtype=wp.int32),
-    compute_virial: bool,
     dE_dCN: wp.array(dtype=wp.float32),  # NOSONAR (S125) "math formula"
     forces: wp.array(dtype=wp.vec3f),
     energy: wp.array(dtype=wp.float32),
-    virial: wp.array(dtype=Any),
 ):
     """
-    Pass 2: Compute direct forces, energy, and accumulate dE/dCN using
-    CSR neighbor list.
+    Pass 2: Compute direct forces, energy, and accumulate dE/dCN using CSR neighbor list.
 
     Notes
     -----
-    Launch with dim=num_atoms (one thread per atom).
+    Launch with dim=(num_atoms, DFTD3_NL_DIRECT_FORCES_BLOCK_SIZE), block_dim=DFTD3_NL_DIRECT_FORCES_BLOCK_SIZE.
+    One warp per atom; threads stride over CSR edges block_stride apart.
+    Tile reduction (warp shuffles); thread 0 writes results.
     """
-    atom_i = wp.tid()
+    atom_i, thread_in_block = wp.tid()
     if atom_i >= numbers.shape[0]:
         return
 
-    # skip padding atoms
     if numbers[atom_i] == 0:
         return
 
@@ -1550,91 +1554,175 @@ def _direct_forces_and_dE_dCN_kernel(  # NOSONAR (S1542) "math formula"
     z_i = numbers[atom_i]
     r4r2_i = r4r2[z_i]
 
-    # Accumulate in local registers (using float64 for better precision)
-    F_acc = wp.vec3d()  # NOSONAR (S117) "math formula"
+    F_acc_x = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_acc_y = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_acc_z = wp.float64(0.0)  # NOSONAR (S117) "math formula"
     dE_dCN_acc = wp.float32(0.0)  # NOSONAR (S117) "math formula"
     energy_acc = wp.float64(0.0)
 
-    # Initialize virial accumulator
-    if compute_virial:
-        virial_acc = wp.mat33d()
-
-    # Iterate over neighbors using CSR pointers
     j_range_start = neighbor_ptr[atom_i]
     j_range_end = neighbor_ptr[atom_i + 1]
 
-    for edge_idx in range(j_range_start, j_range_end):
+    edge_idx = j_range_start + thread_in_block
+    while edge_idx < j_range_end:
         atom_j = idx_j[edge_idx]
 
-        # skip padding atoms
-        if numbers[atom_j] == 0:
-            continue
+        if numbers[atom_j] != 0:
+            r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
+                pos_i, positions[atom_j], cartesian_shifts[edge_idx], periodic, True
+            )
+            if r >= wp.float32(1e-12):
+                cn_j = coord_num[atom_j]
+                z_j = numbers[atom_j]
+                c6ab_mat = c6_reference[z_i, z_j]
+                cnref_i_mat = coord_num_ref[z_i, z_j]
+                cnref_j_mat = coord_num_ref[z_j, z_i]
+                c6_ij, dC6_dCNi, dC6_dCNj = _c6ab_interpolate(  # NOSONAR (S125) "math formula"
+                    cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
+                )
+                if c6_ij >= wp.float32(1e-12):
+                    damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv = _bj_damping(
+                        r, r4r2_i, r4r2[z_j], a1, a2, s6, s8
+                    )
+                    e_ij_sw, F_direct = _dispersion_energy_force(
+                        c6_ij, r, r_hat, damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv,
+                        s6, s8, s5_smoothing_on, s5_smoothing_off, inv_w,
+                    )
+                    F_direct_d = wp.vec3d(F_direct)
+                    F_acc_x += F_direct_d[0]  # NOSONAR (S117) "math formula"
+                    F_acc_y += F_direct_d[1]  # NOSONAR (S117) "math formula"
+                    F_acc_z += F_direct_d[2]  # NOSONAR (S117) "math formula"
+                    energy_acc += wp.float64(e_ij_sw)
+                    dE_dCN_acc += -damp_sum * dC6_dCNi  # NOSONAR (S117) "math formula"
 
-        # Geometry
-        r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
-            pos_i, positions[atom_j], cartesian_shifts[edge_idx], periodic, True
-        )
-        if r < 1e-12:
-            continue
+        edge_idx += block_stride
 
-        cn_j = coord_num[atom_j]
-        z_j = numbers[atom_j]
+    sum_fx     = wp.tile_sum(wp.tile(F_acc_x))[0]
+    sum_fy     = wp.tile_sum(wp.tile(F_acc_y))[0]
+    sum_fz     = wp.tile_sum(wp.tile(F_acc_z))[0]
+    sum_dEdCN  = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
+    sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
 
-        # C6 interpolation
-        c6ab_mat = c6_reference[z_i, z_j]
-        cnref_i_mat = coord_num_ref[z_i, z_j]
-        cnref_j_mat = coord_num_ref[z_j, z_i]
-
-        c6_ij, dC6_dCNi, dC6_dCNj = _c6ab_interpolate(  # NOSONAR (S125) "math formula"
-            cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
-        )
-        if c6_ij < 1e-12:
-            continue
-
-        # BJ damping
-        damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv = _bj_damping(
-            r, r4r2_i, r4r2[z_j], a1, a2, s6, s8
-        )
-
-        # Energy and direct force
-        e_ij_sw, F_direct = _dispersion_energy_force(
-            c6_ij,
-            r,
-            r_hat,
-            damp_sum,
-            r4r2_ij,
-            r6,
-            r4,
-            den6_inv,
-            den8_inv,
-            s6,
-            s8,
-            s5_smoothing_on,
-            s5_smoothing_off,
-            inv_w,
-        )
-
-        # Accumulate in registers
-        F_acc += wp.vec3d(F_direct)
-        energy_acc += wp.float64(e_ij_sw)
-        dE_dCN_acc += -damp_sum * dC6_dCNi  # NOSONAR (S117) "math formula"
-
-        # Accumulate virial if requested
-        if compute_virial:
-            virial_acc += wp.mat33d(wp.outer(F_direct, r_ij))
-
-    # Write final results once (atomic only for shared batch array)
-    # Convert from float64 accumulation to float32 output
-    forces[atom_i] = wp.vec3f(F_acc)
-    dE_dCN[atom_i] = wp.float32(dE_dCN_acc)
-    wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(energy_acc))
-
-    # Add virial contribution with -0.5 scaling for correct sign and double counting
-    if compute_virial:
-        wp.atomic_add(virial, batch_idx[atom_i], -0.5 * wp.mat33f(virial_acc))
+    if thread_in_block == 0:
+        forces[atom_i] = wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+        dE_dCN[atom_i] = sum_dEdCN
+        wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
 
 
-@wp.kernel(enable_backward=False)
+@wp.kernel(enable_backward=False, launch_bounds=(32, 24))
+def _direct_forces_and_dE_dCN_kernel_virial(  # NOSONAR (S1542) "math formula"
+    positions: wp.array(dtype=Any),
+    numbers: wp.array(dtype=wp.int32),
+    idx_j: wp.array(dtype=wp.int32),
+    neighbor_ptr: wp.array(dtype=wp.int32),
+    cartesian_shifts: wp.array(dtype=Any),
+    coord_num: wp.array(dtype=wp.float32),
+    r4r2: wp.array(dtype=wp.float32),
+    c6_reference: wp.array4d(dtype=wp.float32),
+    coord_num_ref: wp.array4d(dtype=wp.float32),
+    k3: wp.float32,
+    a1: wp.float32,
+    a2: wp.float32,
+    s6: wp.float32,
+    s8: wp.float32,
+    s5_smoothing_on: wp.float32,
+    s5_smoothing_off: wp.float32,
+    inv_w: wp.float32,
+    block_stride: wp.int32,
+    periodic: bool,
+    batch_idx: wp.array(dtype=wp.int32),
+    dE_dCN: wp.array(dtype=wp.float32),  # NOSONAR (S125) "math formula"
+    forces: wp.array(dtype=wp.vec3f),
+    energy: wp.array(dtype=wp.float32),
+    virial: wp.array(dtype=Any),
+):
+    """Pass 2 with virial. See _direct_forces_and_dE_dCN_kernel for full docs."""
+    atom_i, thread_in_block = wp.tid()
+    if atom_i >= numbers.shape[0]:
+        return
+
+    if numbers[atom_i] == 0:
+        return
+
+    pos_i = positions[atom_i]
+    cn_i = coord_num[atom_i]
+    z_i = numbers[atom_i]
+    r4r2_i = r4r2[z_i]
+
+    F_acc_x = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_acc_y = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_acc_z = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    dE_dCN_acc = wp.float32(0.0)  # NOSONAR (S117) "math formula"
+    energy_acc = wp.float64(0.0)
+    virial_acc = wp.mat33d()
+
+    j_range_start = neighbor_ptr[atom_i]
+    j_range_end = neighbor_ptr[atom_i + 1]
+
+    edge_idx = j_range_start + thread_in_block
+    while edge_idx < j_range_end:
+        atom_j = idx_j[edge_idx]
+
+        if numbers[atom_j] != 0:
+            r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
+                pos_i, positions[atom_j], cartesian_shifts[edge_idx], periodic, True
+            )
+            if r >= wp.float32(1e-12):
+                cn_j = coord_num[atom_j]
+                z_j = numbers[atom_j]
+                c6ab_mat = c6_reference[z_i, z_j]
+                cnref_i_mat = coord_num_ref[z_i, z_j]
+                cnref_j_mat = coord_num_ref[z_j, z_i]
+                c6_ij, dC6_dCNi, dC6_dCNj = _c6ab_interpolate(  # NOSONAR (S125) "math formula"
+                    cn_i, cn_j, c6ab_mat, cnref_i_mat, cnref_j_mat, k3
+                )
+                if c6_ij >= wp.float32(1e-12):
+                    damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv = _bj_damping(
+                        r, r4r2_i, r4r2[z_j], a1, a2, s6, s8
+                    )
+                    e_ij_sw, F_direct = _dispersion_energy_force(
+                        c6_ij, r, r_hat, damp_sum, r4r2_ij, r6, r4, den6_inv, den8_inv,
+                        s6, s8, s5_smoothing_on, s5_smoothing_off, inv_w,
+                    )
+                    F_direct_d = wp.vec3d(F_direct)
+                    F_acc_x += F_direct_d[0]  # NOSONAR (S117) "math formula"
+                    F_acc_y += F_direct_d[1]  # NOSONAR (S117) "math formula"
+                    F_acc_z += F_direct_d[2]  # NOSONAR (S117) "math formula"
+                    energy_acc += wp.float64(e_ij_sw)
+                    dE_dCN_acc += -damp_sum * dC6_dCNi  # NOSONAR (S117) "math formula"
+                    virial_acc += wp.mat33d(wp.outer(F_direct, r_ij))
+
+        edge_idx += block_stride
+
+    sum_fx     = wp.tile_sum(wp.tile(F_acc_x))[0]
+    sum_fy     = wp.tile_sum(wp.tile(F_acc_y))[0]
+    sum_fz     = wp.tile_sum(wp.tile(F_acc_z))[0]
+    sum_dEdCN  = wp.tile_sum(wp.tile(dE_dCN_acc))[0]  # NOSONAR (S117) "math formula"
+    sum_energy = wp.tile_sum(wp.tile(energy_acc))[0]
+
+    if thread_in_block == 0:
+        forces[atom_i] = wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+        dE_dCN[atom_i] = sum_dEdCN
+        wp.atomic_add(energy, batch_idx[atom_i], 0.5 * wp.float32(sum_energy))
+
+    sum_v00 = wp.tile_sum(wp.tile(virial_acc[0, 0]))[0]  # NOSONAR (S117)
+    sum_v01 = wp.tile_sum(wp.tile(virial_acc[0, 1]))[0]
+    sum_v02 = wp.tile_sum(wp.tile(virial_acc[0, 2]))[0]
+    sum_v10 = wp.tile_sum(wp.tile(virial_acc[1, 0]))[0]
+    sum_v11 = wp.tile_sum(wp.tile(virial_acc[1, 1]))[0]
+    sum_v12 = wp.tile_sum(wp.tile(virial_acc[1, 2]))[0]
+    sum_v20 = wp.tile_sum(wp.tile(virial_acc[2, 0]))[0]
+    sum_v21 = wp.tile_sum(wp.tile(virial_acc[2, 1]))[0]
+    sum_v22 = wp.tile_sum(wp.tile(virial_acc[2, 2]))[0]
+    if thread_in_block == 0:
+        wp.atomic_add(virial, batch_idx[atom_i], wp.float32(-0.5) * wp.mat33f(wp.matrix_from_rows(
+            wp.vec3d(sum_v00, sum_v01, sum_v02),
+            wp.vec3d(sum_v10, sum_v11, sum_v12),
+            wp.vec3d(sum_v20, sum_v21, sum_v22),
+        )))
+
+
+@wp.kernel(enable_backward=False, launch_bounds=(32, 24))
 def _cn_forces_contrib_kernel(
     positions: wp.array(dtype=Any),
     numbers: wp.array(dtype=wp.int32),
@@ -1644,24 +1732,23 @@ def _cn_forces_contrib_kernel(
     covalent_radii: wp.array(dtype=wp.float32),
     dE_dCN: wp.array(dtype=wp.float32),  # NOSONAR (S125) "math formula"
     k1: wp.float32,
+    block_stride: wp.int32,
     periodic: bool,
-    batch_idx: wp.array(dtype=wp.int32),
-    compute_virial: bool,
     forces: wp.array(dtype=wp.vec3f),
-    virial: wp.array(dtype=Any),
 ):
     """
     Pass 3: Add CN-dependent force contribution using CSR neighbor list.
 
     Notes
     -----
-    Launch with dim=num_atoms (one thread per atom).
+    Launch with dim=(num_atoms, DFTD3_NL_DIRECT_FORCES_BLOCK_SIZE), block_dim=DFTD3_NL_DIRECT_FORCES_BLOCK_SIZE.
+    One warp per atom; threads stride over CSR edges block_stride apart.
+    Tile reduction (warp shuffles); thread 0 adds chain term to forces[atom_i].
     """
-    atom_i = wp.tid()
+    atom_i, thread_in_block = wp.tid()
     if atom_i >= numbers.shape[0]:
         return
 
-    # skip padding atoms
     if numbers[atom_i] == 0:
         return
 
@@ -1669,53 +1756,120 @@ def _cn_forces_contrib_kernel(
     pos_i = positions[atom_i]
     rcov_i = covalent_radii[numbers[atom_i]]
 
-    # Accumulate force in local register (using float64 for better precision)
-    F_chain_acc = wp.vec3d()  # NOSONAR (S117) "math formula"
+    F_chain_acc_x = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_chain_acc_y = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_chain_acc_z = wp.float64(0.0)  # NOSONAR (S117) "math formula"
 
-    # Initialize virial accumulator
-    if compute_virial:
-        virial_chain_acc = wp.mat33d()
-
-    # Iterate over neighbors using CSR pointers
     j_range_start = neighbor_ptr[atom_i]
     j_range_end = neighbor_ptr[atom_i + 1]
 
-    for edge_idx in range(j_range_start, j_range_end):
+    edge_idx = j_range_start + thread_in_block
+    while edge_idx < j_range_end:
         atom_j = idx_j[edge_idx]
 
-        if numbers[atom_j] == 0:
-            continue
+        if numbers[atom_j] != 0:
+            r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
+                pos_i, positions[atom_j], cartesian_shifts[edge_idx], periodic, True
+            )
+            if r >= wp.float32(1e-12):
+                f_cn, dCN_dr = _cn_counting(
+                    r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, True
+                )
+                dE_dCN_j = dE_dCN[atom_j]  # NOSONAR (S125) "math formula"
+                dE_dr_chain = (dE_dCN_i + dE_dCN_j) * dCN_dr  # NOSONAR (S125) "math formula"
+                F_chain = dE_dr_chain * r_hat  # NOSONAR (S125) "math formula"
+                F_chain_acc_x += wp.float64(F_chain[0])  # NOSONAR (S117) "math formula"
+                F_chain_acc_y += wp.float64(F_chain[1])  # NOSONAR (S117) "math formula"
+                F_chain_acc_z += wp.float64(F_chain[2])  # NOSONAR (S117) "math formula"
 
-        # Distance
-        r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
-            pos_i, positions[atom_j], cartesian_shifts[edge_idx], periodic, True
-        )
-        if r < 1e-12:
-            continue
+        edge_idx += block_stride
 
-        # CN derivative
-        f_cn, dCN_dr = _cn_counting(
-            r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, True
-        )
+    sum_fx = wp.tile_sum(wp.tile(F_chain_acc_x))[0]  # NOSONAR (S117) "math formula"
+    sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
+    sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
+    if thread_in_block == 0:
+        forces[atom_i] = forces[atom_i] + wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
 
-        # CN-dependent force contribution
-        dE_dCN_j = dE_dCN[atom_j]  # NOSONAR (S125) "math formula"
-        dE_dr_chain = (dE_dCN_i + dE_dCN_j) * dCN_dr  # NOSONAR (S125) "math formula"
-        F_chain = dE_dr_chain * r_hat  # NOSONAR (S125) "math formula"
 
-        F_chain_acc += wp.vec3d(F_chain)
+@wp.kernel(enable_backward=False, launch_bounds=(32, 24))
+def _cn_forces_contrib_kernel_virial(
+    positions: wp.array(dtype=Any),
+    numbers: wp.array(dtype=wp.int32),
+    idx_j: wp.array(dtype=wp.int32),
+    neighbor_ptr: wp.array(dtype=wp.int32),
+    cartesian_shifts: wp.array(dtype=Any),
+    covalent_radii: wp.array(dtype=wp.float32),
+    dE_dCN: wp.array(dtype=wp.float32),  # NOSONAR (S125) "math formula"
+    k1: wp.float32,
+    block_stride: wp.int32,
+    periodic: bool,
+    batch_idx: wp.array(dtype=wp.int32),
+    forces: wp.array(dtype=wp.vec3f),
+    virial: wp.array(dtype=Any),
+):
+    """Pass 3 with virial. See _cn_forces_contrib_kernel for full docs."""
+    atom_i, thread_in_block = wp.tid()
+    if atom_i >= numbers.shape[0]:
+        return
 
-        # Accumulate virial if requested
-        if compute_virial:
-            virial_chain_acc += wp.mat33d(wp.outer(F_chain, r_ij))
+    if numbers[atom_i] == 0:
+        return
 
-    # Add accumulated force to existing forces (direct read-modify-write)
-    # Convert from float64 accumulation to float32 output
-    forces[atom_i] = forces[atom_i] + wp.vec3f(F_chain_acc)
+    dE_dCN_i = dE_dCN[atom_i]  # NOSONAR (S125) "math formula"
+    pos_i = positions[atom_i]
+    rcov_i = covalent_radii[numbers[atom_i]]
 
-    # Add virial contribution with -0.5 scaling for correct sign and double counting
-    if compute_virial:
-        wp.atomic_add(virial, batch_idx[atom_i], -0.5 * wp.mat33f(virial_chain_acc))
+    F_chain_acc_x = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_chain_acc_y = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    F_chain_acc_z = wp.float64(0.0)  # NOSONAR (S117) "math formula"
+    virial_chain_acc = wp.mat33d()
+
+    j_range_start = neighbor_ptr[atom_i]
+    j_range_end = neighbor_ptr[atom_i + 1]
+
+    edge_idx = j_range_start + thread_in_block
+    while edge_idx < j_range_end:
+        atom_j = idx_j[edge_idx]
+
+        if numbers[atom_j] != 0:
+            r, r_inv, r_hat, r_ij = _compute_distance_vector_pbc(
+                pos_i, positions[atom_j], cartesian_shifts[edge_idx], periodic, True
+            )
+            if r >= wp.float32(1e-12):
+                f_cn, dCN_dr = _cn_counting(
+                    r_inv, rcov_i, covalent_radii[numbers[atom_j]], k1, True
+                )
+                dE_dCN_j = dE_dCN[atom_j]  # NOSONAR (S125) "math formula"
+                dE_dr_chain = (dE_dCN_i + dE_dCN_j) * dCN_dr  # NOSONAR (S125) "math formula"
+                F_chain = dE_dr_chain * r_hat  # NOSONAR (S125) "math formula"
+                F_chain_acc_x += wp.float64(F_chain[0])  # NOSONAR (S117) "math formula"
+                F_chain_acc_y += wp.float64(F_chain[1])  # NOSONAR (S117) "math formula"
+                F_chain_acc_z += wp.float64(F_chain[2])  # NOSONAR (S117) "math formula"
+                virial_chain_acc += wp.mat33d(wp.outer(F_chain, r_ij))
+
+        edge_idx += block_stride
+
+    sum_fx = wp.tile_sum(wp.tile(F_chain_acc_x))[0]  # NOSONAR (S117) "math formula"
+    sum_fy = wp.tile_sum(wp.tile(F_chain_acc_y))[0]  # NOSONAR (S117) "math formula"
+    sum_fz = wp.tile_sum(wp.tile(F_chain_acc_z))[0]  # NOSONAR (S117) "math formula"
+    if thread_in_block == 0:
+        forces[atom_i] = forces[atom_i] + wp.vec3f(wp.float32(sum_fx), wp.float32(sum_fy), wp.float32(sum_fz))
+
+    sum_v00 = wp.tile_sum(wp.tile(virial_chain_acc[0, 0]))[0]  # NOSONAR (S117)
+    sum_v01 = wp.tile_sum(wp.tile(virial_chain_acc[0, 1]))[0]
+    sum_v02 = wp.tile_sum(wp.tile(virial_chain_acc[0, 2]))[0]
+    sum_v10 = wp.tile_sum(wp.tile(virial_chain_acc[1, 0]))[0]
+    sum_v11 = wp.tile_sum(wp.tile(virial_chain_acc[1, 1]))[0]
+    sum_v12 = wp.tile_sum(wp.tile(virial_chain_acc[1, 2]))[0]
+    sum_v20 = wp.tile_sum(wp.tile(virial_chain_acc[2, 0]))[0]
+    sum_v21 = wp.tile_sum(wp.tile(virial_chain_acc[2, 1]))[0]
+    sum_v22 = wp.tile_sum(wp.tile(virial_chain_acc[2, 2]))[0]
+    if thread_in_block == 0:
+        wp.atomic_add(virial, batch_idx[atom_i], wp.float32(-0.5) * wp.mat33f(wp.matrix_from_rows(
+            wp.vec3d(sum_v00, sum_v01, sum_v02),
+            wp.vec3d(sum_v10, sum_v11, sum_v12),
+            wp.vec3d(sum_v20, sum_v21, sum_v22),
+        )))
 
 
 # ==============================================================================
@@ -1740,7 +1894,9 @@ _cn_forces_contrib_kernel_matrix_virial_overload = {}
 _compute_cartesian_shifts_overload = {}
 _cn_kernel_overload = {}
 _direct_forces_and_dE_dCN_kernel_overload = {}
+_direct_forces_and_dE_dCN_kernel_virial_overload = {}
 _cn_forces_contrib_kernel_overload = {}
+_cn_forces_contrib_kernel_virial_overload = {}
 
 # Register overloads for all kernel variants
 for t, v, m in zip(T, V, M):
@@ -1883,6 +2039,7 @@ for t, v, m in zip(T, V, M):
             wp.array(dtype=v),
             wp.array(dtype=wp.float32),
             wp.float32,
+            wp.int32,              # block_stride
             wp.bool,
             wp.array(dtype=wp.float32),
         ],
@@ -1907,9 +2064,37 @@ for t, v, m in zip(T, V, M):
             wp.float32,
             wp.float32,
             wp.float32,
+            wp.int32,              # block_stride
             wp.bool,
             wp.array(dtype=wp.int32),
+            wp.array(dtype=wp.float32),
+            wp.array(dtype=wp.vec3f),
+            wp.array(dtype=wp.float32),
+        ],
+    )
+    _direct_forces_and_dE_dCN_kernel_virial_overload[t] = wp.overload(
+        _direct_forces_and_dE_dCN_kernel_virial,
+        [
+            wp.array(dtype=v),
+            wp.array(dtype=wp.int32),
+            wp.array(dtype=wp.int32),
+            wp.array(dtype=wp.int32),
+            wp.array(dtype=v),
+            wp.array(dtype=wp.float32),
+            wp.array(dtype=wp.float32),
+            wp.array4d(dtype=wp.float32),
+            wp.array4d(dtype=wp.float32),
+            wp.float32,
+            wp.float32,
+            wp.float32,
+            wp.float32,
+            wp.float32,
+            wp.float32,
+            wp.float32,
+            wp.float32,
+            wp.int32,              # block_stride
             wp.bool,
+            wp.array(dtype=wp.int32),
             wp.array(dtype=wp.float32),
             wp.array(dtype=wp.vec3f),
             wp.array(dtype=wp.float32),
@@ -1927,9 +2112,25 @@ for t, v, m in zip(T, V, M):
             wp.array(dtype=wp.float32),
             wp.array(dtype=wp.float32),
             wp.float32,
+            wp.int32,              # block_stride
+            wp.bool,
+            wp.array(dtype=wp.vec3f),
+        ],
+    )
+    _cn_forces_contrib_kernel_virial_overload[t] = wp.overload(
+        _cn_forces_contrib_kernel_virial,
+        [
+            wp.array(dtype=v),
+            wp.array(dtype=wp.int32),
+            wp.array(dtype=wp.int32),
+            wp.array(dtype=wp.int32),
+            wp.array(dtype=v),
+            wp.array(dtype=wp.float32),
+            wp.array(dtype=wp.float32),
+            wp.float32,
+            wp.int32,              # block_stride
             wp.bool,
             wp.array(dtype=wp.int32),
-            wp.bool,
             wp.array(dtype=wp.vec3f),
             wp.array(dtype=wp.mat33f),
         ],
@@ -2608,10 +2809,14 @@ def dftd3(
 
     periodic = False
 
+    _block_size = DFTD3_NL_DIRECT_FORCES_BLOCK_SIZE if "cuda" in device else 1
+    _cn_block_size = DFTD3_NL_CN_BLOCK_SIZE if "cuda" in device else 1
+
     # Pass 1: Compute coordination numbers
     wp.launch(
         kernel=_cn_kernel_overload[wp_dtype],
-        dim=num_atoms,
+        dim=(num_atoms, _cn_block_size),
+        block_dim=_cn_block_size,
         inputs=[
             positions,
             numbers,
@@ -2620,6 +2825,7 @@ def dftd3(
             cartesian_shifts,
             covalent_radii,
             wp.float32(k1),
+            wp.int32(_cn_block_size),
             periodic,
         ],
         outputs=[coord_num],
@@ -2627,10 +2833,11 @@ def dftd3(
     )
 
     # Pass 2: Compute direct forces, energy, and accumulate dE/dCN
-    # compute_virial=False for non-periodic systems
+    # Non-periodic systems never need virial; use the non-virial kernel.
     wp.launch(
         kernel=_direct_forces_and_dE_dCN_kernel_overload[wp_dtype],
-        dim=num_atoms,
+        dim=(num_atoms, _block_size),
+        block_dim=_block_size,
         inputs=[
             positions,
             numbers,
@@ -2649,18 +2856,19 @@ def dftd3(
             wp.float32(s5_smoothing_on),
             wp.float32(s5_smoothing_off),
             wp.float32(inv_w),
+            wp.int32(_block_size),
             periodic,
             batch_idx,
-            False,  # compute_virial=False for non-periodic
         ],
-        outputs=[dE_dCN, forces, energy, virial],
+        outputs=[dE_dCN, forces, energy],
         device=device,
     )
 
     # Pass 3: Add CN-dependent force contribution
     wp.launch(
         kernel=_cn_forces_contrib_kernel_overload[wp_dtype],
-        dim=num_atoms,
+        dim=(num_atoms, _block_size),
+        block_dim=_block_size,
         inputs=[
             positions,
             numbers,
@@ -2670,11 +2878,10 @@ def dftd3(
             covalent_radii,
             dE_dCN,
             wp.float32(k1),
+            wp.int32(_block_size),
             periodic,
-            batch_idx,
-            False,  # compute_virial=False for non-periodic
         ],
-        outputs=[forces, virial],
+        outputs=[forces],
         device=device,
     )
 
@@ -2834,6 +3041,9 @@ def dftd3_pbc(
     # Pass 0: Compute cartesian shifts from unit cell shifts
     periodic = True
 
+    _block_size = DFTD3_NL_DIRECT_FORCES_BLOCK_SIZE if "cuda" in device else 1
+    _cn_block_size = DFTD3_NL_CN_BLOCK_SIZE if "cuda" in device else 1
+
     wp.launch(
         kernel=_compute_cartesian_shifts_overload[wp_dtype],
         dim=num_atoms,
@@ -2850,7 +3060,8 @@ def dftd3_pbc(
     # Pass 1: Compute coordination numbers
     wp.launch(
         kernel=_cn_kernel_overload[wp_dtype],
-        dim=num_atoms,
+        dim=(num_atoms, _cn_block_size),
+        block_dim=_cn_block_size,
         inputs=[
             positions,
             numbers,
@@ -2859,6 +3070,7 @@ def dftd3_pbc(
             cartesian_shifts,
             covalent_radii,
             wp.float32(k1),
+            wp.int32(_cn_block_size),
             periodic,
         ],
         outputs=[coord_num],
@@ -2866,52 +3078,106 @@ def dftd3_pbc(
     )
 
     # Pass 2: Compute direct forces, energy, and accumulate dE/dCN
-    wp.launch(
-        kernel=_direct_forces_and_dE_dCN_kernel_overload[wp_dtype],
-        dim=num_atoms,
-        inputs=[
-            positions,
-            numbers,
-            idx_j,
-            neighbor_ptr,
-            cartesian_shifts,
-            coord_num,
-            r4r2,
-            c6_reference,
-            coord_num_ref,
-            wp.float32(k3),
-            wp.float32(a1),
-            wp.float32(a2),
-            wp.float32(s6),
-            wp.float32(s8),
-            wp.float32(s5_smoothing_on),
-            wp.float32(s5_smoothing_off),
-            wp.float32(inv_w),
-            periodic,
-            batch_idx,
-            compute_virial,
-        ],
-        outputs=[dE_dCN, forces, energy, virial],
-        device=device,
-    )
+    if compute_virial:
+        wp.launch(
+            kernel=_direct_forces_and_dE_dCN_kernel_virial_overload[wp_dtype],
+            dim=(num_atoms, _block_size),
+            block_dim=_block_size,
+            inputs=[
+                positions,
+                numbers,
+                idx_j,
+                neighbor_ptr,
+                cartesian_shifts,
+                coord_num,
+                r4r2,
+                c6_reference,
+                coord_num_ref,
+                wp.float32(k3),
+                wp.float32(a1),
+                wp.float32(a2),
+                wp.float32(s6),
+                wp.float32(s8),
+                wp.float32(s5_smoothing_on),
+                wp.float32(s5_smoothing_off),
+                wp.float32(inv_w),
+                wp.int32(_block_size),
+                periodic,
+                batch_idx,
+            ],
+            outputs=[dE_dCN, forces, energy, virial],
+            device=device,
+        )
+    else:
+        wp.launch(
+            kernel=_direct_forces_and_dE_dCN_kernel_overload[wp_dtype],
+            dim=(num_atoms, _block_size),
+            block_dim=_block_size,
+            inputs=[
+                positions,
+                numbers,
+                idx_j,
+                neighbor_ptr,
+                cartesian_shifts,
+                coord_num,
+                r4r2,
+                c6_reference,
+                coord_num_ref,
+                wp.float32(k3),
+                wp.float32(a1),
+                wp.float32(a2),
+                wp.float32(s6),
+                wp.float32(s8),
+                wp.float32(s5_smoothing_on),
+                wp.float32(s5_smoothing_off),
+                wp.float32(inv_w),
+                wp.int32(_block_size),
+                periodic,
+                batch_idx,
+            ],
+            outputs=[dE_dCN, forces, energy],
+            device=device,
+        )
 
     # Pass 3: Add CN-dependent force contribution
-    wp.launch(
-        kernel=_cn_forces_contrib_kernel_overload[wp_dtype],
-        dim=num_atoms,
-        inputs=[
-            positions,
-            numbers,
-            idx_j,
-            neighbor_ptr,
-            cartesian_shifts,
-            covalent_radii,
-            dE_dCN,
-            wp.float32(k1),
-            periodic,
-            batch_idx,
-            compute_virial,
-        ],
-        outputs=[forces, virial],
-        device=device,
-    )
+    if compute_virial:
+        wp.launch(
+            kernel=_cn_forces_contrib_kernel_virial_overload[wp_dtype],
+            dim=(num_atoms, _block_size),
+            block_dim=_block_size,
+            inputs=[
+                positions,
+                numbers,
+                idx_j,
+                neighbor_ptr,
+                cartesian_shifts,
+                covalent_radii,
+                dE_dCN,
+                wp.float32(k1),
+                wp.int32(_block_size),
+                periodic,
+                batch_idx,
+            ],
+            outputs=[forces, virial],
+            device=device,
+        )
+    else:
+        wp.launch(
+            kernel=_cn_forces_contrib_kernel_overload[wp_dtype],
+            dim=(num_atoms, _block_size),
+            block_dim=_block_size,
+            inputs=[
+                positions,
+                numbers,
+                idx_j,
+                neighbor_ptr,
+                cartesian_shifts,
+                covalent_radii,
+                dE_dCN,
+                wp.float32(k1),
+                wp.int32(_block_size),
+                periodic,
+            ],
+            outputs=[forces],
+            device=device,
+        )

--- a/nvalchemiops/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/interactions/dispersion/_dftd3.py
@@ -249,22 +249,15 @@ __all__ = [
     "_cn_forces_contrib_kernel_overload",
 ]
 
-# Threads per atom (CUDA block size) for tile-based _direct_forces_and_dE_dCN_kernel_matrix.
-# One warp per atom: all reductions use warp shuffles with no shared memory.
+# Threads per atom for _direct_forces_and_dE_dCN_kernel_matrix (matrix and NL).
+# 1 warp/atom; reductions via warp shuffles (no shared memory).
 DFTD3_MATRIX_DIRECT_FORCES_BLOCK_SIZE = 32
 
-# Threads per atom for tile-based _cn_kernel_matrix.
-# Two warps per atom (64 threads): with H100 max 32 blocks/SM → 64 warps/SM = 100% warp occupancy.
-# The CN kernel is register-light; launch_bounds=(64, 32) keeps registers ≤32/thread.
+# Threads per atom for _cn_kernel_matrix and _compute_cartesian_shifts_matrix (matrix and NL).
+# 2 warps/atom; register-light kernels — launch_bounds=(64, 32) keeps registers ≤32/thread.
 DFTD3_MATRIX_CN_BLOCK_SIZE = 64
-
-# Threads per atom for tile-based _compute_cartesian_shifts_matrix.
-# Same occupancy rationale as _cn_kernel_matrix: 2 warps per atom, 32 blocks/SM → 100% warp occupancy.
-# The cartesian-shifts kernel is register-light (just a matrix-vector multiply per entry).
 DFTD3_MATRIX_CARTESIAN_SHIFTS_BLOCK_SIZE = 64
 
-# Threads per atom (CUDA block size) for tile-based NL (CSR) kernels.
-# Mirror the matrix kernel block sizes: same occupancy rationale applies.
 DFTD3_NL_CARTESIAN_SHIFTS_BLOCK_SIZE = 64
 DFTD3_NL_DIRECT_FORCES_BLOCK_SIZE = 32
 DFTD3_NL_CN_BLOCK_SIZE = 64
@@ -736,9 +729,8 @@ def _compute_cartesian_shifts_matrix(
 
     Launch with dim=(num_atoms, DFTD3_MATRIX_CARTESIAN_SHIFTS_BLOCK_SIZE),
     block_dim=DFTD3_MATRIX_CARTESIAN_SHIFTS_BLOCK_SIZE. One block per atom;
-    all threads in the block share the same cell matrix (loaded once into L1)
-    and stride through the neighbor list with step=block_stride. Each thread
-    writes its own cartesian_shifts entries independently (no reduction needed).
+    all threads in the block stride through the neighbor list with step=block_stride. 
+    Each thread writes its own cartesian_shifts entries independently.
 
     See Also
     --------
@@ -1444,9 +1436,8 @@ def _compute_cartesian_shifts(
     -----
     Launch with dim=(num_atoms, DFTD3_NL_CARTESIAN_SHIFTS_BLOCK_SIZE),
     block_dim=DFTD3_NL_CARTESIAN_SHIFTS_BLOCK_SIZE. One block per atom; all threads
-    share the same cell matrix (loaded once into L1) and stride through the atom's
-    CSR edge range with step=block_stride. Each thread writes its own cartesian_shifts
-    entries independently (no reduction needed).
+    stride through the atom's CSR edge range with step=block_stride. Each thread 
+    writes its own cartesian_shifts entries independently..
 
     See Also
     --------


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

  All matrix and neighbor-list DFTD3 SIMT kernels are optimized with two key changes:                                                                                                                                                                                                        
                  
  1. **Block-per-atom parallelism**: Each kernel now launches one block per atom; threads within the block stride through the neighbor matrix/list in parallel, replacing the previous one-thread-per-atom model where a single thread iterated over all neighbors serially.                        
  2. **Warp Tiles API for reduction**: Force, energy, dE/dCN, and coordination number accumulations use `wp.tile_sum` (warp shuffles) to avoid atomics. No shared memory needed for the direct-forces kernel (1 warp/atom = 32 threads).

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Other Changes

<!-- List the key changes made in this PR -->

  - **Separate non-virial kernel path**: e.g. `_direct_forces_and_dE_dCN_kernel_matrix` is split into a non-virial variant and a new `_direct_forces_and_dE_dCN_kernel_matrix_virial`, giving 15–20% improvement for the common (non-virial) case.                                                
  - **`launch_bounds` tuned per kernel**: e.g. Direct-forces kernels use `(32, 24)` (1 warp/atom); CN and cartesian-shifts kernels use `(64, 32)` (2 warps/atom, register-light, targeting 100% warp occupancy on H100).
  - **Benchmark extended**: `benchmark_dftd3.py` supports NL (CSR) format and virial benchmarking; PBC benchmarks are gated behind `--virial`. Need ALCHEMI team's help to determine if this makes sense. 
## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`python -m pytest test_dftd3.py`)
- [x] Linting and formatting checks pass (`ruff check && ruff format`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

  ## Performance

Up to 8.9× faster on DFTD3 batch benchmarks (H100 PCIe); median ~2× over all tested nm / nl / virial combinations.  

<img width="2412" height="712" alt="image" src="https://github.com/user-attachments/assets/cabcbcf8-22b1-4284-9658-f11d28624abe" />


<!-- Any additional information that reviewers should know -->


> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
