### PR TITLE
fix(dynamics): treat MTK NPT cell_velocity as strain rate consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
   `cell_velocities` directly as the strain rate `ε̇ = p_g/W`. Passing
   `cells_inv` emits a `DeprecationWarning`; the argument will be
   removed in a future release.
+- `volumes` argument on `compute_cell_kinetic_energy`,
+  `npt_velocity_half_step{,_out}`, and `nph_velocity_half_step{,_out}`.
+  Kernels consume `cell_velocities` directly as the strain rate and
+  no longer need a volume fallback. Passing `volumes` emits a
+  `DeprecationWarning`; the argument will be removed in a future release.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,22 @@
 
 ### Fixed
 
-- **MTK NPT/NPH cell-propagation state-variable mismatch**: the
-  cell-velocity-update kernel wrote a strain-rate-units acceleration
-  (`V·(P − P_ext)/W`) into `cell_velocity` while drag, position, and
-  cell-KE helpers consumed it as `ḣ = dh/dt` and the cell update did
-  `h_new = h + dt·h_dot` (treating it as `dh/dt`). The mismatch cost a
-  factor of cell length in the cell response and suppressed volume
-  fluctuations by ~40× vs ASE `MTKNPT` / TorchSim
-  `npt_nose_hoover_isotropic` in `nvalchemi-toolkit` PR #90's empirical
-  octane comparison. Treats `cell_velocity` as the strain rate
-  `ε̇ = p_g/W` consistently and updates the cell as
-  `h_new = h + dt · ε̇ · h`.
-- **MTK velocity-half-step modular-invariance coupling factor**: the
-  12 NPT/NPH velocity-half-step kernels used `α = 1 + 1/(3N_atoms)`
-  instead of the canonical `α = 1 + d/N_f = 1 + 1/N_atoms`
-  (ASE `IsotropicMTKNPT._integrate_p`, TorchSim
-  `_npt_nose_hoover_isotropic_inner_step`).
+- **MTK NPT/NPH cell propagation**: kernels wrote `V·(P − P_ext)/W`
+  (strain-rate units) into `cell_velocity` while consumers read it as
+  `ḣ = dh/dt`, costing a factor of cell length in the cell response.
+  `cell_velocity` is now the strain rate `ε̇ = p_g/W` everywhere and
+  the cell update is `h_new = h + dt · ε̇ · h`.
+- **MTK velocity-half-step coupling**: isotropic kernels used
+  `α = 1 + 1/(3N_atoms)` instead of the canonical
+  `α = 1 + 1/N_atoms` (ASE `IsotropicMTKNPT._integrate_p`).
+  Anisotropic and triclinic kernels used `(1 + 1/N_atoms)·ε̇`,
+  which only matches ASE `MTKNPT._integrate_p` for uniform strain;
+  replaced with `ε̇ + Tr(ε̇)/(3·N)·I` (canonical trace correction).
 
 ### Breaking Changes
 
-- `cell_velocities` semantics: callers must now store the strain rate
-  `ε̇ = p_g/W`, not the absolute derivative `ḣ = dh/dt`. Kernel
-  signatures are unchanged.
+- `cell_velocities` now stores the strain rate `ε̇ = p_g/W`, not
+  `ḣ = dh/dt`. Kernel signatures unchanged.
 
 ## 0.3.0 - 2026-XX-XX
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,17 @@
   Anisotropic and triclinic kernels used `(1 + 1/N_atoms)·ε̇`,
   which only matches ASE `MTKNPT._integrate_p` for uniform strain;
   replaced with `ε̇ + Tr(ε̇)/(3·N)·I` (canonical trace correction).
+- **MTK barostat half-step thermostat coupling**: NPT
+  cell-velocity-update kernels applied `−η̇₁·ε̇` inline, mixing the
+  pressure/kinetic driving operator with NHC drag. Removed; callers
+  apply barostat-NHC coupling separately, matching ASE and TorchSim.
 
 ### Breaking Changes
 
 - `cell_velocities` now stores the strain rate `ε̇ = p_g/W`, not
   `ḣ = dh/dt`. Kernel signatures unchanged.
+- `npt_barostat_half_step{,_aniso,_triclinic}` drop the `eta_dots`
+  argument; thermostat coupling is now a separate Trotter operator.
 
 ## 0.3.0 - 2026-XX-XX
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@
   pressure/kinetic driving operator with NHC drag. Removed; callers
   apply barostat-NHC coupling separately, matching ASE and TorchSim.
 
+### Deprecated
+
+- `cells_inv` argument on `compute_cell_kinetic_energy`,
+  `npt_velocity_half_step{,_out}`, `npt_position_update{,_out}`,
+  `nph_velocity_half_step{,_out}`, `nph_position_update{,_out}`,
+  `run_npt_step`, and `run_nph_step`. Kernels consume
+  `cell_velocities` directly as the strain rate `ε̇ = p_g/W`. Passing
+  `cells_inv` emits a `DeprecationWarning`; the argument will be
+  removed in a future release.
+
 ### Breaking Changes
 
 - `cell_velocities` now stores the strain rate `ε̇ = p_g/W`, not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **MTK NPT/NPH cell-propagation state-variable mismatch**: the
+  cell-velocity-update kernel wrote a strain-rate-units acceleration
+  (`V·(P − P_ext)/W`) into `cell_velocity` while drag, position, and
+  cell-KE helpers consumed it as `ḣ = dh/dt` and the cell update did
+  `h_new = h + dt·h_dot` (treating it as `dh/dt`). The mismatch cost a
+  factor of cell length in the cell response and suppressed volume
+  fluctuations by ~40× vs ASE `MTKNPT` / TorchSim
+  `npt_nose_hoover_isotropic` in `nvalchemi-toolkit` PR #90's empirical
+  octane comparison. Treats `cell_velocity` as the strain rate
+  `ε̇ = p_g/W` consistently and updates the cell as
+  `h_new = h + dt · ε̇ · h`.
+- **MTK velocity-half-step modular-invariance coupling factor**: the
+  12 NPT/NPH velocity-half-step kernels used `α = 1 + 1/(3N_atoms)`
+  instead of the canonical `α = 1 + d/N_f = 1 + 1/N_atoms`
+  (ASE `IsotropicMTKNPT._integrate_p`, TorchSim
+  `_npt_nose_hoover_isotropic_inner_step`).
+
+### Breaking Changes
+
+- `cell_velocities` semantics: callers must now store the strain rate
+  `ε̇ = p_g/W`, not the absolute derivative `ḣ = dh/dt`. Kernel
+  signatures are unchanged.
+
 ## 0.3.0 - 2026-XX-XX
 
 ### Breaking Changes

--- a/examples/dynamics/_dynamics_utils.py
+++ b/examples/dynamics/_dynamics_utils.py
@@ -1890,7 +1890,6 @@ def run_nph_mtk(
     nph_pressure_tensors = wp.zeros(1, dtype=tensor_dtype, device=system.device)
     nph_volumes = wp.zeros(1, dtype=system.wp_dtype, device=system.device)
     nph_kinetic_energy = wp.zeros(1, dtype=system.wp_dtype, device=system.device)
-    nph_cells_inv = wp.empty(1, dtype=system.wp_mat_dtype, device=system.device)
     nph_kinetic_tensors = wp.zeros((1, 9), dtype=system.wp_dtype, device=system.device)
     nph_num_atoms_per_system = wp.array(
         [system.num_atoms], dtype=wp.int32, device=system.device
@@ -1944,7 +1943,6 @@ def run_nph_mtk(
             pressure_tensors=nph_pressure_tensors,
             volumes=nph_volumes,
             kinetic_energy=nph_kinetic_energy,
-            cells_inv=nph_cells_inv,
             kinetic_tensors=nph_kinetic_tensors,
             num_atoms_per_system=nph_num_atoms_per_system,
             compute_forces_fn=_compute_forces_cb,
@@ -2068,7 +2066,6 @@ def run_npt_mtk(
     npt_pressure_tensors = wp.zeros(1, dtype=tensor_dtype, device=system.device)
     npt_volumes = wp.zeros(1, dtype=system.wp_dtype, device=system.device)
     npt_kinetic_energy = wp.zeros(1, dtype=system.wp_dtype, device=system.device)
-    npt_cells_inv = wp.empty(1, dtype=system.wp_mat_dtype, device=system.device)
     npt_kinetic_tensors = wp.zeros((1, 9), dtype=system.wp_dtype, device=system.device)
     npt_num_atoms_per_system = wp.array(
         [system.num_atoms], dtype=wp.int32, device=system.device
@@ -2129,7 +2126,6 @@ def run_npt_mtk(
             pressure_tensors=npt_pressure_tensors,
             volumes=npt_volumes,
             kinetic_energy=npt_kinetic_energy,
-            cells_inv=npt_cells_inv,
             kinetic_tensors=npt_kinetic_tensors,
             num_atoms_per_system=npt_num_atoms_per_system,
             compute_forces_fn=_compute_forces_cb,

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -161,6 +161,18 @@ def _warn_cells_inv_deprecated(stacklevel: int = 2) -> None:
     )
 
 
+def _warn_volumes_deprecated(stacklevel: int = 2) -> None:
+    """Emit a DeprecationWarning when callers still pass ``volumes``."""
+    warnings.warn(
+        "'volumes' is deprecated and ignored on this entry point; "
+        "kernels consume 'cell_velocities' as the strain rate ε̇ = p_g/W "
+        "and no longer need a volume fallback. "
+        "Will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )
+
+
 # =============================================================================
 # Shared @wp.func for NPT/NPH physics
 # =============================================================================
@@ -1937,7 +1949,8 @@ def compute_cell_kinetic_energy(
         .. deprecated:: 0.3.1
             Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     volumes : wp.array, optional
-        Retained for backwards compatibility; ignored.
+        .. deprecated:: 0.3.1
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     device : str, optional
         Warp device.
 
@@ -1948,6 +1961,9 @@ def compute_cell_kinetic_energy(
     """
     if cells_inv is not None:
         _warn_cells_inv_deprecated()
+    if volumes is not None:
+        _warn_volumes_deprecated()
+        volumes = None
     if device is None:
         device = cell_velocities.device
 
@@ -2211,10 +2227,15 @@ def npt_velocity_half_step(
     masses: wp.array,
     forces: wp.array,
     cell_velocities: wp.array,
-    volumes: wp.array,
-    eta_dots: wp.array,
-    num_atoms: wp.array,
-    dt: wp.array,
+    # NOTE: ``volumes``, ``eta_dots``, ``num_atoms``, and ``dt`` default to
+    # ``None`` only so legacy callers that still pass ``volumes`` positionally
+    # keep working while the deprecation is staged. Once ``volumes`` is
+    # removed (next minor cycle) these can become required positional
+    # arguments again.
+    volumes: wp.array = None,
+    eta_dots: wp.array = None,
+    num_atoms: wp.array = None,
+    dt: wp.array = None,
     batch_idx: wp.array = None,
     num_atoms_per_system: wp.array = None,
     cells_inv: wp.array = None,
@@ -2249,8 +2270,9 @@ def npt_velocity_half_step(
         Forces on particles. Shape (N,).
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
         Strain-rate matrices ε̇ = p_g/W. Shape (B,).
-    volumes : wp.array(dtype=scalar)
-        Cell volumes. Shape (B,).
+    volumes : wp.array, optional
+        .. deprecated:: 0.3.1
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     eta_dots : wp.array2d(dtype=scalar)
         Thermostat chain velocities. Shape (B, chain_length).
     num_atoms : wp.array(dtype=wp.int32)
@@ -2280,8 +2302,8 @@ def npt_velocity_half_step(
     Single system (isotropic):
 
     >>> npt_velocity_half_step(
-    ...     velocities, masses, forces, cell_velocities, volumes,
-    ...     eta_dots, num_atoms=100, dt=0.001
+    ...     velocities, masses, forces, cell_velocities,
+    ...     eta_dots=eta_dots, num_atoms=num_atoms, dt=dt,
     ... )
 
     See Also
@@ -2292,6 +2314,13 @@ def npt_velocity_half_step(
     if cells_inv is not None:
         _warn_cells_inv_deprecated()
         cells_inv = None
+    if volumes is not None:
+        _warn_volumes_deprecated()
+        volumes = None
+    if eta_dots is None or num_atoms is None or dt is None:
+        raise ValueError(
+            "npt_velocity_half_step requires 'eta_dots', 'num_atoms', and 'dt'."
+        )
     # In-place: delegate to _out with velocities as both input and output
     npt_velocity_half_step_out(
         velocities,
@@ -2317,11 +2346,15 @@ def npt_velocity_half_step_out(
     masses: wp.array,
     forces: wp.array,
     cell_velocities: wp.array,
-    volumes: wp.array,
-    eta_dots: wp.array,
-    num_atoms: wp.array,
-    dt: wp.array,
-    velocities_out: wp.array,
+    # NOTE: ``volumes``, ``eta_dots``, ``num_atoms``, ``dt``, and
+    # ``velocities_out`` default to ``None`` only to keep legacy positional
+    # callers working while ``volumes`` is being deprecated. Once ``volumes``
+    # is removed they can become required positional arguments again.
+    volumes: wp.array = None,
+    eta_dots: wp.array = None,
+    num_atoms: wp.array = None,
+    dt: wp.array = None,
+    velocities_out: wp.array = None,
     batch_idx: wp.array = None,
     num_atoms_per_system: wp.array = None,
     cells_inv: wp.array = None,
@@ -2341,8 +2374,9 @@ def npt_velocity_half_step_out(
         Input velocities (not modified when velocities_out differs).
     masses, forces, cell_velocities : wp.array
         System state arrays.
-    volumes : wp.array
-        Cell volumes. Shape (B,).
+    volumes : wp.array, optional
+        .. deprecated:: 0.3.1
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     eta_dots : wp.array
         Thermostat chain velocities.
     num_atoms : wp.array(dtype=wp.int32)
@@ -2372,6 +2406,14 @@ def npt_velocity_half_step_out(
     if cells_inv is not None:
         _warn_cells_inv_deprecated()
         cells_inv = None
+    if volumes is not None:
+        _warn_volumes_deprecated()
+        volumes = None
+    if eta_dots is None or num_atoms is None or dt is None or velocities_out is None:
+        raise ValueError(
+            "npt_velocity_half_step_out requires 'eta_dots', 'num_atoms', "
+            "'dt', and 'velocities_out'."
+        )
     if device is None:
         device = velocities.device
 
@@ -2625,6 +2667,11 @@ def run_npt_step(
     pressure_tensors: wp.array,
     volumes: wp.array,
     kinetic_energy: wp.array,
+    # NOTE: ``cells_inv`` is at its pre-deprecation positional slot;
+    # ``kinetic_tensors`` and ``num_atoms_per_system`` default to ``None``
+    # only so old positional callers (which passed ``cells_inv`` here) keep
+    # working. Once ``cells_inv`` is removed the latter two can become
+    # required positional arguments again.
     cells_inv: wp.array = None,
     kinetic_tensors: wp.array = None,
     num_atoms_per_system: wp.array = None,
@@ -2745,18 +2792,18 @@ def run_npt_step(
     # 3. Velocity half-step.  Refresh caller-provided cells_inv for symmetry.
     if cells_inv is not None:
         compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
+    # Pass deprecated args (volumes / cells_inv) by keyword and omit them so
+    # the orchestrator does not surface DeprecationWarnings the user never asked for.
     npt_velocity_half_step(
         velocities,
         masses,
         forces,
         cell_velocities,
-        volumes,
-        eta_dot,
-        num_atoms,
-        dt,
+        eta_dots=eta_dot,
+        num_atoms=num_atoms,
+        dt=dt,
         batch_idx=batch_idx,
         num_atoms_per_system=num_atoms_per_system,
-        cells_inv=cells_inv,
         device=device,
     )
 
@@ -2767,7 +2814,6 @@ def run_npt_step(
         cells,
         cell_velocities,
         dt,
-        cells_inv=cells_inv,
         batch_idx=batch_idx,
         device=device,
     )
@@ -2808,13 +2854,11 @@ def run_npt_step(
         masses,
         forces,
         cell_velocities,
-        volumes,
-        eta_dot,
-        num_atoms,
-        dt,
+        eta_dots=eta_dot,
+        num_atoms=num_atoms,
+        dt=dt,
         batch_idx=batch_idx,
         num_atoms_per_system=num_atoms_per_system,
-        cells_inv=cells_inv,
         device=device,
     )
 
@@ -3050,9 +3094,13 @@ def nph_velocity_half_step(
     masses: wp.array,
     forces: wp.array,
     cell_velocities: wp.array,
-    volumes: wp.array,
-    num_atoms: wp.array,
-    dt: wp.array,
+    # NOTE: ``volumes``, ``num_atoms``, and ``dt`` default to ``None`` only
+    # so legacy callers that still pass ``volumes`` positionally keep working
+    # while the deprecation is staged. Once ``volumes`` is removed (next
+    # minor cycle) these can become required positional arguments again.
+    volumes: wp.array = None,
+    num_atoms: wp.array = None,
+    dt: wp.array = None,
     batch_idx: wp.array = None,
     num_atoms_per_system: wp.array = None,
     cells_inv: wp.array = None,
@@ -3086,8 +3134,9 @@ def nph_velocity_half_step(
         Forces on particles.
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
         Strain-rate matrices ε̇ = p_g/W.
-    volumes : wp.array(dtype=scalar)
-        Cell volumes. Shape (B,).
+    volumes : wp.array, optional
+        .. deprecated:: 0.3.1
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     num_atoms : wp.array(dtype=wp.int32)
         Atom count for single-system mode. Shape (1,).
     dt : wp.array(dtype=scalar)
@@ -3118,6 +3167,11 @@ def nph_velocity_half_step(
     if cells_inv is not None:
         _warn_cells_inv_deprecated()
         cells_inv = None
+    if volumes is not None:
+        _warn_volumes_deprecated()
+        volumes = None
+    if num_atoms is None or dt is None:
+        raise ValueError("nph_velocity_half_step requires 'num_atoms' and 'dt'.")
     # In-place: delegate to _out with velocities as both input and output
     nph_velocity_half_step_out(
         velocities,
@@ -3145,10 +3199,14 @@ def nph_velocity_half_step_out(
     masses: wp.array,
     forces: wp.array,
     cell_velocities: wp.array,
-    volumes: wp.array,
-    num_atoms: wp.array,
-    dt: wp.array,
-    velocities_out: wp.array,
+    # NOTE: ``volumes``, ``num_atoms``, ``dt``, and ``velocities_out`` default
+    # to ``None`` only to keep legacy positional callers working while
+    # ``volumes`` is being deprecated. Once ``volumes`` is removed they can
+    # become required positional arguments again.
+    volumes: wp.array = None,
+    num_atoms: wp.array = None,
+    dt: wp.array = None,
+    velocities_out: wp.array = None,
     batch_idx: wp.array = None,
     num_atoms_per_system: wp.array = None,
     cells_inv: wp.array = None,
@@ -3167,8 +3225,9 @@ def nph_velocity_half_step_out(
         Input velocities (not modified when velocities_out differs).
     masses, forces, cell_velocities : wp.array
         System state arrays.
-    volumes : wp.array
-        Cell volumes. Shape (B,).
+    volumes : wp.array, optional
+        .. deprecated:: 0.3.1
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     num_atoms : wp.array(dtype=wp.int32)
         Atom count for single-system mode. Shape (1,).
     dt : wp.array(dtype=scalar)
@@ -3194,6 +3253,14 @@ def nph_velocity_half_step_out(
     if cells_inv is not None:
         _warn_cells_inv_deprecated()
         cells_inv = None
+    if volumes is not None:
+        _warn_volumes_deprecated()
+        volumes = None
+    if num_atoms is None or dt is None or velocities_out is None:
+        raise ValueError(
+            "nph_velocity_half_step_out requires 'num_atoms', 'dt', "
+            "and 'velocities_out'."
+        )
     if device is None:
         device = velocities.device
 
@@ -3348,6 +3415,11 @@ def run_nph_step(
     pressure_tensors: wp.array,
     volumes: wp.array,
     kinetic_energy: wp.array,
+    # NOTE: ``cells_inv`` is at its pre-deprecation positional slot;
+    # ``kinetic_tensors`` and ``num_atoms_per_system`` default to ``None``
+    # only so old positional callers (which passed ``cells_inv`` here) keep
+    # working. Once ``cells_inv`` is removed the latter two can become
+    # required positional arguments again.
     cells_inv: wp.array = None,
     kinetic_tensors: wp.array = None,
     num_atoms_per_system: wp.array = None,
@@ -3447,28 +3519,27 @@ def run_nph_step(
     # 2. Velocity half-step
     if cells_inv is not None:
         compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
+    # Pass deprecated args (volumes / cells_inv) by keyword and omit them so
+    # the orchestrator does not surface DeprecationWarnings the user never asked for.
     nph_velocity_half_step(
         velocities,
         masses,
         forces,
         cell_velocities,
-        volumes,
-        num_atoms,
-        dt,
+        num_atoms=num_atoms,
+        dt=dt,
         batch_idx=batch_idx,
         num_atoms_per_system=num_atoms_per_system,
-        cells_inv=cells_inv,
         device=device,
     )
 
-    # 3. Position update (reuses cells_inv from step 2)
+    # 3. Position update
     nph_position_update(
         positions,
         velocities,
         cells,
         cell_velocities,
         dt,
-        cells_inv=cells_inv,
         batch_idx=batch_idx,
         device=device,
     )
@@ -3509,12 +3580,10 @@ def run_nph_step(
         masses,
         forces,
         cell_velocities,
-        volumes,
-        num_atoms,
-        dt,
+        num_atoms=num_atoms,
+        dt=dt,
         batch_idx=batch_idx,
         num_atoms_per_system=num_atoms_per_system,
-        cells_inv=cells_inv,
         device=device,
     )
 

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -58,6 +58,7 @@ All kernels are dtype-agnostic and support both float32 and float64.
 from __future__ import annotations
 
 import os
+import warnings
 from typing import Any
 
 import warp as wp
@@ -146,6 +147,23 @@ def _ensure_cells_inv(
         device = cell_velocities.device
     return wp.zeros(
         cell_velocities.shape[0], dtype=cell_velocities.dtype, device=device
+    )
+
+
+def _warn_cells_inv_deprecated(stacklevel: int = 2) -> None:
+    """Emit a DeprecationWarning when callers still pass ``cells_inv``.
+
+    Centralised so the message is identical at every entry point and the
+    behaviour can be tightened in a future release without touching call
+    sites.
+    """
+    warnings.warn(
+        "The 'cells_inv' argument is deprecated and ignored: "
+        "'cell_velocities' is now the strain rate ε̇ = p_g/W and the kernels "
+        "no longer require an explicit cell inverse. The argument is kept "
+        "for backwards compatibility and will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=stacklevel,
     )
 
 
@@ -739,60 +757,9 @@ def _npt_cell_velocity_update_kernel(
     cell_masses: wp.array(dtype=Any),
     kinetic_energies: wp.array(dtype=Any),
     num_atoms_per_system: wp.array(dtype=wp.int32),
-    eta_dots: wp.array2d(dtype=Any),
     dt: wp.array(dtype=Any),
 ):
-    """
-    NPT isotropic cell velocity update with Nosé-Hoover thermostat coupling.
-
-    Algorithm
-    ---------
-    Updates the cell velocity matrix for isotropic pressure control. The cell
-    velocity evolves according to the Martyna-Tobias-Klein (MTK) equations:
-
-        ḧ = (V/W) * (P_inst - P_ext) - η̇₁ * ḣ
-
-    where:
-    - P_inst = Tr(P_tensor)/3 + 2*KE/(3N*V) is the instantaneous isotropic pressure
-    - P_ext is the target external pressure (scalar)
-    - V is the cell volume, W is the barostat mass
-    - η̇₁ is the first thermostat chain velocity (provides drag)
-
-    For isotropic mode, only diagonal cell velocity components are updated,
-    and they are all set equal (uniform scaling).
-
-    Launch Grid
-    -----------
-    dim = [num_systems]
-        One thread per system in the batch.
-
-    Parameters
-    ----------
-    cell_velocities : wp.array(dtype=mat33f/mat33d)
-        Strain-rate matrices ε̇. Shape (B,). MODIFIED in-place.
-    pressure_tensors : wp.array(dtype=vec9f/vec9d)
-        Pressure tensors from virial. Components [xx,xy,xz,yx,yy,yz,zx,zy,zz].
-    target_pressures : wp.array(dtype=float32/float64)
-        Target scalar pressures. Shape (B,).
-    volumes : wp.array(dtype=float32/float64)
-        Cell volumes V. Shape (B,).
-    cell_masses : wp.array(dtype=float32/float64)
-        Barostat masses W. Shape (B,).
-    kinetic_energies : wp.array(dtype=float32/float64)
-        System kinetic energies. Shape (B,).
-    num_atoms_per_system : wp.array(dtype=wp.int32)
-        Atom counts per system. Shape (B,).
-    eta_dots : wp.array2d(dtype=float32/float64)
-        Thermostat chain velocities. Shape (B, chain_length).
-    dt : wp.array(dtype=float32/float64)
-        Time step per system. Shape (B,).
-
-    Notes
-    -----
-    - This kernel assumes isotropic pressure control (uniform cell scaling).
-    - Off-diagonal cell velocity components are set to zero.
-    - The kinetic correction 2*KE/(3N*V) accounts for ideal gas contribution.
-    """
+    """NPT isotropic cell-velocity update: ε̇ += (dt/2)·(V/W)·(Tr(P)/3 + 2·KE/(3N·V) − P_ext)."""
     sys_id = wp.tid()
     h_dot = cell_velocities[sys_id]
     P_ext = target_pressures[sys_id]
@@ -800,30 +767,20 @@ def _npt_cell_velocity_update_kernel(
     W = cell_masses[sys_id]
     KE = kinetic_energies[sys_id]
     N = num_atoms_per_system[sys_id]
-    eta_dot_1 = eta_dots[sys_id, 0]
 
-    # Current pressure from tensor
     P = pressure_tensors[sys_id]
     P_current = (P[0] + P[4] + P[8]) / type(V)(3.0)
 
-    # Cast KE to match V's type
     KE_typed = type(V)(KE)
-
-    # Degrees of freedom contribution
     N_f = type(V)(3 * N)
     dof_term = type(V)(2.0) * KE_typed / N_f
-
-    # Pressure difference
     P_diff = P_current + dof_term / V - P_ext
 
-    # Cell velocity acceleration (isotropic)
     h_dot_accel = V * P_diff / W
-
-    # Apply thermostat drag
-    zero = type(V)(0.0)
     dt_half = dt[sys_id] * type(V)(0.5)
-    h_dot_new_diag = h_dot[0, 0] + dt_half * (h_dot_accel - eta_dot_1 * h_dot[0, 0])
+    h_dot_new_diag = h_dot[0, 0] + dt_half * h_dot_accel
 
+    zero = type(V)(0.0)
     cell_velocities[sys_id] = type(h_dot)(
         h_dot_new_diag,
         zero,
@@ -941,28 +898,17 @@ def _npt_cell_velocity_update_aniso_kernel(
     cell_masses: wp.array(dtype=Any),
     kinetic_energies: wp.array(dtype=Any),
     num_atoms_per_system: wp.array(dtype=wp.int32),
-    eta_dots: wp.array2d(dtype=Any),
     dt: wp.array(dtype=Any),
 ):
-    """NPT cell velocity update - anisotropic/orthorhombic.
-
-    Independent pressure control for x, y, z axes.
-    Cell remains orthorhombic (diagonal h_dot).
-
-    ḧ_ii = V/W * (P_ii - P_ext_ii) - η̇₁ * ḣ_ii
-
-    Launch Grid: dim = [num_systems]
-    """
+    """NPT anisotropic cell-velocity update: ε̇_ii += (dt/2)·(V/W)·(P_ii − P_ext_ii)."""
     sys_id = wp.tid()
     h_dot = cell_velocities[sys_id]
-    P_ext = target_pressures[sys_id]  # vec3: [Pxx, Pyy, Pzz]
+    P_ext = target_pressures[sys_id]
     V = volumes[sys_id]
     W = cell_masses[sys_id]
     KE = kinetic_energies[sys_id]
     N = num_atoms_per_system[sys_id]
-    eta_dot_1 = eta_dots[sys_id, 0]
 
-    # Current pressure tensor components
     P = pressure_tensors[sys_id]
     P_xx = P[0]
     P_yy = P[4]
@@ -973,23 +919,20 @@ def _npt_cell_velocity_update_aniso_kernel(
     dof_term = type(V)(2.0) * KE_typed / N_f
     dof_V = dof_term / V
 
-    # Pressure differences for each axis
     P_diff_x = P_xx + dof_V - P_ext[0]
     P_diff_y = P_yy + dof_V - P_ext[1]
     P_diff_z = P_zz + dof_V - P_ext[2]
 
-    # Cell velocity accelerations (independent per axis)
     h_dot_accel_x = V * P_diff_x / W
     h_dot_accel_y = V * P_diff_y / W
     h_dot_accel_z = V * P_diff_z / W
 
-    # Apply thermostat drag per axis
-    zero = type(V)(0.0)
     dt_half = dt[sys_id] * type(V)(0.5)
-    h_dot_new_xx = h_dot[0, 0] + dt_half * (h_dot_accel_x - eta_dot_1 * h_dot[0, 0])
-    h_dot_new_yy = h_dot[1, 1] + dt_half * (h_dot_accel_y - eta_dot_1 * h_dot[1, 1])
-    h_dot_new_zz = h_dot[2, 2] + dt_half * (h_dot_accel_z - eta_dot_1 * h_dot[2, 2])
+    h_dot_new_xx = h_dot[0, 0] + dt_half * h_dot_accel_x
+    h_dot_new_yy = h_dot[1, 1] + dt_half * h_dot_accel_y
+    h_dot_new_zz = h_dot[2, 2] + dt_half * h_dot_accel_z
 
+    zero = type(V)(0.0)
     cell_velocities[sys_id] = type(h_dot)(
         h_dot_new_xx, zero, zero, zero, h_dot_new_yy, zero, zero, zero, h_dot_new_zz
     )
@@ -1063,24 +1006,16 @@ def _npt_cell_velocity_update_triclinic_kernel(
     cell_masses: wp.array(dtype=Any),
     kinetic_energies: wp.array(dtype=Any),
     num_atoms_per_system: wp.array(dtype=wp.int32),
-    eta_dots: wp.array2d(dtype=Any),
     dt: wp.array(dtype=Any),
 ):
-    """NPT cell velocity update - full triclinic.
-
-    Full stress tensor control (all 9 components).
-    ḧ_ij = V/W * (P_ij - P_ext_ij) - η̇₁ * ḣ_ij
-
-    Launch Grid: dim = [num_systems]
-    """
+    """NPT triclinic cell-velocity update: ε̇_ij += (dt/2)·(V/W)·(P_ij − P_ext_ij), DOF correction on diagonal only."""
     sys_id = wp.tid()
     h_dot = cell_velocities[sys_id]
-    P_ext = target_pressures[sys_id]  # vec9
+    P_ext = target_pressures[sys_id]
     V = volumes[sys_id]
     W = cell_masses[sys_id]
     KE = kinetic_energies[sys_id]
     N = num_atoms_per_system[sys_id]
-    eta_dot_1 = eta_dots[sys_id, 0]
 
     P = pressure_tensors[sys_id]
 
@@ -1089,8 +1024,6 @@ def _npt_cell_velocity_update_triclinic_kernel(
     dof_term = type(V)(2.0) * KE_typed / N_f
     dof_V = dof_term / V
 
-    # For triclinic, dof correction only applies to diagonal
-    # P_diff for each component
     P_diff_00 = P[0] + dof_V - P_ext[0]
     P_diff_01 = P[1] - P_ext[1]
     P_diff_02 = P[2] - P_ext[2]
@@ -1101,18 +1034,17 @@ def _npt_cell_velocity_update_triclinic_kernel(
     P_diff_21 = P[7] - P_ext[7]
     P_diff_22 = P[8] + dof_V - P_ext[8]
 
-    # Cell velocity accelerations
     V_W = V / W
     dt_half = dt[sys_id] * type(V)(0.5)
-    h_dot_new_00 = h_dot[0, 0] + dt_half * (V_W * P_diff_00 - eta_dot_1 * h_dot[0, 0])
-    h_dot_new_01 = h_dot[0, 1] + dt_half * (V_W * P_diff_01 - eta_dot_1 * h_dot[0, 1])
-    h_dot_new_02 = h_dot[0, 2] + dt_half * (V_W * P_diff_02 - eta_dot_1 * h_dot[0, 2])
-    h_dot_new_10 = h_dot[1, 0] + dt_half * (V_W * P_diff_10 - eta_dot_1 * h_dot[1, 0])
-    h_dot_new_11 = h_dot[1, 1] + dt_half * (V_W * P_diff_11 - eta_dot_1 * h_dot[1, 1])
-    h_dot_new_12 = h_dot[1, 2] + dt_half * (V_W * P_diff_12 - eta_dot_1 * h_dot[1, 2])
-    h_dot_new_20 = h_dot[2, 0] + dt_half * (V_W * P_diff_20 - eta_dot_1 * h_dot[2, 0])
-    h_dot_new_21 = h_dot[2, 1] + dt_half * (V_W * P_diff_21 - eta_dot_1 * h_dot[2, 1])
-    h_dot_new_22 = h_dot[2, 2] + dt_half * (V_W * P_diff_22 - eta_dot_1 * h_dot[2, 2])
+    h_dot_new_00 = h_dot[0, 0] + dt_half * V_W * P_diff_00
+    h_dot_new_01 = h_dot[0, 1] + dt_half * V_W * P_diff_01
+    h_dot_new_02 = h_dot[0, 2] + dt_half * V_W * P_diff_02
+    h_dot_new_10 = h_dot[1, 0] + dt_half * V_W * P_diff_10
+    h_dot_new_11 = h_dot[1, 1] + dt_half * V_W * P_diff_11
+    h_dot_new_12 = h_dot[1, 2] + dt_half * V_W * P_diff_12
+    h_dot_new_20 = h_dot[2, 0] + dt_half * V_W * P_diff_20
+    h_dot_new_21 = h_dot[2, 1] + dt_half * V_W * P_diff_21
+    h_dot_new_22 = h_dot[2, 2] + dt_half * V_W * P_diff_22
 
     cell_velocities[sys_id] = type(h_dot)(
         h_dot_new_00,
@@ -2002,13 +1934,18 @@ def compute_cell_kinetic_energy(
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
         Strain-rate matrices ε̇ = p_g/W. Shape (B,).
     cell_masses : wp.array
-        Barostat masses. Shape (B,).
+        Barostat masses. Shape (B,). Note that this is the per-DOF mass
+        ``W = (d + 1) k_B T τ_p²`` consumed by the strain-rate update,
+        not the full barostat mass ``d · W``.
     kinetic_energy : wp.array(dtype=scalar)
         Output cell kinetic energy. Shape (B,).
     cells_inv : wp.array, optional
-        Retained for backward compat; ignored by kernels.
+        .. deprecated:: 0.3.1
+            Retained for backwards compatibility and ignored. Kernels now
+            consume ``cell_velocities`` directly as the strain rate.
+            Will be removed in a future release.
     volumes : wp.array, optional
-        Retained for backward compat; ignored by kernels.
+        Retained for backwards compatibility; ignored.
     device : str, optional
         Warp device.
 
@@ -2017,6 +1954,8 @@ def compute_cell_kinetic_energy(
     wp.array
         Cell kinetic energy. Shape (B,).
     """
+    if cells_inv is not None:
+        _warn_cells_inv_deprecated()
     if device is None:
         device = cell_velocities.device
 
@@ -2145,127 +2084,35 @@ def npt_barostat_half_step(
     cell_masses: wp.array,
     kinetic_energy: wp.array,
     num_atoms_per_system: wp.array,
-    eta_dots: wp.array,
     dt: wp.array,
     device: str = None,
 ) -> None:
-    """
-    Perform barostat half-step for NPT ensemble (Martyna-Tobias-Klein equations).
+    """NPT barostat half-step: ε̇ += (dt/2)·(V/W)·(P_inst − P_ext).
 
-    This function updates the cell velocity matrix ḣ based on the pressure
-    difference between the instantaneous and target pressures, coupled with
-    the Nosé-Hoover thermostat chain. The pressure control mode is automatically
-    detected from the ``target_pressures`` array dtype:
-
-    - **Isotropic** (scalar dtype): Uniform scaling in all directions
-    - **Anisotropic/Orthorhombic** (vec3 dtype): Independent x, y, z control
-    - **Triclinic** (vec9 dtype): Full stress tensor control
-
-    Mathematical Formulation
-    ------------------------
-    The cell velocity follows the MTK equations of motion:
-
-    **Isotropic mode:**
-
-    .. math::
-
-        \\ddot{h} = \\frac{V}{W}(P - P_{ext}) - \\dot{\\eta}_1 \\dot{h}
-
-    where P is the scalar trace of the pressure tensor (P = Tr(P)/3).
-
-    **Anisotropic mode:**
-
-    .. math::
-
-        \\ddot{h}_{ii} = \\frac{V}{W}(P_{ii} - P_{ext,ii}) - \\dot{\\eta}_1 \\dot{h}_{ii}
-
-    for i ∈ {x, y, z}, with off-diagonal elements remaining zero.
-
-    **Triclinic mode:**
-
-    .. math::
-
-        \\ddot{h}_{ij} = \\frac{V}{W}(P_{ij} - P_{ext,ij}) - \\dot{\\eta}_1 \\dot{h}_{ij}
-
-    for all i, j ∈ {x, y, z}.
-
-    The instantaneous pressure includes a kinetic correction:
-
-    .. math::
-
-        P_{ij}^{inst} = P_{ij}^{virial} + \\frac{2 KE}{N_f V} \\delta_{ij}
+    Mode is dispatched by ``target_pressures`` dtype (scalar / vec3 / vec9).
+    Barostat-NHC coupling is applied separately by the caller.
 
     Parameters
     ----------
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
-        Strain-rate matrices ε̇. Shape (B,) where B is batch size.
-        **MODIFIED in-place.**
+        Strain-rate matrices ε̇. Shape (B,). MODIFIED in-place.
     pressure_tensors : wp.array(dtype=vec9f or vec9d)
         Current pressure tensors from virial. Shape (B,).
-        Components ordered as [xx, xy, xz, yx, yy, yz, zx, zy, zz].
     target_pressures : wp.array
-        External/target pressure(s). The dtype determines the mode:
-
-        - ``wp.float32`` or ``wp.float64``: Isotropic (scalar P). Shape (B,).
-        - ``wp.vec3f`` or ``wp.vec3d``: Anisotropic [Pxx, Pyy, Pzz]. Shape (B,).
-        - ``vec9f`` or ``vec9d``: Full stress tensor. Shape (B,).
-
-    volumes : wp.array(dtype=scalar)
-        Cell volumes V. Shape (B,).
-    cell_masses : wp.array(dtype=scalar)
-        Barostat masses W. Shape (B,). See :func:`compute_barostat_mass`.
-    kinetic_energy : wp.array(dtype=scalar)
-        System kinetic energies. Shape (B,).
+        External pressure(s); dtype selects mode (scalar/vec3/vec9).
+    volumes, cell_masses, kinetic_energy : wp.array(dtype=scalar)
+        Cell volumes V, barostat masses W, system KE. Shape (B,).
     num_atoms_per_system : wp.array(dtype=wp.int32)
-        Number of atoms per system. Shape (B,).
-    eta_dots : wp.array2d(dtype=scalar)
-        Thermostat chain velocities η̇. Shape (B, chain_length).
-        Only eta_dots[:, 0] (first thermostat) couples to barostat.
+        Atoms per system. Shape (B,).
     dt : wp.array(dtype=scalar)
-        Full time step per system. Shape (B,). The half-step factor is applied
-        internally.
+        Full time step; half-step factor applied internally.
     device : str, optional
-        Warp device. Default: inferred from cell_velocities.
-
-    Examples
-    --------
-    Isotropic pressure control (most common):
-
-    >>> target_P = wp.array([1.0], dtype=wp.float32, device="cuda:0")
-    >>> npt_barostat_half_step(
-    ...     cell_velocities, pressure_tensors, target_P,
-    ...     volumes, cell_masses, kinetic_energy,
-    ...     num_atoms_per_system, eta_dots, dt=0.001
-    ... )
-
-    Anisotropic (orthorhombic) pressure control:
-
-    >>> # Different pressures for x, y, z axes
-    >>> target_P = wp.array([[1.0, 2.0, 1.5]], dtype=wp.vec3f, device="cuda:0")
-    >>> npt_barostat_half_step(
-    ...     cell_velocities, pressure_tensors, target_P,
-    ...     volumes, cell_masses, kinetic_energy,
-    ...     num_atoms_per_system, eta_dots, dt=0.001
-    ... )
-
-    Full triclinic stress control:
-
-    >>> # Full 3x3 stress tensor (9 components)
-    >>> target_stress = wp.array(
-    ...     [[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]],
-    ...     dtype=vec9f, device="cuda:0"
-    ... )
-    >>> npt_barostat_half_step(
-    ...     cell_velocities, pressure_tensors, target_stress,
-    ...     volumes, cell_masses, kinetic_energy,
-    ...     num_atoms_per_system, eta_dots, dt=0.001
-    ... )
+        Warp device. Default: inferred from ``cell_velocities``.
 
     See Also
     --------
-    nph_barostat_half_step : Barostat without thermostat coupling.
-    npt_velocity_half_step : Velocity update with barostat/thermostat coupling.
-    compute_barostat_mass : Compute barostat mass from relaxation time.
+    nph_barostat_half_step : NPH (no thermostat).
+    npt_velocity_half_step : Particle velocity update with NHC drag.
 
     References
     ----------
@@ -2277,7 +2124,6 @@ def npt_barostat_half_step(
 
     num_systems = cell_velocities.shape[0]
 
-    # Dispatch based on target_pressures dtype
     tp_dtype = target_pressures.dtype
     kernel = _NPT_BAROSTAT_KERNELS.get(tp_dtype)
     if kernel is None:
@@ -2297,7 +2143,6 @@ def npt_barostat_half_step(
             cell_masses,
             kinetic_energy,
             num_atoms_per_system,
-            eta_dots,
             dt,
         ],
         device=device,
@@ -2313,7 +2158,6 @@ def npt_barostat_half_step_aniso(
     cell_masses: wp.array,
     kinetic_energy: wp.array,
     num_atoms_per_system: wp.array,
-    eta_dots: wp.array,
     dt: wp.array,
     device: str = None,
 ) -> None:
@@ -2332,7 +2176,6 @@ def npt_barostat_half_step_aniso(
             cell_masses,
             kinetic_energy,
             num_atoms_per_system,
-            eta_dots,
             dt,
         ],
         device=device,
@@ -2347,7 +2190,6 @@ def npt_barostat_half_step_triclinic(
     cell_masses: wp.array,
     kinetic_energy: wp.array,
     num_atoms_per_system: wp.array,
-    eta_dots: wp.array,
     dt: wp.array,
     device: str = None,
 ) -> None:
@@ -2366,7 +2208,6 @@ def npt_barostat_half_step_triclinic(
             cell_masses,
             kinetic_energy,
             num_atoms_per_system,
-            eta_dots,
             dt,
         ],
         device=device,
@@ -2398,27 +2239,17 @@ def npt_velocity_half_step(
 
     Mathematical Formulation
     ------------------------
-    The velocity equation of motion in NPT is:
+    Particle drag follows the canonical MTK coupling
+    (cf. Martyna, Tobias & Klein 1994; ASE
+    ``IsotropicMTKNPT._integrate_p`` / ``MTKNPT._integrate_p``):
 
-    .. math::
+    **Isotropic mode** (default)
+        ``v ← v · exp(-Δt · ((1 + 1/N_atoms) · Tr(ε̇)/3 + η̇₁))``
+    **Anisotropic / triclinic mode**
+        ``v ← v · exp(-Δt · (ε̇ + Tr(ε̇)/(3·N_atoms) · I + η̇₁ · I))``
 
-        \\dot{v}_i = \\frac{F_i}{m_i} - \\left(\\gamma \\cdot \\dot{\\varepsilon} + \\dot{\\eta}_1\\right) v_i
-
-    where:
-
-    - F_i / m_i is the acceleration from forces
-    - γ = 1 + d/N_f is the coupling factor (d=3, N_f = 3N)
-    - ε̇ is the strain rate tensor (cell_velocities)
-    - η̇₁ is the first thermostat chain velocity
-
-    **Isotropic mode** (default):
-        Uses scalar strain rate Tr(ε̇)/3
-
-    **Anisotropic mode**:
-        Uses diagonal strain rates ε̇_ii for direction-dependent drag
-
-    **Triclinic mode**:
-        Uses full strain rate tensor ε̇ for full coupling
+    where ``ε̇`` is the strain rate ``cell_velocities = p_g/W`` and ``η̇₁``
+    is the first thermostat-chain velocity.
 
     Parameters
     ----------
@@ -2444,32 +2275,27 @@ def npt_velocity_half_step(
     num_atoms_per_system : wp.array(dtype=wp.int32), optional
         Number of atoms per system. Required for batched simulations.
     cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
-        Retained for backward compat; ignored by kernels.
+        .. deprecated:: 0.3.1
+            Retained for backwards compatibility and ignored. Pass
+            ``cell_velocities`` as the strain rate ``ε̇ = p_g/W`` instead.
+            Will be removed in a future release.
     mode : str, optional
         Pressure control mode. One of:
 
-        - ``"isotropic"`` (default): Uniform scalar strain rate coupling
-        - ``"anisotropic"``: Diagonal strain rate coupling (orthorhombic)
-        - ``"triclinic"``: Full tensor strain rate coupling
+        - ``"isotropic"`` (default): scalar coupling on ``Tr(ε̇)/3``
+        - ``"anisotropic"``: diagonal coupling on ``ε̇``
+        - ``"triclinic"``: full-tensor coupling on ``ε̇``
 
     device : str, optional
         Warp device.
 
     Examples
     --------
-    Single system (isotropic, cubic cell):
+    Single system (isotropic):
 
     >>> npt_velocity_half_step(
     ...     velocities, masses, forces, cell_velocities, volumes,
     ...     eta_dots, num_atoms=100, dt=0.001
-    ... )
-
-    Non-cubic cell (pass cells_inv for exact strain rate):
-
-    >>> npt_velocity_half_step(
-    ...     velocities, masses, forces, cell_velocities, volumes,
-    ...     eta_dots, num_atoms=100, dt=0.001,
-    ...     cells_inv=cells_inv, mode="triclinic"
     ... )
 
     See Also
@@ -2477,6 +2303,9 @@ def npt_velocity_half_step(
     npt_barostat_half_step : Cell velocity update step.
     npt_position_update : Position update step.
     """
+    if cells_inv is not None:
+        _warn_cells_inv_deprecated()
+        cells_inv = None
     # In-place: delegate to _out with velocities as both input and output
     npt_velocity_half_step_out(
         velocities,
@@ -2527,8 +2356,7 @@ def npt_velocity_half_step_out(
     masses, forces, cell_velocities : wp.array
         System state arrays.
     volumes : wp.array
-        Cell volumes. Shape (B,). Used as fallback when ``cells_inv``
-        is not provided (only valid for cubic cells).
+        Cell volumes. Shape (B,).
     eta_dots : wp.array
         Thermostat chain velocities.
     num_atoms : wp.array(dtype=wp.int32)
@@ -2543,7 +2371,10 @@ def npt_velocity_half_step_out(
     num_atoms_per_system : wp.array, optional
         Atom counts per system.
     cells_inv : wp.array, optional
-        Retained for backward compat; ignored by kernels.
+        .. deprecated:: 0.3.1
+            Retained for backwards compatibility and ignored. Kernels now
+            consume ``cell_velocities`` directly as the strain rate.
+            Will be removed in a future release.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".
     device : str, optional
@@ -2554,6 +2385,9 @@ def npt_velocity_half_step_out(
     wp.array
         Updated velocities.
     """
+    if cells_inv is not None:
+        _warn_cells_inv_deprecated()
+        cells_inv = None
     if device is None:
         device = velocities.device
 
@@ -2569,7 +2403,6 @@ def npt_velocity_half_step_out(
         raise ValueError(
             f"Unknown mode: '{mode}'. Expected 'isotropic', 'anisotropic', or 'triclinic'."
         )
-    # cells_inv retained for backward compat but ignored by kernels.
 
     family = _NPT_VELOCITY_FAMILIES[mode]
 
@@ -2631,12 +2464,17 @@ def npt_position_update(
     dt : wp.array(dtype=scalar)
         Full time step per system. Shape (B,).
     cells_inv : wp.array, optional
-        Retained for backward compat; ignored by kernels.
+        .. deprecated:: 0.3.1
+            Retained for backwards compatibility and ignored.
+            Will be removed in a future release.
     batch_idx : wp.array, optional
         System index for each atom.
     device : str, optional
         Warp device.
     """
+    if cells_inv is not None:
+        _warn_cells_inv_deprecated()
+        cells_inv = None
     # In-place: delegate to _out with positions as both input and output
     npt_position_update_out(
         positions,
@@ -2670,13 +2508,18 @@ def npt_position_update_out(
     Parameters
     ----------
     cells_inv : wp.array, optional
-        Retained for backward compat; ignored by kernels.
+        .. deprecated:: 0.3.1
+            Retained for backwards compatibility and ignored.
+            Will be removed in a future release.
 
     Returns
     -------
     wp.array
         Updated positions.
     """
+    if cells_inv is not None:
+        _warn_cells_inv_deprecated()
+        cells_inv = None
     if device is None:
         device = positions.device
 
@@ -2905,7 +2748,6 @@ def run_npt_step(
         cell_masses,
         kinetic_energy,
         num_atoms_per_system,
-        eta_dot,
         dt,
         device=device,
     )
@@ -2995,7 +2837,6 @@ def run_npt_step(
         cell_masses,
         kinetic_energy,
         num_atoms_per_system,
-        eta_dot,
         dt,
         device=device,
     )

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -128,34 +128,8 @@ vec3d = wp.vec3d
 
 
 # =============================================================================
-# Helper: compute h_inv from volumes when cells_inv is not provided
+# Helper: cells_inv compatibility shim
 # =============================================================================
-
-
-@wp.kernel
-def _build_identity_h_inv_kernel(
-    volumes: wp.array(dtype=Any),
-    h_inv_out: wp.array(dtype=Any),
-):
-    """Build h_inv = V^{-1/3} * I, valid for cubic cells.
-
-    Launch Grid: dim = [num_systems]
-    """
-    sys = wp.tid()
-    inv_L = wp.cbrt(type(volumes[sys])(1.0) / volumes[sys])
-    z = type(volumes[sys])(0.0)
-    h_inv_out[sys] = type(h_inv_out[sys])(inv_L, z, z, z, inv_L, z, z, z, inv_L)
-
-
-_build_identity_h_inv_kernel_overload = {}
-for _t, _m in zip(
-    [wp.float32, wp.float64],
-    [wp.mat33f, wp.mat33d],
-):
-    _build_identity_h_inv_kernel_overload[_t] = wp.overload(
-        _build_identity_h_inv_kernel,
-        [wp.array(dtype=_t), wp.array(dtype=_m)],
-    )
 
 
 def _ensure_cells_inv(
@@ -164,28 +138,20 @@ def _ensure_cells_inv(
     cell_velocities: wp.array,
     device: str | None,
 ) -> wp.array:
-    """Return ``cells_inv`` if provided; else build from ``volumes`` or zeros.
+    """Return ``cells_inv`` if provided, else a zero placeholder.
 
     Kernels no longer dereference ``h_inv``; this helper is kept for
-    backward compatibility.
+    backward compatibility with callers that still pass ``cells_inv`` /
+    ``volumes``.  The returned array's only purpose is to satisfy
+    unchanged kernel signatures.
     """
     if cells_inv is not None:
         return cells_inv
-    num_systems = cell_velocities.shape[0]
-    mat_dtype = cell_velocities.dtype
     if device is None:
         device = cell_velocities.device
-    if volumes is not None:
-        scalar_dtype = volumes.dtype
-        h_inv = wp.empty(num_systems, dtype=mat_dtype, device=device)
-        wp.launch(
-            _build_identity_h_inv_kernel_overload[scalar_dtype],
-            dim=num_systems,
-            inputs=[volumes, h_inv],
-            device=device,
-        )
-        return h_inv
-    return wp.zeros(num_systems, dtype=mat_dtype, device=device)
+    return wp.zeros(
+        cell_velocities.shape[0], dtype=cell_velocities.dtype, device=device
+    )
 
 
 # =============================================================================
@@ -560,7 +526,7 @@ def _npt_velocity_half_step_single_kernel(
 ):
     """NPT isotropic velocity half-step, single system (out-only).
 
-    v_new = v + dt/2 * (F/m - (1 + 1/N_f) * ε̇ * v - η̇₁ * v)
+    v_new = v + dt/2 * (F/m - (1 + d/N_f) * ε̇ * v - η̇₁ * v)
 
     where ε̇ is the isotropic strain rate.
 
@@ -639,7 +605,7 @@ def _nph_velocity_half_step_single_kernel(
 ):
     """NPH isotropic velocity half-step, single system (out-only).
 
-    v_new = v + dt/2 * (F/m - (1 + 1/N_f) * ε̇ * v)
+    v_new = v + dt/2 * (F/m - (1 + d/N_f) * ε̇ * v)
 
     where ε̇ is the isotropic strain rate.
 
@@ -2034,13 +2000,10 @@ def compute_cell_kinetic_energy(
         Barostat masses. Shape (B,).
     kinetic_energy : wp.array(dtype=scalar)
         Output cell kinetic energy. Shape (B,).
-    cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
-        Inverse cell matrices h⁻¹. Shape (B,). Required for non-cubic
-        cells. Retained for backward compat; ignored by kernels.
-    volumes : wp.array(dtype=scalar), optional
-        Cell volumes. Shape (B,). Used as fallback when ``cells_inv`` is not
-        provided: computes h⁻¹ = V^{-1/3} I, which is only valid for cubic
-        cells. For non-cubic cells the caller must provide ``cells_inv``.
+    cells_inv : wp.array, optional
+        Retained for backward compat; ignored by kernels.
+    volumes : wp.array, optional
+        Retained for backward compat; ignored by kernels.
     device : str, optional
         Warp device.
 
@@ -2048,11 +2011,6 @@ def compute_cell_kinetic_energy(
     -------
     wp.array
         Cell kinetic energy. Shape (B,).
-
-    Notes
-    -----
-    At least one of ``cells_inv`` or ``volumes`` must be provided.
-    If both are given, ``cells_inv`` takes precedence.
     """
     if device is None:
         device = cell_velocities.device
@@ -2468,8 +2426,7 @@ def npt_velocity_half_step(
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
         Strain-rate matrices ε̇ = p_g/W. Shape (B,).
     volumes : wp.array(dtype=scalar)
-        Cell volumes. Shape (B,). Used to build h⁻¹ = V^{-1/3}·I when
-        ``cells_inv`` is not provided (only valid for cubic cells).
+        Cell volumes. Shape (B,).
     eta_dots : wp.array2d(dtype=scalar)
         Thermostat chain velocities. Shape (B, chain_length).
     num_atoms : wp.array(dtype=wp.int32)
@@ -2482,7 +2439,6 @@ def npt_velocity_half_step(
     num_atoms_per_system : wp.array(dtype=wp.int32), optional
         Number of atoms per system. Required for batched simulations.
     cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
-        Inverse cell matrices h⁻¹. Shape (B,). When provided, the
         Retained for backward compat; ignored by kernels.
     mode : str, optional
         Pressure control mode. One of:
@@ -2582,7 +2538,6 @@ def npt_velocity_half_step_out(
     num_atoms_per_system : wp.array, optional
         Atom counts per system.
     cells_inv : wp.array, optional
-        Inverse cell matrices h⁻¹. Shape (B,). When provided, the
         Retained for backward compat; ignored by kernels.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".
@@ -2651,7 +2606,7 @@ def npt_position_update(
     cells: wp.array,
     cell_velocities: wp.array,
     dt: wp.array,
-    cells_inv: wp.array,
+    cells_inv: wp.array = None,
     batch_idx: wp.array = None,
     device: str = None,
 ) -> None:
@@ -2667,12 +2622,11 @@ def npt_position_update(
     cells : wp.array
         Cell matrices.
     cell_velocities : wp.array
-        Cell velocity matrices.
+        Strain-rate matrices ε̇.
     dt : wp.array(dtype=scalar)
         Full time step per system. Shape (B,).
-    cells_inv : wp.array
-        Pre-computed cell inverses. Caller must pre-compute via
-        ``compute_cell_inverse``.
+    cells_inv : wp.array, optional
+        Retained for backward compat; ignored by kernels.
     batch_idx : wp.array, optional
         System index for each atom.
     device : str, optional
@@ -2686,7 +2640,7 @@ def npt_position_update(
         cell_velocities,
         dt,
         positions,
-        cells_inv,
+        cells_inv=cells_inv,
         batch_idx=batch_idx,
         device=device,
         _skip_validation=True,
@@ -2700,7 +2654,7 @@ def npt_position_update_out(
     cell_velocities: wp.array,
     dt: wp.array,
     positions_out: wp.array,
-    cells_inv: wp.array,
+    cells_inv: wp.array = None,
     batch_idx: wp.array = None,
     device: str = None,
     _skip_validation: bool = False,
@@ -2710,9 +2664,8 @@ def npt_position_update_out(
 
     Parameters
     ----------
-    cells_inv : wp.array
-        Pre-computed cell inverses. Caller must pre-compute via
-        ``compute_cell_inverse``.
+    cells_inv : wp.array, optional
+        Retained for backward compat; ignored by kernels.
 
     Returns
     -------
@@ -2724,6 +2677,8 @@ def npt_position_update_out(
 
     if not _skip_validation:
         validate_out_array(positions_out, positions, "positions_out")
+
+    cells_inv = _ensure_cells_inv(cells_inv, None, cell_velocities, device)
 
     exec_mode = resolve_execution_mode(batch_idx, None)
     num_atoms = positions.shape[0]
@@ -2840,9 +2795,9 @@ def run_npt_step(
     pressure_tensors: wp.array,
     volumes: wp.array,
     kinetic_energy: wp.array,
-    cells_inv: wp.array,
     kinetic_tensors: wp.array,
     num_atoms_per_system: wp.array,
+    cells_inv: wp.array = None,
     compute_forces_fn=None,
     batch_idx: wp.array = None,
     device: str = None,
@@ -2950,8 +2905,11 @@ def run_npt_step(
         device=device,
     )
 
-    # 3. Velocity half-step
-    compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
+    # 3. Velocity half-step (cells_inv is no longer load-bearing; if a
+    # caller-provided buffer is given, we still populate it for symmetry
+    # with prior versions).
+    if cells_inv is not None:
+        compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
     npt_velocity_half_step(
         velocities,
         masses,
@@ -2967,7 +2925,7 @@ def run_npt_step(
         device=device,
     )
 
-    # 4. Position update (reuses cells_inv from step 3)
+    # 4. Position update
     npt_position_update(
         positions,
         velocities,
@@ -2988,7 +2946,8 @@ def run_npt_step(
 
     # Recompute pressure, volumes, and cell inverses after cell update
     compute_cell_volume(cells, volumes=volumes, device=device)
-    compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
+    if cells_inv is not None:
+        compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
     compute_kinetic_energy(
         velocities,
         masses,
@@ -3303,8 +3262,7 @@ def nph_velocity_half_step(
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
         Strain-rate matrices ε̇ = p_g/W.
     volumes : wp.array(dtype=scalar)
-        Cell volumes. Shape (B,). Used to build h⁻¹ = V^{-1/3}·I when
-        ``cells_inv`` is not provided (only valid for cubic cells).
+        Cell volumes. Shape (B,).
     num_atoms : wp.array(dtype=wp.int32)
         Atom count for single-system mode. Shape (1,).
     dt : wp.array(dtype=scalar)
@@ -3315,7 +3273,6 @@ def nph_velocity_half_step(
     num_atoms_per_system : wp.array, optional
         Number of atoms per system.
     cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
-        Inverse cell matrices h⁻¹. Shape (B,). When provided, the
         Retained for backward compat; ignored by kernels.
     mode : str, optional
         Pressure control mode:
@@ -3394,7 +3351,6 @@ def nph_velocity_half_step_out(
     batch_idx, num_atoms_per_system : wp.array, optional
         For batched simulations.
     cells_inv : wp.array, optional
-        Inverse cell matrices h⁻¹. Shape (B,). When provided, the
         Retained for backward compat; ignored by kernels.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".
@@ -3461,7 +3417,7 @@ def nph_position_update(
     cells: wp.array,
     cell_velocities: wp.array,
     dt: wp.array,
-    cells_inv: wp.array,
+    cells_inv: wp.array = None,
     batch_idx: wp.array = None,
     device: str = None,
 ) -> None:
@@ -3476,7 +3432,7 @@ def nph_position_update(
         cells,
         cell_velocities,
         dt,
-        cells_inv,
+        cells_inv=cells_inv,
         batch_idx=batch_idx,
         device=device,
     )
@@ -3489,7 +3445,7 @@ def nph_position_update_out(
     cell_velocities: wp.array,
     dt: wp.array,
     positions_out: wp.array,
-    cells_inv: wp.array,
+    cells_inv: wp.array = None,
     batch_idx: wp.array = None,
     device: str = None,
 ) -> wp.array:
@@ -3508,7 +3464,7 @@ def nph_position_update_out(
         cell_velocities,
         dt,
         positions_out,
-        cells_inv,
+        cells_inv=cells_inv,
         batch_idx=batch_idx,
         device=device,
     )
@@ -3543,9 +3499,9 @@ def run_nph_step(
     pressure_tensors: wp.array,
     volumes: wp.array,
     kinetic_energy: wp.array,
-    cells_inv: wp.array,
     kinetic_tensors: wp.array,
     num_atoms_per_system: wp.array,
+    cells_inv: wp.array = None,
     compute_forces_fn=None,
     batch_idx: wp.array = None,
     device: str = None,
@@ -3632,7 +3588,8 @@ def run_nph_step(
     )
 
     # 2. Velocity half-step
-    compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
+    if cells_inv is not None:
+        compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
     nph_velocity_half_step(
         velocities,
         masses,
@@ -3668,7 +3625,8 @@ def run_nph_step(
 
     # Recompute pressure, volumes, and cell inverses after cell update
     compute_cell_volume(cells, volumes=volumes, device=device)
-    compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
+    if cells_inv is not None:
+        compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
     compute_kinetic_energy(
         velocities,
         masses,

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -151,17 +151,11 @@ def _ensure_cells_inv(
 
 
 def _warn_cells_inv_deprecated(stacklevel: int = 2) -> None:
-    """Emit a DeprecationWarning when callers still pass ``cells_inv``.
-
-    Centralised so the message is identical at every entry point and the
-    behaviour can be tightened in a future release without touching call
-    sites.
-    """
+    """Emit a DeprecationWarning when callers still pass ``cells_inv``."""
     warnings.warn(
-        "The 'cells_inv' argument is deprecated and ignored: "
-        "'cell_velocities' is now the strain rate ε̇ = p_g/W and the kernels "
-        "no longer require an explicit cell inverse. The argument is kept "
-        "for backwards compatibility and will be removed in a future release.",
+        "'cells_inv' is deprecated and ignored; kernels consume "
+        "'cell_velocities' as the strain rate ε̇ = p_g/W. "
+        "Will be removed in a future release.",
         DeprecationWarning,
         stacklevel=stacklevel,
     )
@@ -1941,9 +1935,7 @@ def compute_cell_kinetic_energy(
         Output cell kinetic energy. Shape (B,).
     cells_inv : wp.array, optional
         .. deprecated:: 0.3.1
-            Retained for backwards compatibility and ignored. Kernels now
-            consume ``cell_velocities`` directly as the strain rate.
-            Will be removed in a future release.
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     volumes : wp.array, optional
         Retained for backwards compatibility; ignored.
     device : str, optional
@@ -2239,17 +2231,13 @@ def npt_velocity_half_step(
 
     Mathematical Formulation
     ------------------------
-    Particle drag follows the canonical MTK coupling
-    (cf. Martyna, Tobias & Klein 1994; ASE
-    ``IsotropicMTKNPT._integrate_p`` / ``MTKNPT._integrate_p``):
-
     **Isotropic mode** (default)
         ``v ← v · exp(-Δt · ((1 + 1/N_atoms) · Tr(ε̇)/3 + η̇₁))``
     **Anisotropic / triclinic mode**
         ``v ← v · exp(-Δt · (ε̇ + Tr(ε̇)/(3·N_atoms) · I + η̇₁ · I))``
 
-    where ``ε̇`` is the strain rate ``cell_velocities = p_g/W`` and ``η̇₁``
-    is the first thermostat-chain velocity.
+    where ``ε̇ = cell_velocities = p_g/W`` and ``η̇₁`` is the first
+    thermostat-chain velocity.
 
     Parameters
     ----------
@@ -2276,9 +2264,7 @@ def npt_velocity_half_step(
         Number of atoms per system. Required for batched simulations.
     cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
         .. deprecated:: 0.3.1
-            Retained for backwards compatibility and ignored. Pass
-            ``cell_velocities`` as the strain rate ``ε̇ = p_g/W`` instead.
-            Will be removed in a future release.
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     mode : str, optional
         Pressure control mode. One of:
 
@@ -2372,9 +2358,7 @@ def npt_velocity_half_step_out(
         Atom counts per system.
     cells_inv : wp.array, optional
         .. deprecated:: 0.3.1
-            Retained for backwards compatibility and ignored. Kernels now
-            consume ``cell_velocities`` directly as the strain rate.
-            Will be removed in a future release.
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".
     device : str, optional
@@ -2465,8 +2449,7 @@ def npt_position_update(
         Full time step per system. Shape (B,).
     cells_inv : wp.array, optional
         .. deprecated:: 0.3.1
-            Retained for backwards compatibility and ignored.
-            Will be removed in a future release.
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     batch_idx : wp.array, optional
         System index for each atom.
     device : str, optional
@@ -2509,8 +2492,7 @@ def npt_position_update_out(
     ----------
     cells_inv : wp.array, optional
         .. deprecated:: 0.3.1
-            Retained for backwards compatibility and ignored.
-            Will be removed in a future release.
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
 
     Returns
     -------
@@ -2643,9 +2625,9 @@ def run_npt_step(
     pressure_tensors: wp.array,
     volumes: wp.array,
     kinetic_energy: wp.array,
-    kinetic_tensors: wp.array,
-    num_atoms_per_system: wp.array,
     cells_inv: wp.array = None,
+    kinetic_tensors: wp.array = None,
+    num_atoms_per_system: wp.array = None,
     compute_forces_fn=None,
     batch_idx: wp.array = None,
     device: str = None,
@@ -2697,8 +2679,9 @@ def run_npt_step(
     kinetic_energy : wp.array(dtype=scalar)
         Scratch array for kinetic energy. Shape (B,).
         Zeroed internally before each use.
-    cells_inv : wp.array(dtype=mat33)
-        Scratch array for cell inverses. Shape (B,).
+    cells_inv : wp.array, optional
+        .. deprecated:: 0.3.1
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     kinetic_tensors : wp.array(dtype=scalar, ndim=2)
         Scratch array for kinetic tensor accumulation. Shape (B, 9).
         Zeroed internally before each use.
@@ -2711,6 +2694,13 @@ def run_npt_step(
     device : str, optional
         Warp device.
     """
+    if cells_inv is not None:
+        _warn_cells_inv_deprecated()
+        cells_inv = None
+    if kinetic_tensors is None or num_atoms_per_system is None:
+        raise ValueError(
+            "run_npt_step requires 'kinetic_tensors' and 'num_atoms_per_system'."
+        )
     if device is None:
         device = positions.device
 
@@ -3081,19 +3071,10 @@ def nph_velocity_half_step(
 
     Mathematical Formulation
     ------------------------
-    The NPH velocity equation of motion:
-
-    .. math::
-
-        \\dot{v}_i = \\frac{F_i}{m_i} - \\gamma \\cdot \\dot{\\varepsilon} \\cdot v_i
-
-    where γ = 1 + d/N_f is the coupling factor.
-
-    **Isotropic mode**: Uses scalar strain rate Tr(ε̇)/3
-
-    **Anisotropic mode**: Uses diagonal strain rates ε̇_ii
-
-    **Triclinic mode**: Uses full strain rate tensor ε̇
+    **Isotropic mode**
+        ``v ← v · exp(-Δt · (1 + 1/N_atoms) · Tr(ε̇)/3)``
+    **Anisotropic / triclinic mode**
+        ``v ← v · exp(-Δt · (ε̇ + Tr(ε̇)/(3·N_atoms) · I))``
 
     Parameters
     ----------
@@ -3117,13 +3098,14 @@ def nph_velocity_half_step(
     num_atoms_per_system : wp.array, optional
         Number of atoms per system.
     cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
-        Retained for backward compat; ignored by kernels.
+        .. deprecated:: 0.3.1
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     mode : str, optional
         Pressure control mode:
 
-        - ``"isotropic"``: Uniform scalar strain rate coupling
-        - ``"anisotropic"``: Diagonal strain rate coupling (orthorhombic)
-        - ``"triclinic"``: Full tensor coupling
+        - ``"isotropic"``: scalar coupling on ``Tr(ε̇)/3``
+        - ``"anisotropic"``: diagonal coupling on ``ε̇``
+        - ``"triclinic"``: full-tensor coupling on ``ε̇``
 
     device : str, optional
         Warp device.
@@ -3133,6 +3115,9 @@ def nph_velocity_half_step(
     nph_barostat_half_step : Cell velocity update.
     npt_velocity_half_step : Velocity update with thermostat.
     """
+    if cells_inv is not None:
+        _warn_cells_inv_deprecated()
+        cells_inv = None
     # In-place: delegate to _out with velocities as both input and output
     nph_velocity_half_step_out(
         velocities,
@@ -3183,8 +3168,7 @@ def nph_velocity_half_step_out(
     masses, forces, cell_velocities : wp.array
         System state arrays.
     volumes : wp.array
-        Cell volumes. Shape (B,). Used as fallback when ``cells_inv``
-        is not provided (only valid for cubic cells).
+        Cell volumes. Shape (B,).
     num_atoms : wp.array(dtype=wp.int32)
         Atom count for single-system mode. Shape (1,).
     dt : wp.array(dtype=scalar)
@@ -3195,7 +3179,8 @@ def nph_velocity_half_step_out(
     batch_idx, num_atoms_per_system : wp.array, optional
         For batched simulations.
     cells_inv : wp.array, optional
-        Retained for backward compat; ignored by kernels.
+        .. deprecated:: 0.3.1
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".
     device : str, optional
@@ -3206,6 +3191,9 @@ def nph_velocity_half_step_out(
     wp.array
         Updated velocities.
     """
+    if cells_inv is not None:
+        _warn_cells_inv_deprecated()
+        cells_inv = None
     if device is None:
         device = velocities.device
 
@@ -3221,7 +3209,6 @@ def nph_velocity_half_step_out(
         raise ValueError(
             f"Unknown mode: '{mode}'. Expected 'isotropic', 'anisotropic', or 'triclinic'."
         )
-    # cells_inv retained for backward compat but ignored by kernels.
 
     family = _NPH_VELOCITY_FAMILIES[mode]
 
@@ -3269,7 +3256,16 @@ def nph_position_update(
     Update positions for NPH integration.
 
     Uses same kernel as NPT since position update is identical.
+
+    Parameters
+    ----------
+    cells_inv : wp.array, optional
+        .. deprecated:: 0.3.1
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     """
+    if cells_inv is not None:
+        _warn_cells_inv_deprecated()
+        cells_inv = None
     npt_position_update(
         positions,
         velocities,
@@ -3296,11 +3292,20 @@ def nph_position_update_out(
     """
     Update positions for NPH integration (non-mutating).
 
+    Parameters
+    ----------
+    cells_inv : wp.array, optional
+        .. deprecated:: 0.3.1
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
+
     Returns
     -------
     wp.array
         Updated positions.
     """
+    if cells_inv is not None:
+        _warn_cells_inv_deprecated()
+        cells_inv = None
     return npt_position_update_out(
         positions,
         velocities,
@@ -3343,9 +3348,9 @@ def run_nph_step(
     pressure_tensors: wp.array,
     volumes: wp.array,
     kinetic_energy: wp.array,
-    kinetic_tensors: wp.array,
-    num_atoms_per_system: wp.array,
     cells_inv: wp.array = None,
+    kinetic_tensors: wp.array = None,
+    num_atoms_per_system: wp.array = None,
     compute_forces_fn=None,
     batch_idx: wp.array = None,
     device: str = None,
@@ -3389,8 +3394,9 @@ def run_nph_step(
     kinetic_energy : wp.array(dtype=scalar)
         Scratch array for kinetic energy. Shape (B,).
         Zeroed internally before each use.
-    cells_inv : wp.array(dtype=mat33)
-        Scratch array for cell inverses. Shape (B,).
+    cells_inv : wp.array, optional
+        .. deprecated:: 0.3.1
+            Ignored; ``cell_velocities`` is the strain rate ``ε̇ = p_g/W``.
     kinetic_tensors : wp.array(dtype=scalar, ndim=2)
         Scratch array for kinetic tensor accumulation. Shape (B, 9).
         Zeroed internally before each use.
@@ -3403,6 +3409,13 @@ def run_nph_step(
     device : str, optional
         Warp device.
     """
+    if cells_inv is not None:
+        _warn_cells_inv_deprecated()
+        cells_inv = None
+    if kinetic_tensors is None or num_atoms_per_system is None:
+        raise ValueError(
+            "run_nph_step requires 'kinetic_tensors' and 'num_atoms_per_system'."
+        )
     if device is None:
         device = positions.device
 

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -138,13 +138,8 @@ def _ensure_cells_inv(
     cell_velocities: wp.array,
     device: str | None,
 ) -> wp.array:
-    """Return ``cells_inv`` if provided, else a zero placeholder.
-
-    Kernels no longer dereference ``h_inv``; this helper is kept for
-    backward compatibility with callers that still pass ``cells_inv`` /
-    ``volumes``.  The returned array's only purpose is to satisfy
-    unchanged kernel signatures.
-    """
+    """Return ``cells_inv`` if provided, else a zero placeholder for
+    callers that still pass it; kernels no longer consume it."""
     if cells_inv is not None:
         return cells_inv
     if device is None:
@@ -175,29 +170,39 @@ def _drag_isotropic(eps_dot: Any, coupling: Any, eta_dot_1: Any, v: Any) -> Any:
 
 
 @wp.func
-def _drag_anisotropic(eps_dot: Any, coupling: Any, eta_dot_1: Any, v: Any) -> Any:
-    """Anisotropic (diagonal) drag using ε̇ from cell_velocities."""
+def _drag_anisotropic(eps_dot: Any, inv_three_n: Any, eta_dot_1: Any, v: Any) -> Any:
+    """Anisotropic drag: (ε̇_ii + Tr(ε̇)·inv_three_n + eta_dot_1) * v_i."""
+    trace_eps = eps_dot[0, 0] + eps_dot[1, 1] + eps_dot[2, 2]
+    trace_corr = trace_eps * inv_three_n
     return type(v)(
-        (coupling * eps_dot[0, 0] + eta_dot_1) * v[0],
-        (coupling * eps_dot[1, 1] + eta_dot_1) * v[1],
-        (coupling * eps_dot[2, 2] + eta_dot_1) * v[2],
+        (eps_dot[0, 0] + trace_corr + eta_dot_1) * v[0],
+        (eps_dot[1, 1] + trace_corr + eta_dot_1) * v[1],
+        (eps_dot[2, 2] + trace_corr + eta_dot_1) * v[2],
     )
 
 
 @wp.func
-def _drag_triclinic(eps_dot: Any, coupling: Any, eta_dot_1: Any, v: Any) -> Any:
-    """Triclinic (full tensor) drag: (coupling * ε̇ + eta_dot_1 * I) @ v."""
+def _drag_triclinic(eps_dot: Any, inv_three_n: Any, eta_dot_1: Any, v: Any) -> Any:
+    """Triclinic drag: (ε̇ + (Tr(ε̇)·inv_three_n + eta_dot_1)·I) @ v."""
+    trace_eps = eps_dot[0, 0] + eps_dot[1, 1] + eps_dot[2, 2]
+    diag_corr = trace_eps * inv_three_n + eta_dot_1
     drag_x = (
-        coupling * (eps_dot[0, 0] * v[0] + eps_dot[0, 1] * v[1] + eps_dot[0, 2] * v[2])
-        + eta_dot_1 * v[0]
+        eps_dot[0, 0] * v[0]
+        + eps_dot[0, 1] * v[1]
+        + eps_dot[0, 2] * v[2]
+        + diag_corr * v[0]
     )
     drag_y = (
-        coupling * (eps_dot[1, 0] * v[0] + eps_dot[1, 1] * v[1] + eps_dot[1, 2] * v[2])
-        + eta_dot_1 * v[1]
+        eps_dot[1, 0] * v[0]
+        + eps_dot[1, 1] * v[1]
+        + eps_dot[1, 2] * v[2]
+        + diag_corr * v[1]
     )
     drag_z = (
-        coupling * (eps_dot[2, 0] * v[0] + eps_dot[2, 1] * v[1] + eps_dot[2, 2] * v[2])
-        + eta_dot_1 * v[2]
+        eps_dot[2, 0] * v[0]
+        + eps_dot[2, 1] * v[1]
+        + eps_dot[2, 2] * v[2]
+        + diag_corr * v[2]
     )
     return type(v)(drag_x, drag_y, drag_z)
 
@@ -1220,10 +1225,10 @@ def _npt_velocity_half_step_aniso_single_kernel(
     eta_dot_1 = eta_dot[0, 0]
 
     N_f = type(m)(3 * num_atoms[0])
-    coupling = type(m)(1.0) + type(m)(3.0) / N_f
+    inv_three_n = type(m)(1.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_anisotropic(h_dot, coupling, eta_dot_1, v)
+    drag = _drag_anisotropic(h_dot, inv_three_n, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1257,10 +1262,10 @@ def _npt_velocity_half_step_aniso_kernel(
     N = num_atoms_per_system[sys_id]
 
     N_f = type(m)(3 * N)
-    coupling = type(m)(1.0) + type(m)(3.0) / N_f
+    inv_three_n = type(m)(1.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_anisotropic(h_dot, coupling, eta_dot_1, v)
+    drag = _drag_anisotropic(h_dot, inv_three_n, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1296,10 +1301,10 @@ def _npt_velocity_half_step_triclinic_single_kernel(
     eta_dot_1 = eta_dot[0, 0]
 
     N_f = type(m)(3 * num_atoms[0])
-    coupling = type(m)(1.0) + type(m)(3.0) / N_f
+    inv_three_n = type(m)(1.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_triclinic(h_dot, coupling, eta_dot_1, v)
+    drag = _drag_triclinic(h_dot, inv_three_n, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1333,10 +1338,10 @@ def _npt_velocity_half_step_triclinic_kernel(
     N = num_atoms_per_system[sys_id]
 
     N_f = type(m)(3 * N)
-    coupling = type(m)(1.0) + type(m)(3.0) / N_f
+    inv_three_n = type(m)(1.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_triclinic(h_dot, coupling, eta_dot_1, v)
+    drag = _drag_triclinic(h_dot, inv_three_n, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1370,10 +1375,10 @@ def _nph_velocity_half_step_triclinic_single_kernel(
     h_dot = cell_velocity[0]
 
     N_f = type(m)(3 * num_atoms[0])
-    coupling = type(m)(1.0) + type(m)(3.0) / N_f
+    inv_three_n = type(m)(1.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_triclinic(h_dot, coupling, type(m)(0.0), v)
+    drag = _drag_triclinic(h_dot, inv_three_n, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1405,10 +1410,10 @@ def _nph_velocity_half_step_triclinic_kernel(
     N = num_atoms_per_system[sys_id]
 
     N_f = type(m)(3 * N)
-    coupling = type(m)(1.0) + type(m)(3.0) / N_f
+    inv_three_n = type(m)(1.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_triclinic(h_dot, coupling, type(m)(0.0), v)
+    drag = _drag_triclinic(h_dot, inv_three_n, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1437,10 +1442,10 @@ def _nph_velocity_half_step_aniso_single_kernel(
     h_dot = cell_velocity[0]
 
     N_f = type(m)(3 * num_atoms[0])
-    coupling = type(m)(1.0) + type(m)(3.0) / N_f
+    inv_three_n = type(m)(1.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_anisotropic(h_dot, coupling, type(m)(0.0), v)
+    drag = _drag_anisotropic(h_dot, inv_three_n, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1472,10 +1477,10 @@ def _nph_velocity_half_step_aniso_kernel(
     N = num_atoms_per_system[sys_id]
 
     N_f = type(m)(3 * N)
-    coupling = type(m)(1.0) + type(m)(3.0) / N_f
+    inv_three_n = type(m)(1.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_anisotropic(h_dot, coupling, type(m)(0.0), v)
+    drag = _drag_anisotropic(h_dot, inv_three_n, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -2905,9 +2910,7 @@ def run_npt_step(
         device=device,
     )
 
-    # 3. Velocity half-step (cells_inv is no longer load-bearing; if a
-    # caller-provided buffer is given, we still populate it for symmetry
-    # with prior versions).
+    # 3. Velocity half-step.  Refresh caller-provided cells_inv for symmetry.
     if cells_inv is not None:
         compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
     npt_velocity_half_step(

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -37,10 +37,10 @@ Pressure Control Modes
 
 Conventions
 -----------
-**Cell velocities** (``cell_velocities``) are the absolute time derivative
-of the cell matrix: ḣ = dh/dt.  The strain rate tensor ε̇ = ḣ h⁻¹ is
-computed internally wherever it is needed (drag, position update, cell
-kinetic energy).  Callers should *not* pre-convert to strain rate.
+**Cell velocities** (``cell_velocities``) are the strain-rate tensor
+ε̇ = p_g / W (canonical MTK / ASE / TorchSim convention).  The absolute
+time derivative is ḣ = ε̇ · h, applied multiplicatively in the cell
+update step.  Callers should not pre-multiply by h.
 
 **Virial sign**: ``compute_pressure_tensor`` expects the virial
 W = -dE/dε as defined in ``docs/userguide/about/conventions.md``.
@@ -164,41 +164,28 @@ def _ensure_cells_inv(
     cell_velocities: wp.array,
     device: str | None,
 ) -> wp.array:
-    """Return cells_inv if provided, otherwise build V^{-1/3}·I from volumes.
+    """Return ``cells_inv`` if provided; else build from ``volumes`` or zeros.
 
-    Parameters
-    ----------
-    cells_inv : wp.array or None
-        Caller-provided inverse cell matrices.
-    volumes : wp.array or None
-        Cell volumes, used as fallback.
-    cell_velocities : wp.array
-        Used only to infer mat dtype (mat33f or mat33d).
-    device : str or None
-        Warp device.
-
-    Returns
-    -------
-    wp.array
-        Inverse cell matrices (either caller-provided or computed).
+    Kernels no longer dereference ``h_inv``; this helper is kept for
+    backward compatibility.
     """
     if cells_inv is not None:
         return cells_inv
-    if volumes is None:
-        raise ValueError("Either cells_inv or volumes must be provided.")
-    num_systems = volumes.shape[0]
+    num_systems = cell_velocities.shape[0]
     mat_dtype = cell_velocities.dtype
     if device is None:
         device = cell_velocities.device
-    scalar_dtype = volumes.dtype
-    h_inv = wp.empty(num_systems, dtype=mat_dtype, device=device)
-    wp.launch(
-        _build_identity_h_inv_kernel_overload[scalar_dtype],
-        dim=num_systems,
-        inputs=[volumes, h_inv],
-        device=device,
-    )
-    return h_inv
+    if volumes is not None:
+        scalar_dtype = volumes.dtype
+        h_inv = wp.empty(num_systems, dtype=mat_dtype, device=device)
+        wp.launch(
+            _build_identity_h_inv_kernel_overload[scalar_dtype],
+            dim=num_systems,
+            inputs=[volumes, h_inv],
+            device=device,
+        )
+        return h_inv
+    return wp.zeros(num_systems, dtype=mat_dtype, device=device)
 
 
 # =============================================================================
@@ -214,22 +201,16 @@ def _npt_accel(f: Any, m: Any) -> Any:
 
 
 @wp.func
-def _drag_isotropic(
-    h_dot: Any, h_inv: Any, coupling: Any, eta_dot_1: Any, v: Any
-) -> Any:
-    """Isotropic drag: (coupling * Tr(ε̇)/3 + eta_dot_1) * v, where ε̇ = ḣ h⁻¹."""
-    eps_dot = wp.mul(h_dot, h_inv)
+def _drag_isotropic(eps_dot: Any, coupling: Any, eta_dot_1: Any, v: Any) -> Any:
+    """Isotropic drag: (coupling * Tr(ε̇)/3 + eta_dot_1) * v."""
     trace_eps = eps_dot[0, 0] + eps_dot[1, 1] + eps_dot[2, 2]
     eps_scalar = trace_eps / type(trace_eps)(3.0)
     return (coupling * eps_scalar + eta_dot_1) * v
 
 
 @wp.func
-def _drag_anisotropic(
-    h_dot: Any, h_inv: Any, coupling: Any, eta_dot_1: Any, v: Any
-) -> Any:
-    """Anisotropic (diagonal) drag using ε̇ = ḣ h⁻¹."""
-    eps_dot = wp.mul(h_dot, h_inv)
+def _drag_anisotropic(eps_dot: Any, coupling: Any, eta_dot_1: Any, v: Any) -> Any:
+    """Anisotropic (diagonal) drag using ε̇ from cell_velocities."""
     return type(v)(
         (coupling * eps_dot[0, 0] + eta_dot_1) * v[0],
         (coupling * eps_dot[1, 1] + eta_dot_1) * v[1],
@@ -238,11 +219,8 @@ def _drag_anisotropic(
 
 
 @wp.func
-def _drag_triclinic(
-    h_dot: Any, h_inv: Any, coupling: Any, eta_dot_1: Any, v: Any
-) -> Any:
-    """Triclinic (full tensor) drag: (coupling * ḣ h⁻¹ + eta_dot_1 * I) @ v."""
-    eps_dot = wp.mul(h_dot, h_inv)
+def _drag_triclinic(eps_dot: Any, coupling: Any, eta_dot_1: Any, v: Any) -> Any:
+    """Triclinic (full tensor) drag: (coupling * ε̇ + eta_dot_1 * I) @ v."""
     drag_x = (
         coupling * (eps_dot[0, 0] * v[0] + eps_dot[0, 1] * v[1] + eps_dot[0, 2] * v[2])
         + eta_dot_1 * v[0]
@@ -259,9 +237,8 @@ def _drag_triclinic(
 
 
 @wp.func
-def _npt_position_step(r: Any, v: Any, h_dot: Any, h_inv: Any, dt: Any) -> Any:
-    """Position update: r + dt * (v + eps_dot @ r)."""
-    eps_dot = wp.mul(h_dot, h_inv)
+def _npt_position_step(r: Any, v: Any, eps_dot: Any, dt: Any) -> Any:
+    """Position update: r + dt * (v + ε̇ · r)."""
     eps_dot_r = wp.mul(eps_dot, r)
     return r + dt * (v + eps_dot_r)
 
@@ -532,16 +509,14 @@ def _compute_cell_kinetic_energy_kernel(
     cell_masses: wp.array(dtype=Any),
     kinetic_energy: wp.array(dtype=Any),
 ):
-    """Compute cell kinetic energy: KE = 0.5 * W * ||ε̇||²_F, where ε̇ = ḣ h⁻¹.
+    """Compute cell kinetic energy: KE = 0.5 * W * ||ε̇||²_F where ε̇ = cell_velocities.
 
     Launch Grid: dim = [num_systems]
     """
     sys_id = wp.tid()
-    h_dot = cell_velocities[sys_id]
-    h_inv = cells_inv[sys_id]
+    eps_dot = cell_velocities[sys_id]
     W = cell_masses[sys_id]
 
-    eps_dot = wp.mul(h_dot, h_inv)
     ke = type(W)(0.0)
     for i in range(3):
         for j in range(3):
@@ -587,7 +562,7 @@ def _npt_velocity_half_step_single_kernel(
 
     v_new = v + dt/2 * (F/m - (1 + 1/N_f) * ε̇ * v - η̇₁ * v)
 
-    where ε̇ = Tr(ḣ h⁻¹)/3 is the isotropic strain rate.
+    where ε̇ is the isotropic strain rate.
 
     For in-place: host passes same array as velocities and velocities_out.
 
@@ -598,14 +573,13 @@ def _npt_velocity_half_step_single_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocity[0]
-    h_inv = cell_inv[0]
     eta_dot_1 = eta_dot[0, 0]
 
     N_f = type(m)(3 * num_atoms[0])
-    coupling = type(m)(1.0) + type(m)(1.0) / N_f
+    coupling = type(m)(1.0) + type(m)(3.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_isotropic(h_dot, h_inv, coupling, eta_dot_1, v)
+    drag = _drag_isotropic(h_dot, coupling, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -635,15 +609,14 @@ def _npt_velocity_half_step_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocities[sys_id]
-    h_inv = cells_inv[sys_id]
     eta_dot_1 = eta_dots[sys_id, 0]
     N = num_atoms_per_system[sys_id]
 
     N_f = type(m)(3 * N)
-    coupling = type(m)(1.0) + type(m)(1.0) / N_f
+    coupling = type(m)(1.0) + type(m)(3.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_isotropic(h_dot, h_inv, coupling, eta_dot_1, v)
+    drag = _drag_isotropic(h_dot, coupling, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -668,7 +641,7 @@ def _nph_velocity_half_step_single_kernel(
 
     v_new = v + dt/2 * (F/m - (1 + 1/N_f) * ε̇ * v)
 
-    where ε̇ = Tr(ḣ h⁻¹)/3 is the isotropic strain rate.
+    where ε̇ is the isotropic strain rate.
 
     For in-place: host passes same array as velocities and velocities_out.
 
@@ -679,13 +652,12 @@ def _nph_velocity_half_step_single_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocity[0]
-    h_inv = cell_inv[0]
 
     N_f = type(m)(3 * num_atoms[0])
-    coupling = type(m)(1.0) + type(m)(1.0) / N_f
+    coupling = type(m)(1.0) + type(m)(3.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_isotropic(h_dot, h_inv, coupling, type(m)(0.0), v)
+    drag = _drag_isotropic(h_dot, coupling, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -714,14 +686,13 @@ def _nph_velocity_half_step_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocities[sys_id]
-    h_inv = cells_inv[sys_id]
     N = num_atoms_per_system[sys_id]
 
     N_f = type(m)(3 * N)
-    coupling = type(m)(1.0) + type(m)(1.0) / N_f
+    coupling = type(m)(1.0) + type(m)(3.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_isotropic(h_dot, h_inv, coupling, type(m)(0.0), v)
+    drag = _drag_isotropic(h_dot, coupling, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -752,10 +723,9 @@ def _position_update_single_kernel(
     atom_idx = wp.tid()
     r = positions[atom_idx]
     v = velocities[atom_idx]
-    h_inv = cell_inv[0]
     h_dot = cell_velocity[0]
 
-    positions_out[atom_idx] = _npt_position_step(r, v, h_dot, h_inv, dt[0])
+    positions_out[atom_idx] = _npt_position_step(r, v, h_dot, dt[0])
 
 
 @wp.kernel
@@ -779,10 +749,9 @@ def _position_update_kernel(
     sys_id = batch_idx[atom_idx]
     r = positions[atom_idx]
     v = velocities[atom_idx]
-    h_inv = cells_inv[sys_id]
     h_dot = cell_velocities[sys_id]
 
-    positions_out[atom_idx] = _npt_position_step(r, v, h_dot, h_inv, dt[sys_id])
+    positions_out[atom_idx] = _npt_position_step(r, v, h_dot, dt[sys_id])
 
 
 # ==============================================================================
@@ -829,7 +798,7 @@ def _npt_cell_velocity_update_kernel(
     Parameters
     ----------
     cell_velocities : wp.array(dtype=mat33f/mat33d)
-        Cell velocity matrices ḣ. Shape (B,). MODIFIED in-place.
+        Strain-rate matrices ε̇. Shape (B,). MODIFIED in-place.
     pressure_tensors : wp.array(dtype=vec9f/vec9d)
         Pressure tensors from virial. Components [xx,xy,xz,yx,yy,yz,zx,zy,zz].
     target_pressures : wp.array(dtype=float32/float64)
@@ -1282,14 +1251,13 @@ def _npt_velocity_half_step_aniso_single_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocity[0]
-    h_inv = cell_inv[0]
     eta_dot_1 = eta_dot[0, 0]
 
     N_f = type(m)(3 * num_atoms[0])
-    coupling = type(m)(1.0) + type(m)(1.0) / N_f
+    coupling = type(m)(1.0) + type(m)(3.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_anisotropic(h_dot, h_inv, coupling, eta_dot_1, v)
+    drag = _drag_anisotropic(h_dot, coupling, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1319,15 +1287,14 @@ def _npt_velocity_half_step_aniso_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocities[sys_id]
-    h_inv = cells_inv[sys_id]
     eta_dot_1 = eta_dots[sys_id, 0]
     N = num_atoms_per_system[sys_id]
 
     N_f = type(m)(3 * N)
-    coupling = type(m)(1.0) + type(m)(1.0) / N_f
+    coupling = type(m)(1.0) + type(m)(3.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_anisotropic(h_dot, h_inv, coupling, eta_dot_1, v)
+    drag = _drag_anisotropic(h_dot, coupling, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1360,14 +1327,13 @@ def _npt_velocity_half_step_triclinic_single_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocity[0]
-    h_inv = cell_inv[0]
     eta_dot_1 = eta_dot[0, 0]
 
     N_f = type(m)(3 * num_atoms[0])
-    coupling = type(m)(1.0) + type(m)(1.0) / N_f
+    coupling = type(m)(1.0) + type(m)(3.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_triclinic(h_dot, h_inv, coupling, eta_dot_1, v)
+    drag = _drag_triclinic(h_dot, coupling, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1397,15 +1363,14 @@ def _npt_velocity_half_step_triclinic_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocities[sys_id]
-    h_inv = cells_inv[sys_id]
     eta_dot_1 = eta_dots[sys_id, 0]
     N = num_atoms_per_system[sys_id]
 
     N_f = type(m)(3 * N)
-    coupling = type(m)(1.0) + type(m)(1.0) / N_f
+    coupling = type(m)(1.0) + type(m)(3.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_triclinic(h_dot, h_inv, coupling, eta_dot_1, v)
+    drag = _drag_triclinic(h_dot, coupling, eta_dot_1, v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1437,13 +1402,12 @@ def _nph_velocity_half_step_triclinic_single_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocity[0]
-    h_inv = cell_inv[0]
 
     N_f = type(m)(3 * num_atoms[0])
-    coupling = type(m)(1.0) + type(m)(1.0) / N_f
+    coupling = type(m)(1.0) + type(m)(3.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_triclinic(h_dot, h_inv, coupling, type(m)(0.0), v)
+    drag = _drag_triclinic(h_dot, coupling, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1472,14 +1436,13 @@ def _nph_velocity_half_step_triclinic_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocities[sys_id]
-    h_inv = cells_inv[sys_id]
     N = num_atoms_per_system[sys_id]
 
     N_f = type(m)(3 * N)
-    coupling = type(m)(1.0) + type(m)(1.0) / N_f
+    coupling = type(m)(1.0) + type(m)(3.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_triclinic(h_dot, h_inv, coupling, type(m)(0.0), v)
+    drag = _drag_triclinic(h_dot, coupling, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1506,13 +1469,12 @@ def _nph_velocity_half_step_aniso_single_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocity[0]
-    h_inv = cell_inv[0]
 
     N_f = type(m)(3 * num_atoms[0])
-    coupling = type(m)(1.0) + type(m)(1.0) / N_f
+    coupling = type(m)(1.0) + type(m)(3.0) / N_f
     dt_half = dt[0] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_anisotropic(h_dot, h_inv, coupling, type(m)(0.0), v)
+    drag = _drag_anisotropic(h_dot, coupling, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1541,14 +1503,13 @@ def _nph_velocity_half_step_aniso_kernel(
     m = masses[atom_idx]
     f = forces[atom_idx]
     h_dot = cell_velocities[sys_id]
-    h_inv = cells_inv[sys_id]
     N = num_atoms_per_system[sys_id]
 
     N_f = type(m)(3 * N)
-    coupling = type(m)(1.0) + type(m)(1.0) / N_f
+    coupling = type(m)(1.0) + type(m)(3.0) / N_f
     dt_half = dt[sys_id] * type(m)(0.5)
     accel = _npt_accel(f, m)
-    drag = _drag_anisotropic(h_dot, h_inv, coupling, type(m)(0.0), v)
+    drag = _drag_anisotropic(h_dot, coupling, type(m)(0.0), v)
 
     velocities_out[atom_idx] = v + dt_half * (accel - drag)
 
@@ -1565,7 +1526,7 @@ def _cell_update_kernel(
     dt: wp.array(dtype=Any),
     cells_out: wp.array(dtype=Any),
 ):
-    """Update cell matrix: h_new = h + dt * ḣ (out-only).
+    """Update cell matrix: h_new = h + dt * ε̇ * h (out-only, multiplicative).
 
     For in-place: host passes same array as cells and cells_out.
 
@@ -1574,7 +1535,7 @@ def _cell_update_kernel(
     sys_id = wp.tid()
     h = cells[sys_id]
     h_dot = cell_velocities[sys_id]
-    cells_out[sys_id] = h + dt[sys_id] * h_dot
+    cells_out[sys_id] = h + dt[sys_id] * wp.mul(h_dot, h)
 
 
 # ==============================================================================
@@ -2063,19 +2024,19 @@ def compute_cell_kinetic_energy(
     """
     Compute kinetic energy of cell degrees of freedom.
 
-    KE_cell = 0.5 * W * ||ε̇||²_F, where ε̇ = ḣ h⁻¹
+    KE_cell = 0.5 * W * ||ε̇||²_F
 
     Parameters
     ----------
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
-        Cell velocity matrices ḣ = dh/dt. Shape (B,).
+        Strain-rate matrices ε̇ = p_g/W. Shape (B,).
     cell_masses : wp.array
         Barostat masses. Shape (B,).
     kinetic_energy : wp.array(dtype=scalar)
         Output cell kinetic energy. Shape (B,).
     cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
         Inverse cell matrices h⁻¹. Shape (B,). Required for non-cubic
-        cells to compute the exact strain rate ε̇ = ḣ h⁻¹.
+        cells. Retained for backward compat; ignored by kernels.
     volumes : wp.array(dtype=scalar), optional
         Cell volumes. Shape (B,). Used as fallback when ``cells_inv`` is not
         provided: computes h⁻¹ = V^{-1/3} I, which is only valid for cubic
@@ -2274,7 +2235,7 @@ def npt_barostat_half_step(
     Parameters
     ----------
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
-        Cell velocity matrices ḣ. Shape (B,) where B is batch size.
+        Strain-rate matrices ε̇. Shape (B,) where B is batch size.
         **MODIFIED in-place.**
     pressure_tensors : wp.array(dtype=vec9f or vec9d)
         Current pressure tensors from virial. Shape (B,).
@@ -2483,18 +2444,18 @@ def npt_velocity_half_step(
     where:
 
     - F_i / m_i is the acceleration from forces
-    - γ = 1 + 1/N_f is the coupling factor (N_f = 3N degrees of freedom)
-    - ε̇ = ḣ h⁻¹ is the strain rate tensor
+    - γ = 1 + d/N_f is the coupling factor (d=3, N_f = 3N)
+    - ε̇ is the strain rate tensor (cell_velocities)
     - η̇₁ is the first thermostat chain velocity
 
     **Isotropic mode** (default):
-        Uses scalar strain rate ε̇ = Tr(ḣ h⁻¹)/3
+        Uses scalar strain rate Tr(ε̇)/3
 
     **Anisotropic mode**:
-        Uses diagonal strain rates ε̇_ii = (ḣ h⁻¹)_ii for direction-dependent drag
+        Uses diagonal strain rates ε̇_ii for direction-dependent drag
 
     **Triclinic mode**:
-        Uses full strain rate tensor ε̇ = ḣ h⁻¹ for full coupling
+        Uses full strain rate tensor ε̇ for full coupling
 
     Parameters
     ----------
@@ -2505,7 +2466,7 @@ def npt_velocity_half_step(
     forces : wp.array(dtype=wp.vec3f or wp.vec3d)
         Forces on particles. Shape (N,).
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
-        Cell velocity matrices ḣ = dh/dt. Shape (B,).
+        Strain-rate matrices ε̇ = p_g/W. Shape (B,).
     volumes : wp.array(dtype=scalar)
         Cell volumes. Shape (B,). Used to build h⁻¹ = V^{-1/3}·I when
         ``cells_inv`` is not provided (only valid for cubic cells).
@@ -2522,7 +2483,7 @@ def npt_velocity_half_step(
         Number of atoms per system. Required for batched simulations.
     cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
         Inverse cell matrices h⁻¹. Shape (B,). When provided, the
-        strain rate ε̇ = ḣ h⁻¹ is used. Required for non-cubic cells.
+        Retained for backward compat; ignored by kernels.
     mode : str, optional
         Pressure control mode. One of:
 
@@ -2622,7 +2583,7 @@ def npt_velocity_half_step_out(
         Atom counts per system.
     cells_inv : wp.array, optional
         Inverse cell matrices h⁻¹. Shape (B,). When provided, the
-        strain rate ε̇ = ḣ h⁻¹ is used. Required for non-cubic cells.
+        Retained for backward compat; ignored by kernels.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".
     device : str, optional
@@ -2648,8 +2609,7 @@ def npt_velocity_half_step_out(
         raise ValueError(
             f"Unknown mode: '{mode}'. Expected 'isotropic', 'anisotropic', or 'triclinic'."
         )
-    if mode == "triclinic" and cells_inv is None:
-        raise ValueError("mode='triclinic' requires cells_inv parameter.")
+    # cells_inv retained for backward compat but ignored by kernels.
 
     family = _NPT_VELOCITY_FAMILIES[mode]
 
@@ -2803,7 +2763,7 @@ def npt_cell_update(
     device: str = None,
 ) -> None:
     """
-    Update cell matrices: h_new = h + dt * ḣ.
+    Update cell matrices: h_new = h + dt · ε̇ · h.
 
     Parameters
     ----------
@@ -2990,7 +2950,7 @@ def run_npt_step(
         device=device,
     )
 
-    # 3. Velocity half-step (needs h^-1 for strain rate)
+    # 3. Velocity half-step
     compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
     npt_velocity_half_step(
         velocities,
@@ -3148,7 +3108,7 @@ def nph_barostat_half_step(
     Parameters
     ----------
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
-        Cell velocity matrices ḣ. Shape (B,). **MODIFIED in-place.**
+        Strain-rate matrices ε̇. Shape (B,). **MODIFIED in-place.**
     pressure_tensors : wp.array(dtype=vec9f or vec9d)
         Current pressure tensors from virial. Shape (B,).
     target_pressures : wp.array
@@ -3324,13 +3284,13 @@ def nph_velocity_half_step(
 
         \\dot{v}_i = \\frac{F_i}{m_i} - \\gamma \\cdot \\dot{\\varepsilon} \\cdot v_i
 
-    where γ = 1 + 1/N_f is the coupling factor and ε̇ = ḣ h⁻¹.
+    where γ = 1 + d/N_f is the coupling factor.
 
-    **Isotropic mode**: Uses scalar strain rate ε̇ = Tr(ḣ h⁻¹)/3
+    **Isotropic mode**: Uses scalar strain rate Tr(ε̇)/3
 
-    **Anisotropic mode**: Uses diagonal strain rates ε̇_ii = (ḣ h⁻¹)_ii
+    **Anisotropic mode**: Uses diagonal strain rates ε̇_ii
 
-    **Triclinic mode**: Uses full strain rate tensor ε̇ = ḣ h⁻¹
+    **Triclinic mode**: Uses full strain rate tensor ε̇
 
     Parameters
     ----------
@@ -3341,7 +3301,7 @@ def nph_velocity_half_step(
     forces : wp.array(dtype=wp.vec3f or wp.vec3d)
         Forces on particles.
     cell_velocities : wp.array(dtype=wp.mat33f or wp.mat33d)
-        Cell velocity matrices ḣ = dh/dt.
+        Strain-rate matrices ε̇ = p_g/W.
     volumes : wp.array(dtype=scalar)
         Cell volumes. Shape (B,). Used to build h⁻¹ = V^{-1/3}·I when
         ``cells_inv`` is not provided (only valid for cubic cells).
@@ -3356,7 +3316,7 @@ def nph_velocity_half_step(
         Number of atoms per system.
     cells_inv : wp.array(dtype=wp.mat33f or wp.mat33d), optional
         Inverse cell matrices h⁻¹. Shape (B,). When provided, the
-        strain rate ε̇ = ḣ h⁻¹ is used. Required for non-cubic cells.
+        Retained for backward compat; ignored by kernels.
     mode : str, optional
         Pressure control mode:
 
@@ -3435,7 +3395,7 @@ def nph_velocity_half_step_out(
         For batched simulations.
     cells_inv : wp.array, optional
         Inverse cell matrices h⁻¹. Shape (B,). When provided, the
-        strain rate ε̇ = ḣ h⁻¹ is used. Required for non-cubic cells.
+        Retained for backward compat; ignored by kernels.
     mode : str, optional
         Pressure control mode: "isotropic", "anisotropic", or "triclinic".
     device : str, optional
@@ -3461,8 +3421,7 @@ def nph_velocity_half_step_out(
         raise ValueError(
             f"Unknown mode: '{mode}'. Expected 'isotropic', 'anisotropic', or 'triclinic'."
         )
-    if mode == "triclinic" and cells_inv is None:
-        raise ValueError("mode='triclinic' requires cells_inv parameter.")
+    # cells_inv retained for backward compat but ignored by kernels.
 
     family = _NPH_VELOCITY_FAMILIES[mode]
 
@@ -3672,7 +3631,7 @@ def run_nph_step(
         device=device,
     )
 
-    # 2. Velocity half-step (needs h^-1 for strain rate)
+    # 2. Velocity half-step
     compute_cell_inverse(cells, cells_inv=cells_inv, device=device)
     nph_velocity_half_step(
         velocities,

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -445,7 +445,7 @@ class TestBarostatUtilitiesAPI:
         wp.synchronize_device(device)
 
         assert ke.shape[0] == 1
-        # KE = 0.5 * W * ||ε̇||²_F where ε̇ = ḣ h⁻¹
+        # KE = 0.5 * W * ||ε̇||²_F where ε̇ = cell_velocities
         # With h⁻¹ = I: ε̇ = ḣ, so ||ε̇||²_F = 3 * 0.1² = 0.03
         expected = 0.5 * 100.0 * 0.03
         np.testing.assert_allclose(ke.numpy()[0], expected, rtol=1e-5)
@@ -3139,7 +3139,7 @@ class TestAdditionalCoverage:
 
         wp.synchronize_device(device)
         assert result is kinetic_energy
-        # KE = 0.5 * W * ||ε̇||²_F where ε̇ = ḣ h⁻¹
+        # KE = 0.5 * W * ||ε̇||²_F where ε̇ = cell_velocities
         # With h⁻¹ = I: ε̇ = ḣ, so ||ε̇||²_F = 3 * 0.1² = 0.03
         np.testing.assert_allclose(result.numpy()[0], 1.5, rtol=1e-4)
 

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -1524,7 +1524,6 @@ class TestAnisotropicBarostat:
             system["cell_masses"],
             system["kinetic_energy"],
             system["num_atoms_per_system"],
-            system["eta_dot"],
             dt=system["dt"],
             device=device,
         )
@@ -1568,7 +1567,6 @@ class TestAnisotropicBarostat:
             system["cell_masses"],
             system["kinetic_energy"],
             system["num_atoms_per_system"],
-            system["eta_dot"],
             dt=system["dt"],
             device=device,
         )
@@ -2263,7 +2261,6 @@ class TestExplicitBarostatFunctions:
         num_atoms_per_system = wp.array(
             [num_atoms, num_atoms], dtype=wp.int32, device=device
         )
-        eta_dots = wp.zeros((num_systems, 3), dtype=scalar_dtype, device=device)
 
         dt = wp.array([0.001, 0.001], dtype=scalar_dtype, device=device)
         npt_barostat_half_step_aniso(
@@ -2274,7 +2271,6 @@ class TestExplicitBarostatFunctions:
             cell_masses,
             kinetic_energy,
             num_atoms_per_system,
-            eta_dots,
             dt=dt,
             device=device,
         )
@@ -2311,7 +2307,6 @@ class TestExplicitBarostatFunctions:
         num_atoms_per_system = wp.array(
             [num_atoms, num_atoms], dtype=wp.int32, device=device
         )
-        eta_dots = wp.zeros((num_systems, 3), dtype=scalar_dtype, device=device)
 
         dt = wp.array([0.001, 0.001], dtype=scalar_dtype, device=device)
         npt_barostat_half_step_triclinic(
@@ -2322,7 +2317,6 @@ class TestExplicitBarostatFunctions:
             cell_masses,
             kinetic_energy,
             num_atoms_per_system,
-            eta_dots,
             dt=dt,
             device=device,
         )
@@ -2751,7 +2745,6 @@ class TestNPTCoverageExtras:
     def test_npt_barostat_half_step_device_inference(self, device):
         """Test npt_barostat_half_step with device inference."""
         num_systems = 1
-        chain_length = 3
 
         cell_velocities = wp.zeros(num_systems, dtype=wp.mat33f, device=device)
         pressure_tensors = wp.empty(num_systems, dtype=vec9f, device=device)
@@ -2760,10 +2753,6 @@ class TestNPTCoverageExtras:
         cell_masses = wp.array([100.0], dtype=wp.float32, device=device)
         kinetic_energy = wp.array([10.0], dtype=wp.float32, device=device)
         num_atoms_per_system = wp.array([100], dtype=wp.int32, device=device)
-        # eta_dots must be 2D: (B, chain_length)
-        eta_dots = wp.zeros(
-            (num_systems, chain_length), dtype=wp.float32, device=device
-        )
 
         dt = wp.array([0.001], dtype=wp.float32, device=device)
         # Don't pass device
@@ -2775,7 +2764,6 @@ class TestNPTCoverageExtras:
             cell_masses,
             kinetic_energy,
             num_atoms_per_system,
-            eta_dots,
             dt=dt,
         )
 
@@ -2884,7 +2872,6 @@ class TestNPTCoverageExtras:
         )
 
         num_systems = 1
-        chain_length = 3
 
         cell_velocities = wp.zeros(num_systems, dtype=wp.mat33f, device=device)
         pressure_tensors = wp.empty(num_systems, dtype=vec9f, device=device)
@@ -2892,10 +2879,6 @@ class TestNPTCoverageExtras:
         cell_masses = wp.array([100.0], dtype=wp.float32, device=device)
         kinetic_energy = wp.array([10.0], dtype=wp.float32, device=device)
         num_atoms_per_system = wp.array([100], dtype=wp.int32, device=device)
-        # eta_dots must be 2D: (B, chain_length)
-        eta_dots = wp.zeros(
-            (num_systems, chain_length), dtype=wp.float32, device=device
-        )
 
         dt = wp.array([0.001], dtype=wp.float32, device=device)
         # Test NPT aniso
@@ -2910,7 +2893,6 @@ class TestNPTCoverageExtras:
             cell_masses,
             kinetic_energy,
             num_atoms_per_system,
-            eta_dots,
             dt=dt,
             device=device,
         )
@@ -2925,7 +2907,6 @@ class TestNPTCoverageExtras:
             cell_masses,
             kinetic_energy,
             num_atoms_per_system,
-            eta_dots,
             dt=dt,
             device=device,
         )
@@ -3824,3 +3805,60 @@ class TestStrainRateDrag:
         drag = (eps_dot_np @ v_np[0]) + trace_corr * v_np[0]
         expected = v_np + (dt_val / 2.0) * (0.0 - drag[None, :])
         np.testing.assert_allclose(vel_out.numpy(), expected, rtol=1e-10)
+
+
+class TestBarostatHalfStepNoThermostatDrag:
+    """npt_barostat_half_step applies only the MTK pressure/kinetic term."""
+
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_isotropic_canonical_form(self, device):
+        """ε̇ += (dt/2) · (V/W) · (P_inst − P_ext)."""
+        np_dtype = np.float64
+        scalar_dtype = wp.float64
+        mat_dtype = wp.mat33d
+
+        num_atoms = 8
+        dt_val = 1.0
+        V = 1000.0
+        W = 100.0
+        KE = 12.0
+        P_inst_diag = 0.05
+        P_ext = 0.02
+        eps_dot_init = 0.03
+
+        eps_dot_np = np.diag([eps_dot_init] * 3).astype(np_dtype)
+        cell_velocities = wp.array(
+            [mat_dtype(*eps_dot_np.flatten())], dtype=mat_dtype, device=device
+        )
+        P_full = np.diag([P_inst_diag] * 3).astype(np_dtype).flatten()
+        pressure_tensors = wp.array([vec9d(*P_full)], dtype=vec9d, device=device)
+        target_pressures = wp.array([P_ext], dtype=scalar_dtype, device=device)
+        volumes = wp.array([V], dtype=scalar_dtype, device=device)
+        cell_masses = wp.array([W], dtype=scalar_dtype, device=device)
+        kinetic_energy = wp.array([KE], dtype=scalar_dtype, device=device)
+        num_atoms_per_system = wp.array([num_atoms], dtype=wp.int32, device=device)
+        dt = wp.array([dt_val], dtype=scalar_dtype, device=device)
+
+        npt_barostat_half_step(
+            cell_velocities,
+            pressure_tensors,
+            target_pressures,
+            volumes,
+            cell_masses,
+            kinetic_energy,
+            num_atoms_per_system,
+            dt,
+            device=device,
+        )
+        wp.synchronize_device(device)
+
+        # Canonical: ε̇_new = ε̇ + (dt/2) · (V/W) · (P + 2·KE/(3N·V) − P_ext).
+        dof_term = 2.0 * KE / (3.0 * num_atoms)
+        P_diff = P_inst_diag + dof_term / V - P_ext
+        accel = V * P_diff / W
+        expected_diag = eps_dot_init + (dt_val / 2.0) * accel
+        expected = np.diag([expected_diag] * 3)
+
+        np.testing.assert_allclose(
+            cell_velocities.numpy()[0], expected, rtol=1e-12, atol=1e-12
+        )

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -3862,3 +3862,191 @@ class TestBarostatHalfStepNoThermostatDrag:
         np.testing.assert_allclose(
             cell_velocities.numpy()[0], expected, rtol=1e-12, atol=1e-12
         )
+
+
+class TestNPHStrainRateDrag:
+    """nph_velocity_half_step matches ASE MTKNPT particle drag (no thermostat)."""
+
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_anisotropic_drag_per_axis_strain(self, device):
+        """Aniso NPH: drag_i = (ε̇_ii + Tr(ε̇)/(3·N)) · v_i."""
+        np_dtype = np.float64
+        scalar_dtype = wp.float64
+        mat_dtype = wp.mat33d
+        vec_dtype = wp.vec3d
+
+        num_atoms = 1
+        dt_val = 1.0
+
+        eps_dot_np = np.diag([0.020, 0.010, 0.015]).astype(np_dtype)
+        cell_velocities = wp.array(
+            [mat_dtype(*eps_dot_np.flatten())], dtype=mat_dtype, device=device
+        )
+
+        v_np = np.array([[1.0, 2.0, 3.0]], dtype=np_dtype)
+        velocities = wp.array(v_np, dtype=vec_dtype, device=device)
+        masses = wp.array([1.0], dtype=scalar_dtype, device=device)
+        forces = wp.zeros(num_atoms, dtype=vec_dtype, device=device)
+
+        h_np = np.diag([10.0, 12.0, 8.0]).astype(np_dtype)
+        V = float(np.linalg.det(h_np))
+        volumes = wp.array([V], dtype=scalar_dtype, device=device)
+        num_atoms_arr = wp.array([num_atoms], dtype=wp.int32, device=device)
+        dt = wp.array([dt_val], dtype=scalar_dtype, device=device)
+
+        vel_out = wp.empty(num_atoms, dtype=vec_dtype, device=device)
+        nph_velocity_half_step_out(
+            velocities,
+            masses,
+            forces,
+            cell_velocities,
+            volumes,
+            num_atoms_arr,
+            dt,
+            vel_out,
+            mode="anisotropic",
+            device=device,
+        )
+        wp.synchronize_device(device)
+
+        N_atoms = float(num_atoms)
+        trace_corr = np.trace(eps_dot_np) / (3.0 * N_atoms)
+        drag = np.array(
+            [
+                [
+                    (eps_dot_np[0, 0] + trace_corr) * v_np[0, 0],
+                    (eps_dot_np[1, 1] + trace_corr) * v_np[0, 1],
+                    (eps_dot_np[2, 2] + trace_corr) * v_np[0, 2],
+                ]
+            ]
+        )
+        expected = v_np + (dt_val / 2.0) * (0.0 - drag)
+        np.testing.assert_allclose(vel_out.numpy(), expected, rtol=1e-10)
+
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_triclinic_drag_with_off_diagonal_strain(self, device):
+        """Triclinic NPH: drag = ε̇ @ v + Tr(ε̇)/(3·N) · v."""
+        np_dtype = np.float64
+        scalar_dtype = wp.float64
+        mat_dtype = wp.mat33d
+        vec_dtype = wp.vec3d
+
+        num_atoms = 1
+        dt_val = 1.0
+
+        eps_dot_np = np.array(
+            [[0.020, 0.005, 0.0], [0.005, 0.010, 0.003], [0.0, 0.003, 0.015]],
+            dtype=np_dtype,
+        )
+        cell_velocities = wp.array(
+            [mat_dtype(*eps_dot_np.flatten())], dtype=mat_dtype, device=device
+        )
+
+        v_np = np.array([[1.0, 2.0, 3.0]], dtype=np_dtype)
+        velocities = wp.array(v_np, dtype=vec_dtype, device=device)
+        masses = wp.array([1.0], dtype=scalar_dtype, device=device)
+        forces = wp.zeros(num_atoms, dtype=vec_dtype, device=device)
+
+        h_np = np.diag([10.0, 12.0, 8.0]).astype(np_dtype)
+        V = float(np.linalg.det(h_np))
+        volumes = wp.array([V], dtype=scalar_dtype, device=device)
+        num_atoms_arr = wp.array([num_atoms], dtype=wp.int32, device=device)
+        dt = wp.array([dt_val], dtype=scalar_dtype, device=device)
+
+        vel_out = wp.empty(num_atoms, dtype=vec_dtype, device=device)
+        nph_velocity_half_step_out(
+            velocities,
+            masses,
+            forces,
+            cell_velocities,
+            volumes,
+            num_atoms_arr,
+            dt,
+            vel_out,
+            mode="triclinic",
+            device=device,
+        )
+        wp.synchronize_device(device)
+
+        N_atoms = float(num_atoms)
+        trace_corr = np.trace(eps_dot_np) / (3.0 * N_atoms)
+        drag = (eps_dot_np @ v_np[0]) + trace_corr * v_np[0]
+        expected = v_np + (dt_val / 2.0) * (0.0 - drag[None, :])
+        np.testing.assert_allclose(vel_out.numpy(), expected, rtol=1e-10)
+
+
+class TestTriclinicWithoutCellsInv:
+    """Triclinic position/velocity updates run with cells_inv omitted."""
+
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_triclinic_position_update_runs(self, device):
+        """h_new positions: r_new = r + dt · ε̇ · r (no h⁻¹ needed)."""
+        np_dtype = np.float64
+        scalar_dtype = wp.float64
+        mat_dtype = wp.mat33d
+        vec_dtype = wp.vec3d
+
+        num_atoms = 1
+        dt_val = 1.0
+
+        eps_dot_np = np.array(
+            [[0.020, 0.005, 0.0], [0.005, 0.010, 0.003], [0.0, 0.003, 0.015]],
+            dtype=np_dtype,
+        )
+        cell_velocities = wp.array(
+            [mat_dtype(*eps_dot_np.flatten())], dtype=mat_dtype, device=device
+        )
+
+        r_np = np.array([[1.0, 2.0, 3.0]], dtype=np_dtype)
+        positions = wp.array(r_np, dtype=vec_dtype, device=device)
+        velocities = wp.zeros(num_atoms, dtype=vec_dtype, device=device)
+        cells = wp.array(
+            [mat_dtype(*np.eye(3).flatten().astype(np_dtype))],
+            dtype=mat_dtype,
+            device=device,
+        )
+        dt = wp.array([dt_val], dtype=scalar_dtype, device=device)
+
+        # cells_inv omitted: kernels must derive everything from cell_velocities.
+        npt_position_update(
+            positions, velocities, cells, cell_velocities, dt, device=device
+        )
+        wp.synchronize_device(device)
+
+        # Linear cell-strain update on positions: r_new = r + dt · (ε̇ · r).
+        expected = r_np + dt_val * (eps_dot_np @ r_np[0])[None, :]
+        np.testing.assert_allclose(positions.numpy(), expected, rtol=1e-10)
+
+
+class TestCellKineticEnergyConvention:
+    """compute_cell_kinetic_energy expects the per-DOF barostat mass W."""
+
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_isotropic_per_dof_mass(self, device):
+        """KE_cell = 0.5 · W · ||ε̇||²_F with W the per-DOF barostat mass."""
+        np_dtype = np.float64
+        scalar_dtype = wp.float64
+        mat_dtype = wp.mat33d
+
+        # Pick W and ε̇ so the expected value is exact in float64.
+        W = 101.0  # per-DOF barostat mass
+        eps = 0.01
+        eps_dot_np = np.diag([eps, eps, eps]).astype(np_dtype)
+
+        cell_velocities = wp.array(
+            [mat_dtype(*eps_dot_np.flatten())], dtype=mat_dtype, device=device
+        )
+        cell_masses = wp.array([W], dtype=scalar_dtype, device=device)
+        kinetic_energy = wp.zeros(1, dtype=scalar_dtype, device=device)
+
+        compute_cell_kinetic_energy(
+            cell_velocities, cell_masses, kinetic_energy, device=device
+        )
+        wp.synchronize_device(device)
+
+        # KE = 0.5 · W · 3 · eps² = 0.5 · 101 · 3 · 1e-4 = 0.01515.
+        expected = 0.5 * W * 3.0 * eps**2
+        np.testing.assert_allclose(
+            kinetic_energy.numpy()[0], expected, rtol=1e-12, atol=1e-12
+        )
+        np.testing.assert_allclose(kinetic_energy.numpy()[0], 0.01515, rtol=1e-12)

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -3654,7 +3654,7 @@ class TestVirialSignConvention:
 
 
 class TestStrainRateDrag:
-    """Velocity half-step drag uses ε̇ directly with α = 1 + d/N_f, d=3."""
+    """Velocity half-step drag matches ASE MTKNPT/IsotropicMTKNPT."""
 
     @pytest.mark.parametrize("device", DEVICES)
     def test_isotropic_drag_non_uniform_strain(self, device):
@@ -3667,9 +3667,7 @@ class TestStrainRateDrag:
         num_atoms = 1
         dt_val = 1.0
 
-        # Strain rate tensor (passed directly as cell_velocities under the
-        # canonical MTK convention).  Non-uniform diagonals to exercise the
-        # Tr(ε̇)/3 averaging in the isotropic drag.
+        # Non-uniform diagonals exercise the Tr(ε̇)/3 averaging.
         eps_dot_np = np.diag([0.012, 0.008, 0.010]).astype(np_dtype)
         cell_velocities = wp.array(
             [mat_dtype(*eps_dot_np.flatten())], dtype=mat_dtype, device=device
@@ -3680,8 +3678,7 @@ class TestStrainRateDrag:
         masses = wp.array([1.0], dtype=scalar_dtype, device=device)
         forces = wp.zeros(num_atoms, dtype=vec_dtype, device=device)
 
-        # Cell side info kept only to satisfy the kernel signature; the
-        # kernels no longer consume them under the strain-rate convention.
+        # Cell side info satisfies the kernel signature; not consumed.
         h_np = np.diag([10.0, 12.0, 8.0]).astype(np_dtype)
         V = float(np.linalg.det(h_np))
         volumes = wp.array([V], dtype=scalar_dtype, device=device)
@@ -3717,7 +3714,7 @@ class TestStrainRateDrag:
 
     @pytest.mark.parametrize("device", DEVICES)
     def test_anisotropic_drag_per_axis_strain(self, device):
-        """Anisotropic: drag_i = α · ε̇_ii · v_i."""
+        """Anisotropic: drag_i = (ε̇_ii + Tr(ε̇)/(3·N)) · v_i."""
         np_dtype = np.float64
         scalar_dtype = wp.float64
         mat_dtype = wp.mat33d
@@ -3726,8 +3723,7 @@ class TestStrainRateDrag:
         num_atoms = 1
         dt_val = 1.0
 
-        # Strain rate diagonals chosen distinct so we can detect any axis-
-        # mixing regression.
+        # Distinct diagonals so a scalar (1+1/N)·ε̇ coupling cannot match.
         eps_dot_np = np.diag([0.020, 0.010, 0.015]).astype(np_dtype)
         cell_velocities = wp.array(
             [mat_dtype(*eps_dot_np.flatten())], dtype=mat_dtype, device=device
@@ -3762,15 +3758,69 @@ class TestStrainRateDrag:
         wp.synchronize_device(device)
 
         N_atoms = float(num_atoms)
-        coupling = 1.0 + 1.0 / N_atoms
+        trace_corr = np.trace(eps_dot_np) / (3.0 * N_atoms)
         drag = np.array(
             [
                 [
-                    coupling * eps_dot_np[0, 0] * v_np[0, 0],
-                    coupling * eps_dot_np[1, 1] * v_np[0, 1],
-                    coupling * eps_dot_np[2, 2] * v_np[0, 2],
+                    (eps_dot_np[0, 0] + trace_corr) * v_np[0, 0],
+                    (eps_dot_np[1, 1] + trace_corr) * v_np[0, 1],
+                    (eps_dot_np[2, 2] + trace_corr) * v_np[0, 2],
                 ]
             ]
         )
         expected = v_np + (dt_val / 2.0) * (0.0 - drag)
+        np.testing.assert_allclose(vel_out.numpy(), expected, rtol=1e-10)
+
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_triclinic_drag_with_off_diagonal_strain(self, device):
+        """Triclinic: drag = ε̇ @ v + Tr(ε̇)/(3·N) · v."""
+        np_dtype = np.float64
+        scalar_dtype = wp.float64
+        mat_dtype = wp.mat33d
+        vec_dtype = wp.vec3d
+
+        num_atoms = 1
+        dt_val = 1.0
+
+        # Off-diagonals so a (1+1/N)·ε̇ kernel cannot silently match.
+        eps_dot_np = np.array(
+            [[0.020, 0.005, 0.0], [0.005, 0.010, 0.003], [0.0, 0.003, 0.015]],
+            dtype=np_dtype,
+        )
+        cell_velocities = wp.array(
+            [mat_dtype(*eps_dot_np.flatten())], dtype=mat_dtype, device=device
+        )
+
+        v_np = np.array([[1.0, 2.0, 3.0]], dtype=np_dtype)
+        velocities = wp.array(v_np, dtype=vec_dtype, device=device)
+        masses = wp.array([1.0], dtype=scalar_dtype, device=device)
+        forces = wp.zeros(num_atoms, dtype=vec_dtype, device=device)
+
+        h_np = np.diag([10.0, 12.0, 8.0]).astype(np_dtype)
+        V = float(np.linalg.det(h_np))
+        volumes = wp.array([V], dtype=scalar_dtype, device=device)
+        eta_dot = wp.zeros((1, 1), dtype=scalar_dtype, device=device)
+        num_atoms_arr = wp.array([num_atoms], dtype=wp.int32, device=device)
+        dt = wp.array([dt_val], dtype=scalar_dtype, device=device)
+
+        vel_out = wp.empty(num_atoms, dtype=vec_dtype, device=device)
+        npt_velocity_half_step_out(
+            velocities,
+            masses,
+            forces,
+            cell_velocities,
+            volumes,
+            eta_dot,
+            num_atoms_arr,
+            dt,
+            vel_out,
+            mode="triclinic",
+            device=device,
+        )
+        wp.synchronize_device(device)
+
+        N_atoms = float(num_atoms)
+        trace_corr = np.trace(eps_dot_np) / (3.0 * N_atoms)
+        drag = (eps_dot_np @ v_np[0]) + trace_corr * v_np[0]
+        expected = v_np + (dt_val / 2.0) * (0.0 - drag[None, :])
         np.testing.assert_allclose(vel_out.numpy(), expected, rtol=1e-10)

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -450,68 +450,67 @@ class TestBarostatUtilitiesAPI:
         expected = 0.5 * 100.0 * 0.03
         np.testing.assert_allclose(ke.numpy()[0], expected, rtol=1e-5)
 
-    def test_compute_cell_kinetic_energy_non_identity_cell(self, dtype, device):
-        """Test cell KE with non-identity h⁻¹ to exercise strain-rate path."""
+    def test_compute_cell_kinetic_energy_full_strain_rate(self, dtype, device):
+        """Cell KE = 0.5 W ||ε̇||²_F with a non-trivial strain-rate tensor."""
         mat_dtype = wp.mat33f if dtype == "float32" else wp.mat33d
         scalar_dtype = wp.float32 if dtype == "float32" else wp.float64
         np_dtype = np.float32 if dtype == "float32" else np.float64
 
-        # Non-cubic cell: h = diag(2, 3, 4), h⁻¹ = diag(0.5, 1/3, 0.25)
-        h_inv_np = np.diag([0.5, 1.0 / 3.0, 0.25]).astype(np_dtype)
-        # ḣ = diag(0.2, 0.3, 0.4)
-        h_dot_np = np.diag([0.2, 0.3, 0.4]).astype(np_dtype)
-        # ε̇ = ḣ h⁻¹ = diag(0.1, 0.1, 0.1) — same strain rate, different ḣ
-        eps_dot_np = h_dot_np @ h_inv_np
+        # Non-trivial strain-rate tensor with off-diagonal coupling.
+        eps_dot_np = np.array(
+            [[0.1, 0.02, 0.0], [0.02, 0.05, 0.01], [0.0, 0.01, -0.03]],
+            dtype=np_dtype,
+        )
 
-        h_dot_mat = mat_dtype(*h_dot_np.flatten())
-        h_inv_mat = mat_dtype(*h_inv_np.flatten())
-        cell_velocities = wp.array([h_dot_mat], dtype=mat_dtype, device=device)
-        cells_inv = wp.array([h_inv_mat], dtype=mat_dtype, device=device)
+        cell_velocities = wp.array(
+            [mat_dtype(*eps_dot_np.flatten())], dtype=mat_dtype, device=device
+        )
         W = 100.0
         cell_masses = wp.array([W], dtype=scalar_dtype, device=device)
         ke_out = wp.empty(1, dtype=scalar_dtype, device=device)
 
         ke = compute_cell_kinetic_energy(
-            cell_velocities, cell_masses, ke_out, cells_inv=cells_inv, device=device
+            cell_velocities, cell_masses, ke_out, device=device
         )
         wp.synchronize_device(device)
 
-        # KE = 0.5 * W * ||ε̇||²_F = 0.5 * 100 * (0.1² + 0.1² + 0.1²) = 1.5
-        frob_sq = float(np.sum(eps_dot_np**2))
-        expected = 0.5 * W * frob_sq
+        expected = 0.5 * W * float(np.sum(eps_dot_np**2))
         np.testing.assert_allclose(ke.numpy()[0], expected, rtol=1e-5)
 
-        # Verify this differs from naive ||ḣ||²_F
-        naive_frob_sq = float(np.sum(h_dot_np**2))
-        assert not np.isclose(frob_sq, naive_frob_sq), (
-            "Test is degenerate: ||ε̇||² == ||ḣ||² — use a non-identity h⁻¹"
-        )
-
-    def test_compute_cell_kinetic_energy_volumes_fallback(self, dtype, device):
-        """Test cell KE using volumes-only fallback (no cells_inv) for non-unit cubic cell."""
+    def test_compute_cell_kinetic_energy_ignores_cells_inv(self, dtype, device):
+        """cells_inv is accepted but does not affect KE (backward compat)."""
         mat_dtype = wp.mat33f if dtype == "float32" else wp.mat33d
         scalar_dtype = wp.float32 if dtype == "float32" else wp.float64
 
-        L = 10.0
-        V = L**3
-        h_dot_np = np.diag([0.1, 0.1, 0.1])
-        h_dot_mat = mat_dtype(*h_dot_np.flatten())
-        cell_velocities = wp.array([h_dot_mat], dtype=mat_dtype, device=device)
-
-        volumes = wp.array([V], dtype=scalar_dtype, device=device)
+        eps_dot = wp.array(
+            [mat_dtype(0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1)],
+            dtype=mat_dtype,
+            device=device,
+        )
+        cells_inv_a = wp.array(
+            [mat_dtype(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)],
+            dtype=mat_dtype,
+            device=device,
+        )
+        cells_inv_b = wp.array(
+            [mat_dtype(0.5, 0.0, 0.0, 0.0, 0.25, 0.0, 0.0, 0.0, 2.0)],
+            dtype=mat_dtype,
+            device=device,
+        )
         W = 100.0
         cell_masses = wp.array([W], dtype=scalar_dtype, device=device)
-        ke_out = wp.empty(1, dtype=scalar_dtype, device=device)
+        ke_a = wp.empty(1, dtype=scalar_dtype, device=device)
+        ke_b = wp.empty(1, dtype=scalar_dtype, device=device)
 
-        ke = compute_cell_kinetic_energy(
-            cell_velocities, cell_masses, ke_out, volumes=volumes, device=device
+        compute_cell_kinetic_energy(
+            eps_dot, cell_masses, ke_a, cells_inv=cells_inv_a, device=device
+        )
+        compute_cell_kinetic_energy(
+            eps_dot, cell_masses, ke_b, cells_inv=cells_inv_b, device=device
         )
         wp.synchronize_device(device)
 
-        # ε̇ = ḣ · V^{-1/3}·I = diag(0.01, 0.01, 0.01)
-        eps_dot = 0.1 / L
-        expected = 0.5 * W * 3.0 * eps_dot**2
-        np.testing.assert_allclose(ke.numpy()[0], expected, rtol=1e-4)
+        np.testing.assert_allclose(ke_a.numpy(), ke_b.numpy(), rtol=1e-6)
 
     def test_compute_barostat_potential_energy_runs(self, dtype, device):
         """Test barostat potential energy computation."""
@@ -585,6 +584,37 @@ class TestNPTIntegrationAPI:
             system["cells"], system["cell_velocities"], dt=system["dt"], device=device
         )
         wp.synchronize_device(device)
+
+    def test_npt_cell_update_uses_multiplicative_form(self, dtype, device):
+        """Cell update is h_new = h + dt · ε̇ · h with correct mat-mul order."""
+        mat_dtype = wp.mat33f if dtype == "float32" else wp.mat33d
+        scalar_dtype = wp.float32 if dtype == "float32" else wp.float64
+        np_dtype = np.float32 if dtype == "float32" else np.float64
+
+        # Triclinic cell + asymmetric strain rate so ε̇ @ h ≠ h @ ε̇.
+        h_np = np.array(
+            [[10.0, 0.5, 0.0], [0.0, 12.0, 0.3], [0.0, 0.0, 8.0]], dtype=np_dtype
+        )
+        eps_dot_np = np.array(
+            [[0.01, 0.005, 0.0], [0.0, 0.02, 0.0], [0.0, 0.0, 0.015]], dtype=np_dtype
+        )
+        # Sanity: matrices do not commute.
+        assert not np.allclose(eps_dot_np @ h_np, h_np @ eps_dot_np)
+        dt_val = np_dtype(0.5)
+
+        cells = wp.array([mat_dtype(*h_np.flatten())], dtype=mat_dtype, device=device)
+        cell_velocities = wp.array(
+            [mat_dtype(*eps_dot_np.flatten())], dtype=mat_dtype, device=device
+        )
+        dt = wp.array([dt_val], dtype=scalar_dtype, device=device)
+
+        npt_cell_update(cells, cell_velocities, dt=dt, device=device)
+        wp.synchronize_device(device)
+
+        expected = h_np + dt_val * (eps_dot_np @ h_np)
+        np.testing.assert_allclose(
+            np.array(cells.numpy()).reshape(3, 3), expected, rtol=1e-5
+        )
 
     def test_run_npt_step_runs(self, dtype, device):
         """Test that run_npt_step runs without errors."""
@@ -3623,17 +3653,12 @@ class TestVirialSignConvention:
 # ==============================================================================
 
 
-class TestNonCubicDrag:
-    """Verify drag uses ε̇ = ḣ h⁻¹ (not ḣ/V) with orthorhombic cells."""
+class TestStrainRateDrag:
+    """Velocity half-step drag uses ε̇ directly with α = 1 + d/N_f, d=3."""
 
     @pytest.mark.parametrize("device", DEVICES)
-    def test_isotropic_drag_non_cubic(self, device):
-        """Isotropic velocity half-step with orthorhombic cell h = diag(10,12,8).
-
-        With ḣ = diag(0.1, 0.12, 0.08), we get ε̇ = ḣ h⁻¹ = diag(0.01, 0.01, 0.01)
-        so Tr(ε̇)/3 = 0.01.  The naive formula Tr(ḣ)/(3V) = 0.3/(3*960) ≈ 1.04e-4
-        gives a very different drag.  Large dt amplifies the difference.
-        """
+    def test_isotropic_drag_non_uniform_strain(self, device):
+        """Isotropic: drag = α · Tr(ε̇)/3 · v."""
         np_dtype = np.float64
         scalar_dtype = wp.float64
         mat_dtype = wp.mat33d
@@ -3642,26 +3667,22 @@ class TestNonCubicDrag:
         num_atoms = 1
         dt_val = 1.0
 
-        # Orthorhombic cell
-        h_np = np.diag([10.0, 12.0, 8.0]).astype(np_dtype)
-        h_inv_np = np.linalg.inv(h_np).astype(np_dtype)
-
-        cells_inv = wp.array(
-            [mat_dtype(*h_inv_np.flatten())], dtype=mat_dtype, device=device
-        )
-
-        # ḣ chosen so ε̇ = ḣ h⁻¹ = 0.01 * I (uniform strain rate)
-        h_dot_np = np.diag([0.1, 0.12, 0.08]).astype(np_dtype)
+        # Strain rate tensor (passed directly as cell_velocities under the
+        # canonical MTK convention).  Non-uniform diagonals to exercise the
+        # Tr(ε̇)/3 averaging in the isotropic drag.
+        eps_dot_np = np.diag([0.012, 0.008, 0.010]).astype(np_dtype)
         cell_velocities = wp.array(
-            [mat_dtype(*h_dot_np.flatten())], dtype=mat_dtype, device=device
+            [mat_dtype(*eps_dot_np.flatten())], dtype=mat_dtype, device=device
         )
 
-        # Single atom: v = (1,1,1), m = 1, F = 0, η̇₁ = 0
         v_np = np.array([[1.0, 1.0, 1.0]], dtype=np_dtype)
         velocities = wp.array(v_np, dtype=vec_dtype, device=device)
         masses = wp.array([1.0], dtype=scalar_dtype, device=device)
         forces = wp.zeros(num_atoms, dtype=vec_dtype, device=device)
 
+        # Cell side info kept only to satisfy the kernel signature; the
+        # kernels no longer consume them under the strain-rate convention.
+        h_np = np.diag([10.0, 12.0, 8.0]).astype(np_dtype)
         V = float(np.linalg.det(h_np))
         volumes = wp.array([V], dtype=scalar_dtype, device=device)
         eta_dot = wp.zeros((1, 1), dtype=scalar_dtype, device=device)
@@ -3679,44 +3700,24 @@ class TestNonCubicDrag:
             num_atoms_arr,
             dt,
             vel_out,
-            cells_inv=cells_inv,
             mode="isotropic",
             device=device,
         )
         wp.synchronize_device(device)
 
-        # Expected: v_new = v + dt/2 * (F/m - drag)
-        # drag = coupling * Tr(ε̇)/3 * v  (η̇₁ = 0)
-        # coupling = 1 + 1/N_f = 1 + 1/3 = 4/3
-        # Tr(ε̇)/3 = 0.01
-        # drag = (4/3) * 0.01 * v = 0.01333... * v
-        eps_dot = h_dot_np @ h_inv_np
-        trace_eps_3 = np.trace(eps_dot) / 3.0
-        N_f = 3.0 * num_atoms
-        coupling = 1.0 + 1.0 / N_f
+        # Expected: v_new = v + dt/2 * (F/m − drag)
+        # drag = α · Tr(ε̇)/3 · v with α = 1 + d/N_f = 1 + 3/(3·N) = 1 + 1/N.
+        trace_eps_3 = np.trace(eps_dot_np) / 3.0
+        N_atoms = float(num_atoms)
+        coupling = 1.0 + 1.0 / N_atoms
         drag = coupling * trace_eps_3 * v_np
         expected = v_np + (dt_val / 2.0) * (0.0 - drag)
 
-        actual = vel_out.numpy()
-        np.testing.assert_allclose(actual, expected, rtol=1e-10)
-
-        # Also verify this differs from the naive Tr(ḣ)/(3V) formula
-        V = np.linalg.det(h_np)
-        naive_eps = (h_dot_np[0, 0] + h_dot_np[1, 1] + h_dot_np[2, 2]) / (3.0 * V)
-        naive_drag = coupling * naive_eps * v_np
-        naive_expected = v_np + (dt_val / 2.0) * (0.0 - naive_drag)
-        assert not np.allclose(actual, naive_expected, rtol=1e-5), (
-            "Test is degenerate: correct and naive formulas give the same result"
-        )
+        np.testing.assert_allclose(vel_out.numpy(), expected, rtol=1e-10)
 
     @pytest.mark.parametrize("device", DEVICES)
-    def test_anisotropic_drag_non_cubic(self, device):
-        """Anisotropic velocity half-step with non-uniform strain rates.
-
-        h = diag(10, 12, 8), ḣ = diag(0.2, 0.12, 0.16)
-        → ε̇ = diag(0.02, 0.01, 0.02) — different per-axis strain rates.
-        Large dt amplifies the difference vs the naive ḣ/V formula.
-        """
+    def test_anisotropic_drag_per_axis_strain(self, device):
+        """Anisotropic: drag_i = α · ε̇_ii · v_i."""
         np_dtype = np.float64
         scalar_dtype = wp.float64
         mat_dtype = wp.mat33d
@@ -3725,16 +3726,11 @@ class TestNonCubicDrag:
         num_atoms = 1
         dt_val = 1.0
 
-        h_np = np.diag([10.0, 12.0, 8.0]).astype(np_dtype)
-        h_inv_np = np.linalg.inv(h_np).astype(np_dtype)
-        cells_inv = wp.array(
-            [mat_dtype(*h_inv_np.flatten())], dtype=mat_dtype, device=device
-        )
-
-        # Non-uniform ḣ → different ε̇ per axis
-        h_dot_np = np.diag([0.2, 0.12, 0.16]).astype(np_dtype)
+        # Strain rate diagonals chosen distinct so we can detect any axis-
+        # mixing regression.
+        eps_dot_np = np.diag([0.020, 0.010, 0.015]).astype(np_dtype)
         cell_velocities = wp.array(
-            [mat_dtype(*h_dot_np.flatten())], dtype=mat_dtype, device=device
+            [mat_dtype(*eps_dot_np.flatten())], dtype=mat_dtype, device=device
         )
 
         v_np = np.array([[1.0, 2.0, 3.0]], dtype=np_dtype)
@@ -3742,6 +3738,7 @@ class TestNonCubicDrag:
         masses = wp.array([1.0], dtype=scalar_dtype, device=device)
         forces = wp.zeros(num_atoms, dtype=vec_dtype, device=device)
 
+        h_np = np.diag([10.0, 12.0, 8.0]).astype(np_dtype)
         V = float(np.linalg.det(h_np))
         volumes = wp.array([V], dtype=scalar_dtype, device=device)
         eta_dot = wp.zeros((1, 1), dtype=scalar_dtype, device=device)
@@ -3759,42 +3756,21 @@ class TestNonCubicDrag:
             num_atoms_arr,
             dt,
             vel_out,
-            cells_inv=cells_inv,
             mode="anisotropic",
             device=device,
         )
         wp.synchronize_device(device)
 
-        # drag_i = (coupling * ε̇_ii + η̇₁) * v_i
-        eps_dot = h_dot_np @ h_inv_np
-        N_f = 3.0 * num_atoms
-        coupling = 1.0 + 1.0 / N_f
+        N_atoms = float(num_atoms)
+        coupling = 1.0 + 1.0 / N_atoms
         drag = np.array(
             [
                 [
-                    (coupling * eps_dot[0, 0]) * v_np[0, 0],
-                    (coupling * eps_dot[1, 1]) * v_np[0, 1],
-                    (coupling * eps_dot[2, 2]) * v_np[0, 2],
+                    coupling * eps_dot_np[0, 0] * v_np[0, 0],
+                    coupling * eps_dot_np[1, 1] * v_np[0, 1],
+                    coupling * eps_dot_np[2, 2] * v_np[0, 2],
                 ]
             ]
         )
         expected = v_np + (dt_val / 2.0) * (0.0 - drag)
-
-        actual = vel_out.numpy()
-        np.testing.assert_allclose(actual, expected, rtol=1e-10)
-
-        # Naive formula: ε̇_ii = ḣ_ii / V gives uniform rate, losing axis info
-        V = np.linalg.det(h_np)
-        naive_drag = np.array(
-            [
-                [
-                    (coupling * h_dot_np[0, 0] / V) * v_np[0, 0],
-                    (coupling * h_dot_np[1, 1] / V) * v_np[0, 1],
-                    (coupling * h_dot_np[2, 2] / V) * v_np[0, 2],
-                ]
-            ]
-        )
-        naive_expected = v_np + (dt_val / 2.0) * (0.0 - naive_drag)
-        assert not np.allclose(actual, naive_expected, rtol=1e-5), (
-            "Test is degenerate: correct and naive formulas give the same result"
-        )
+        np.testing.assert_allclose(vel_out.numpy(), expected, rtol=1e-10)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Six fixes in the MTK NPT/NPH integrator (`nvalchemiops/dynamics/integrators/npt.py`):

1. **`cell_velocity` state-variable mismatch**: the cell-velocity-acceleration kernel writes a strain-rate-units acceleration `V·(P − P_ext)/W` into `cell_velocity`, while the drag/position/cell-KE helpers consume it as `ḣ = dh/dt` and the cell update propagates it as `h + dt·h_dot`. The mismatch costs a factor of cell length L₀ in the cell response. Treats `cell_velocity` as the strain rate `ε̇ = p_g/W` consistently (canonical MTK / ASE / TorchSim) and updates the cell as `h_new = h + dt · ε̇ · h`.

2. **Isotropic velocity-half-step coupling**: the four isotropic NPT/NPH velocity-half-step kernels used `α = 1 + 1/(3N_atoms)` instead of canonical `α = 1 + 1/N_atoms` (cf. ASE `IsotropicMTKNPT._integrate_p`, TorchSim `_npt_nose_hoover_isotropic_inner_step`).

3. **Anisotropic/triclinic velocity-half-step coupling**: the eight anisotropic/triclinic NPT/NPH kernels applied a scalar `(1 + 1/N_atoms) · ε̇` coupling, which agrees with ASE `MTKNPT._integrate_p` (per-eigen-direction `κ_i = λ_i + Tr(p_g)/(3·N)`) only when `ε̇` is isotropic. Replaced with `ε̇ + Tr(ε̇)/(3·N) · I`.

4. **Inline thermostat drag in NPT cell-velocity update**: the three NPT cell-velocity-update kernels applied `−η̇₁·ε̇` inline, mixing the pressure/kinetic driving operator with NHC drag. ASE `IsotropicMTKBarostat._integrate_p_cell` and TorchSim keep these as distinct Trotter operators. Removed the inline drag; `eta_dots` dropped from the three kernels and from `npt_barostat_half_step{,_aniso,_triclinic}`.

5. **`cells_inv` deprecation**: passing `cells_inv` to the public NPT/NPH helpers now emits a `DeprecationWarning` (one minor cycle before removal). Positional ordering of `run_npt_step` / `run_nph_step` is preserved.

6. **`volumes` deprecation**: same pattern on `compute_cell_kinetic_energy` and the four NPT/NPH velocity-half-step entries, which no longer need a volume fallback after the strain-rate refactor. `volumes` is still required by the `*_barostat_half_step*` family, `compute_pressure_tensor`, `compute_barostat_potential_energy`, and the `run_*_step` orchestrators.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

The breaking part is the `cell_velocities` semantics flip from `ḣ = dh/dt` (PR #66) back to the strain rate `ε̇ = p_g/W`, plus dropping `eta_dots` from `npt_barostat_half_step{,_aniso,_triclinic}`. `cells_inv` is deprecated, not removed.

## Related Issues

Relates to NVIDIA/nvalchemi-toolkit#89 (root issue) and NVIDIA/nvalchemi-toolkit#90 (companion wrapper-side fix).

## Changes Made

- `_cell_update_kernel`: `h_new = h + dt · h_dot` → `h_new = h + dt · wp.mul(h_dot, h)` (multiplicative).
- `_drag_isotropic`, `_drag_anisotropic`, `_drag_triclinic`, `_npt_position_step`, `_compute_cell_kinetic_energy_kernel`: drop `eps_dot = wp.mul(h_dot, h_inv)` conversion; use `cell_velocities` directly as `ε̇`. Helper signatures dropped the now-unused `h_inv` parameter; 14 dead `h_inv = cells_inv[sys_id]` locals at velocity-half-step kernel call sites were also removed.
- Four isotropic velocity-half-step kernels: `coupling = 1.0 + 1.0/N_f` → `1.0 + 3.0/N_f`.
- Eight anisotropic/triclinic velocity-half-step kernels: scalar `(1 + 1/N_atoms)·ε̇` coupling replaced with the canonical trace-correction form `ε̇ + Tr(ε̇)/(3·N)·I`. `_drag_anisotropic` / `_drag_triclinic` now take `inv_three_n = 1/(3·N_atoms)` instead of `coupling`.
- Three NPT cell-velocity-update kernels (`_npt_cell_velocity_update_kernel{,_aniso,_triclinic}`): drop `eta_dots` parameter and `−η̇₁·ε̇` term. Host wrappers `npt_barostat_half_step{,_aniso,_triclinic}` and `run_npt_step` updated accordingly.
- `cells_inv` made optional on `npt_velocity_half_step[_out]`, `nph_velocity_half_step[_out]`, `npt_position_update[_out]`, `nph_position_update[_out]`, `run_npt_step`, and `run_nph_step`; passing it emits a `DeprecationWarning` via `_warn_cells_inv_deprecated`. `cells_inv` slot in `run_npt_step` / `run_nph_step` restored to its pre-PR position; `kinetic_tensors` and `num_atoms_per_system` made optional with runtime validation to keep old positional calls working.
- `volumes` deprecated on `compute_cell_kinetic_energy` and the four NPT/NPH velocity-half-step entries; passing it emits a `DeprecationWarning` via `_warn_volumes_deprecated`. To preserve positional compatibility, `volumes` / `eta_dots` / `num_atoms` / `dt` (and `velocities_out` on the `_out` variants) default to `None` on those four entries with runtime validation when the legitimately required ones are missing — same shim as `run_*_step` for `cells_inv`. TODO notes mark the defaults so they tighten back to required positionals once `volumes` is removed.
- Deleted now-dead `_build_identity_h_inv_kernel` and its overload registration; `_ensure_cells_inv` is a thin compat shim.
- Module-level `Conventions` block and host-wrapper docstrings updated; stale `(1 + 1/N_f)`, `h⁻¹ = V^{-1/3}·I`, and `pass cells_inv for exact strain rate` fragments cleaned.

## Testing

- [x] Unit tests pass locally (`make pytest`) — 162 passed
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Test changes:
- Replaced `TestBarostatUtilitiesAPI.test_compute_cell_kinetic_energy_non_identity_cell` and `test_compute_cell_kinetic_energy_volumes_fallback` with `test_compute_cell_kinetic_energy_full_strain_rate` and `test_compute_cell_kinetic_energy_ignores_cells_inv`.
- Replaced `TestNonCubicDrag` with `TestStrainRateDrag`: isotropic asserts `α = 1 + 1/N_atoms`; anisotropic asserts `κ_i = ε̇_ii + Tr(ε̇)/(3·N)` with distinct diagonals; triclinic uses off-diagonal `ε̇` so a scalar coupling cannot silently match.
- Added `TestNPTIntegrationAPI.test_npt_cell_update_uses_multiplicative_form`: triclinic `h` + asymmetric `ε̇` chosen so `ε̇ @ h ≠ h @ ε̇`, asserts `h_new = h + dt · (ε̇ @ h)`.
- Added `TestBarostatHalfStepNoThermostatDrag`: pins `ε̇ += (dt/2)·(V/W)·(P_inst − P_ext)`.
- Added `TestNPHStrainRateDrag` (aniso + triclinic), `TestTriclinicWithoutCellsInv`, and `TestCellKineticEnergyConvention` for parity, omitted-`cells_inv`, and per-DOF `W` coverage.

### Empirical validation

In the companion toolkit PR #90 octane NPT comparison (520 atoms, Orb-v3 + DFT-D3(BJ), T=298 K, P=1 atm, dt=0.5 fs, τ_T=100 fs, τ_P=5000 fs), with both PR #90's wrapper-side fixes and this PR's kernel-side fixes applied, density σ_ρ over step ∈ [2000, 10000]:

<img width="2880" height="1440" alt="density_comparison_3way_post_codex_fix" src="https://github.com/user-attachments/assets/fc8b68d9-f45f-40aa-baa2-0d573e3d80da" />

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

The linear-vs-analytic distinction between toolkit's cell update (`h + dt · ε̇ · h`) and ASE/TorchSim's analytic form (`h · exp(ε̇ · dt)`) remains. At typical `dt · ε̇ ≈ 10⁻⁵` the two forms agree to `O((dt · ε̇)²) ≈ 10⁻¹⁰` per step — not a numerical concern. ASE/TS guarantee strict cell positivity via the exponential; toolkit's linear form does not, but extreme strain rates are not encountered in normal NPT.
