### PR TITLE
dispersion pme (WIP)

### DIFF
--- a/examples/dispersion/04_lj_pme_reciprocal.py
+++ b/examples/dispersion/04_lj_pme_reciprocal.py
@@ -1,0 +1,380 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+LJ-PME Reciprocal-Space + Self-Energy (PR1 of LJ-PME)
+======================================================
+
+This example demonstrates the FFT-based reciprocal-space and self-energy
+components of Lennard-Jones PME (LJ-PME) for the attractive dispersion
+(:math:`r^{-6}`) interaction. With geometric combination rules
+(:math:`C_{6,ij} = \\sqrt{C_{6,ii}\\,C_{6,jj}}`) the long-range sum
+factorizes into a single FFT — the same cost as Coulomb PME.
+
+The total LJ-PME energy (Wennberg et al., JCTC 2013) is
+
+.. math::
+
+    V_{\\text{total}} = V_{\\text{real}} + V_{\\text{recip}} - V_{\\text{self}}.
+
+This example covers the *reciprocal-space* and *self-energy* terms only
+(landed in PR1). The damped real-space term arrives in PR2; the unified
+``lj_pme()`` top-level orchestrator in PR3.
+
+Two backends are demonstrated side-by-side from the same script:
+
+* **PyTorch** — eager evaluation through ``torch.compile``-friendly
+  ``warp_custom_op`` wrappers.
+* **JAX** — JIT-compatible ``jax_kernel`` wrappers (skipped if JAX is
+  not installed).
+
+In this example you will learn:
+
+- Compute the reciprocal-space dispersion energy with
+  ``pme_dispersion_reciprocal_space``
+- Compute the self-energy correction with
+  ``pme_dispersion_energy_corrections``
+- Verify the isolated-atom limit: with no neighbors, V_recip → V_self
+- Watch mesh convergence of V_recip at fixed β
+- Run multiple independent systems in a single batched call
+- Compose with ``jax.jit`` (JAX backend)
+
+.. important::
+    This script is intended as an API demonstration. Do not use it for
+    performance benchmarking; refer to the ``benchmarks`` folder instead.
+"""
+
+# %%
+# Setup and Imports
+# -----------------
+
+from __future__ import annotations
+
+import numpy as np
+
+# %%
+# Build a Backend-Neutral System Description
+# ------------------------------------------
+# Generate positions / C6 / cell as NumPy arrays so the same data feeds
+# both backends. We use argon FCC as a clean dispersion test bed: a
+# single element, neutral, and dominated by London dispersion.
+
+
+def create_argon_fcc(n_cells: int = 3, lattice_constant: float = 5.26):
+    """Argon FCC supercell (NumPy arrays)."""
+    fcc_basis = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.5, 0.0],
+            [0.5, 0.0, 0.5],
+            [0.0, 0.5, 0.5],
+        ]
+    )
+    positions = []
+    for i in range(n_cells):
+        for j in range(n_cells):
+            for k in range(n_cells):
+                offset = np.array([i, j, k])
+                positions.extend(
+                    (frac + offset) * lattice_constant for frac in fcc_basis
+                )
+    positions_np = np.array(positions, dtype=np.float64)
+    c6_np = np.full(positions_np.shape[0], 60.0, dtype=np.float64)
+    cell_np = (np.eye(3, dtype=np.float64) * lattice_constant * n_cells)[None, :, :]
+    return positions_np, c6_np, cell_np
+
+
+# A medium supercell for the bulk demonstration, plus a single-atom box
+# for the isolated-atom convergence check.
+pos_np, c6_np, cell_np = create_argon_fcc(n_cells=3)
+beta_val = 0.35
+mesh_dimensions = (32, 32, 32)
+print(f"System: {pos_np.shape[0]}-atom argon FCC supercell")
+print(f"  Cell length: {cell_np[0, 0, 0]:.2f} Å")
+print(f"  C6 per atom: {c6_np[0]:.1f}  (illustrative units)")
+
+# Isolated-atom test system: one atom at the center of a 20 Å cubic box.
+pos_iso_np = np.array([[10.0, 10.0, 10.0]], dtype=np.float64)
+c6_iso_np = np.array([60.0], dtype=np.float64)
+cell_iso_np = (np.eye(3, dtype=np.float64) * 20.0)[None, :, :]
+
+# Two independent systems for the batched demonstration.
+pos_a, c6_a, cell_a = create_argon_fcc(n_cells=2, lattice_constant=5.20)
+pos_b, c6_b, cell_b = create_argon_fcc(n_cells=2, lattice_constant=5.45)
+pos_batch_np = np.concatenate([pos_a, pos_b], axis=0)
+c6_batch_np = np.concatenate([c6_a, c6_b], axis=0)
+cell_batch_np = np.concatenate([cell_a, cell_b], axis=0)
+batch_idx_np = np.concatenate(
+    [
+        np.zeros(pos_a.shape[0], dtype=np.int32),
+        np.ones(pos_b.shape[0], dtype=np.int32),
+    ]
+)
+beta_batch_np = np.array([0.35, 0.40], dtype=np.float64)
+
+
+# =============================================================================
+# PyTorch Backend
+# =============================================================================
+print("\n" + "=" * 70)
+print("PyTorch backend")
+print("=" * 70)
+
+try:
+    import torch
+
+    from nvalchemiops.torch.interactions.dispersion import (
+        pme_dispersion_energy_corrections,
+        pme_dispersion_reciprocal_space,
+    )
+
+    HAS_TORCH = True
+except ImportError as exc:
+    HAS_TORCH = False
+    print(f"  PyTorch backend unavailable ({exc}); skipping.")
+
+if HAS_TORCH:
+    if torch.cuda.is_available():
+        torch_device = torch.device("cuda:0")
+        print(f"  Device: {torch.cuda.get_device_name(0)}")
+    else:
+        torch_device = torch.device("cpu")
+        print("  Device: CPU")
+
+    DTYPE = torch.float64
+
+    def _t(arr, dtype=DTYPE):
+        """numpy -> torch on the active device."""
+        if isinstance(arr, np.ndarray) and arr.dtype.kind == "i":
+            return torch.from_numpy(arr).to(torch_device)
+        return torch.tensor(arr, dtype=dtype, device=torch_device)
+
+    positions = _t(pos_np)
+    c6 = _t(c6_np)
+    cell = _t(cell_np)
+    beta = torch.tensor([beta_val], dtype=DTYPE, device=torch_device)
+
+    E_recip = pme_dispersion_reciprocal_space(
+        positions=positions,
+        c6_coefficients=c6,
+        cell=cell,
+        beta=beta,
+        mesh_dimensions=mesh_dimensions,
+        spline_order=4,
+    )
+    E_self = pme_dispersion_energy_corrections(c6, beta)
+    print(f"\n  beta = {float(beta[0]):.3f} Å⁻¹  mesh = {mesh_dimensions}")
+    print(f"    V_recip = {E_recip.item():+.6f}  (FFT-based long-range sum)")
+    print(f"    V_self  = {E_self.item():+.6f}  (= -β⁶ ΣC6_ii / 12)")
+
+    # Isolated-atom convergence
+    pos_iso = _t(pos_iso_np)
+    c6_iso = _t(c6_iso_np)
+    cell_iso = _t(cell_iso_np)
+    print("\n  Isolated-atom convergence (V_recip / V_self → 1):")
+    print("      beta  | V_recip      | V_self       | (V_recip-V_self)/|V_self|")
+    print("    " + "-" * 65)
+    for bv in [0.2, 0.3, 0.5, 0.8, 1.0]:
+        b_t = torch.tensor([bv], dtype=DTYPE, device=torch_device)
+        er = pme_dispersion_reciprocal_space(
+            pos_iso,
+            c6_iso,
+            cell_iso,
+            b_t,
+            mesh_dimensions=(64, 64, 64),
+            spline_order=4,
+        )
+        es = pme_dispersion_energy_corrections(c6_iso, b_t)
+        rel = (er.item() - es.item()) / abs(es.item())
+        print(f"     {bv:.2f}  | {er.item():+11.4e} | {es.item():+11.4e} | {rel:+.2e}")
+
+    # Mesh convergence
+    print("\n  Mesh convergence (β=0.35, fixed argon supercell):")
+    print("      mesh   | V_recip        | |ΔV_recip| vs finest")
+    print("    " + "-" * 55)
+    finest = None
+    results = []
+    for n in [16, 24, 32, 48, 64, 96]:
+        er = pme_dispersion_reciprocal_space(
+            positions,
+            c6,
+            cell,
+            beta,
+            mesh_dimensions=(n, n, n),
+            spline_order=4,
+        )
+        results.append((n, er.item()))
+        finest = er.item()
+    for n, val in results:
+        err = abs(val - finest)
+        print(f"     {n:3d}³  | {val:+13.6e}  | {err:.2e}")
+
+    # Batched evaluation
+    pos_batch = _t(pos_batch_np)
+    c6_batch = _t(c6_batch_np)
+    cell_batch = _t(cell_batch_np)
+    batch_idx = _t(batch_idx_np, dtype=torch.int32)
+    beta_batch = _t(beta_batch_np)
+    E_recip_batch = pme_dispersion_reciprocal_space(
+        positions=pos_batch,
+        c6_coefficients=c6_batch,
+        cell=cell_batch,
+        beta=beta_batch,
+        mesh_dimensions=(32, 32, 32),
+        spline_order=4,
+        batch_idx=batch_idx,
+    )
+    E_self_batch = pme_dispersion_energy_corrections(
+        c6_batch, beta_batch, batch_idx=batch_idx
+    )
+    print("\n  Batched evaluation (two argon supercells):")
+    for s in range(2):
+        print(
+            f"    system {s}: V_recip = {E_recip_batch[s].item():+.4e}, "
+            f"V_self = {E_self_batch[s].item():+.4e}"
+        )
+
+
+# =============================================================================
+# JAX Backend
+# =============================================================================
+print("\n" + "=" * 70)
+print("JAX backend")
+print("=" * 70)
+
+try:
+    import jax
+    import jax.numpy as jnp
+
+    from nvalchemiops.jax.interactions.dispersion import (
+        pme_dispersion_energy_corrections as jax_pme_dispersion_energy_corrections,
+    )
+    from nvalchemiops.jax.interactions.dispersion import (
+        pme_dispersion_reciprocal_space as jax_pme_dispersion_reciprocal_space,
+    )
+
+    HAS_JAX = True
+except ImportError as exc:
+    HAS_JAX = False
+    print(f"  JAX backend unavailable ({exc}); skipping.")
+
+if HAS_JAX:
+    print(f"  JAX devices: {jax.devices()}")
+
+    def _j(arr, dtype=jnp.float64):
+        """numpy -> jax."""
+        if isinstance(arr, np.ndarray) and arr.dtype.kind == "i":
+            return jnp.array(arr, dtype=jnp.int32)
+        return jnp.array(arr, dtype=dtype)
+
+    positions_j = _j(pos_np)
+    c6_j = _j(c6_np)
+    cell_j = _j(cell_np)
+    beta_j = jnp.array([beta_val], dtype=jnp.float64)
+
+    E_recip_j = jax_pme_dispersion_reciprocal_space(
+        positions=positions_j,
+        c6_coefficients=c6_j,
+        cell=cell_j,
+        beta=beta_j,
+        mesh_dimensions=mesh_dimensions,
+        spline_order=4,
+    )
+    E_self_j = jax_pme_dispersion_energy_corrections(c6_j, beta_j)
+    print(f"\n  beta = {float(beta_j[0]):.3f} Å⁻¹  mesh = {mesh_dimensions}")
+    print(f"    V_recip = {float(E_recip_j[0]):+.6f}")
+    print(f"    V_self  = {float(E_self_j[0]):+.6f}")
+
+    # JIT-compiled evaluation
+    @jax.jit
+    def lj_pme_recip_minus_self_jit(positions, c6, cell, beta):
+        """JIT-compiled reciprocal + self-energy total for a single system."""
+        e_recip = jax_pme_dispersion_reciprocal_space(
+            positions=positions,
+            c6_coefficients=c6,
+            cell=cell,
+            beta=beta,
+            mesh_dimensions=mesh_dimensions,
+            spline_order=4,
+        )
+        e_self = jax_pme_dispersion_energy_corrections(c6, beta)
+        return e_recip - e_self
+
+    e_pr1 = lj_pme_recip_minus_self_jit(positions_j, c6_j, cell_j, beta_j)
+    print(f"    jit (V_recip - V_self) = {float(e_pr1[0]):+.6f}")
+
+    # Isolated-atom convergence (JAX)
+    pos_iso_j = _j(pos_iso_np)
+    c6_iso_j = _j(c6_iso_np)
+    cell_iso_j = _j(cell_iso_np)
+    print("\n  Isolated-atom convergence (V_recip / V_self → 1):")
+    print("      beta  | V_recip      | V_self       | (V_recip-V_self)/|V_self|")
+    print("    " + "-" * 65)
+    for bv in [0.2, 0.3, 0.5, 0.8, 1.0]:
+        b_j = jnp.array([bv], dtype=jnp.float64)
+        er = jax_pme_dispersion_reciprocal_space(
+            pos_iso_j,
+            c6_iso_j,
+            cell_iso_j,
+            b_j,
+            mesh_dimensions=(64, 64, 64),
+            spline_order=4,
+        )
+        es = jax_pme_dispersion_energy_corrections(c6_iso_j, b_j)
+        rel = (float(er[0]) - float(es[0])) / abs(float(es[0]))
+        print(
+            f"     {bv:.2f}  | {float(er[0]):+11.4e} | {float(es[0]):+11.4e} | {rel:+.2e}"
+        )
+
+    # Batched evaluation (JAX)
+    pos_batch_j = _j(pos_batch_np)
+    c6_batch_j = _j(c6_batch_np)
+    cell_batch_j = _j(cell_batch_np)
+    batch_idx_j = _j(batch_idx_np, dtype=jnp.int32)
+    beta_batch_j = _j(beta_batch_np)
+    E_recip_batch_j = jax_pme_dispersion_reciprocal_space(
+        positions=pos_batch_j,
+        c6_coefficients=c6_batch_j,
+        cell=cell_batch_j,
+        beta=beta_batch_j,
+        mesh_dimensions=(32, 32, 32),
+        spline_order=4,
+        batch_idx=batch_idx_j,
+    )
+    E_self_batch_j = jax_pme_dispersion_energy_corrections(
+        c6_batch_j, beta_batch_j, batch_idx=batch_idx_j
+    )
+    print("\n  Batched evaluation (two argon supercells):")
+    for s in range(2):
+        print(
+            f"    system {s}: V_recip = {float(E_recip_batch_j[s]):+.4e}, "
+            f"V_self = {float(E_self_batch_j[s]):+.4e}"
+        )
+
+
+# %%
+# Summary
+# -------
+# - ``pme_dispersion_reciprocal_space`` returns the FFT-based long-range
+#   :math:`r^{-6}` lattice sum with B-spline spreading and gathering.
+# - ``pme_dispersion_energy_corrections`` returns the closed-form
+#   :math:`V_{\\text{self}} = -\\beta^6 \\sum_i C_{6,ii}/12`.
+# - Both functions accept a ``batch_idx`` for evaluating many independent
+#   systems in one call.
+# - The PyTorch and JAX backends are interchangeable; the JAX path also
+#   composes with ``jax.jit``.
+# - The damped real-space term (``lj_pme_real_space``) and the unified
+#   ``lj_pme()`` orchestrator land in subsequent PRs.
+print("\nDone.")

--- a/examples/dispersion/05_lj_pme_real_space.py
+++ b/examples/dispersion/05_lj_pme_real_space.py
@@ -1,0 +1,388 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Real-Space LJ-PME (PR2): Damped Energy, Forces, and Virial
+==========================================================
+
+This example demonstrates the *real-space* component of Lennard-Jones PME
+(LJ-PME) introduced in PR2. Combined with the reciprocal-space and
+self-energy terms from PR1, this gives the total LJ-PME energy
+(Wennberg et al., JCTC 2013):
+
+.. math::
+
+    V_{\\text{total}} = V_{\\text{real}} + V_{\\text{recip}} - V_{\\text{self}}.
+
+The real-space term computes, for each neighbor pair (i, j) within a
+cutoff,
+
+.. math::
+
+    V_{ij} = \\frac{C_{12,ij}}{r_{ij}^{12}}
+             - \\frac{C_{6,ij} \\, g(\\beta r_{ij})}{r_{ij}^{6}},
+    \\qquad
+    g(x) = e^{-x^2}\\!\\left(1 + x^2 + \\tfrac{x^4}{2}\\right),
+
+with geometric combination rules. The damping function :math:`g(\\beta r)`
+is the Wennberg complement of the long-range PME term.
+
+Two backends are demonstrated side-by-side from the same script:
+
+* **PyTorch** — autograd-aware ``warp_custom_op`` wrappers.
+* **JAX** — JIT-compatible ``jax_kernel`` wrappers (skipped if JAX is
+  not installed).
+
+In this example you will learn:
+
+- Compute the damped real-space dispersion energy with
+  ``lj_pme_real_space``
+- Compute forces via the kernel and confirm they match autograd (Torch)
+- Verify momentum conservation
+- Compute the virial tensor (used for pressure / NPT)
+- Combine ``V_real``, ``V_recip``, and ``V_self`` to recover the total
+  LJ-PME energy
+- See how the real- vs. reciprocal-space split is tuned by ``beta``
+- Compose with ``jax.jit`` (JAX backend)
+
+.. important::
+    This script is intended as an API demonstration. Do not use it for
+    performance benchmarking; refer to the ``benchmarks`` folder instead.
+"""
+
+# %%
+# Setup and Imports
+# -----------------
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+# %%
+# Build a Backend-Neutral System Description
+# ------------------------------------------
+# A small argon supercell — neutral, single-element, dominated by
+# dispersion, geometric combination is trivially exact.
+
+
+def create_argon_fcc(n_cells: int = 3, lattice_constant: float = 5.26):
+    """Argon FCC supercell (NumPy arrays)."""
+    fcc_basis = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.5, 0.0],
+            [0.5, 0.0, 0.5],
+            [0.0, 0.5, 0.5],
+        ]
+    )
+    positions = []
+    for i in range(n_cells):
+        for j in range(n_cells):
+            for k in range(n_cells):
+                offset = np.array([i, j, k])
+                positions.extend(
+                    (frac + offset) * lattice_constant for frac in fcc_basis
+                )
+    positions_np = np.array(positions, dtype=np.float64)
+    c6_np = np.full(positions_np.shape[0], 60.0, dtype=np.float64)
+    c12_np = np.full(positions_np.shape[0], 5.5e4, dtype=np.float64)
+    cell_np = (np.eye(3, dtype=np.float64) * lattice_constant * n_cells)[None, :, :]
+    return positions_np, c6_np, c12_np, cell_np
+
+
+pos_np, c6_np, c12_np, cell_np = create_argon_fcc(n_cells=3)
+cutoff = 9.0  # Å
+beta_val = 0.35
+mesh_dimensions = (32, 32, 32)
+print(f"System: {pos_np.shape[0]}-atom argon FCC supercell")
+print(f"  Cell length: {cell_np[0, 0, 0]:.2f} Å")
+print(f"  Cutoff: {cutoff} Å,  beta: {beta_val} Å⁻¹")
+
+
+# =============================================================================
+# PyTorch Backend
+# =============================================================================
+print("\n" + "=" * 70)
+print("PyTorch backend")
+print("=" * 70)
+
+try:
+    import torch
+
+    from nvalchemiops.torch.interactions.dispersion import (
+        lj_pme_real_space,
+        pme_dispersion_energy_corrections,
+        pme_dispersion_reciprocal_space,
+    )
+    from nvalchemiops.torch.neighbors import neighbor_list as torch_nbr_list
+
+    HAS_TORCH = True
+except ImportError as exc:
+    HAS_TORCH = False
+    print(f"  PyTorch backend unavailable ({exc}); skipping.")
+
+if HAS_TORCH:
+    if torch.cuda.is_available():
+        torch_device = torch.device("cuda:0")
+        print(f"  Device: {torch.cuda.get_device_name(0)}")
+    else:
+        torch_device = torch.device("cpu")
+        print("  Device: CPU")
+
+    DTYPE = torch.float64
+    positions = torch.tensor(pos_np, dtype=DTYPE, device=torch_device)
+    c6 = torch.tensor(c6_np, dtype=DTYPE, device=torch_device)
+    c12 = torch.tensor(c12_np, dtype=DTYPE, device=torch_device)
+    cell = torch.tensor(cell_np, dtype=DTYPE, device=torch_device)
+    beta = torch.tensor([beta_val], dtype=DTYPE, device=torch_device)
+
+    pbc = torch.tensor([[True, True, True]], dtype=torch.bool, device=torch_device)
+    nbr_mat, num_nbrs, nbr_shifts = torch_nbr_list(
+        positions, cutoff, cell=cell, pbc=pbc, return_neighbor_list=False
+    )
+    print(
+        f"  Neighbor matrix: shape={tuple(nbr_mat.shape)},"
+        f" mean neighbors/atom = {float(num_nbrs.float().mean()):.2f}"
+    )
+
+    # Energy + Forces + Virial
+    energies, forces, virial = lj_pme_real_space(
+        positions,
+        c6,
+        c12,
+        cell,
+        nbr_mat,
+        nbr_shifts,
+        beta=beta,
+        cutoff=cutoff,
+        num_neighbors=num_nbrs,
+        compute_forces=True,
+        compute_virial=True,
+        half_neighbor_list=False,  # neighbor_list_fn returns a full list
+    )
+    V_real = energies.sum().item()
+    F_max = torch.linalg.vector_norm(forces, dim=1).max().item()
+    F_sum = forces.sum(dim=0).abs().max().item()
+    print(f"\n  V_real           = {V_real:+.4f}")
+    print(f"  Max force         = {F_max:.4e}")
+    print(f"  |Σ F| (momentum)  = {F_sum:.2e}    (should be ~0)")
+    print(f"  Virial trace tr(W)= {virial.diag().sum().item():+.4f}")
+
+    # Autograd cross-check (Torch)
+    positions_g = positions.clone().requires_grad_(True)
+    e_g = lj_pme_real_space(
+        positions_g,
+        c6,
+        c12,
+        cell,
+        nbr_mat,
+        nbr_shifts,
+        beta=beta,
+        cutoff=cutoff,
+        num_neighbors=num_nbrs,
+        half_neighbor_list=False,
+    )
+    e_g.sum().backward()
+    force_diff = (forces - (-positions_g.grad)).abs().max().item()
+    print(
+        f"  max |F_kernel - (-dE/dr)|         = {force_diff:.2e}  (autograd cross-check)"
+    )
+
+    # Total LJ-PME energy
+    V_recip = pme_dispersion_reciprocal_space(
+        positions, c6, cell, beta, mesh_dimensions=mesh_dimensions, spline_order=4
+    ).item()
+    V_self = pme_dispersion_energy_corrections(c6, beta).item()
+    V_total = V_real + V_recip - V_self
+    print(
+        f"\n  LJ-PME total at β={beta_val}, cutoff={cutoff} Å, mesh={mesh_dimensions}:"
+    )
+    print(f"    V_real  = {V_real:+.4f}")
+    print(f"    V_recip = {V_recip:+.4f}")
+    print(f"    V_self  = {V_self:+.4f}")
+    print(f"    V_total = {V_total:+.4f}")
+
+    # Beta sweep (fixed parameters, not jointly tuned)
+    print("\n  beta sweep with fixed cutoff and mesh=48³ (not jointly tuned):")
+    print("      beta  | V_real      | V_recip     | V_self      | V_total")
+    print("    " + "-" * 65)
+    for bv in [0.25, 0.30, 0.35, 0.40]:
+        b_t = torch.tensor([bv], dtype=DTYPE, device=torch_device)
+        Vr = (
+            lj_pme_real_space(
+                positions,
+                c6,
+                c12,
+                cell,
+                nbr_mat,
+                nbr_shifts,
+                beta=b_t,
+                cutoff=cutoff,
+                num_neighbors=num_nbrs,
+                half_neighbor_list=False,
+            )
+            .sum()
+            .item()
+        )
+        Vk = pme_dispersion_reciprocal_space(
+            positions, c6, cell, b_t, mesh_dimensions=(48, 48, 48), spline_order=4
+        ).item()
+        Vs = pme_dispersion_energy_corrections(c6, b_t).item()
+        Vt = Vr + Vk - Vs
+        print(
+            f"     {bv:.2f}  | {Vr:+9.4f}   | {Vk:+9.4f}   | {Vs:+9.4f}   | {Vt:+9.4f}"
+        )
+
+
+# =============================================================================
+# JAX Backend
+# =============================================================================
+print("\n" + "=" * 70)
+print("JAX backend")
+print("=" * 70)
+
+try:
+    import jax
+    import jax.numpy as jnp
+
+    from nvalchemiops.jax.interactions.dispersion import (
+        lj_pme_real_space as jax_lj_pme_real_space,
+    )
+    from nvalchemiops.jax.interactions.dispersion import (
+        pme_dispersion_energy_corrections as jax_pme_dispersion_energy_corrections,
+    )
+    from nvalchemiops.jax.interactions.dispersion import (
+        pme_dispersion_reciprocal_space as jax_pme_dispersion_reciprocal_space,
+    )
+    from nvalchemiops.jax.neighbors import neighbor_list as jax_nbr_list
+
+    HAS_JAX = True
+except ImportError as exc:
+    HAS_JAX = False
+    print(f"  JAX backend unavailable ({exc}); skipping.")
+
+if HAS_JAX:
+    print(f"  JAX devices: {jax.devices()}")
+
+    positions_j = jnp.array(pos_np, dtype=jnp.float64)
+    c6_j = jnp.array(c6_np, dtype=jnp.float64)
+    c12_j = jnp.array(c12_np, dtype=jnp.float64)
+    cell_j = jnp.array(cell_np, dtype=jnp.float64)
+    beta_j = jnp.array([beta_val], dtype=jnp.float64)
+
+    pbc_j = jnp.array([[True, True, True]], dtype=jnp.bool_)
+    nbr_mat_j, num_nbrs_j, nbr_shifts_j = jax_nbr_list(
+        positions_j, cutoff, cell=cell_j, pbc=pbc_j, return_neighbor_list=False
+    )
+    print(
+        f"  Neighbor matrix: shape={tuple(nbr_mat_j.shape)},"
+        f" mean neighbors/atom = {float(num_nbrs_j.astype(jnp.float64).mean()):.2f}"
+    )
+
+    # Energy + Forces + Virial
+    energies_j, forces_j, virial_j = jax_lj_pme_real_space(
+        positions_j,
+        c6_j,
+        c12_j,
+        cell_j,
+        nbr_mat_j,
+        nbr_shifts_j,
+        beta=beta_j,
+        cutoff=cutoff,
+        num_neighbors=num_nbrs_j,
+        compute_forces=True,
+        compute_virial=True,
+        half_neighbor_list=False,
+    )
+    V_real_j = float(energies_j.sum())
+    F_max_j = float(jnp.linalg.norm(forces_j, axis=1).max())
+    F_sum_j = float(jnp.abs(forces_j.sum(axis=0)).max())
+    print(f"\n  V_real           = {V_real_j:+.4f}")
+    print(f"  Max force         = {F_max_j:.4e}")
+    print(f"  |Σ F| (momentum)  = {F_sum_j:.2e}")
+    print(f"  Virial trace tr(W)= {float(virial_j.diagonal().sum()):+.4f}")
+
+    # JIT-compiled total LJ-PME energy
+    @jax.jit
+    def lj_pme_total_energy_jit(positions, c6, c12, cell, nm, ns, nn, beta):
+        """JIT-compiled V_real + V_recip - V_self for one system."""
+        e_real = jax_lj_pme_real_space(
+            positions,
+            c6,
+            c12,
+            cell,
+            nm,
+            ns,
+            beta=beta,
+            cutoff=cutoff,
+            num_neighbors=nn,
+            half_neighbor_list=False,
+        )
+        e_recip = jax_pme_dispersion_reciprocal_space(
+            positions, c6, cell, beta, mesh_dimensions=mesh_dimensions, spline_order=4
+        )
+        e_self = jax_pme_dispersion_energy_corrections(c6, beta)
+        return e_real.sum() + e_recip[0] - e_self[0]
+
+    V_total_j = float(
+        lj_pme_total_energy_jit(
+            positions_j,
+            c6_j,
+            c12_j,
+            cell_j,
+            nbr_mat_j,
+            nbr_shifts_j,
+            num_nbrs_j,
+            beta_j,
+        )
+    )
+    print(f"\n  jit V_total = V_real + V_recip - V_self = {V_total_j:+.4f}")
+
+
+# %%
+# Damping Function Behavior (backend-independent)
+# -----------------------------------------------
+# ``g(βr)`` smoothly transitions from 1 at r=0 to 0 at large r,
+# truncating dispersion before the cutoff:
+
+print("\nDamping function g(beta·r) = exp(-x²)(1 + x² + x⁴/2):")
+print("    r (Å) | β·r   | g(β·r)")
+print("  " + "-" * 40)
+for r in [1.0, 2.0, 3.0, 5.0, 7.0, 9.0]:
+    x = beta_val * r
+    g = math.exp(-(x * x)) * (1.0 + x * x + 0.5 * x * x * x * x)
+    print(f"   {r:5.1f}  | {x:5.2f} | {g:.4f}")
+
+# %%
+# Summary
+# -------
+# - ``lj_pme_real_space`` computes the damped pair sum
+#   :math:`C_{12}/r^{12} - C_6\\, g(\\beta r)/r^6` over neighbor pairs and
+#   returns per-atom energies, plus optional forces and the 3×3 virial.
+# - PyTorch: kernel forces match autograd derivatives to machine
+#   precision.
+# - JAX: composes with ``jax.jit`` for end-to-end JIT-compiled
+#   evaluation.
+# - Combined with ``pme_dispersion_reciprocal_space`` (PR1) and
+#   ``pme_dispersion_energy_corrections`` (PR1), it produces the total
+#   LJ-PME energy.
+# - At a jointly-tuned (β, cutoff, mesh) the total is independent of β;
+#   moving β alone shifts mass between the two sums and exposes the
+#   per-term truncation error.
+# - The top-level ``lj_pme()`` wrapper with automatic β/mesh estimation
+#   arrives in PR3.
+print("\nDone.")

--- a/examples/dispersion/06_lj_pme.py
+++ b/examples/dispersion/06_lj_pme.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unified LJ-PME (PR3): Top-level ``lj_pme()`` with Auto Parameter Estimation
+===========================================================================
+
+This example demonstrates the unified ``lj_pme()`` top-level
+orchestrator that combines the three LJ-PME components from PR1 and PR2:
+
+.. math::
+
+    V_{\\text{total}} = V_{\\text{real}} + V_{\\text{recip}} - V_{\\text{self}},
+
+with automatic estimation of the dispersion splitting parameter β and
+the FFT mesh dimensions (Wennberg et al., JCTC 2013; GROMACS-style
+matched-tail criterion). Pass an ``accuracy`` and a cutoff and the
+estimator picks β and mesh that put both tails below that threshold.
+
+In this example you will learn:
+
+- Call ``lj_pme()`` with default parameter estimation
+- Compute forces alongside the energy
+- Inspect the parameters chosen by
+  ``estimate_pme_dispersion_parameters``
+- See β-balance: total energy stays consistent as β varies, provided
+  cutoff and mesh are jointly tuned
+- Compose with ``jax.jit`` (JAX backend)
+
+Two backends are demonstrated side-by-side from the same script:
+
+* **PyTorch** — autograd-aware wrappers
+* **JAX** — JIT-compatible wrappers (skipped if JAX is not installed)
+
+.. important::
+    Demonstrates the API. Not a performance benchmark.
+"""
+
+# %%
+# Setup and Imports
+# -----------------
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def create_argon_fcc(n_cells: int = 3, lattice_constant: float = 5.26):
+    """Argon FCC supercell as NumPy arrays."""
+    fcc_basis = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.5, 0.0],
+            [0.5, 0.0, 0.5],
+            [0.0, 0.5, 0.5],
+        ]
+    )
+    positions = []
+    for i in range(n_cells):
+        for j in range(n_cells):
+            for k in range(n_cells):
+                offset = np.array([i, j, k])
+                positions.extend(
+                    (frac + offset) * lattice_constant for frac in fcc_basis
+                )
+    positions_np = np.array(positions, dtype=np.float64)
+    c6_np = np.full(positions_np.shape[0], 60.0, dtype=np.float64)
+    c12_np = np.full(positions_np.shape[0], 5.5e4, dtype=np.float64)
+    cell_np = np.eye(3, dtype=np.float64) * lattice_constant * n_cells
+    return positions_np, c6_np, c12_np, cell_np
+
+
+pos_np, c6_np, c12_np, cell_np = create_argon_fcc(n_cells=3)
+cutoff = 9.0  # Å
+print(f"System: {pos_np.shape[0]}-atom argon FCC supercell")
+print(f"  Cell length: {cell_np[0, 0]:.2f} Å")
+print(f"  Real-space cutoff: {cutoff} Å")
+
+
+# =============================================================================
+# PyTorch Backend
+# =============================================================================
+print("\n" + "=" * 70)
+print("PyTorch backend")
+print("=" * 70)
+
+try:
+    import torch
+
+    from nvalchemiops.torch.interactions.dispersion import (
+        estimate_pme_dispersion_parameters,
+        lj_pme,
+    )
+    from nvalchemiops.torch.neighbors import neighbor_list as torch_nbr_list
+
+    HAS_TORCH = True
+except ImportError as exc:
+    HAS_TORCH = False
+    print(f"  PyTorch backend unavailable ({exc}); skipping.")
+
+if HAS_TORCH:
+    if torch.cuda.is_available():
+        torch_device = torch.device("cuda:0")
+        print(f"  Device: {torch.cuda.get_device_name(0)}")
+    else:
+        torch_device = torch.device("cpu")
+        print("  Device: CPU")
+
+    DTYPE = torch.float64
+    positions = torch.tensor(pos_np, dtype=DTYPE, device=torch_device)
+    c6 = torch.tensor(c6_np, dtype=DTYPE, device=torch_device)
+    c12 = torch.tensor(c12_np, dtype=DTYPE, device=torch_device)
+    cell = torch.tensor(cell_np, dtype=DTYPE, device=torch_device)
+    pbc = torch.tensor([[True, True, True]], dtype=torch.bool, device=torch_device)
+
+    # %%
+    # Parameter Estimation
+    # --------------------
+    # Pick the cutoff (real-space tail), and the estimator chooses β and
+    # the mesh to match the same accuracy threshold on both sides.
+    params = estimate_pme_dispersion_parameters(cell, cutoff=cutoff, accuracy=1e-3)
+    print(
+        f"\n  Auto-estimated parameters (accuracy=1e-3):\n"
+        f"    cutoff = {params.cutoff} Å\n"
+        f"    beta   = {float(params.beta[0]):.4f} Å⁻¹\n"
+        f"    mesh   = {params.mesh_dimensions}\n"
+        f"    mesh_spacing = {[f'{float(s):.2f}' for s in params.mesh_spacing[0]]} Å"
+    )
+
+    # %%
+    # Energy via the Unified API
+    # --------------------------
+    # ``lj_pme()`` builds the matching neighbor list for the chosen
+    # cutoff and runs the three LJ-PME components. With no β/cutoff/mesh
+    # supplied it falls back to the joint estimator.
+
+    nbr_mat, num_nbrs, nbr_shifts = torch_nbr_list(
+        positions,
+        params.cutoff,
+        cell=cell.unsqueeze(0),
+        pbc=pbc,
+        return_neighbor_list=False,
+    )
+
+    E = lj_pme(
+        positions,
+        c6,
+        c12,
+        cell,
+        nbr_mat,
+        nbr_shifts,
+        num_neighbors=num_nbrs,
+    )
+    print(f"\n  V_total (auto-parameters): {E.item():+.4f}")
+
+    # %%
+    # Energy + Forces
+    # ---------------
+    E, F = lj_pme(
+        positions,
+        c6,
+        c12,
+        cell,
+        nbr_mat,
+        nbr_shifts,
+        num_neighbors=num_nbrs,
+        compute_forces=True,
+    )
+    F_max = torch.linalg.vector_norm(F, dim=1).max().item()
+    F_sum = F.sum(dim=0).abs().max().item()
+    print(f"  V_total = {E.item():+.4f}")
+    print(f"  Max |F| = {F_max:.4e}")
+    print(f"  |Σ F|   = {F_sum:.2e}    (should be ~0)")
+
+    # %%
+    # β-balance with Jointly-Tuned Parameters
+    # ----------------------------------------
+    # Sweep cutoff; for each cutoff the estimator picks the matching β
+    # and mesh. V_total should be approximately invariant (the residual
+    # depends on the chosen accuracy and the system size).
+    print("\n  β-balance sweep (accuracy=1e-5, joint estimator):")
+    print("      cutoff | beta    | mesh         | V_total")
+    print("    " + "-" * 55)
+    for cut in [7.0, 9.0, 12.0]:
+        params_i = estimate_pme_dispersion_parameters(cell, cutoff=cut, accuracy=1e-5)
+        nm_i, nn_i, ns_i = torch_nbr_list(
+            positions, cut, cell=cell.unsqueeze(0), pbc=pbc, return_neighbor_list=False
+        )
+        E_i = lj_pme(
+            positions,
+            c6,
+            c12,
+            cell,
+            nm_i,
+            ns_i,
+            num_neighbors=nn_i,
+            beta=params_i.beta,
+            cutoff=params_i.cutoff,
+            mesh_dimensions=params_i.mesh_dimensions,
+            accuracy=1e-5,
+        )
+        print(
+            f"      {cut:5.1f}  | {float(params_i.beta[0]):.4f}  | {str(params_i.mesh_dimensions):12s} | {E_i.item():+.4f}"
+        )
+
+
+# =============================================================================
+# JAX Backend
+# =============================================================================
+print("\n" + "=" * 70)
+print("JAX backend")
+print("=" * 70)
+
+try:
+    import jax
+    import jax.numpy as jnp
+
+    from nvalchemiops.jax.interactions.dispersion import (
+        estimate_pme_dispersion_parameters as jax_estimate_pme_dispersion_parameters,
+    )
+    from nvalchemiops.jax.interactions.dispersion import (
+        lj_pme as jax_lj_pme,
+    )
+    from nvalchemiops.jax.neighbors import neighbor_list as jax_nbr_list
+
+    HAS_JAX = True
+except ImportError as exc:
+    HAS_JAX = False
+    print(f"  JAX backend unavailable ({exc}); skipping.")
+
+if HAS_JAX:
+    try:
+        print(f"  JAX devices: {jax.devices()}")
+    except (NameError, AttributeError):  # Exception:
+        pass
+
+    positions_j = jnp.array(pos_np, dtype=jnp.float64)
+    c6_j = jnp.array(c6_np, dtype=jnp.float64)
+    c12_j = jnp.array(c12_np, dtype=jnp.float64)
+    cell_j = jnp.array(cell_np, dtype=jnp.float64)
+    pbc_j = jnp.array([[True, True, True]], dtype=jnp.bool_)
+
+    params_j = jax_estimate_pme_dispersion_parameters(
+        cell_j, cutoff=cutoff, accuracy=1e-3
+    )
+    print(
+        f"\n  Auto-estimated parameters (accuracy=1e-3):\n"
+        f"    cutoff = {params_j.cutoff} Å\n"
+        f"    beta   = {float(params_j.beta[0]):.4f} Å⁻¹\n"
+        f"    mesh   = {params_j.mesh_dimensions}"
+    )
+
+    nbr_mat_j, num_nbrs_j, nbr_shifts_j = jax_nbr_list(
+        positions_j,
+        params_j.cutoff,
+        cell=cell_j[None],
+        pbc=pbc_j,
+        return_neighbor_list=False,
+    )
+
+    E_j = jax_lj_pme(
+        positions_j,
+        c6_j,
+        c12_j,
+        cell_j,
+        nbr_mat_j,
+        nbr_shifts_j,
+        num_neighbors=num_nbrs_j,
+    )
+    print(f"\n  V_total (auto-parameters): {float(E_j[0]):+.4f}")
+
+    # JIT compilation
+    @jax.jit
+    def lj_pme_energy_jit(positions, c6, c12, cell, nm, ns, nn):
+        return jax_lj_pme(
+            positions,
+            c6,
+            c12,
+            cell,
+            nm,
+            ns,
+            num_neighbors=nn,
+            beta=0.3723,
+            cutoff=cutoff,
+            mesh_dimensions=(16, 16, 16),
+        )[0]
+
+    E_jit = float(
+        lj_pme_energy_jit(
+            positions_j, c6_j, c12_j, cell_j, nbr_mat_j, nbr_shifts_j, num_nbrs_j
+        )
+    )
+    print(f"  jit-compiled V_total:     {E_jit:+.4f}")
+
+
+# %%
+# Summary
+# -------
+# - ``lj_pme()`` is the recommended entry point: pass a system + cutoff,
+#   get the total LJ-PME energy with optional forces.
+# - β, mesh dimensions, and the real-space cutoff can be supplied
+#   explicitly or auto-estimated jointly from ``accuracy``.
+# - ``estimate_pme_dispersion_parameters()`` exposes the estimator so
+#   users can pre-compute and reuse the parameters in MD loops.
+# - The PyTorch path is autograd-aware; the JAX path composes with
+#   ``jax.jit``.
+print("\nDone.")

--- a/nvalchemiops/interactions/dispersion/pme_dispersion_kernels.py
+++ b/nvalchemiops/interactions/dispersion/pme_dispersion_kernels.py
@@ -1,0 +1,1220 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+PME Dispersion Kernels (LJ-PME)
+================================
+
+GPU-accelerated Warp kernels for Particle Mesh Ewald applied to the
+attractive dispersion (:math:`r^{-6}`) component of the Lennard-Jones
+interaction. With geometric combination rules
+(:math:`C_{6,ij} = \\sqrt{C_{6,ii} \\cdot C_{6,jj}}`) the long-range sum
+factorizes into a single FFT — the same cost as Coulomb PME.
+
+MATHEMATICAL FORMULATION
+========================
+
+The total LJ-PME energy is decomposed (Wennberg et al. JCTC 2013) as:
+
+.. math::
+
+    V_{\\text{total}} = V_{\\text{real}} + V_{\\text{recip}} - V_{\\text{self}}
+
+with reciprocal-space term
+
+.. math::
+
+    V_{\\text{recip}} = \\frac{\\pi^{3/2} \\beta^3}{2V}
+        \\sum_{m \\neq 0} f(\\pi|m|/\\beta) \\, |\\rho_{\\text{disp}}(m)|^2
+
+where :math:`\\rho_{\\text{disp}}(m) = \\sum_i \\sqrt{C_{6,ii}}\\, e^{2\\pi i\\,m \\cdot r_i}`
+is the dispersion structure factor spread on the mesh and
+
+.. math::
+
+    f(x) = \\tfrac{1}{3}\\bigl[(1 - 2x^2) e^{-x^2}
+                + 2 x^3 \\sqrt{\\pi}\\, \\text{erfc}(x)\\bigr].
+
+In terms of the reciprocal-vector magnitude on the mesh, :math:`|k| = 2\\pi |m|`,
+so :math:`x = \\pi|m|/\\beta = |k|/(2\\beta)` and :math:`x^2 = |k|^2/(4\\beta^2)`.
+
+The self-energy correction is
+
+.. math::
+
+    V_{\\text{self}} = -\\frac{\\beta^6}{12} \\sum_i C_{6,ii}.
+
+The B-spline structure-factor correction :math:`C^2(k)` is identical to
+Coulomb PME (mesh- and spline-order-dependent only).
+
+KERNEL ORGANIZATION
+===================
+
+Green's function kernels:
+    _pme_dispersion_green_structure_factor_kernel        — single system
+    _batch_pme_dispersion_green_structure_factor_kernel  — batched
+
+Self-energy correction kernels:
+    _pme_dispersion_self_energy_kernel        — single system, per-atom
+    _batch_pme_dispersion_self_energy_kernel  — batched, per-atom
+
+Each emits a per-atom value :math:`-\\beta^6 C_{6,ii}/12`. The binding layer
+reduces over atoms (or per system in the batched case) to obtain the total
+self-energy correction.
+
+REFERENCES
+==========
+
+- Wennberg, Hess, Lindahl (2013). JCTC 9, 3527. (LJ lattice summation.)
+- Essmann et al. (1995). J. Chem. Phys. 103, 8577 (SPME).
+"""
+
+import math
+from typing import Any
+
+import warp as wp
+
+# Mathematical constants
+PI = math.pi
+TWOPI = 2.0 * PI
+SQRT_PI = math.sqrt(PI)
+PI_3_2 = PI * SQRT_PI  # pi^(3/2)
+
+
+###########################################################################################
+########################### Helper Functions ##############################################
+###########################################################################################
+
+
+@wp.func
+def compute_sinc(x: Any) -> Any:
+    """Compute normalized sinc function: :math:`\\sin(\\pi x)/(\\pi x)`.
+
+    Uses Taylor expansion near zero for numerical stability.
+    """
+    abs_x = wp.abs(x)
+    one = type(x)(1.0)
+    threshold = type(x)(1e-6)
+
+    if abs_x < threshold:
+        return one
+
+    pi_x = type(x)(PI) * x
+    return wp.sin(pi_x) / pi_x
+
+
+@wp.func
+def dispersion_green_f(x_sq: Any) -> Any:
+    """Compute the dispersion Green's function radial factor.
+
+    .. math::
+
+        f(x) = \\tfrac{1}{3}\\bigl[(1 - 2x^2) e^{-x^2}
+                    + 2 x^3 \\sqrt{\\pi}\\, \\text{erfc}(x)\\bigr]
+
+    Takes :math:`x^2` as input to avoid an extra sqrt when not needed.
+    """
+    one = type(x_sq)(1.0)
+    two = type(x_sq)(2.0)
+    one_third = type(x_sq)(1.0 / 3.0)
+    sqrt_pi = type(x_sq)(SQRT_PI)
+
+    x = wp.sqrt(x_sq)
+    exp_term = (one - two * x_sq) * wp.exp(-x_sq)
+    erfc_term = two * x_sq * x * sqrt_pi * wp.erfc(x)
+    return one_third * (exp_term + erfc_term)
+
+
+###########################################################################################
+########################### Green Function with Structure Factor ##########################
+###########################################################################################
+
+
+@wp.kernel
+def _pme_dispersion_green_structure_factor_kernel(
+    k_squared: wp.array3d(dtype=Any),  # (Nx, Ny, Nz_rfft)
+    miller_x: wp.array(dtype=Any),  # (Nx,)
+    miller_y: wp.array(dtype=Any),  # (Ny,)
+    miller_z: wp.array(dtype=Any),  # (Nz_rfft,)
+    beta: wp.array(dtype=Any),  # (1,)
+    volume: wp.array(dtype=Any),  # (1,)
+    mesh_nx: wp.int32,
+    mesh_ny: wp.int32,
+    mesh_nz: wp.int32,
+    spline_order: wp.int32,
+    green_function: wp.array3d(dtype=Any),  # (Nx, Ny, Nz_rfft)
+    structure_factor_sq: wp.array3d(dtype=Any),  # (Nx, Ny, Nz_rfft)
+):
+    """Compute dispersion PME Green's function and B-spline correction.
+
+    Computes two arrays needed for LJ-PME reciprocal space:
+
+    1. Green's function: :math:`G_{\\text{disp}}(k) = (\\pi^{3/2}\\beta^3/(2V))
+       \\cdot f(|k|/(2\\beta))`.
+    2. Structure factor squared: :math:`|B(k)|^2` for B-spline dealiasing
+       (identical to Coulomb PME).
+
+    Launch Grid
+    -----------
+    dim = [Nx, Ny, Nz_rfft]
+
+    Each thread processes one grid point in the FFT mesh (using rfft symmetry).
+
+    Parameters
+    ----------
+    k_squared : wp.array3d, shape (Nx, Ny, Nz_rfft)
+        Squared magnitude of k-vectors at each grid point.
+    miller_x, miller_y, miller_z : wp.array
+        Miller indices (from fftfreq/rfftfreq).
+    beta : wp.array, shape (1,)
+        Dispersion Ewald splitting parameter.
+    volume : wp.array, shape (1,)
+        Unit cell volume.
+    mesh_nx, mesh_ny, mesh_nz : wp.int32
+        Full mesh dimensions (Nz is the full size, not rfft size).
+    spline_order : wp.int32
+        B-spline order (1-4). Order 4 (cubic) recommended.
+    green_function : wp.array3d
+        OUTPUT: Dispersion Green's function values per grid point.
+    structure_factor_sq : wp.array3d
+        OUTPUT: :math:`|B(k)|^2` structure factor squared per grid point.
+
+    Notes
+    -----
+    - k=0 (grid point [0,0,0]) is explicitly set to zero (the m=0 term
+      is excluded from the dispersion reciprocal sum).
+    - Near-zero k² values are clamped to zero in the Green's function.
+    - Structure factor is clamped to avoid division by zero in dealiasing.
+    """
+    i, j, k = wp.tid()
+
+    k_sq = k_squared[i, j, k]
+    beta_ = beta[0]
+    volume_ = volume[0]
+    mi_x = miller_x[i]
+    mi_y = miller_y[j]
+    mi_z = miller_z[k]
+
+    # Get dtype-specific constants
+    zero = type(k_sq)(0.0)
+    two = type(k_sq)(2.0)
+    four = type(k_sq)(4.0)
+    threshold = type(k_sq)(1e-10)
+    clamp_threshold = type(k_sq)(1e-10)
+    pi32 = type(k_sq)(PI_3_2)
+
+    # Green's function:
+    #   x^2 = k^2 / (4 * beta^2)
+    #   G(k) = -(pi^(3/2) * beta^3) / (2V) * f(x)
+    # The minus sign reflects the attractive r^-6 dispersion: V_recip is
+    # the lattice-summed long-range complement -(1/2)Σ √C6·√C6·(1-g)/r^6
+    # so the FT kernel acquires the same overall sign.
+    if k_sq < threshold:
+        green_function[i, j, k] = zero
+    else:
+        x_sq = k_sq / (four * beta_ * beta_)
+        f_val = dispersion_green_f(x_sq)
+        beta_cubed = beta_ * beta_ * beta_
+        green_function[i, j, k] = -pi32 * beta_cubed * f_val / (two * volume_)
+
+    if i == 0 and j == 0 and k == 0:
+        green_function[i, j, k] = zero
+
+    # Structure factor: sinc(mi_x/Nx) * sinc(mi_y/Ny) * sinc(mi_z/Nz)
+    sinc_x = compute_sinc(mi_x / type(mi_x)(mesh_nx))
+    sinc_y = compute_sinc(mi_y / type(mi_y)(mesh_ny))
+    sinc_z = compute_sinc(mi_z / type(mi_z)(mesh_nz))
+
+    sinc_product = sinc_x * sinc_y * sinc_z
+
+    # Raise to spline_order power
+    sf = sinc_product
+    for _ in range(1, 4):  # Max order 4
+        if _ < spline_order:
+            sf = sf * sinc_product
+
+    if sf < clamp_threshold:
+        sf = clamp_threshold
+
+    structure_factor_sq[i, j, k] = sf * sf
+
+
+@wp.kernel
+def _batch_pme_dispersion_green_structure_factor_kernel(
+    k_squared: wp.array4d(dtype=Any),  # (B, Nx, Ny, Nz_rfft)
+    miller_x: wp.array(dtype=Any),  # (Nx,)
+    miller_y: wp.array(dtype=Any),  # (Ny,)
+    miller_z: wp.array(dtype=Any),  # (Nz_rfft,)
+    beta: wp.array(dtype=Any),  # (B,)
+    volumes: wp.array(dtype=Any),  # (B,)
+    mesh_nx: wp.int32,
+    mesh_ny: wp.int32,
+    mesh_nz: wp.int32,
+    spline_order: wp.int32,
+    green_function: wp.array4d(dtype=Any),  # (B, Nx, Ny, Nz_rfft)
+    structure_factor_sq: wp.array3d(dtype=Any),  # (Nx, Ny, Nz_rfft)
+):
+    """Compute dispersion PME Green's function and B-spline correction (batched).
+
+    Batched version. Each system can have different beta and volume values,
+    but shares the same mesh dimensions.
+
+    Launch Grid
+    -----------
+    dim = [B, Nx, Ny, Nz_rfft]
+    """
+    batch_idx, i, j, k = wp.tid()
+
+    k_sq = k_squared[batch_idx, i, j, k]
+    system_beta = beta[batch_idx]
+    system_volume = volumes[batch_idx]
+    mi_x = miller_x[i]
+    mi_y = miller_y[j]
+    mi_z = miller_z[k]
+
+    zero = type(k_sq)(0.0)
+    two = type(k_sq)(2.0)
+    four = type(k_sq)(4.0)
+    threshold = type(k_sq)(1e-10)
+    clamp_threshold = type(k_sq)(1e-10)
+    pi32 = type(k_sq)(PI_3_2)
+
+    if k_sq < threshold:
+        green_function[batch_idx, i, j, k] = zero
+    else:
+        x_sq = k_sq / (four * system_beta * system_beta)
+        f_val = dispersion_green_f(x_sq)
+        beta_cubed = system_beta * system_beta * system_beta
+        green_function[batch_idx, i, j, k] = (
+            -pi32 * beta_cubed * f_val / (two * system_volume)
+        )
+
+    if i == 0 and j == 0 and k == 0:
+        green_function[batch_idx, i, j, k] = zero
+
+    # Structure factor only computed once per k-point (at batch_idx=0)
+    if batch_idx == wp.int32(0):
+        sinc_x = compute_sinc(mi_x / type(mi_x)(mesh_nx))
+        sinc_y = compute_sinc(mi_y / type(mi_y)(mesh_ny))
+        sinc_z = compute_sinc(mi_z / type(mi_z)(mesh_nz))
+
+        sinc_product = sinc_x * sinc_y * sinc_z
+
+        sf = sinc_product
+        for _ in range(1, 4):
+            if _ < spline_order:
+                sf = sf * sinc_product
+
+        if sf < clamp_threshold:
+            sf = clamp_threshold
+
+        structure_factor_sq[i, j, k] = sf * sf
+
+
+###########################################################################################
+########################### Dispersion Self-Energy Correction #############################
+###########################################################################################
+
+
+@wp.kernel
+def _pme_dispersion_self_energy_kernel(
+    c6_coefficients: wp.array(dtype=Any),  # (N,) homoatomic C6_ii
+    beta: wp.array(dtype=Any),  # (1,)
+    energy_correction: wp.array(dtype=Any),  # OUT (N,) per-atom contribution
+):
+    """Compute per-atom dispersion self-energy correction.
+
+    Each atom's contribution is
+
+    .. math::
+
+        V_{\\text{self},i} = -\\frac{\\beta^6}{12} C_{6,ii}.
+
+    The total :math:`V_{\\text{self}}` is obtained by summing over atoms; this
+    is handled in the binding layer.
+
+    Launch Grid
+    -----------
+    dim = [num_atoms]
+    """
+    atom_idx = wp.tid()
+
+    c6 = c6_coefficients[atom_idx]
+    beta_ = beta[0]
+
+    twelve = type(c6)(12.0)
+    beta_sq = beta_ * beta_
+    beta_sixth = beta_sq * beta_sq * beta_sq
+
+    energy_correction[atom_idx] = -beta_sixth * c6 / twelve
+
+
+@wp.kernel
+def _batch_pme_dispersion_self_energy_kernel(
+    c6_coefficients: wp.array(dtype=Any),  # (N_total,) homoatomic C6_ii
+    batch_idx: wp.array(dtype=wp.int32),  # (N_total,) system index per atom
+    beta: wp.array(dtype=Any),  # (B,)
+    energy_correction: wp.array(dtype=Any),  # OUT (N_total,)
+):
+    """Batched per-atom dispersion self-energy correction.
+
+    Each atom uses its system's beta via ``batch_idx``.
+
+    Launch Grid
+    -----------
+    dim = [num_atoms_total]
+    """
+    atom_idx = wp.tid()
+
+    system_id = batch_idx[atom_idx]
+    c6 = c6_coefficients[atom_idx]
+    beta_ = beta[system_id]
+
+    twelve = type(c6)(12.0)
+    beta_sq = beta_ * beta_
+    beta_sixth = beta_sq * beta_sq * beta_sq
+
+    energy_correction[atom_idx] = -beta_sixth * c6 / twelve
+
+
+###########################################################################################
+########################### Real-Space LJ-PME Kernels #####################################
+###########################################################################################
+#
+# Real-space (short-range) term of LJ-PME:
+#
+#   V_pair(r) = C12_ij / r^12 - C6_ij * g(beta*r) / r^6
+#
+# where g(x) = exp(-x^2) * (1 + x^2 + x^4/2) is the Wennberg damping function
+# (its long-range complement (1 - g(beta*r))/r^6 is what reciprocal-space PME
+# evaluates). Geometric combination rules:
+#
+#   C6_ij  = sqrt(c6_ii * c6_jj)
+#   C12_ij = sqrt(c12_ii * c12_jj)
+#
+# Forces (derived from -dV/dr * r_hat with r_hat = (r_i - r_j)/r):
+#
+#   F_i = [ 12*C12/r^13  -  C6 * beta^6 * exp(-beta^2 r^2) / r  -  6*C6*g/r^7 ] * r_hat
+#       = [ 12*C12/r^14  -  C6 * beta^6 * exp(-beta^2 r^2) / r^2 -  6*C6*g/r^8 ] * r_ij
+#
+# The bracket is precomputed as ``force_mag_over_r`` and applied to r_ij.
+# Sign convention: r_ij = r_i - r_j, half neighbor list — pair appears once
+# in the (i, j) row; Newton's third law is applied to atom j inside the kernel.
+
+
+@wp.func
+def _lj_pme_damping_g(x_sq: Any) -> Any:
+    """Wennberg damping factor g(x) = exp(-x^2)*(1 + x^2 + x^4/2). Takes x^2."""
+    one = type(x_sq)(1.0)
+    half = type(x_sq)(0.5)
+    return wp.exp(-x_sq) * (one + x_sq + half * x_sq * x_sq)
+
+
+@wp.kernel
+def _lj_pme_real_space_energy_kernel(
+    positions: wp.array(dtype=Any),  # (N,) vec3
+    c6_coefficients: wp.array(dtype=Any),  # (N,)
+    c12_coefficients: wp.array(dtype=Any),  # (N,)
+    cell: wp.array(dtype=Any),  # (1,) mat33
+    neighbor_matrix: wp.array2d(dtype=wp.int32),
+    neighbor_matrix_shifts: wp.array2d(dtype=wp.vec3i),
+    num_neighbors: wp.array(dtype=wp.int32),
+    beta: wp.array(dtype=Any),  # (1,)
+    cutoff: wp.array(dtype=Any),  # (1,)
+    mask_value: wp.int32,
+    half_neighbor_list: wp.bool,
+    atomic_energies: wp.array(dtype=Any),  # OUT (N,)
+):
+    """Real-space LJ-PME energy with neighbor matrix.
+
+    Computes ``V = C12/r^12 - C6 * g(beta*r) / r^6`` for each pair within the
+    cutoff. Energy accumulation depends on ``half_neighbor_list``:
+
+    * half list: each pair (i, j) appears once; adds V/2 to both i and j.
+    * full list: each pair appears twice (once in i's row, once in j's row);
+      adds V/2 to atom_i only (the matching (j, i) row handles atom j).
+
+    Launch Grid
+    -----------
+    dim = [num_atoms]
+    """
+    atom_i = wp.tid()
+    num_atoms = positions.shape[0]
+    max_neighbors = neighbor_matrix.shape[1]
+    if atom_i >= num_atoms:
+        return
+
+    ri = positions[atom_i]
+    c6_i = wp.float64(c6_coefficients[atom_i])
+    c12_i = wp.float64(c12_coefficients[atom_i])
+    cell_t = wp.transpose(cell[0])
+    beta_ = wp.float64(beta[0])
+    cut = wp.float64(cutoff[0])
+    cutoff_sq = cut * cut
+
+    n_neighbors = num_neighbors[atom_i]
+    for slot in range(n_neighbors):
+        if slot >= max_neighbors:
+            break
+        j = neighbor_matrix[atom_i, slot]
+        if j == mask_value or j >= num_atoms:
+            continue
+
+        rj = positions[j]
+        shift = neighbor_matrix_shifts[atom_i, slot]
+        shift_vec = cell_t * type(ri)(
+            type(ri[0])(shift[0]),
+            type(ri[0])(shift[1]),
+            type(ri[0])(shift[2]),
+        )
+        r_ij = ri - rj - shift_vec
+        r_sq = wp.float64(wp.dot(r_ij, r_ij))
+        if r_sq >= cutoff_sq or r_sq < wp.float64(1e-10):
+            continue
+
+        c6_j = wp.float64(c6_coefficients[j])
+        c12_j = wp.float64(c12_coefficients[j])
+        c6_ij = wp.sqrt(c6_i * c6_j)
+        c12_ij = wp.sqrt(c12_i * c12_j)
+
+        r_sq_2 = r_sq * r_sq
+        r_sq_3 = r_sq_2 * r_sq
+        r_sq_6 = r_sq_3 * r_sq_3
+        inv_r6 = wp.float64(1.0) / r_sq_3
+        inv_r12 = wp.float64(1.0) / r_sq_6
+
+        x_sq = beta_ * beta_ * r_sq
+        g = _lj_pme_damping_g(x_sq)
+
+        pair_energy = c12_ij * inv_r12 - c6_ij * g * inv_r6
+        half_energy = wp.float64(0.5) * pair_energy
+        wp.atomic_add(atomic_energies, atom_i, type(atomic_energies[0])(half_energy))
+        if half_neighbor_list:
+            wp.atomic_add(atomic_energies, j, type(atomic_energies[0])(half_energy))
+
+
+@wp.kernel
+def _lj_pme_real_space_energy_forces_kernel(
+    positions: wp.array(dtype=Any),
+    c6_coefficients: wp.array(dtype=Any),
+    c12_coefficients: wp.array(dtype=Any),
+    cell: wp.array(dtype=Any),
+    neighbor_matrix: wp.array2d(dtype=wp.int32),
+    neighbor_matrix_shifts: wp.array2d(dtype=wp.vec3i),
+    num_neighbors: wp.array(dtype=wp.int32),
+    beta: wp.array(dtype=Any),
+    cutoff: wp.array(dtype=Any),
+    mask_value: wp.int32,
+    half_neighbor_list: wp.bool,
+    atomic_energies: wp.array(dtype=Any),
+    atomic_forces: wp.array(dtype=Any),  # OUT (N,) vec3
+):
+    """Real-space LJ-PME energy and forces.
+
+    Half list: applies Newton's third law and updates both i and j.
+    Full list: updates only atom_i (the matching (j, i) row handles j).
+
+    Force on atom i:
+
+        F_i = [ 12 C12/r^14 - C6 beta^6 exp(-beta^2 r^2)/r^2 - 6 C6 g/r^8 ] * r_ij
+    """
+    atom_i = wp.tid()
+    num_atoms = positions.shape[0]
+    max_neighbors = neighbor_matrix.shape[1]
+    if atom_i >= num_atoms:
+        return
+
+    ri = positions[atom_i]
+    c6_i = wp.float64(c6_coefficients[atom_i])
+    c12_i = wp.float64(c12_coefficients[atom_i])
+    cell_t = wp.transpose(cell[0])
+    beta_ = wp.float64(beta[0])
+    cut = wp.float64(cutoff[0])
+    cutoff_sq = cut * cut
+
+    force_acc = type(ri)(
+        type(ri[0])(0.0),
+        type(ri[0])(0.0),
+        type(ri[0])(0.0),
+    )
+
+    n_neighbors = num_neighbors[atom_i]
+    for slot in range(n_neighbors):
+        if slot >= max_neighbors:
+            break
+        j = neighbor_matrix[atom_i, slot]
+        if j == mask_value or j >= num_atoms:
+            continue
+
+        rj = positions[j]
+        shift = neighbor_matrix_shifts[atom_i, slot]
+        shift_vec = cell_t * type(ri)(
+            type(ri[0])(shift[0]),
+            type(ri[0])(shift[1]),
+            type(ri[0])(shift[2]),
+        )
+        r_ij = ri - rj - shift_vec
+        r_sq = wp.float64(wp.dot(r_ij, r_ij))
+        if r_sq >= cutoff_sq or r_sq < wp.float64(1e-10):
+            continue
+
+        c6_j = wp.float64(c6_coefficients[j])
+        c12_j = wp.float64(c12_coefficients[j])
+        c6_ij = wp.sqrt(c6_i * c6_j)
+        c12_ij = wp.sqrt(c12_i * c12_j)
+
+        r_sq_2 = r_sq * r_sq
+        r_sq_3 = r_sq_2 * r_sq
+        r_sq_4 = r_sq_2 * r_sq_2
+        r_sq_6 = r_sq_3 * r_sq_3
+        r_sq_7 = r_sq_4 * r_sq_3
+        inv_r2 = wp.float64(1.0) / r_sq
+        inv_r6 = wp.float64(1.0) / r_sq_3
+        inv_r8 = wp.float64(1.0) / r_sq_4
+        inv_r12 = wp.float64(1.0) / r_sq_6
+        inv_r14 = wp.float64(1.0) / r_sq_7
+
+        beta_sq = beta_ * beta_
+        x_sq = beta_sq * r_sq
+        beta_sixth = beta_sq * beta_sq * beta_sq
+        exp_x_sq = wp.exp(-x_sq)
+        g = exp_x_sq * (wp.float64(1.0) + x_sq + wp.float64(0.5) * x_sq * x_sq)
+
+        pair_energy = c12_ij * inv_r12 - c6_ij * g * inv_r6
+        # F_i = (12 C12/r^14 - C6 beta^6 e^(-beta^2 r^2)/r^2 - 6 C6 g/r^8) * r_ij
+        force_mag_over_r = (
+            wp.float64(12.0) * c12_ij * inv_r14
+            - c6_ij * beta_sixth * exp_x_sq * inv_r2
+            - wp.float64(6.0) * c6_ij * g * inv_r8
+        )
+
+        half_energy = wp.float64(0.5) * pair_energy
+        wp.atomic_add(atomic_energies, atom_i, type(atomic_energies[0])(half_energy))
+        if half_neighbor_list:
+            wp.atomic_add(atomic_energies, j, type(atomic_energies[0])(half_energy))
+
+        force_ij = type(ri)(
+            type(ri[0])(force_mag_over_r) * r_ij[0],
+            type(ri[0])(force_mag_over_r) * r_ij[1],
+            type(ri[0])(force_mag_over_r) * r_ij[2],
+        )
+        force_acc += force_ij
+        if half_neighbor_list:
+            wp.atomic_sub(atomic_forces, j, force_ij)
+    wp.atomic_add(atomic_forces, atom_i, force_acc)
+
+
+@wp.kernel
+def _lj_pme_real_space_energy_forces_virial_kernel(
+    positions: wp.array(dtype=Any),
+    c6_coefficients: wp.array(dtype=Any),
+    c12_coefficients: wp.array(dtype=Any),
+    cell: wp.array(dtype=Any),
+    neighbor_matrix: wp.array2d(dtype=wp.int32),
+    neighbor_matrix_shifts: wp.array2d(dtype=wp.vec3i),
+    num_neighbors: wp.array(dtype=wp.int32),
+    beta: wp.array(dtype=Any),
+    cutoff: wp.array(dtype=Any),
+    mask_value: wp.int32,
+    half_neighbor_list: wp.bool,
+    atomic_energies: wp.array(dtype=Any),
+    atomic_forces: wp.array(dtype=Any),
+    virial: wp.array(dtype=Any),  # OUT (9,) flattened 3x3
+):
+    """Real-space LJ-PME energy, forces, and virial.
+
+    Virial convention: ``W_{ab} = sum_{i<j} r_ij,a * F_ij,b`` where F_ij is the
+    force on atom i due to the pair. Output is the flattened 9-element matrix.
+
+    For ``half_neighbor_list=False`` (full neighbor matrix), each pair appears
+    twice; the per-pair virial contribution is scaled by 1/2 to compensate.
+    """
+    atom_i = wp.tid()
+    num_atoms = positions.shape[0]
+    max_neighbors = neighbor_matrix.shape[1]
+    if atom_i >= num_atoms:
+        return
+
+    ri = positions[atom_i]
+    c6_i = wp.float64(c6_coefficients[atom_i])
+    c12_i = wp.float64(c12_coefficients[atom_i])
+    cell_t = wp.transpose(cell[0])
+    beta_ = wp.float64(beta[0])
+    cut = wp.float64(cutoff[0])
+    cutoff_sq = cut * cut
+
+    force_acc = type(ri)(
+        type(ri[0])(0.0),
+        type(ri[0])(0.0),
+        type(ri[0])(0.0),
+    )
+
+    vir_xx = wp.float64(0.0)
+    vir_xy = wp.float64(0.0)
+    vir_xz = wp.float64(0.0)
+    vir_yx = wp.float64(0.0)
+    vir_yy = wp.float64(0.0)
+    vir_yz = wp.float64(0.0)
+    vir_zx = wp.float64(0.0)
+    vir_zy = wp.float64(0.0)
+    vir_zz = wp.float64(0.0)
+
+    n_neighbors = num_neighbors[atom_i]
+    for slot in range(n_neighbors):
+        if slot >= max_neighbors:
+            break
+        j = neighbor_matrix[atom_i, slot]
+        if j == mask_value or j >= num_atoms:
+            continue
+
+        rj = positions[j]
+        shift = neighbor_matrix_shifts[atom_i, slot]
+        shift_vec = cell_t * type(ri)(
+            type(ri[0])(shift[0]),
+            type(ri[0])(shift[1]),
+            type(ri[0])(shift[2]),
+        )
+        r_ij = ri - rj - shift_vec
+        r_sq = wp.float64(wp.dot(r_ij, r_ij))
+        if r_sq >= cutoff_sq or r_sq < wp.float64(1e-10):
+            continue
+
+        c6_j = wp.float64(c6_coefficients[j])
+        c12_j = wp.float64(c12_coefficients[j])
+        c6_ij = wp.sqrt(c6_i * c6_j)
+        c12_ij = wp.sqrt(c12_i * c12_j)
+
+        r_sq_2 = r_sq * r_sq
+        r_sq_3 = r_sq_2 * r_sq
+        r_sq_4 = r_sq_2 * r_sq_2
+        r_sq_6 = r_sq_3 * r_sq_3
+        r_sq_7 = r_sq_4 * r_sq_3
+        inv_r2 = wp.float64(1.0) / r_sq
+        inv_r6 = wp.float64(1.0) / r_sq_3
+        inv_r8 = wp.float64(1.0) / r_sq_4
+        inv_r12 = wp.float64(1.0) / r_sq_6
+        inv_r14 = wp.float64(1.0) / r_sq_7
+
+        beta_sq = beta_ * beta_
+        x_sq = beta_sq * r_sq
+        beta_sixth = beta_sq * beta_sq * beta_sq
+        exp_x_sq = wp.exp(-x_sq)
+        g = exp_x_sq * (wp.float64(1.0) + x_sq + wp.float64(0.5) * x_sq * x_sq)
+
+        pair_energy = c12_ij * inv_r12 - c6_ij * g * inv_r6
+        force_mag_over_r = (
+            wp.float64(12.0) * c12_ij * inv_r14
+            - c6_ij * beta_sixth * exp_x_sq * inv_r2
+            - wp.float64(6.0) * c6_ij * g * inv_r8
+        )
+
+        half_energy = wp.float64(0.5) * pair_energy
+        wp.atomic_add(atomic_energies, atom_i, type(atomic_energies[0])(half_energy))
+        if half_neighbor_list:
+            wp.atomic_add(atomic_energies, j, type(atomic_energies[0])(half_energy))
+
+        force_ij = type(ri)(
+            type(ri[0])(force_mag_over_r) * r_ij[0],
+            type(ri[0])(force_mag_over_r) * r_ij[1],
+            type(ri[0])(force_mag_over_r) * r_ij[2],
+        )
+        force_acc += force_ij
+        if half_neighbor_list:
+            wp.atomic_sub(atomic_forces, j, force_ij)
+
+        r_ij_0 = wp.float64(r_ij[0])
+        r_ij_1 = wp.float64(r_ij[1])
+        r_ij_2 = wp.float64(r_ij[2])
+        f_ij_0 = wp.float64(force_ij[0])
+        f_ij_1 = wp.float64(force_ij[1])
+        f_ij_2 = wp.float64(force_ij[2])
+        # Virial scaling: full list double-counts each pair, so scale by 1/2.
+        vir_scale = wp.float64(1.0) if half_neighbor_list else wp.float64(0.5)
+        vir_xx += vir_scale * (r_ij_0 * f_ij_0)
+        vir_xy += vir_scale * (r_ij_0 * f_ij_1)
+        vir_xz += vir_scale * (r_ij_0 * f_ij_2)
+        vir_yx += vir_scale * (r_ij_1 * f_ij_0)
+        vir_yy += vir_scale * (r_ij_1 * f_ij_1)
+        vir_yz += vir_scale * (r_ij_1 * f_ij_2)
+        vir_zx += vir_scale * (r_ij_2 * f_ij_0)
+        vir_zy += vir_scale * (r_ij_2 * f_ij_1)
+        vir_zz += vir_scale * (r_ij_2 * f_ij_2)
+
+    wp.atomic_add(atomic_forces, atom_i, force_acc)
+
+    wp.atomic_add(virial, 0, type(virial[0])(vir_xx))
+    wp.atomic_add(virial, 1, type(virial[0])(vir_xy))
+    wp.atomic_add(virial, 2, type(virial[0])(vir_xz))
+    wp.atomic_add(virial, 3, type(virial[0])(vir_yx))
+    wp.atomic_add(virial, 4, type(virial[0])(vir_yy))
+    wp.atomic_add(virial, 5, type(virial[0])(vir_yz))
+    wp.atomic_add(virial, 6, type(virial[0])(vir_zx))
+    wp.atomic_add(virial, 7, type(virial[0])(vir_zy))
+    wp.atomic_add(virial, 8, type(virial[0])(vir_zz))
+
+
+###########################################################################################
+########################### Kernel Overloads for Dtype Flexibility ########################
+###########################################################################################
+
+_T = [wp.float32, wp.float64]
+_V = [wp.vec3f, wp.vec3d]
+_M = [wp.mat33f, wp.mat33d]
+
+_pme_dispersion_green_structure_factor_kernel_overload = {}
+_batch_pme_dispersion_green_structure_factor_kernel_overload = {}
+_pme_dispersion_self_energy_kernel_overload = {}
+_batch_pme_dispersion_self_energy_kernel_overload = {}
+_lj_pme_real_space_energy_kernel_overload = {}
+_lj_pme_real_space_energy_forces_kernel_overload = {}
+_lj_pme_real_space_energy_forces_virial_kernel_overload = {}
+
+for t in _T:
+    _pme_dispersion_green_structure_factor_kernel_overload[t] = wp.overload(
+        _pme_dispersion_green_structure_factor_kernel,
+        [
+            wp.array3d(dtype=t),  # k_squared
+            wp.array(dtype=t),  # miller_x
+            wp.array(dtype=t),  # miller_y
+            wp.array(dtype=t),  # miller_z
+            wp.array(dtype=t),  # beta
+            wp.array(dtype=t),  # volume
+            wp.int32,  # mesh_nx
+            wp.int32,  # mesh_ny
+            wp.int32,  # mesh_nz
+            wp.int32,  # spline_order
+            wp.array3d(dtype=t),  # green_function
+            wp.array3d(dtype=t),  # structure_factor_sq
+        ],
+    )
+
+    _batch_pme_dispersion_green_structure_factor_kernel_overload[t] = wp.overload(
+        _batch_pme_dispersion_green_structure_factor_kernel,
+        [
+            wp.array4d(dtype=t),  # k_squared
+            wp.array(dtype=t),  # miller_x
+            wp.array(dtype=t),  # miller_y
+            wp.array(dtype=t),  # miller_z
+            wp.array(dtype=t),  # beta
+            wp.array(dtype=t),  # volumes
+            wp.int32,  # mesh_nx
+            wp.int32,  # mesh_ny
+            wp.int32,  # mesh_nz
+            wp.int32,  # spline_order
+            wp.array4d(dtype=t),  # green_function
+            wp.array3d(dtype=t),  # structure_factor_sq
+        ],
+    )
+
+    _pme_dispersion_self_energy_kernel_overload[t] = wp.overload(
+        _pme_dispersion_self_energy_kernel,
+        [
+            wp.array(dtype=t),  # c6_coefficients
+            wp.array(dtype=t),  # beta
+            wp.array(dtype=t),  # energy_correction
+        ],
+    )
+
+    _batch_pme_dispersion_self_energy_kernel_overload[t] = wp.overload(
+        _batch_pme_dispersion_self_energy_kernel,
+        [
+            wp.array(dtype=t),  # c6_coefficients
+            wp.array(dtype=wp.int32),  # batch_idx
+            wp.array(dtype=t),  # beta
+            wp.array(dtype=t),  # energy_correction
+        ],
+    )
+
+for t, v, m in zip(_T, _V, _M):
+    _lj_pme_real_space_energy_kernel_overload[t] = wp.overload(
+        _lj_pme_real_space_energy_kernel,
+        [
+            wp.array(dtype=v),  # positions
+            wp.array(dtype=t),  # c6_coefficients
+            wp.array(dtype=t),  # c12_coefficients
+            wp.array(dtype=m),  # cell
+            wp.array2d(dtype=wp.int32),  # neighbor_matrix
+            wp.array2d(dtype=wp.vec3i),  # neighbor_matrix_shifts
+            wp.array(dtype=wp.int32),  # num_neighbors
+            wp.array(dtype=t),  # beta
+            wp.array(dtype=t),  # cutoff
+            wp.int32,  # mask_value
+            wp.bool,  # half_neighbor_list
+            wp.array(dtype=t),  # atomic_energies
+        ],
+    )
+
+    _lj_pme_real_space_energy_forces_kernel_overload[t] = wp.overload(
+        _lj_pme_real_space_energy_forces_kernel,
+        [
+            wp.array(dtype=v),  # positions
+            wp.array(dtype=t),  # c6_coefficients
+            wp.array(dtype=t),  # c12_coefficients
+            wp.array(dtype=m),  # cell
+            wp.array2d(dtype=wp.int32),  # neighbor_matrix
+            wp.array2d(dtype=wp.vec3i),  # neighbor_matrix_shifts
+            wp.array(dtype=wp.int32),  # num_neighbors
+            wp.array(dtype=t),  # beta
+            wp.array(dtype=t),  # cutoff
+            wp.int32,  # mask_value
+            wp.bool,  # half_neighbor_list
+            wp.array(dtype=t),  # atomic_energies
+            wp.array(dtype=v),  # atomic_forces
+        ],
+    )
+
+    _lj_pme_real_space_energy_forces_virial_kernel_overload[t] = wp.overload(
+        _lj_pme_real_space_energy_forces_virial_kernel,
+        [
+            wp.array(dtype=v),  # positions
+            wp.array(dtype=t),  # c6_coefficients
+            wp.array(dtype=t),  # c12_coefficients
+            wp.array(dtype=m),  # cell
+            wp.array2d(dtype=wp.int32),  # neighbor_matrix
+            wp.array2d(dtype=wp.vec3i),  # neighbor_matrix_shifts
+            wp.array(dtype=wp.int32),  # num_neighbors
+            wp.array(dtype=t),  # beta
+            wp.array(dtype=t),  # cutoff
+            wp.int32,  # mask_value
+            wp.bool,  # half_neighbor_list
+            wp.array(dtype=t),  # atomic_energies
+            wp.array(dtype=v),  # atomic_forces
+            wp.array(dtype=t),  # virial
+        ],
+    )
+
+
+###########################################################################################
+########################### Warp Launcher Functions #######################################
+###########################################################################################
+
+
+def pme_dispersion_green_structure_factor(
+    k_squared: wp.array,
+    miller_x: wp.array,
+    miller_y: wp.array,
+    miller_z: wp.array,
+    beta: wp.array,
+    volume: wp.array,
+    mesh_nx: int,
+    mesh_ny: int,
+    mesh_nz: int,
+    spline_order: int,
+    green_function: wp.array,
+    structure_factor_sq: wp.array,
+    wp_dtype: type,
+    device: str | None = None,
+) -> None:
+    """Framework-agnostic launcher for the single-system dispersion Green's function.
+
+    Computes :math:`G_{\\text{disp}}(k) = (\\pi^{3/2}\\beta^3/(2V))\\cdot f(|k|/(2\\beta))`
+    and the B-spline structure-factor squared :math:`|B(k)|^2`.
+
+    Parameters
+    ----------
+    k_squared : wp.array, shape (Nx, Ny, Nz_rfft)
+        Squared magnitude of k-vectors at each grid point.
+    miller_x, miller_y, miller_z : wp.array
+        Miller indices.
+    beta : wp.array, shape (1,)
+        Dispersion Ewald splitting parameter.
+    volume : wp.array, shape (1,)
+        Unit cell volume.
+    mesh_nx, mesh_ny, mesh_nz : int
+        Full mesh dimensions.
+    spline_order : int
+        B-spline order (1-4).
+    green_function : wp.array, shape (Nx, Ny, Nz_rfft)
+        OUTPUT: dispersion Green's function values.
+    structure_factor_sq : wp.array, shape (Nx, Ny, Nz_rfft)
+        OUTPUT: :math:`|B(k)|^2`.
+    wp_dtype : type
+        Warp scalar dtype (wp.float32 or wp.float64).
+    device : str | None
+        Warp device string. If None, inferred from arrays.
+    """
+    nx, ny, nz_rfft = k_squared.shape[0], k_squared.shape[1], k_squared.shape[2]
+
+    kernel = _pme_dispersion_green_structure_factor_kernel_overload[wp_dtype]
+    wp.launch(
+        kernel,
+        dim=(nx, ny, nz_rfft),
+        inputs=[
+            k_squared,
+            miller_x,
+            miller_y,
+            miller_z,
+            beta,
+            volume,
+            wp.int32(mesh_nx),
+            wp.int32(mesh_ny),
+            wp.int32(mesh_nz),
+            wp.int32(spline_order),
+        ],
+        outputs=[green_function, structure_factor_sq],
+        device=device,
+    )
+
+
+def batch_pme_dispersion_green_structure_factor(
+    k_squared: wp.array,
+    miller_x: wp.array,
+    miller_y: wp.array,
+    miller_z: wp.array,
+    beta: wp.array,
+    volumes: wp.array,
+    mesh_nx: int,
+    mesh_ny: int,
+    mesh_nz: int,
+    spline_order: int,
+    green_function: wp.array,
+    structure_factor_sq: wp.array,
+    wp_dtype: type,
+    device: str | None = None,
+) -> None:
+    """Framework-agnostic batched launcher for the dispersion Green's function.
+
+    Each system can have different beta and volume values but shares the same
+    mesh dimensions.
+    """
+    num_systems = k_squared.shape[0]
+    nx, ny, nz_rfft = k_squared.shape[1], k_squared.shape[2], k_squared.shape[3]
+
+    kernel = _batch_pme_dispersion_green_structure_factor_kernel_overload[wp_dtype]
+    wp.launch(
+        kernel,
+        dim=(num_systems, nx, ny, nz_rfft),
+        inputs=[
+            k_squared,
+            miller_x,
+            miller_y,
+            miller_z,
+            beta,
+            volumes,
+            wp.int32(mesh_nx),
+            wp.int32(mesh_ny),
+            wp.int32(mesh_nz),
+            wp.int32(spline_order),
+        ],
+        outputs=[green_function, structure_factor_sq],
+        device=device,
+    )
+
+
+def pme_dispersion_self_energy(
+    c6_coefficients: wp.array,
+    beta: wp.array,
+    energy_correction: wp.array,
+    wp_dtype: type,
+    device: str | None = None,
+) -> None:
+    """Framework-agnostic launcher for the per-atom dispersion self-energy.
+
+    Computes :math:`V_{\\text{self},i} = -\\beta^6 C_{6,ii}/12` for each atom.
+    The binding layer reduces over atoms to obtain the total :math:`V_{\\text{self}}`.
+
+    Parameters
+    ----------
+    c6_coefficients : wp.array, shape (N,)
+        Per-atom homoatomic :math:`C_{6,ii}` values.
+    beta : wp.array, shape (1,)
+        Dispersion Ewald splitting parameter.
+    energy_correction : wp.array, shape (N,)
+        OUTPUT: per-atom self-energy contribution.
+    wp_dtype : type
+        Warp scalar dtype.
+    device : str | None
+        Warp device string.
+    """
+    num_atoms = c6_coefficients.shape[0]
+
+    kernel = _pme_dispersion_self_energy_kernel_overload[wp_dtype]
+    wp.launch(
+        kernel,
+        dim=num_atoms,
+        inputs=[c6_coefficients, beta],
+        outputs=[energy_correction],
+        device=device,
+    )
+
+
+def batch_pme_dispersion_self_energy(
+    c6_coefficients: wp.array,
+    batch_idx: wp.array,
+    beta: wp.array,
+    energy_correction: wp.array,
+    wp_dtype: type,
+    device: str | None = None,
+) -> None:
+    """Batched framework-agnostic launcher for the per-atom dispersion self-energy."""
+    num_atoms = c6_coefficients.shape[0]
+
+    kernel = _batch_pme_dispersion_self_energy_kernel_overload[wp_dtype]
+    wp.launch(
+        kernel,
+        dim=num_atoms,
+        inputs=[c6_coefficients, batch_idx, beta],
+        outputs=[energy_correction],
+        device=device,
+    )
+
+
+def lj_pme_real_space_energy(
+    positions: wp.array,
+    c6_coefficients: wp.array,
+    c12_coefficients: wp.array,
+    cell: wp.array,
+    neighbor_matrix: wp.array,
+    neighbor_matrix_shifts: wp.array,
+    num_neighbors: wp.array,
+    beta: wp.array,
+    cutoff: wp.array,
+    mask_value: int,
+    atomic_energies: wp.array,
+    wp_dtype: type,
+    half_neighbor_list: bool = True,
+    device: str | None = None,
+) -> None:
+    """Real-space LJ-PME energy launcher (single system, neighbor matrix)."""
+    num_atoms = positions.shape[0]
+    kernel = _lj_pme_real_space_energy_kernel_overload[wp_dtype]
+    wp.launch(
+        kernel,
+        dim=num_atoms,
+        inputs=[
+            positions,
+            c6_coefficients,
+            c12_coefficients,
+            cell,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            num_neighbors,
+            beta,
+            cutoff,
+            wp.int32(mask_value),
+            bool(half_neighbor_list),
+        ],
+        outputs=[atomic_energies],
+        device=device,
+    )
+
+
+def lj_pme_real_space_energy_forces(
+    positions: wp.array,
+    c6_coefficients: wp.array,
+    c12_coefficients: wp.array,
+    cell: wp.array,
+    neighbor_matrix: wp.array,
+    neighbor_matrix_shifts: wp.array,
+    num_neighbors: wp.array,
+    beta: wp.array,
+    cutoff: wp.array,
+    mask_value: int,
+    atomic_energies: wp.array,
+    atomic_forces: wp.array,
+    wp_dtype: type,
+    half_neighbor_list: bool = True,
+    device: str | None = None,
+) -> None:
+    """Real-space LJ-PME energy and forces launcher."""
+    num_atoms = positions.shape[0]
+    kernel = _lj_pme_real_space_energy_forces_kernel_overload[wp_dtype]
+    wp.launch(
+        kernel,
+        dim=num_atoms,
+        inputs=[
+            positions,
+            c6_coefficients,
+            c12_coefficients,
+            cell,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            num_neighbors,
+            beta,
+            cutoff,
+            wp.int32(mask_value),
+            bool(half_neighbor_list),
+        ],
+        outputs=[atomic_energies, atomic_forces],
+        device=device,
+    )
+
+
+def lj_pme_real_space_energy_forces_virial(
+    positions: wp.array,
+    c6_coefficients: wp.array,
+    c12_coefficients: wp.array,
+    cell: wp.array,
+    neighbor_matrix: wp.array,
+    neighbor_matrix_shifts: wp.array,
+    num_neighbors: wp.array,
+    beta: wp.array,
+    cutoff: wp.array,
+    mask_value: int,
+    atomic_energies: wp.array,
+    atomic_forces: wp.array,
+    virial: wp.array,
+    wp_dtype: type,
+    half_neighbor_list: bool = True,
+    device: str | None = None,
+) -> None:
+    """Real-space LJ-PME energy, forces, and virial launcher."""
+    num_atoms = positions.shape[0]
+    kernel = _lj_pme_real_space_energy_forces_virial_kernel_overload[wp_dtype]
+    wp.launch(
+        kernel,
+        dim=num_atoms,
+        inputs=[
+            positions,
+            c6_coefficients,
+            c12_coefficients,
+            cell,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            num_neighbors,
+            beta,
+            cutoff,
+            wp.int32(mask_value),
+            bool(half_neighbor_list),
+        ],
+        outputs=[atomic_energies, atomic_forces, virial],
+        device=device,
+    )
+
+
+###########################################################################################
+########################### Module Exports ################################################
+###########################################################################################
+
+__all__ = [
+    # Reciprocal-space kernel overloads (PR1)
+    "_pme_dispersion_green_structure_factor_kernel_overload",
+    "_batch_pme_dispersion_green_structure_factor_kernel_overload",
+    "_pme_dispersion_self_energy_kernel_overload",
+    "_batch_pme_dispersion_self_energy_kernel_overload",
+    # Real-space kernel overloads (PR2)
+    "_lj_pme_real_space_energy_kernel_overload",
+    "_lj_pme_real_space_energy_forces_kernel_overload",
+    "_lj_pme_real_space_energy_forces_virial_kernel_overload",
+    # Reciprocal-space Warp launchers (PR1)
+    "pme_dispersion_green_structure_factor",
+    "batch_pme_dispersion_green_structure_factor",
+    "pme_dispersion_self_energy",
+    "batch_pme_dispersion_self_energy",
+    # Real-space Warp launchers (PR2)
+    "lj_pme_real_space_energy",
+    "lj_pme_real_space_energy_forces",
+    "lj_pme_real_space_energy_forces_virial",
+]

--- a/nvalchemiops/jax/interactions/dispersion/__init__.py
+++ b/nvalchemiops/jax/interactions/dispersion/__init__.py
@@ -21,8 +21,26 @@ This module provides JAX bindings for dispersion corrections (DFT-D3).
 from __future__ import annotations
 
 from nvalchemiops.jax.interactions.dispersion._dftd3 import D3Parameters, dftd3
+from nvalchemiops.jax.interactions.dispersion.parameters import (
+    PMEDispersionParameters,
+    estimate_pme_dispersion_parameters,
+)
+from nvalchemiops.jax.interactions.dispersion.pme import (
+    lj_pme,
+    lj_pme_real_space,
+    pme_dispersion_energy_corrections,
+    pme_dispersion_green_structure_factor,
+    pme_dispersion_reciprocal_space,
+)
 
 __all__ = [
     "dftd3",
     "D3Parameters",
+    "pme_dispersion_reciprocal_space",
+    "pme_dispersion_green_structure_factor",
+    "pme_dispersion_energy_corrections",
+    "lj_pme_real_space",
+    "lj_pme",
+    "estimate_pme_dispersion_parameters",
+    "PMEDispersionParameters",
 ]

--- a/nvalchemiops/jax/interactions/dispersion/parameters.py
+++ b/nvalchemiops/jax/interactions/dispersion/parameters.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parameter estimation for LJ-PME (dispersion PME).
+
+Implements the GROMACS-style two-tail accuracy criterion of Wennberg
+et al. (JCTC 2013): pick a real-space cutoff, then choose β so the
+damped real-space tail at the cutoff is below the target accuracy, and
+choose mesh dimensions so the reciprocal-space truncation tail matches
+the same accuracy.
+
+The relative real-space tail at cutoff is
+
+.. math::
+
+    \\frac{|V_{\\text{real}}(r_c) - V(r_c)|}{|V(r_c)|}
+    \\approx g(\\beta r_c) = e^{-(\\beta r_c)^2}
+        \\bigl(1 + (\\beta r_c)^2 + (\\beta r_c)^4/2\\bigr).
+
+Setting :math:`g(x_\\varepsilon) = \\varepsilon` and writing
+:math:`\\beta = x_\\varepsilon / r_c` gives a one-parameter family of
+matched (β, r_c). The reciprocal-space tail uses the same threshold
+:math:`x_\\varepsilon` to bound the high-k truncation:
+
+.. math::
+
+    \\frac{\\pi N}{2 L \\beta} \\geq x_\\varepsilon
+    \\;\\Longleftrightarrow\\;
+    N \\geq \\frac{2 L \\beta x_\\varepsilon}{\\pi}.
+
+GROMACS's default ``ewald-rtol-lj = 1e-3`` is a reasonable starting
+accuracy (looser than Coulomb).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+
+__all__ = [
+    "PMEDispersionParameters",
+    "estimate_pme_dispersion_parameters",
+    "estimate_pme_dispersion_mesh_dimensions",
+    "solve_dispersion_beta",
+    "DISPERSION_DEFAULT_ACCURACY",
+    "DISPERSION_DEFAULT_CUTOFF",
+]
+
+
+# GROMACS default for the dispersion-PME accuracy. Looser than Coulomb
+# (1e-5/1e-6) because the r^-6 kernel is short-range relative to 1/r.
+DISPERSION_DEFAULT_ACCURACY = 1e-3
+DISPERSION_DEFAULT_CUTOFF = 9.0  # Å — typical LJ cutoff
+
+
+@dataclass
+class PMEDispersionParameters:
+    """Container for LJ-PME parameters.
+
+    Attributes
+    ----------
+    beta : jax.Array, shape (B,)
+        Dispersion Ewald splitting parameter.
+    cutoff : float
+        Real-space cutoff (shared across systems).
+    mesh_dimensions : tuple[int, int, int]
+        FFT mesh dimensions (nx, ny, nz), the largest needed across the
+        batch.
+    mesh_spacing : jax.Array, shape (B, 3)
+        Actual mesh spacing along each lattice direction.
+    accuracy : float
+        Target relative accuracy (e.g. 1e-3).
+    """
+
+    beta: jax.Array
+    cutoff: float
+    mesh_dimensions: tuple[int, int, int]
+    mesh_spacing: jax.Array
+    accuracy: float
+
+
+def solve_dispersion_beta(cutoff: float, accuracy: float) -> float:
+    """Solve :math:`g(\\beta \\cdot r_c) = \\varepsilon` for β·r_c, return β.
+
+    Uses bisection over :math:`x = \\beta r_c \\in [0.1, 20]`. :math:`g(x)` is
+    monotonically decreasing on this interval, so bisection is unconditionally
+    convergent.
+
+    Parameters
+    ----------
+    cutoff : float
+        Real-space cutoff :math:`r_c`.
+    accuracy : float
+        Target relative accuracy :math:`\\varepsilon` (e.g. 1e-3).
+
+    Returns
+    -------
+    float
+        Dispersion splitting parameter β.
+    """
+    if cutoff <= 0:
+        raise ValueError(f"cutoff must be positive, got {cutoff}")
+    if not (0 < accuracy < 1):
+        raise ValueError(f"accuracy must be in (0, 1), got {accuracy}")
+
+    def g(x: float) -> float:
+        return math.exp(-x * x) * (1.0 + x * x + 0.5 * x * x * x * x)
+
+    lo, hi = 0.1, 20.0
+    if g(lo) < accuracy:
+        # Threshold already met at small x: β can be very small.
+        return lo / cutoff
+    if g(hi) > accuracy:
+        # Threshold unreachable in our window: clamp to maximum β.
+        return hi / cutoff
+
+    for _ in range(100):
+        mid = 0.5 * (lo + hi)
+        if g(mid) > accuracy:
+            lo = mid
+        else:
+            hi = mid
+        if hi - lo < 1e-10:
+            break
+    x_eps = 0.5 * (lo + hi)
+    return x_eps / cutoff
+
+
+def _next_fft_friendly(n: int) -> int:
+    """Round ``n`` up to the next integer of the form :math:`2^a 3^b 5^c`.
+
+    FFT libraries are typically fastest on such mesh dimensions. Falls back
+    to the next power of 2 if no small composite is close enough.
+    """
+    if n <= 1:
+        return 1
+    candidate = n
+    while True:
+        m = candidate
+        for p in (2, 3, 5):
+            while m % p == 0:
+                m //= p
+        if m == 1:
+            return candidate
+        candidate += 1
+        if candidate > 4 * n:
+            # safeguard: fall back to next power of 2
+            return 1 << (n - 1).bit_length()
+
+
+def estimate_pme_dispersion_mesh_dimensions(
+    cell: jax.Array,
+    beta: jax.Array,
+    accuracy: float = DISPERSION_DEFAULT_ACCURACY,
+) -> tuple[int, int, int]:
+    """Pick mesh dimensions matching the dispersion-PME accuracy target.
+
+    The high-k truncation tail of the dispersion Green's function is
+
+    .. math::
+
+        \\frac{|V_{\\text{recip,trunc}}|}{|V_{\\text{recip}}|}
+        \\approx g\\!\\left(\\tfrac{\\pi N}{2 L \\beta}\\right),
+
+    so requiring this to be below :math:`\\varepsilon` gives
+    :math:`N \\geq 2 L \\beta x_\\varepsilon / \\pi` with the same
+    :math:`x_\\varepsilon` that fixes β.
+
+    Parameters
+    ----------
+    cell : jax.Array, shape (3, 3) or (B, 3, 3)
+        Unit cell matrix.
+    beta : jax.Array, scalar or shape (B,)
+        Dispersion Ewald splitting parameter.
+    accuracy : float
+        Target relative accuracy.
+
+    Returns
+    -------
+    tuple[int, int, int]
+        Mesh dimensions, shared across the batch (max over systems and
+        axes), rounded up to a 2-3-5-smooth integer.
+    """
+    if cell.ndim == 2:
+        cell = cell[None, ...]
+
+    # Cell lengths along each axis: (B, 3)
+    cell_lengths = jnp.linalg.norm(cell, axis=2)
+
+    # Solve g(x_eps) = accuracy once (host-side); reuse for all axes.
+    def g(x: float) -> float:
+        return math.exp(-x * x) * (1.0 + x * x + 0.5 * x * x * x * x)
+
+    lo, hi = 0.1, 20.0
+    for _ in range(100):
+        mid = 0.5 * (lo + hi)
+        if g(mid) > accuracy:
+            lo = mid
+        else:
+            hi = mid
+        if hi - lo < 1e-10:
+            break
+    x_eps = 0.5 * (lo + hi)
+
+    beta_arr = jnp.asarray(beta, dtype=cell_lengths.dtype)
+    if beta_arr.ndim == 0:
+        beta_arr = beta_arr[None]
+    # N >= 2 L beta x_eps / pi
+    n_per_axis = 2.0 * cell_lengths * beta_arr[:, None] * x_eps / math.pi
+    max_n = jnp.max(n_per_axis, axis=0)  # (3,)
+    raw = [int(math.ceil(float(max_n[i]))) for i in range(3)]
+    return (
+        _next_fft_friendly(raw[0]),
+        _next_fft_friendly(raw[1]),
+        _next_fft_friendly(raw[2]),
+    )
+
+
+def estimate_pme_dispersion_parameters(
+    cell: jax.Array,
+    cutoff: float = DISPERSION_DEFAULT_CUTOFF,
+    accuracy: float = DISPERSION_DEFAULT_ACCURACY,
+) -> PMEDispersionParameters:
+    """Estimate (β, mesh) for LJ-PME at a target accuracy.
+
+    Picks β so that :math:`g(\\beta r_c) \\le \\varepsilon` (real-space tail at
+    the cutoff) and then mesh dimensions so that the reciprocal-space
+    truncation tail matches the same threshold.
+
+    Parameters
+    ----------
+    cell : jax.Array, shape (3, 3) or (B, 3, 3)
+        Unit cell matrix.
+    cutoff : float, default=9.0
+        Real-space cutoff in cell-length units (Å for typical inputs).
+    accuracy : float, default=1e-3
+        Target relative accuracy. GROMACS's default for LJ-PME.
+
+    Returns
+    -------
+    PMEDispersionParameters
+        β (per system), shared cutoff, mesh dimensions, mesh spacing,
+        and the accuracy threshold used.
+    """
+    if cell.ndim == 2:
+        cell = cell[None, ...]
+    num_systems = cell.shape[0]
+
+    beta_scalar = solve_dispersion_beta(cutoff, accuracy)
+    beta = jnp.full(num_systems, beta_scalar, dtype=cell.dtype)
+
+    mesh_dims = estimate_pme_dispersion_mesh_dimensions(cell, beta, accuracy)
+
+    cell_lengths = jnp.linalg.norm(cell, axis=2)  # (B, 3)
+    mesh_dims_arr = jnp.asarray(mesh_dims, dtype=cell_lengths.dtype)
+    mesh_spacing = cell_lengths / mesh_dims_arr
+
+    return PMEDispersionParameters(
+        beta=beta,
+        cutoff=cutoff,
+        mesh_dimensions=mesh_dims,
+        mesh_spacing=mesh_spacing,
+        accuracy=accuracy,
+    )

--- a/nvalchemiops/jax/interactions/dispersion/pme.py
+++ b/nvalchemiops/jax/interactions/dispersion/pme.py
@@ -1,0 +1,950 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JAX bindings for dispersion (LJ-PME).
+
+This module provides:
+
+* The reciprocal-space and self-energy components of LJ-PME (PR1):
+  :func:`pme_dispersion_reciprocal_space`,
+  :func:`pme_dispersion_green_structure_factor`,
+  :func:`pme_dispersion_energy_corrections`.
+* The damped real-space LJ-PME term (PR2): :func:`lj_pme_real_space` —
+  computes :math:`V = C_{12}/r^{12} - C_6\\,g(\\beta r)/r^6` for atom pairs
+  within a cutoff, optionally with explicit forces and a virial tensor.
+
+The total LJ-PME energy combines these as
+
+.. math::
+
+    V_{\\text{total}} = V_{\\text{real}} + V_{\\text{recip}} - V_{\\text{self}}.
+
+The top-level ``lj_pme()`` orchestrator (with automatic β/mesh estimation)
+arrives in a later PR.
+
+References
+----------
+Wennberg, Hess, Lindahl (2013). JCTC 9, 3527.
+"""
+
+from __future__ import annotations
+
+import math
+
+import jax
+import jax.numpy as jnp
+import warp as wp
+from warp.jax_experimental import jax_kernel
+
+from nvalchemiops.interactions.dispersion.pme_dispersion_kernels import (
+    _batch_pme_dispersion_green_structure_factor_kernel_overload,
+    _batch_pme_dispersion_self_energy_kernel_overload,
+    _lj_pme_real_space_energy_forces_kernel_overload,
+    _lj_pme_real_space_energy_forces_virial_kernel_overload,
+    _lj_pme_real_space_energy_kernel_overload,
+    _pme_dispersion_green_structure_factor_kernel_overload,
+    _pme_dispersion_self_energy_kernel_overload,
+)
+from nvalchemiops.jax.interactions.dispersion.parameters import (
+    DISPERSION_DEFAULT_ACCURACY,
+    DISPERSION_DEFAULT_CUTOFF,
+    estimate_pme_dispersion_mesh_dimensions,
+    solve_dispersion_beta,
+)
+from nvalchemiops.jax.interactions.electrostatics.k_vectors import (
+    generate_k_vectors_pme,
+)
+from nvalchemiops.jax.spline import (
+    spline_gather,
+    spline_gather_vec3,
+    spline_spread,
+)
+
+__all__ = [
+    "pme_dispersion_reciprocal_space",
+    "pme_dispersion_green_structure_factor",
+    "pme_dispersion_energy_corrections",
+    "lj_pme_real_space",
+    "lj_pme",
+]
+
+
+# ==============================================================================
+# Helpers
+# ==============================================================================
+
+
+def _make_jax_kernels(
+    wp_overload_dict: dict,
+    num_outputs: int,
+    in_out_argnames: list[str],
+) -> dict:
+    """Map JAX dtypes to Warp kernel overloads."""
+    _JAX_TO_WP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
+    return {
+        jax_dtype: jax_kernel(
+            wp_overload_dict[wp_dtype],
+            num_outputs=num_outputs,
+            in_out_argnames=in_out_argnames,
+            enable_backward=False,
+        )
+        for jax_dtype, wp_dtype in _JAX_TO_WP.items()
+    }
+
+
+def _normalize_dtype(dtype):
+    """Normalize dtype for kernel dictionary lookup."""
+    if dtype == jnp.float32 or str(dtype) == "float32":
+        return jnp.float32
+    elif dtype == jnp.float64 or str(dtype) == "float64":
+        return jnp.float64
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+
+
+# ==============================================================================
+# JAX Kernel Wrappers
+# ==============================================================================
+
+_jax_pme_disp_green_sf = _make_jax_kernels(
+    _pme_dispersion_green_structure_factor_kernel_overload,
+    2,
+    ["green_function", "structure_factor_sq"],
+)
+
+_jax_batch_pme_disp_green_sf = _make_jax_kernels(
+    _batch_pme_dispersion_green_structure_factor_kernel_overload,
+    2,
+    ["green_function", "structure_factor_sq"],
+)
+
+_jax_pme_disp_self_energy = _make_jax_kernels(
+    _pme_dispersion_self_energy_kernel_overload,
+    1,
+    ["energy_correction"],
+)
+
+_jax_batch_pme_disp_self_energy = _make_jax_kernels(
+    _batch_pme_dispersion_self_energy_kernel_overload,
+    1,
+    ["energy_correction"],
+)
+
+_jax_lj_pme_real_space_energy = _make_jax_kernels(
+    _lj_pme_real_space_energy_kernel_overload,
+    1,
+    ["atomic_energies"],
+)
+_jax_lj_pme_real_space_energy_forces = _make_jax_kernels(
+    _lj_pme_real_space_energy_forces_kernel_overload,
+    2,
+    ["atomic_energies", "atomic_forces"],
+)
+_jax_lj_pme_real_space_energy_forces_virial = _make_jax_kernels(
+    _lj_pme_real_space_energy_forces_virial_kernel_overload,
+    3,
+    ["atomic_energies", "atomic_forces", "virial"],
+)
+
+
+# ==============================================================================
+# Public API: Green's function + structure factor
+# ==============================================================================
+
+
+def pme_dispersion_green_structure_factor(
+    k_squared: jax.Array,
+    mesh_dimensions: tuple[int, int, int],
+    beta: jax.Array,
+    cell: jax.Array,
+    spline_order: int = 4,
+    batch_idx: jax.Array | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    """Compute dispersion Green's function and B-spline structure factor.
+
+    Green's function (volume-normalized):
+
+    .. math::
+
+        G_{\\text{disp}}(k) = \\frac{\\pi^{3/2} \\beta^3}{2V}
+            \\, f\\!\\left(\\tfrac{|k|}{2\\beta}\\right),
+        \\qquad
+        f(x) = \\tfrac{1}{3}\\bigl[(1 - 2x^2) e^{-x^2}
+            + 2 x^3 \\sqrt{\\pi}\\, \\text{erfc}(x)\\bigr].
+
+    Structure-factor correction :math:`C^2(k)` is identical to Coulomb PME
+    (depends only on the mesh and spline order).
+
+    Parameters
+    ----------
+    k_squared : jax.Array
+        :math:`|k|^2` at each FFT grid point.
+        - Single-system: shape (Nx, Ny, Nz_rfft)
+        - Batch: shape (B, Nx, Ny, Nz_rfft)
+    mesh_dimensions : tuple[int, int, int]
+        Full mesh dimensions (Nx, Ny, Nz).
+    beta : jax.Array
+        Dispersion Ewald splitting parameter.
+        - Single-system: shape (1,) or scalar
+        - Batch: shape (B,)
+    cell : jax.Array
+        Unit cell matrices. Shape (3, 3) / (1, 3, 3) / (B, 3, 3).
+    spline_order : int, default=4
+        B-spline interpolation order.
+    batch_idx : jax.Array | None
+        If provided, dispatches to batch kernels.
+
+    Returns
+    -------
+    green_function : jax.Array
+        Volume-normalized dispersion Green's function.
+    structure_factor_sq : jax.Array
+        Squared structure factor :math:`C^2(k)` for B-spline deconvolution.
+    """
+    mesh_nx, mesh_ny, mesh_nz = mesh_dimensions
+    input_dtype = _normalize_dtype(k_squared.dtype)
+
+    if cell.ndim == 2:
+        cell = cell[jnp.newaxis, :, :]
+    volume = jnp.abs(jnp.linalg.det(cell)).astype(input_dtype)
+
+    miller_x = jnp.fft.fftfreq(mesh_nx, d=1.0 / mesh_nx).astype(input_dtype)
+    miller_y = jnp.fft.fftfreq(mesh_ny, d=1.0 / mesh_ny).astype(input_dtype)
+    miller_z = jnp.fft.rfftfreq(mesh_nz, d=1.0 / mesh_nz).astype(input_dtype)
+
+    if beta.ndim == 0:
+        beta = beta.reshape(1)
+    beta = beta.astype(input_dtype)
+
+    if batch_idx is None:
+        kernel = _jax_pme_disp_green_sf[input_dtype]
+
+        green_function = jnp.zeros(
+            (mesh_nx, mesh_ny, mesh_nz // 2 + 1), dtype=input_dtype
+        )
+        structure_factor_sq = jnp.zeros(
+            (mesh_nx, mesh_ny, mesh_nz // 2 + 1), dtype=input_dtype
+        )
+
+        green_out, sf_out = kernel(
+            k_squared.astype(input_dtype),
+            miller_x,
+            miller_y,
+            miller_z,
+            beta,
+            volume,
+            int(mesh_nx),
+            int(mesh_ny),
+            int(mesh_nz),
+            int(spline_order),
+            green_function,
+            structure_factor_sq,
+            launch_dims=(mesh_nx, mesh_ny, mesh_nz // 2 + 1),
+        )
+        return green_out, sf_out
+    else:
+        num_systems = cell.shape[0]
+        kernel = _jax_batch_pme_disp_green_sf[input_dtype]
+
+        k_sq = k_squared.astype(input_dtype)
+        if k_sq.ndim == 3:
+            k_sq = jnp.broadcast_to(
+                k_sq[jnp.newaxis], (num_systems, mesh_nx, mesh_ny, mesh_nz // 2 + 1)
+            )
+
+        green_function = jnp.zeros(
+            (num_systems, mesh_nx, mesh_ny, mesh_nz // 2 + 1), dtype=input_dtype
+        )
+        structure_factor_sq = jnp.zeros(
+            (mesh_nx, mesh_ny, mesh_nz // 2 + 1), dtype=input_dtype
+        )
+
+        green_out, sf_out = kernel(
+            k_sq,
+            miller_x,
+            miller_y,
+            miller_z,
+            beta,
+            volume,
+            int(mesh_nx),
+            int(mesh_ny),
+            int(mesh_nz),
+            int(spline_order),
+            green_function,
+            structure_factor_sq,
+            launch_dims=(num_systems, mesh_nx, mesh_ny, mesh_nz // 2 + 1),
+        )
+        return green_out, sf_out
+
+
+# ==============================================================================
+# Public API: Self-energy correction
+# ==============================================================================
+
+
+def pme_dispersion_energy_corrections(
+    c6_coefficients: jax.Array,
+    beta: jax.Array,
+    batch_idx: jax.Array | None = None,
+) -> jax.Array:
+    """Compute the dispersion self-energy correction term.
+
+    Returns the per-system self-energy
+
+    .. math::
+
+        V_{\\text{self}} = -\\frac{\\beta^6}{12} \\sum_i C_{6,ii}.
+
+    Following the proposal convention, the total LJ-PME energy is then
+    :math:`V_{\\text{total}} = V_{\\text{real}} + V_{\\text{recip}} - V_{\\text{self}}`.
+
+    Parameters
+    ----------
+    c6_coefficients : jax.Array, shape (N,) or (N_total,)
+        Per-atom homoatomic :math:`C_{6,ii}` values.
+    beta : jax.Array
+        Dispersion Ewald splitting parameter.
+        - Single-system: shape (1,) or scalar
+        - Batch: shape (B,)
+    batch_idx : jax.Array | None
+        System index for each atom. If provided, uses batched kernel.
+
+    Returns
+    -------
+    energy_corrections : jax.Array
+        - Single-system: shape (1,) — total :math:`V_{\\text{self}}` for the system.
+        - Batch: shape (B,) — total per system.
+    """
+    input_dtype = _normalize_dtype(c6_coefficients.dtype)
+    num_atoms = c6_coefficients.shape[0]
+    c6 = c6_coefficients.astype(input_dtype)
+
+    if beta.ndim == 0:
+        beta = beta.reshape(1)
+    beta = beta.astype(input_dtype)
+
+    if batch_idx is None:
+        kernel = _jax_pme_disp_self_energy[input_dtype]
+        per_atom = jnp.zeros(num_atoms, dtype=input_dtype)
+        (per_atom_out,) = kernel(
+            c6,
+            beta,
+            per_atom,
+            launch_dims=(num_atoms,),
+        )
+        return per_atom_out.sum().reshape(1)
+    else:
+        kernel = _jax_batch_pme_disp_self_energy[input_dtype]
+        num_systems = int(beta.shape[0])
+        per_atom = jnp.zeros(num_atoms, dtype=input_dtype)
+        (per_atom_out,) = kernel(
+            c6,
+            batch_idx.astype(jnp.int32),
+            beta,
+            per_atom,
+            launch_dims=(num_atoms,),
+        )
+        out = jnp.zeros(num_systems, dtype=input_dtype)
+        return out.at[batch_idx].add(per_atom_out)
+
+
+# ==============================================================================
+# Public API: Reciprocal-space dispersion PME
+# ==============================================================================
+
+
+def pme_dispersion_reciprocal_space(
+    positions: jax.Array,
+    c6_coefficients: jax.Array,
+    cell: jax.Array,
+    beta: jax.Array,
+    mesh_dimensions: tuple[int, int, int] | None = None,
+    mesh_spacing: float | None = None,
+    spline_order: int = 4,
+    batch_idx: jax.Array | None = None,
+    k_vectors: jax.Array | None = None,
+    k_squared: jax.Array | None = None,
+    compute_forces: bool = False,
+) -> jax.Array | tuple[jax.Array, jax.Array]:
+    """Compute the dispersion PME reciprocal-space energy.
+
+    Implements the FFT-based long-range :math:`r^{-6}` contribution using
+    B-spline interpolation and convolution with the dispersion Green's
+    function:
+
+    .. math::
+
+        V_{\\text{recip}} = \\frac{\\pi^{3/2}\\beta^3}{2V}
+            \\sum_{m \\neq 0} f(\\pi|m|/\\beta)\\, |\\rho_{\\text{disp}}(m)|^2.
+
+    The spread quantity is :math:`\\sqrt{C_{6,ii}}` (geometric combination).
+
+    Pipeline:
+
+    1. Spread :math:`\\sqrt{C_{6,ii}}` to mesh (``spline_spread``).
+    2. FFT to reciprocal space.
+    3. Multiply by :math:`G_{\\text{disp}}(k) / C^2(k)`.
+    4. Inverse FFT to potential mesh.
+    5. Gather potential at atoms (``spline_gather``).
+    6. Sum :math:`\\sqrt{C_{6,ii}} \\cdot \\varphi_i` over atoms.
+
+    Parameters
+    ----------
+    positions : jax.Array, shape (N, 3)
+        Atomic coordinates.
+    c6_coefficients : jax.Array, shape (N,)
+        Per-atom homoatomic :math:`C_{6,ii}` values (non-negative).
+    cell : jax.Array, shape (3, 3) or (B, 3, 3)
+        Unit cell matrices.
+    beta : jax.Array
+        Dispersion Ewald splitting parameter.
+        - Single-system: shape (1,) or scalar
+        - Batch: shape (B,)
+    mesh_dimensions : tuple[int, int, int], optional
+        Explicit FFT mesh dimensions. Required if mesh_spacing is None.
+    mesh_spacing : float, optional
+        Target mesh spacing in cell units. Used to compute mesh_dimensions
+        if those are not provided.
+    spline_order : int, default=4
+        B-spline interpolation order.
+    batch_idx : jax.Array | None
+        System index for each atom.
+    k_vectors : jax.Array, optional
+        Precomputed k-vectors from ``generate_k_vectors_pme``.
+    k_squared : jax.Array, optional
+        Precomputed :math:`|k|^2` values.
+
+    Returns
+    -------
+    energy : jax.Array
+        - Single-system: shape (1,) — total reciprocal-space dispersion energy.
+        - Batch: shape (B,) — total per system.
+
+    Notes
+    -----
+    Unlike Coulomb PME, dispersion is short-range physically but
+    long-range for slowly-decaying-tail PME purposes; the returned
+    energy is the lattice-summed reciprocal contribution and is meant to
+    be combined with the real-space damped term and the self-energy
+    correction to form the total LJ-PME energy.
+    """
+    num_atoms = positions.shape[0]
+    input_dtype = _normalize_dtype(positions.dtype)
+    is_batch = batch_idx is not None
+    fft_dims = (1, 2, 3) if is_batch else (0, 1, 2)
+
+    if cell.ndim == 2:
+        cell_b = cell[jnp.newaxis, :, :]
+    else:
+        cell_b = cell
+    num_systems = cell_b.shape[0]
+
+    # Handle empty systems
+    if num_atoms == 0:
+        empty_e = jnp.zeros(num_systems if is_batch else 1, dtype=input_dtype)
+        if compute_forces:
+            return empty_e, jnp.zeros((0, 3), dtype=input_dtype)
+        return empty_e
+
+    # Determine mesh dimensions
+    if mesh_dimensions is None:
+        if mesh_spacing is None:
+            raise ValueError("Either mesh_dimensions or mesh_spacing must be provided")
+        cell_lengths = jnp.linalg.norm(cell_b[0], axis=1)
+        mesh_dimensions = tuple(
+            int(math.ceil(float(length) / mesh_spacing)) for length in cell_lengths
+        )
+
+    mesh_nx, mesh_ny, mesh_nz = mesh_dimensions
+
+    # Spread sqrt(C6) — geometric combination factorizes the kernel
+    sqrt_c6 = jnp.sqrt(jnp.clip(c6_coefficients.astype(input_dtype), min=0.0))
+
+    mesh_grid = spline_spread(
+        positions,
+        sqrt_c6,
+        cell_b if is_batch else cell,
+        mesh_dims=mesh_dimensions,
+        spline_order=spline_order,
+        batch_idx=batch_idx,
+    )
+
+    # FFT to reciprocal space
+    mesh_fft = jnp.fft.rfftn(mesh_grid, axes=fft_dims, norm="backward")
+
+    # k-vectors and Green's function
+    if k_vectors is None or k_squared is None:
+        k_vectors, k_squared = generate_k_vectors_pme(cell_b, mesh_dimensions)
+
+    # Prepare beta in correct shape
+    if beta.ndim == 0:
+        beta = beta.reshape(1)
+    beta = beta.astype(input_dtype)
+    if is_batch and beta.shape[0] == 1 and num_systems > 1:
+        beta = jnp.broadcast_to(beta, (num_systems,))
+
+    green_function, structure_factor_sq = pme_dispersion_green_structure_factor(
+        k_squared,
+        mesh_dimensions,
+        beta,
+        cell_b,
+        spline_order,
+        batch_idx,
+    )
+
+    # Apply B-spline deconvolution and convolve with Green's function
+    complex_dtype = jnp.complex64 if input_dtype == jnp.float32 else jnp.complex128
+    mesh_fft = mesh_fft.astype(complex_dtype) / structure_factor_sq
+    convolved_mesh = mesh_fft * green_function
+
+    # IFFT to potential mesh
+    potential_mesh = jnp.fft.irfftn(
+        convolved_mesh, s=mesh_dimensions, axes=fft_dims, norm="forward"
+    )
+
+    # Gather potential at atoms
+    raw_potential = spline_gather(
+        positions,
+        potential_mesh,
+        cell_b if is_batch else cell,
+        spline_order=spline_order,
+        batch_idx=batch_idx,
+    )
+
+    # Energy: per-atom sqrt(C6) * phi summed (Green's function already includes
+    # the 1/(2V) prefactor + sign for the reciprocal sum).
+    per_atom_energy = sqrt_c6 * raw_potential
+
+    if is_batch:
+        energy = jnp.zeros(num_systems, dtype=input_dtype)
+        energy = energy.at[batch_idx].add(per_atom_energy)
+    else:
+        energy = per_atom_energy.sum().reshape(1)
+
+    if not compute_forces:
+        return energy
+
+    # Forces via Fourier gradient (same trick as Coulomb PME):
+    #
+    #   V_recip = Σ_i √C6_i · φ(r_i)       with φ on mesh from gather step
+    #   F_i = -dV_recip/dr_i = 2 · √C6_i · ∇φ(r_i)   (factor 2 from the
+    #         double-counting in the quadratic |ρ|² structure).
+    #
+    # Compute ∇φ at atom positions by inverse-FFTing -i k * convolved_mesh,
+    # then gathering with weight √C6_i. Sign convention: ∇φ ↔ -i k.
+    Ex_fft = -1j * k_vectors[..., 0] * convolved_mesh
+    Ey_fft = -1j * k_vectors[..., 1] * convolved_mesh
+    Ez_fft = -1j * k_vectors[..., 2] * convolved_mesh
+    Ex = jnp.fft.irfftn(Ex_fft, s=mesh_dimensions, axes=fft_dims, norm="forward")
+    Ey = jnp.fft.irfftn(Ey_fft, s=mesh_dimensions, axes=fft_dims, norm="forward")
+    Ez = jnp.fft.irfftn(Ez_fft, s=mesh_dimensions, axes=fft_dims, norm="forward")
+    gradient_field_mesh = jnp.stack([Ex, Ey, Ez], axis=-1).astype(input_dtype)
+
+    interpolated_gradient = spline_gather_vec3(
+        positions,
+        sqrt_c6,
+        gradient_field_mesh,
+        cell_b if is_batch else cell,
+        spline_order=spline_order,
+        batch_idx=batch_idx,
+    )
+    forces = 2.0 * interpolated_gradient
+    return energy, forces
+
+
+# ==============================================================================
+# Public API: Real-space LJ-PME (PR2)
+# ==============================================================================
+
+
+def lj_pme_real_space(
+    positions: jax.Array,
+    c6_coefficients: jax.Array,
+    c12_coefficients: jax.Array,
+    cell: jax.Array,
+    neighbor_matrix: jax.Array,
+    neighbor_matrix_shifts: jax.Array,
+    beta: jax.Array,
+    cutoff: float,
+    num_neighbors: jax.Array | None = None,
+    mask_value: int | None = None,
+    compute_forces: bool = False,
+    compute_virial: bool = False,
+    half_neighbor_list: bool = True,
+) -> jax.Array | tuple[jax.Array, ...]:
+    """Real-space LJ-PME pair energy (and optionally forces and virial).
+
+    For each pair (i, j) with :math:`r_{ij} < r_{\\text{cut}}` the kernel
+    computes the damped Lennard-Jones pair contribution
+
+    .. math::
+
+        V_{ij} = \\frac{C_{12,ij}}{r_{ij}^{12}}
+                 - \\frac{C_{6,ij} \\, g(\\beta r_{ij})}{r_{ij}^{6}},
+        \\qquad
+        g(x) = e^{-x^2}\\bigl(1 + x^2 + x^4/2\\bigr),
+
+    with geometric combination rules
+    :math:`C_{6,ij} = \\sqrt{C_{6,ii} C_{6,jj}}`,
+    :math:`C_{12,ij} = \\sqrt{C_{12,ii} C_{12,jj}}`. The damping function
+    :math:`g` is the Wennberg complement of the long-range PME term so that
+    :math:`V_{\\text{real}} + V_{\\text{recip}} - V_{\\text{self}}` recovers
+    the bare :math:`r^{-6}` lattice sum.
+
+    Parameters
+    ----------
+    positions : jax.Array, shape (N, 3)
+        Atomic coordinates.
+    c6_coefficients : jax.Array, shape (N,)
+        Per-atom homoatomic :math:`C_{6,ii}` values.
+    c12_coefficients : jax.Array, shape (N,)
+        Per-atom homoatomic :math:`C_{12,ii}` values.
+    cell : jax.Array, shape (3, 3) or (1, 3, 3)
+        Unit cell matrix.
+    neighbor_matrix : jax.Array, shape (N, max_neighbors), dtype int32
+        Half neighbor matrix: each pair (i, j) appears exactly once.
+        Invalid entries should be marked with ``mask_value``.
+    neighbor_matrix_shifts : jax.Array, shape (N, max_neighbors, 3), dtype int32
+        Periodic image shifts.
+    beta : jax.Array, scalar or shape (1,)
+        Dispersion Ewald splitting parameter.
+    cutoff : float
+        Real-space cutoff radius. Pairs with :math:`r \\geq r_{\\text{cut}}`
+        are skipped.
+    num_neighbors : jax.Array | None, shape (N,), dtype int32
+        Valid neighbor count per atom. If None, inferred as
+        ``(neighbor_matrix != mask_value).sum(axis=1)``.
+    mask_value : int | None
+        Sentinel value marking invalid entries in ``neighbor_matrix``.
+        Defaults to ``num_atoms``.
+    compute_forces : bool, default=False
+        If True, return explicit forces alongside the per-atom energy.
+    compute_virial : bool, default=False
+        If True, return the virial tensor
+        :math:`W_{ab} = \\sum_{i<j} r_{ij,a} F_{ij,b}` (3×3) alongside the
+        energy.
+
+    Returns
+    -------
+    energies : jax.Array, shape (N,)
+        Per-atom real-space dispersion energy (half-counted per pair).
+    forces : jax.Array, shape (N, 3), optional
+        Per-atom forces. Only returned if ``compute_forces=True``.
+    virial : jax.Array, shape (3, 3), optional
+        Virial tensor. Only returned if ``compute_virial=True``;
+        always last in the return tuple.
+    """
+    input_dtype = _normalize_dtype(positions.dtype)
+    num_atoms = positions.shape[0]
+
+    if cell.ndim == 2:
+        cell_b = cell[jnp.newaxis, :, :]
+    elif cell.shape[0] == 1:
+        cell_b = cell
+    else:
+        raise ValueError(
+            "lj_pme_real_space currently supports single-system cells; "
+            f"got cell shape {cell.shape}."
+        )
+
+    positions_cast = positions.astype(input_dtype)
+    c6_cast = c6_coefficients.astype(input_dtype)
+    c12_cast = c12_coefficients.astype(input_dtype)
+    cell_cast = cell_b.astype(input_dtype)
+    if beta.ndim == 0:
+        beta = beta.reshape(1)
+    beta_cast = beta.astype(input_dtype)
+    cutoff_cast = jnp.array([float(cutoff)], dtype=input_dtype)
+
+    nbr_mat = neighbor_matrix.astype(jnp.int32)
+    nbr_shifts = neighbor_matrix_shifts.astype(jnp.int32)
+
+    if mask_value is None:
+        mask_value = num_atoms
+
+    if num_neighbors is None:
+        valid = nbr_mat != jnp.int32(mask_value)
+        num_neighbors_i32 = valid.sum(axis=1).astype(jnp.int32)
+    else:
+        num_neighbors_i32 = num_neighbors.astype(jnp.int32)
+
+    atomic_energies = jnp.zeros(num_atoms, dtype=input_dtype)
+
+    half_flag = bool(half_neighbor_list)
+    if compute_virial:
+        atomic_forces = jnp.zeros((num_atoms, 3), dtype=input_dtype)
+        virial_flat = jnp.zeros(9, dtype=input_dtype)
+        kernel = _jax_lj_pme_real_space_energy_forces_virial[input_dtype]
+        atomic_energies, atomic_forces, virial_flat = kernel(
+            positions_cast,
+            c6_cast,
+            c12_cast,
+            cell_cast,
+            nbr_mat,
+            nbr_shifts,
+            num_neighbors_i32,
+            beta_cast,
+            cutoff_cast,
+            int(mask_value),
+            half_flag,
+            atomic_energies,
+            atomic_forces,
+            virial_flat,
+            launch_dims=(num_atoms,),
+        )
+        virial = virial_flat.reshape(3, 3)
+        if compute_forces:
+            return atomic_energies, atomic_forces, virial
+        return atomic_energies, virial
+    elif compute_forces:
+        atomic_forces = jnp.zeros((num_atoms, 3), dtype=input_dtype)
+        kernel = _jax_lj_pme_real_space_energy_forces[input_dtype]
+        atomic_energies, atomic_forces = kernel(
+            positions_cast,
+            c6_cast,
+            c12_cast,
+            cell_cast,
+            nbr_mat,
+            nbr_shifts,
+            num_neighbors_i32,
+            beta_cast,
+            cutoff_cast,
+            int(mask_value),
+            half_flag,
+            atomic_energies,
+            atomic_forces,
+            launch_dims=(num_atoms,),
+        )
+        return atomic_energies, atomic_forces
+    else:
+        kernel = _jax_lj_pme_real_space_energy[input_dtype]
+        (atomic_energies,) = kernel(
+            positions_cast,
+            c6_cast,
+            c12_cast,
+            cell_cast,
+            nbr_mat,
+            nbr_shifts,
+            num_neighbors_i32,
+            beta_cast,
+            cutoff_cast,
+            int(mask_value),
+            half_flag,
+            atomic_energies,
+            launch_dims=(num_atoms,),
+        )
+        return atomic_energies
+
+
+# ==============================================================================
+# Public API: Top-level LJ-PME orchestrator (PR3)
+# ==============================================================================
+
+
+def lj_pme(
+    positions: jax.Array,
+    c6_coefficients: jax.Array,
+    c12_coefficients: jax.Array,
+    cell: jax.Array,
+    neighbor_matrix: jax.Array,
+    neighbor_matrix_shifts: jax.Array,
+    beta: float | jax.Array | None = None,
+    cutoff: float | None = None,
+    mesh_spacing: float | None = None,
+    mesh_dimensions: tuple[int, int, int] | None = None,
+    spline_order: int = 4,
+    batch_idx: jax.Array | None = None,
+    num_neighbors: jax.Array | None = None,
+    mask_value: int | None = None,
+    compute_forces: bool = False,
+    accuracy: float = DISPERSION_DEFAULT_ACCURACY,
+    half_neighbor_list: bool = False,
+) -> jax.Array | tuple[jax.Array, jax.Array]:
+    """Complete LJ-PME energy (and optionally forces) for one or more systems.
+
+    Computes :math:`V_{\\text{total}} = V_{\\text{real}} + V_{\\text{recip}} - V_{\\text{self}}`
+    with geometric combination rules, where
+
+    * :math:`V_{\\text{real}}` is the damped real-space pair sum
+      :math:`C_{12,ij}/r^{12} - C_{6,ij} g(\\beta r)/r^6` (from
+      :func:`lj_pme_real_space`),
+    * :math:`V_{\\text{recip}}` is the FFT-based long-range :math:`r^{-6}`
+      lattice sum (from :func:`pme_dispersion_reciprocal_space`),
+    * :math:`V_{\\text{self}} = -\\beta^6 \\sum_i C_{6,ii} / 12` is the
+      self-energy correction (from :func:`pme_dispersion_energy_corrections`).
+
+    If ``beta``, ``cutoff``, or ``mesh_dimensions`` are not provided they
+    are estimated jointly from the target ``accuracy`` (GROMACS-style
+    matched-tail criterion, see
+    :func:`estimate_pme_dispersion_parameters`).
+
+    Parameters
+    ----------
+    positions : jax.Array, shape (N, 3)
+        Atomic coordinates.
+    c6_coefficients : jax.Array, shape (N,)
+        Per-atom homoatomic :math:`C_{6,ii}` values.
+    c12_coefficients : jax.Array, shape (N,)
+        Per-atom homoatomic :math:`C_{12,ii}` values.
+    cell : jax.Array, shape (3, 3) or (B, 3, 3)
+        Unit cell matrices.
+    neighbor_matrix : jax.Array, shape (N, max_neighbors), dtype int32
+        Half neighbor matrix for the real-space term.
+    neighbor_matrix_shifts : jax.Array, shape (N, max_neighbors, 3), dtype int32
+        Periodic image shifts for ``neighbor_matrix``.
+    beta : float | jax.Array | None
+        Dispersion splitting parameter. If None, estimated from
+        ``cutoff`` and ``accuracy``.
+    cutoff : float | None
+        Real-space cutoff radius. If None, defaults to
+        :data:`DISPERSION_DEFAULT_CUTOFF` (9 Å).
+    mesh_spacing : float | None
+        Target mesh spacing. Alternative to ``mesh_dimensions``.
+    mesh_dimensions : tuple[int, int, int] | None
+        Explicit FFT mesh dimensions. If None, estimated.
+    spline_order : int, default=4
+        B-spline interpolation order.
+    batch_idx : jax.Array | None
+        System index for each atom (for batched evaluation).
+    num_neighbors : jax.Array | None, shape (N,), dtype int32
+        Valid neighbor count per atom (passed through to the real-space
+        kernel; inferred from ``mask_value`` if None).
+    mask_value : int | None
+        Sentinel value marking invalid entries in ``neighbor_matrix``.
+        Defaults to ``num_atoms``.
+    compute_forces : bool, default=False
+        If True, return the per-atom force tensor alongside the energy.
+    accuracy : float, default=1e-3
+        Target relative accuracy for joint parameter estimation
+        (GROMACS's ``ewald-rtol-lj`` default).
+
+    Returns
+    -------
+    energy : jax.Array
+        Per-system total LJ-PME energy. Shape (1,) for single system,
+        (B,) for batched.
+    forces : jax.Array, optional
+        Per-atom forces (shape (N, 3)) if ``compute_forces=True``.
+    """
+    is_batch = batch_idx is not None
+
+    # Joint parameter estimation if any of (beta, cutoff, mesh) is missing.
+    if cell.ndim == 2:
+        cell_b = cell[jnp.newaxis, :, :]
+    else:
+        cell_b = cell
+    num_systems = cell_b.shape[0]
+
+    if cutoff is None:
+        cutoff = DISPERSION_DEFAULT_CUTOFF
+    if beta is None:
+        beta_scalar = solve_dispersion_beta(cutoff, accuracy)
+        beta_arr = jnp.full(num_systems, beta_scalar, dtype=cell_b.dtype)
+    elif isinstance(beta, (int, float)):
+        beta_arr = jnp.full(num_systems, float(beta), dtype=cell_b.dtype)
+    else:
+        beta_arr = jnp.asarray(beta, dtype=cell_b.dtype)
+        if beta_arr.ndim == 0:
+            beta_arr = jnp.broadcast_to(beta_arr[None], (num_systems,))
+        elif beta_arr.shape[0] == 1 and num_systems > 1:
+            beta_arr = jnp.broadcast_to(beta_arr, (num_systems,))
+
+    if mesh_dimensions is None:
+        if mesh_spacing is not None:
+            cell_lengths_np = jnp.linalg.norm(cell_b[0], axis=1)
+            mesh_dimensions = tuple(
+                int(math.ceil(float(length) / mesh_spacing))
+                for length in cell_lengths_np
+            )
+        else:
+            mesh_dimensions = estimate_pme_dispersion_mesh_dimensions(
+                cell_b, beta_arr, accuracy
+            )
+
+    # Real-space contribution.
+    if compute_forces:
+        e_real_per_atom, f_real = lj_pme_real_space(
+            positions,
+            c6_coefficients,
+            c12_coefficients,
+            cell_b if is_batch else cell,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            beta_arr if not is_batch else beta_arr[0:1],
+            cutoff,
+            num_neighbors=num_neighbors,
+            mask_value=mask_value,
+            compute_forces=True,
+            half_neighbor_list=half_neighbor_list,
+        )
+    else:
+        e_real_per_atom = lj_pme_real_space(
+            positions,
+            c6_coefficients,
+            c12_coefficients,
+            cell_b if is_batch else cell,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            beta_arr if not is_batch else beta_arr[0:1],
+            cutoff,
+            num_neighbors=num_neighbors,
+            mask_value=mask_value,
+            compute_forces=False,
+            half_neighbor_list=half_neighbor_list,
+        )
+        f_real = None
+
+    # Reciprocal-space contribution.
+    if compute_forces:
+        e_recip, f_recip = pme_dispersion_reciprocal_space(
+            positions,
+            c6_coefficients,
+            cell_b if is_batch else cell,
+            beta_arr,
+            mesh_dimensions=mesh_dimensions,
+            spline_order=spline_order,
+            batch_idx=batch_idx,
+            compute_forces=True,
+        )
+    else:
+        e_recip = pme_dispersion_reciprocal_space(
+            positions,
+            c6_coefficients,
+            cell_b if is_batch else cell,
+            beta_arr,
+            mesh_dimensions=mesh_dimensions,
+            spline_order=spline_order,
+            batch_idx=batch_idx,
+        )
+        f_recip = None
+
+    # Self-energy.
+    e_self = pme_dispersion_energy_corrections(
+        c6_coefficients, beta_arr, batch_idx=batch_idx
+    )
+
+    # Combine per-system.
+    if is_batch:
+        e_real_per_system = jnp.zeros(num_systems, dtype=positions.dtype)
+        e_real_per_system = e_real_per_system.at[batch_idx].add(e_real_per_atom)
+    else:
+        e_real_per_system = e_real_per_atom.sum().reshape(1)
+
+    energy = e_real_per_system + e_recip - e_self
+
+    if compute_forces:
+        forces = f_real + f_recip
+        return energy, forces
+    return energy

--- a/nvalchemiops/torch/interactions/dispersion/__init__.py
+++ b/nvalchemiops/torch/interactions/dispersion/__init__.py
@@ -15,8 +15,26 @@
 """PyTorch bindings for dispersion corrections."""
 
 from nvalchemiops.torch.interactions.dispersion._dftd3 import D3Parameters, dftd3
+from nvalchemiops.torch.interactions.dispersion.parameters import (
+    PMEDispersionParameters,
+    estimate_pme_dispersion_parameters,
+)
+from nvalchemiops.torch.interactions.dispersion.pme import (
+    lj_pme,
+    lj_pme_real_space,
+    pme_dispersion_energy_corrections,
+    pme_dispersion_green_structure_factor,
+    pme_dispersion_reciprocal_space,
+)
 
 __all__ = [
     "dftd3",
     "D3Parameters",
+    "pme_dispersion_reciprocal_space",
+    "pme_dispersion_green_structure_factor",
+    "pme_dispersion_energy_corrections",
+    "lj_pme_real_space",
+    "lj_pme",
+    "estimate_pme_dispersion_parameters",
+    "PMEDispersionParameters",
 ]

--- a/nvalchemiops/torch/interactions/dispersion/parameters.py
+++ b/nvalchemiops/torch/interactions/dispersion/parameters.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parameter estimation for LJ-PME (PyTorch).
+
+Mirror of ``nvalchemiops/jax/interactions/dispersion/parameters.py`` —
+see that module for the underlying math.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+__all__ = [
+    "PMEDispersionParameters",
+    "estimate_pme_dispersion_parameters",
+    "estimate_pme_dispersion_mesh_dimensions",
+    "solve_dispersion_beta",
+    "DISPERSION_DEFAULT_ACCURACY",
+    "DISPERSION_DEFAULT_CUTOFF",
+]
+
+
+DISPERSION_DEFAULT_ACCURACY = 1e-3
+DISPERSION_DEFAULT_CUTOFF = 9.0
+
+
+@dataclass
+class PMEDispersionParameters:
+    """Container for LJ-PME parameters (PyTorch).
+
+    Attributes
+    ----------
+    beta : torch.Tensor, shape (B,)
+        Dispersion Ewald splitting parameter.
+    cutoff : float
+        Real-space cutoff (shared across systems).
+    mesh_dimensions : tuple[int, int, int]
+        FFT mesh dimensions.
+    mesh_spacing : torch.Tensor, shape (B, 3)
+        Actual mesh spacing along each lattice direction.
+    accuracy : float
+        Target relative accuracy.
+    """
+
+    beta: torch.Tensor
+    cutoff: float
+    mesh_dimensions: tuple[int, int, int]
+    mesh_spacing: torch.Tensor
+    accuracy: float
+
+
+def solve_dispersion_beta(cutoff: float, accuracy: float) -> float:
+    """Solve :math:`g(\\beta \\cdot r_c) = \\varepsilon` for :math:`\\beta r_c`, return β."""
+    if cutoff <= 0:
+        raise ValueError(f"cutoff must be positive, got {cutoff}")
+    if not (0 < accuracy < 1):
+        raise ValueError(f"accuracy must be in (0, 1), got {accuracy}")
+
+    def g(x: float) -> float:
+        return math.exp(-x * x) * (1.0 + x * x + 0.5 * x * x * x * x)
+
+    lo, hi = 0.1, 20.0
+    if g(lo) < accuracy:
+        return lo / cutoff
+    if g(hi) > accuracy:
+        return hi / cutoff
+
+    for _ in range(100):
+        mid = 0.5 * (lo + hi)
+        if g(mid) > accuracy:
+            lo = mid
+        else:
+            hi = mid
+        if hi - lo < 1e-10:
+            break
+    return 0.5 * (lo + hi) / cutoff
+
+
+def _next_fft_friendly(n: int) -> int:
+    """Round ``n`` up to the next integer of the form :math:`2^a 3^b 5^c`."""
+    if n <= 1:
+        return 1
+    candidate = n
+    while True:
+        m = candidate
+        for p in (2, 3, 5):
+            while m % p == 0:
+                m //= p
+        if m == 1:
+            return candidate
+        candidate += 1
+        if candidate > 4 * n:
+            return 1 << (n - 1).bit_length()
+
+
+def estimate_pme_dispersion_mesh_dimensions(
+    cell: torch.Tensor,
+    beta: float | torch.Tensor,
+    accuracy: float = DISPERSION_DEFAULT_ACCURACY,
+) -> tuple[int, int, int]:
+    """Pick mesh dimensions for LJ-PME at a target accuracy."""
+    if cell.dim() == 2:
+        cell = cell.unsqueeze(0)
+
+    cell_lengths = torch.linalg.norm(cell, dim=2)  # (B, 3)
+
+    def g(x: float) -> float:
+        return math.exp(-x * x) * (1.0 + x * x + 0.5 * x * x * x * x)
+
+    lo, hi = 0.1, 20.0
+    for _ in range(100):
+        mid = 0.5 * (lo + hi)
+        if g(mid) > accuracy:
+            lo = mid
+        else:
+            hi = mid
+        if hi - lo < 1e-10:
+            break
+    x_eps = 0.5 * (lo + hi)
+
+    if isinstance(beta, (int, float)):
+        beta_t = torch.tensor(
+            [float(beta)], dtype=cell_lengths.dtype, device=cell.device
+        )
+    else:
+        beta_t = beta.to(dtype=cell_lengths.dtype, device=cell.device)
+        if beta_t.dim() == 0:
+            beta_t = beta_t.reshape(1)
+
+    n_per_axis = 2.0 * cell_lengths * beta_t.view(-1, 1) * x_eps / math.pi
+    max_n = n_per_axis.max(dim=0).values
+    raw = [int(math.ceil(float(max_n[i]))) for i in range(3)]
+    return (
+        _next_fft_friendly(raw[0]),
+        _next_fft_friendly(raw[1]),
+        _next_fft_friendly(raw[2]),
+    )
+
+
+def estimate_pme_dispersion_parameters(
+    cell: torch.Tensor,
+    cutoff: float = DISPERSION_DEFAULT_CUTOFF,
+    accuracy: float = DISPERSION_DEFAULT_ACCURACY,
+) -> PMEDispersionParameters:
+    """Estimate (β, mesh) for LJ-PME at a target accuracy."""
+    if cell.dim() == 2:
+        cell = cell.unsqueeze(0)
+    num_systems = cell.shape[0]
+
+    beta_scalar = solve_dispersion_beta(cutoff, accuracy)
+    beta = torch.full((num_systems,), beta_scalar, dtype=cell.dtype, device=cell.device)
+
+    mesh_dims = estimate_pme_dispersion_mesh_dimensions(cell, beta, accuracy)
+
+    cell_lengths = torch.linalg.norm(cell, dim=2)
+    mesh_dims_t = torch.tensor(
+        mesh_dims, dtype=cell_lengths.dtype, device=cell_lengths.device
+    )
+    mesh_spacing = cell_lengths / mesh_dims_t
+
+    return PMEDispersionParameters(
+        beta=beta,
+        cutoff=cutoff,
+        mesh_dimensions=mesh_dims,
+        mesh_spacing=mesh_spacing,
+        accuracy=accuracy,
+    )

--- a/nvalchemiops/torch/interactions/dispersion/pme.py
+++ b/nvalchemiops/torch/interactions/dispersion/pme.py
@@ -1,0 +1,1395 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PyTorch bindings for dispersion (LJ-PME).
+
+Reciprocal-space and self-energy components (PR1):
+:func:`pme_dispersion_reciprocal_space`,
+:func:`pme_dispersion_green_structure_factor`,
+:func:`pme_dispersion_energy_corrections`.
+
+Real-space damped LJ-PME term (PR2): :func:`lj_pme_real_space`.
+
+The total LJ-PME energy combines these as
+:math:`V_{\\text{total}} = V_{\\text{real}} + V_{\\text{recip}} - V_{\\text{self}}`.
+A top-level ``lj_pme()`` orchestrator with automatic β/mesh estimation
+arrives in a later PR.
+
+References
+----------
+Wennberg, Hess, Lindahl (2013). JCTC 9, 3527.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import warp as wp
+
+from nvalchemiops.interactions.dispersion.pme_dispersion_kernels import (
+    _batch_pme_dispersion_green_structure_factor_kernel_overload,
+    _batch_pme_dispersion_self_energy_kernel_overload,
+    _lj_pme_real_space_energy_forces_kernel_overload,
+    _lj_pme_real_space_energy_forces_virial_kernel_overload,
+    _lj_pme_real_space_energy_kernel_overload,
+    _pme_dispersion_green_structure_factor_kernel_overload,
+    _pme_dispersion_self_energy_kernel_overload,
+)
+from nvalchemiops.torch.autograd import (
+    OutputSpec,
+    WarpAutogradContextManager,
+    attach_for_backward,
+    needs_grad,
+    warp_custom_op,
+    warp_from_torch,
+)
+from nvalchemiops.torch.interactions.dispersion.parameters import (
+    DISPERSION_DEFAULT_ACCURACY,
+    DISPERSION_DEFAULT_CUTOFF,
+    estimate_pme_dispersion_mesh_dimensions,
+    solve_dispersion_beta,
+)
+from nvalchemiops.torch.interactions.electrostatics.k_vectors import (
+    generate_k_vectors_pme,
+)
+from nvalchemiops.torch.spline import spline_gather, spline_gather_vec3, spline_spread
+from nvalchemiops.torch.types import get_wp_dtype, get_wp_mat_dtype, get_wp_vec_dtype
+
+__all__ = [
+    "pme_dispersion_reciprocal_space",
+    "pme_dispersion_green_structure_factor",
+    "pme_dispersion_energy_corrections",
+    "lj_pme_real_space",
+    "lj_pme",
+]
+
+
+###########################################################################################
+########################### Helpers #######################################################
+###########################################################################################
+
+
+def _prepare_beta(
+    beta: float | torch.Tensor,
+    num_systems: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Convert beta to a per-system tensor of length num_systems."""
+    if isinstance(beta, (int, float)):
+        return torch.full((num_systems,), float(beta), dtype=dtype, device=device)
+    if isinstance(beta, torch.Tensor):
+        if beta.dim() == 0:
+            return beta.expand(num_systems).to(dtype=dtype, device=device)
+        if beta.shape[0] != num_systems:
+            if beta.shape[0] == 1:
+                return beta.expand(num_systems).to(dtype=dtype, device=device)
+            raise ValueError(
+                f"beta has {beta.shape[0]} values but there are {num_systems} systems"
+            )
+        return beta.to(dtype=dtype, device=device)
+    raise TypeError(f"beta must be float or torch.Tensor, got {type(beta)}")
+
+
+def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, int]:
+    """Ensure cell is (B, 3, 3) and return number of systems."""
+    if cell.dim() == 2:
+        cell = cell.unsqueeze(0)
+    return cell, cell.shape[0]
+
+
+def _materialize_complex(tensor: torch.Tensor) -> torch.Tensor:
+    """Force a fresh complex tensor for compiled FFT consumers."""
+    if not tensor.is_complex():
+        return tensor
+    return torch.complex(tensor.real, tensor.imag)
+
+
+###########################################################################################
+########################### Green's function custom ops ###################################
+###########################################################################################
+
+
+def _green_output_shape(k_squared, *_):
+    return k_squared.shape
+
+
+def _struct_output_shape(k_squared, *_):
+    return k_squared.shape
+
+
+@warp_custom_op(
+    name="alchemiops::_pme_dispersion_green_structure_factor",
+    outputs=[
+        OutputSpec("green_function", wp.array(dtype=Any, ndim=3), _green_output_shape),
+        OutputSpec(
+            "structure_factor_sq", wp.array(dtype=Any, ndim=3), _struct_output_shape
+        ),
+    ],
+    grad_arrays=["green_function", "k_squared", "beta", "volume"],
+)
+def _pme_dispersion_green_structure_factor_op(
+    k_squared: torch.Tensor,
+    miller_x: torch.Tensor,
+    miller_y: torch.Tensor,
+    miller_z: torch.Tensor,
+    beta: torch.Tensor,
+    volume: torch.Tensor,
+    mesh_nx: int,
+    mesh_ny: int,
+    mesh_nz: int,
+    spline_order: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Single-system dispersion Green's function and B-spline correction."""
+    device = wp.device_from_torch(k_squared.device)
+    input_dtype = k_squared.dtype
+    wp_dtype = get_wp_dtype(input_dtype)
+    nx, ny, nz_rfft = k_squared.shape
+    needs_grad_flag = needs_grad(k_squared, beta, volume)
+
+    wp_k_squared = warp_from_torch(
+        k_squared.contiguous(), wp_dtype, requires_grad=needs_grad_flag
+    )
+    wp_miller_x = warp_from_torch(
+        miller_x.to(input_dtype).contiguous(), wp_dtype, requires_grad=False
+    )
+    wp_miller_y = warp_from_torch(
+        miller_y.to(input_dtype).contiguous(), wp_dtype, requires_grad=False
+    )
+    wp_miller_z = warp_from_torch(
+        miller_z.to(input_dtype).contiguous(), wp_dtype, requires_grad=False
+    )
+    wp_beta = warp_from_torch(
+        beta.to(input_dtype).contiguous(), wp_dtype, requires_grad=needs_grad_flag
+    )
+    wp_volume = warp_from_torch(
+        volume.to(input_dtype).contiguous(), wp_dtype, requires_grad=needs_grad_flag
+    )
+
+    green_function = torch.zeros(
+        (nx, ny, nz_rfft), dtype=input_dtype, device=k_squared.device
+    )
+    structure_factor_sq = torch.zeros(
+        (nx, ny, nz_rfft), dtype=input_dtype, device=k_squared.device
+    )
+
+    wp_green = warp_from_torch(green_function, wp_dtype, requires_grad=needs_grad_flag)
+    wp_struct = warp_from_torch(structure_factor_sq, wp_dtype, requires_grad=False)
+
+    kernel = _pme_dispersion_green_structure_factor_kernel_overload[wp_dtype]
+
+    with WarpAutogradContextManager(needs_grad_flag) as tape:
+        wp.launch(
+            kernel,
+            dim=(nx, ny, nz_rfft),
+            inputs=[
+                wp_k_squared,
+                wp_miller_x,
+                wp_miller_y,
+                wp_miller_z,
+                wp_beta,
+                wp_volume,
+                wp.int32(mesh_nx),
+                wp.int32(mesh_ny),
+                wp.int32(mesh_nz),
+                wp.int32(spline_order),
+            ],
+            outputs=[wp_green, wp_struct],
+            device=device,
+        )
+
+    if needs_grad_flag:
+        attach_for_backward(
+            green_function,
+            tape=tape,
+            green_function=wp_green,
+            k_squared=wp_k_squared,
+            beta=wp_beta,
+            volume=wp_volume,
+        )
+
+    return green_function, structure_factor_sq
+
+
+def _batch_green_output_shape(
+    k_squared, miller_x, miller_y, miller_z, beta, volumes, *_
+):
+    if k_squared.dim() == 3:
+        _, nx, ny, nz_rfft = (1,) + k_squared.shape
+    else:
+        _, nx, ny, nz_rfft = k_squared.shape
+    num_systems = volumes.shape[0]
+    return (num_systems, nx, ny, nz_rfft)
+
+
+def _batch_struct_output_shape(k_squared, *_):
+    if k_squared.dim() == 3:
+        return k_squared.shape
+    return k_squared.shape[1:]
+
+
+@warp_custom_op(
+    name="alchemiops::_batch_pme_dispersion_green_structure_factor",
+    outputs=[
+        OutputSpec(
+            "green_function", wp.array(dtype=Any, ndim=4), _batch_green_output_shape
+        ),
+        OutputSpec(
+            "structure_factor_sq",
+            wp.array(dtype=Any, ndim=3),
+            _batch_struct_output_shape,
+        ),
+    ],
+    grad_arrays=["green_function", "k_squared", "beta", "volumes"],
+)
+def _batch_pme_dispersion_green_structure_factor_op(
+    k_squared: torch.Tensor,
+    miller_x: torch.Tensor,
+    miller_y: torch.Tensor,
+    miller_z: torch.Tensor,
+    beta: torch.Tensor,
+    volumes: torch.Tensor,
+    mesh_nx: int,
+    mesh_ny: int,
+    mesh_nz: int,
+    spline_order: int,
+    num_systems: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Batched dispersion Green's function and B-spline correction."""
+    device = wp.device_from_torch(k_squared.device)
+    if k_squared.dim() == 3:
+        k_squared = k_squared.unsqueeze(0)
+    input_dtype = k_squared.dtype
+    wp_dtype = get_wp_dtype(input_dtype)
+    _, nx, ny, nz_rfft = k_squared.shape
+    needs_grad_flag = needs_grad(k_squared, beta, volumes)
+
+    wp_k_squared = warp_from_torch(
+        k_squared.contiguous(), wp_dtype, requires_grad=needs_grad_flag
+    )
+    wp_miller_x = warp_from_torch(
+        miller_x.to(input_dtype).contiguous(), wp_dtype, requires_grad=False
+    )
+    wp_miller_y = warp_from_torch(
+        miller_y.to(input_dtype).contiguous(), wp_dtype, requires_grad=False
+    )
+    wp_miller_z = warp_from_torch(
+        miller_z.to(input_dtype).contiguous(), wp_dtype, requires_grad=False
+    )
+    wp_beta = warp_from_torch(
+        beta.to(input_dtype).contiguous(), wp_dtype, requires_grad=needs_grad_flag
+    )
+    wp_volumes = warp_from_torch(
+        volumes.to(input_dtype).contiguous(), wp_dtype, requires_grad=needs_grad_flag
+    )
+
+    green_function = torch.zeros(
+        (num_systems, nx, ny, nz_rfft), dtype=input_dtype, device=k_squared.device
+    )
+    structure_factor_sq = torch.zeros(
+        (nx, ny, nz_rfft), dtype=input_dtype, device=k_squared.device
+    )
+
+    wp_green = warp_from_torch(green_function, wp_dtype, requires_grad=needs_grad_flag)
+    wp_struct = warp_from_torch(structure_factor_sq, wp_dtype, requires_grad=False)
+
+    kernel = _batch_pme_dispersion_green_structure_factor_kernel_overload[wp_dtype]
+
+    with WarpAutogradContextManager(needs_grad_flag) as tape:
+        wp.launch(
+            kernel,
+            dim=(num_systems, nx, ny, nz_rfft),
+            inputs=[
+                wp_k_squared,
+                wp_miller_x,
+                wp_miller_y,
+                wp_miller_z,
+                wp_beta,
+                wp_volumes,
+                wp.int32(mesh_nx),
+                wp.int32(mesh_ny),
+                wp.int32(mesh_nz),
+                wp.int32(spline_order),
+            ],
+            outputs=[wp_green, wp_struct],
+            device=device,
+        )
+
+    if needs_grad_flag:
+        attach_for_backward(
+            green_function,
+            tape=tape,
+            green_function=wp_green,
+            k_squared=wp_k_squared,
+            beta=wp_beta,
+            volumes=wp_volumes,
+        )
+
+    return green_function, structure_factor_sq
+
+
+def pme_dispersion_green_structure_factor(
+    k_squared: torch.Tensor,
+    mesh_dimensions: tuple[int, int, int],
+    beta: torch.Tensor,
+    cell: torch.Tensor,
+    spline_order: int = 4,
+    batch_idx: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute dispersion Green's function and B-spline structure factor.
+
+    Green's function:
+
+    .. math::
+
+        G_{\\text{disp}}(k) = \\frac{\\pi^{3/2} \\beta^3}{2V}
+            \\, f\\!\\left(\\tfrac{|k|}{2\\beta}\\right),
+        \\qquad
+        f(x) = \\tfrac{1}{3}\\bigl[(1 - 2x^2) e^{-x^2}
+            + 2 x^3 \\sqrt{\\pi}\\, \\text{erfc}(x)\\bigr].
+    """
+    mesh_nx, mesh_ny, mesh_nz = mesh_dimensions
+    device = k_squared.device
+    input_dtype = k_squared.dtype
+
+    cell = cell if cell.dim() == 3 else cell.unsqueeze(0)
+    volume = torch.abs(torch.det(cell)).to(input_dtype)
+
+    miller_x = torch.fft.fftfreq(
+        mesh_nx, d=1.0 / mesh_nx, device=device, dtype=input_dtype
+    )
+    miller_y = torch.fft.fftfreq(
+        mesh_ny, d=1.0 / mesh_ny, device=device, dtype=input_dtype
+    )
+    miller_z = torch.fft.rfftfreq(
+        mesh_nz, d=1.0 / mesh_nz, device=device, dtype=input_dtype
+    )
+
+    if batch_idx is None:
+        return _pme_dispersion_green_structure_factor_op(
+            k_squared,
+            miller_x,
+            miller_y,
+            miller_z,
+            beta.to(input_dtype),
+            volume,
+            mesh_nx,
+            mesh_ny,
+            mesh_nz,
+            spline_order,
+        )
+    num_systems = cell.shape[0]
+    return _batch_pme_dispersion_green_structure_factor_op(
+        k_squared,
+        miller_x,
+        miller_y,
+        miller_z,
+        beta.to(input_dtype),
+        volume,
+        mesh_nx,
+        mesh_ny,
+        mesh_nz,
+        spline_order,
+        num_systems,
+    )
+
+
+###########################################################################################
+########################### Self-energy custom ops ########################################
+###########################################################################################
+
+
+@warp_custom_op(
+    name="alchemiops::_pme_dispersion_self_energy",
+    outputs=[
+        OutputSpec(
+            "energy_correction",
+            wp.array(dtype=Any, ndim=1),
+            lambda c6_coefficients, *_: (c6_coefficients.shape[0],),
+        ),
+    ],
+    grad_arrays=["energy_correction", "c6_coefficients", "beta"],
+)
+def _pme_dispersion_self_energy_op(
+    c6_coefficients: torch.Tensor,
+    beta: torch.Tensor,
+) -> torch.Tensor:
+    """Per-atom dispersion self-energy: :math:`-\\beta^6 C_{6,ii}/12`."""
+    device = wp.device_from_torch(c6_coefficients.device)
+    input_dtype = c6_coefficients.dtype
+    wp_dtype = get_wp_dtype(input_dtype)
+    num_atoms = c6_coefficients.shape[0]
+    needs_grad_flag = needs_grad(c6_coefficients, beta)
+
+    wp_c6 = warp_from_torch(
+        c6_coefficients.contiguous(), wp_dtype, requires_grad=needs_grad_flag
+    )
+    wp_beta = warp_from_torch(
+        beta.to(input_dtype).contiguous(), wp_dtype, requires_grad=needs_grad_flag
+    )
+
+    energy_correction = torch.zeros(
+        num_atoms, dtype=input_dtype, device=c6_coefficients.device
+    )
+    wp_energy = warp_from_torch(
+        energy_correction, wp_dtype, requires_grad=needs_grad_flag
+    )
+
+    kernel = _pme_dispersion_self_energy_kernel_overload[wp_dtype]
+
+    with WarpAutogradContextManager(needs_grad_flag) as tape:
+        wp.launch(
+            kernel,
+            dim=num_atoms,
+            inputs=[wp_c6, wp_beta],
+            outputs=[wp_energy],
+            device=device,
+        )
+
+    if needs_grad_flag:
+        attach_for_backward(
+            energy_correction,
+            tape=tape,
+            energy_correction=wp_energy,
+            c6_coefficients=wp_c6,
+            beta=wp_beta,
+        )
+    return energy_correction
+
+
+@warp_custom_op(
+    name="alchemiops::_batch_pme_dispersion_self_energy",
+    outputs=[
+        OutputSpec(
+            "energy_correction",
+            wp.array(dtype=Any, ndim=1),
+            lambda c6_coefficients, *_: (c6_coefficients.shape[0],),
+        ),
+    ],
+    grad_arrays=["energy_correction", "c6_coefficients", "beta"],
+)
+def _batch_pme_dispersion_self_energy_op(
+    c6_coefficients: torch.Tensor,
+    batch_idx: torch.Tensor,
+    beta: torch.Tensor,
+) -> torch.Tensor:
+    """Batched per-atom dispersion self-energy."""
+    device = wp.device_from_torch(c6_coefficients.device)
+    input_dtype = c6_coefficients.dtype
+    wp_dtype = get_wp_dtype(input_dtype)
+    num_atoms = c6_coefficients.shape[0]
+    needs_grad_flag = needs_grad(c6_coefficients, beta)
+
+    wp_c6 = warp_from_torch(
+        c6_coefficients.contiguous(), wp_dtype, requires_grad=needs_grad_flag
+    )
+    wp_batch_idx = warp_from_torch(
+        batch_idx.contiguous(), wp.int32, requires_grad=False
+    )
+    wp_beta = warp_from_torch(
+        beta.to(input_dtype).contiguous(), wp_dtype, requires_grad=needs_grad_flag
+    )
+
+    energy_correction = torch.zeros(
+        num_atoms, dtype=input_dtype, device=c6_coefficients.device
+    )
+    wp_energy = warp_from_torch(
+        energy_correction, wp_dtype, requires_grad=needs_grad_flag
+    )
+
+    kernel = _batch_pme_dispersion_self_energy_kernel_overload[wp_dtype]
+
+    with WarpAutogradContextManager(needs_grad_flag) as tape:
+        wp.launch(
+            kernel,
+            dim=num_atoms,
+            inputs=[wp_c6, wp_batch_idx, wp_beta],
+            outputs=[wp_energy],
+            device=device,
+        )
+
+    if needs_grad_flag:
+        attach_for_backward(
+            energy_correction,
+            tape=tape,
+            energy_correction=wp_energy,
+            c6_coefficients=wp_c6,
+            beta=wp_beta,
+        )
+    return energy_correction
+
+
+def pme_dispersion_energy_corrections(
+    c6_coefficients: torch.Tensor,
+    beta: torch.Tensor,
+    batch_idx: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute the dispersion self-energy correction term.
+
+    Returns the per-system self-energy
+
+    .. math::
+
+        V_{\\text{self}} = -\\frac{\\beta^6}{12} \\sum_i C_{6,ii}.
+
+    The total LJ-PME energy is :math:`V_{\\text{total}} = V_{\\text{real}}
+    + V_{\\text{recip}} - V_{\\text{self}}`.
+
+    Parameters
+    ----------
+    c6_coefficients : torch.Tensor, shape (N,) or (N_total,)
+        Per-atom homoatomic :math:`C_{6,ii}` values.
+    beta : torch.Tensor
+        Dispersion Ewald splitting parameter.
+        - Single-system: shape (1,)
+        - Batch: shape (B,)
+    batch_idx : torch.Tensor | None
+        System index for each atom. If provided, uses batched kernel.
+
+    Returns
+    -------
+    energy_corrections : torch.Tensor
+        - Single-system: shape (1,)
+        - Batch: shape (B,)
+    """
+    input_dtype = c6_coefficients.dtype
+
+    if batch_idx is None:
+        per_atom = _pme_dispersion_self_energy_op(
+            c6_coefficients,
+            beta.to(input_dtype),
+        )
+        return per_atom.sum().reshape(1)
+
+    num_systems = beta.shape[0]
+    per_atom = _batch_pme_dispersion_self_energy_op(
+        c6_coefficients,
+        batch_idx.to(torch.int32),
+        beta.to(input_dtype),
+    )
+    out = torch.zeros(num_systems, dtype=input_dtype, device=c6_coefficients.device)
+    out.scatter_add_(0, batch_idx.to(torch.int64), per_atom)
+    return out
+
+
+###########################################################################################
+########################### Reciprocal-space dispersion PME ###############################
+###########################################################################################
+
+
+def pme_dispersion_reciprocal_space(
+    positions: torch.Tensor,
+    c6_coefficients: torch.Tensor,
+    cell: torch.Tensor,
+    beta: float | torch.Tensor,
+    mesh_dimensions: tuple[int, int, int] | None = None,
+    mesh_spacing: float | None = None,
+    spline_order: int = 4,
+    batch_idx: torch.Tensor | None = None,
+    k_vectors: torch.Tensor | None = None,
+    k_squared: torch.Tensor | None = None,
+    compute_forces: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Compute the dispersion PME reciprocal-space energy.
+
+    Implements the FFT-based long-range :math:`r^{-6}` contribution using
+    B-spline interpolation and convolution with the dispersion Green's
+    function:
+
+    .. math::
+
+        V_{\\text{recip}} = \\frac{\\pi^{3/2}\\beta^3}{2V}
+            \\sum_{m \\neq 0} f(\\pi|m|/\\beta)\\, |\\rho_{\\text{disp}}(m)|^2.
+
+    The spread quantity is :math:`\\sqrt{C_{6,ii}}` (geometric combination).
+
+    Parameters
+    ----------
+    positions : torch.Tensor, shape (N, 3)
+        Atomic coordinates.
+    c6_coefficients : torch.Tensor, shape (N,)
+        Per-atom homoatomic :math:`C_{6,ii}` values (non-negative).
+    cell : torch.Tensor, shape (3, 3) or (B, 3, 3)
+        Unit cell matrices.
+    beta : float or torch.Tensor
+        Dispersion Ewald splitting parameter. Scalar (broadcast) or shape (B,).
+    mesh_dimensions : tuple[int, int, int], optional
+        Explicit FFT mesh dimensions.
+    mesh_spacing : float, optional
+        Target mesh spacing in cell units.
+    spline_order : int, default=4
+        B-spline interpolation order.
+    batch_idx : torch.Tensor | None
+        System index for each atom.
+    k_vectors : torch.Tensor, optional
+        Precomputed k-vectors from ``generate_k_vectors_pme``.
+    k_squared : torch.Tensor, optional
+        Precomputed :math:`|k|^2` values.
+
+    Returns
+    -------
+    energy : torch.Tensor
+        - Single-system: shape (1,).
+        - Batch: shape (B,).
+    """
+    num_atoms = positions.shape[0]
+    input_dtype = positions.dtype
+    device = positions.device
+    is_batch = batch_idx is not None
+    fft_dims = (1, 2, 3) if is_batch else (0, 1, 2)
+
+    cell_b, num_systems = _prepare_cell(cell)
+
+    if num_atoms == 0:
+        empty_e = torch.zeros(
+            num_systems if is_batch else 1, dtype=input_dtype, device=device
+        )
+        if compute_forces:
+            return empty_e, torch.zeros((0, 3), dtype=input_dtype, device=device)
+        return empty_e
+
+    if mesh_dimensions is None:
+        if mesh_spacing is None:
+            raise ValueError("Either mesh_dimensions or mesh_spacing must be provided")
+        cell_lengths = torch.norm(cell_b[0], dim=1)
+        mesh_dimensions = tuple(
+            int(math.ceil(float(length) / mesh_spacing)) for length in cell_lengths
+        )
+
+    mesh_nx, mesh_ny, mesh_nz = mesh_dimensions
+    beta_tensor = _prepare_beta(beta, num_systems, input_dtype, device)
+
+    c6 = c6_coefficients.to(input_dtype)
+    sqrt_c6 = torch.sqrt(torch.clamp(c6, min=0.0))
+
+    mesh_grid = spline_spread(
+        positions,
+        sqrt_c6,
+        cell_b,
+        mesh_dims=(mesh_nx, mesh_ny, mesh_nz),
+        spline_order=spline_order,
+        batch_idx=batch_idx,
+    )
+
+    mesh_fft = torch.fft.rfftn(mesh_grid, norm="backward", dim=fft_dims)
+
+    if k_vectors is None or k_squared is None:
+        k_vectors, k_squared = generate_k_vectors_pme(cell_b, mesh_dimensions)
+
+    green_function, structure_factor_sq = pme_dispersion_green_structure_factor(
+        k_squared,
+        mesh_dimensions,
+        beta_tensor,
+        cell_b,
+        spline_order,
+        batch_idx=batch_idx,
+    )
+
+    mesh_fft = mesh_fft / structure_factor_sq
+    convolved_mesh = _materialize_complex(mesh_fft * green_function)
+
+    potential_mesh = torch.fft.irfftn(
+        convolved_mesh, norm="forward", s=mesh_dimensions, dim=fft_dims
+    )
+    potential_mesh = potential_mesh.to(input_dtype)
+
+    raw_potential = spline_gather(
+        positions,
+        potential_mesh,
+        cell_b,
+        spline_order=spline_order,
+        batch_idx=batch_idx,
+    )
+
+    per_atom = sqrt_c6 * raw_potential
+
+    if is_batch:
+        energy = torch.zeros(num_systems, dtype=input_dtype, device=device)
+        energy.scatter_add_(0, batch_idx.to(torch.int64), per_atom)
+    else:
+        energy = per_atom.sum().reshape(1)
+
+    if not compute_forces:
+        return energy
+
+    # Forces via Fourier gradient (same trick as Coulomb PME).
+    Ex_fft = _materialize_complex(-1j * k_vectors[..., 0] * convolved_mesh)
+    Ey_fft = _materialize_complex(-1j * k_vectors[..., 1] * convolved_mesh)
+    Ez_fft = _materialize_complex(-1j * k_vectors[..., 2] * convolved_mesh)
+    Ex = torch.fft.irfftn(Ex_fft, norm="forward", s=mesh_dimensions, dim=fft_dims)
+    Ey = torch.fft.irfftn(Ey_fft, norm="forward", s=mesh_dimensions, dim=fft_dims)
+    Ez = torch.fft.irfftn(Ez_fft, norm="forward", s=mesh_dimensions, dim=fft_dims)
+    gradient_field_mesh = torch.stack([Ex, Ey, Ez], dim=-1).to(input_dtype)
+
+    interpolated_gradient = spline_gather_vec3(
+        positions,
+        sqrt_c6,
+        gradient_field_mesh,
+        cell_b,
+        spline_order=spline_order,
+        batch_idx=batch_idx,
+    )
+    forces = 2.0 * interpolated_gradient
+    return energy, forces
+
+
+###########################################################################################
+########################### Real-space LJ-PME custom ops (PR2) ############################
+###########################################################################################
+
+
+@warp_custom_op(
+    name="alchemiops::_lj_pme_real_space_energy",
+    outputs=[
+        OutputSpec(
+            "atomic_energies",
+            lambda pos, *_: get_wp_dtype(pos.dtype),
+            lambda pos, *_: (pos.shape[0],),
+        ),
+    ],
+    grad_arrays=[
+        "atomic_energies",
+        "positions",
+        "c6_coefficients",
+        "c12_coefficients",
+        "cell",
+        "beta",
+    ],
+)
+def _lj_pme_real_space_energy_op(
+    positions: torch.Tensor,
+    c6_coefficients: torch.Tensor,
+    c12_coefficients: torch.Tensor,
+    cell: torch.Tensor,
+    neighbor_matrix: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor,
+    num_neighbors: torch.Tensor,
+    beta: torch.Tensor,
+    cutoff: torch.Tensor,
+    mask_value: int,
+    half_neighbor_list: bool,
+) -> torch.Tensor:
+    """Internal: real-space LJ-PME energies (single system, neighbor matrix)."""
+    num_atoms = positions.shape[0]
+    input_dtype = positions.dtype
+    device = wp.device_from_torch(positions.device)
+
+    wp_scalar = get_wp_dtype(input_dtype)
+    wp_vec = get_wp_vec_dtype(input_dtype)
+    wp_mat = get_wp_mat_dtype(input_dtype)
+    needs_grad_flag = needs_grad(
+        positions, c6_coefficients, c12_coefficients, cell, beta
+    )
+
+    wp_positions = warp_from_torch(positions, wp_vec, requires_grad=needs_grad_flag)
+    wp_c6 = warp_from_torch(c6_coefficients, wp_scalar, requires_grad=needs_grad_flag)
+    wp_c12 = warp_from_torch(c12_coefficients, wp_scalar, requires_grad=needs_grad_flag)
+    wp_cell = warp_from_torch(cell, wp_mat, requires_grad=needs_grad_flag)
+    wp_nbr = warp_from_torch(neighbor_matrix, wp.int32)
+    wp_nbr_shifts = warp_from_torch(neighbor_matrix_shifts, wp.vec3i)
+    wp_num_nbrs = warp_from_torch(num_neighbors, wp.int32)
+    wp_beta = warp_from_torch(beta, wp_scalar, requires_grad=needs_grad_flag)
+    wp_cutoff = warp_from_torch(cutoff, wp_scalar)
+
+    energies = torch.zeros(num_atoms, dtype=input_dtype, device=positions.device)
+    wp_energies = warp_from_torch(energies, wp_scalar, requires_grad=needs_grad_flag)
+
+    kernel = _lj_pme_real_space_energy_kernel_overload[wp_scalar]
+    with WarpAutogradContextManager(needs_grad_flag) as tape:
+        wp.launch(
+            kernel,
+            dim=num_atoms,
+            inputs=[
+                wp_positions,
+                wp_c6,
+                wp_c12,
+                wp_cell,
+                wp_nbr,
+                wp_nbr_shifts,
+                wp_num_nbrs,
+                wp_beta,
+                wp_cutoff,
+                wp.int32(mask_value),
+                bool(half_neighbor_list),
+            ],
+            outputs=[wp_energies],
+            device=device,
+        )
+    if needs_grad_flag:
+        attach_for_backward(
+            energies,
+            tape=tape,
+            atomic_energies=wp_energies,
+            positions=wp_positions,
+            c6_coefficients=wp_c6,
+            c12_coefficients=wp_c12,
+            cell=wp_cell,
+            beta=wp_beta,
+        )
+    return energies
+
+
+@warp_custom_op(
+    name="alchemiops::_lj_pme_real_space_energy_forces",
+    outputs=[
+        OutputSpec(
+            "atomic_energies",
+            lambda pos, *_: get_wp_dtype(pos.dtype),
+            lambda pos, *_: (pos.shape[0],),
+        ),
+        OutputSpec(
+            "atomic_forces",
+            lambda pos, *_: get_wp_vec_dtype(pos.dtype),
+            lambda pos, *_: (pos.shape[0], 3),
+        ),
+    ],
+    grad_arrays=[
+        "atomic_energies",
+        "atomic_forces",
+        "positions",
+        "c6_coefficients",
+        "c12_coefficients",
+        "cell",
+        "beta",
+    ],
+)
+def _lj_pme_real_space_energy_forces_op(
+    positions: torch.Tensor,
+    c6_coefficients: torch.Tensor,
+    c12_coefficients: torch.Tensor,
+    cell: torch.Tensor,
+    neighbor_matrix: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor,
+    num_neighbors: torch.Tensor,
+    beta: torch.Tensor,
+    cutoff: torch.Tensor,
+    mask_value: int,
+    half_neighbor_list: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Internal: real-space LJ-PME energies + forces."""
+    num_atoms = positions.shape[0]
+    input_dtype = positions.dtype
+    device = wp.device_from_torch(positions.device)
+
+    wp_scalar = get_wp_dtype(input_dtype)
+    wp_vec = get_wp_vec_dtype(input_dtype)
+    wp_mat = get_wp_mat_dtype(input_dtype)
+    needs_grad_flag = needs_grad(
+        positions, c6_coefficients, c12_coefficients, cell, beta
+    )
+
+    wp_positions = warp_from_torch(positions, wp_vec, requires_grad=needs_grad_flag)
+    wp_c6 = warp_from_torch(c6_coefficients, wp_scalar, requires_grad=needs_grad_flag)
+    wp_c12 = warp_from_torch(c12_coefficients, wp_scalar, requires_grad=needs_grad_flag)
+    wp_cell = warp_from_torch(cell, wp_mat, requires_grad=needs_grad_flag)
+    wp_nbr = warp_from_torch(neighbor_matrix, wp.int32)
+    wp_nbr_shifts = warp_from_torch(neighbor_matrix_shifts, wp.vec3i)
+    wp_num_nbrs = warp_from_torch(num_neighbors, wp.int32)
+    wp_beta = warp_from_torch(beta, wp_scalar, requires_grad=needs_grad_flag)
+    wp_cutoff = warp_from_torch(cutoff, wp_scalar)
+
+    energies = torch.zeros(num_atoms, dtype=input_dtype, device=positions.device)
+    forces = torch.zeros((num_atoms, 3), dtype=input_dtype, device=positions.device)
+    wp_energies = warp_from_torch(energies, wp_scalar, requires_grad=needs_grad_flag)
+    wp_forces = warp_from_torch(forces, wp_vec, requires_grad=needs_grad_flag)
+
+    kernel = _lj_pme_real_space_energy_forces_kernel_overload[wp_scalar]
+    with WarpAutogradContextManager(needs_grad_flag) as tape:
+        wp.launch(
+            kernel,
+            dim=num_atoms,
+            inputs=[
+                wp_positions,
+                wp_c6,
+                wp_c12,
+                wp_cell,
+                wp_nbr,
+                wp_nbr_shifts,
+                wp_num_nbrs,
+                wp_beta,
+                wp_cutoff,
+                wp.int32(mask_value),
+                bool(half_neighbor_list),
+            ],
+            outputs=[wp_energies, wp_forces],
+            device=device,
+        )
+    if needs_grad_flag:
+        attach_for_backward(
+            energies,
+            tape=tape,
+            atomic_energies=wp_energies,
+            atomic_forces=wp_forces,
+            positions=wp_positions,
+            c6_coefficients=wp_c6,
+            c12_coefficients=wp_c12,
+            cell=wp_cell,
+            beta=wp_beta,
+        )
+    return energies, forces
+
+
+@warp_custom_op(
+    name="alchemiops::_lj_pme_real_space_energy_forces_virial",
+    outputs=[
+        OutputSpec(
+            "atomic_energies",
+            lambda pos, *_: get_wp_dtype(pos.dtype),
+            lambda pos, *_: (pos.shape[0],),
+        ),
+        OutputSpec(
+            "atomic_forces",
+            lambda pos, *_: get_wp_vec_dtype(pos.dtype),
+            lambda pos, *_: (pos.shape[0], 3),
+        ),
+        OutputSpec(
+            "virial",
+            lambda pos, *_: get_wp_dtype(pos.dtype),
+            lambda *_: (9,),
+        ),
+    ],
+    grad_arrays=[
+        "atomic_energies",
+        "atomic_forces",
+        "virial",
+        "positions",
+        "c6_coefficients",
+        "c12_coefficients",
+        "cell",
+        "beta",
+    ],
+)
+def _lj_pme_real_space_energy_forces_virial_op(
+    positions: torch.Tensor,
+    c6_coefficients: torch.Tensor,
+    c12_coefficients: torch.Tensor,
+    cell: torch.Tensor,
+    neighbor_matrix: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor,
+    num_neighbors: torch.Tensor,
+    beta: torch.Tensor,
+    cutoff: torch.Tensor,
+    mask_value: int,
+    half_neighbor_list: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Internal: real-space LJ-PME energies + forces + virial."""
+    num_atoms = positions.shape[0]
+    input_dtype = positions.dtype
+    device = wp.device_from_torch(positions.device)
+
+    wp_scalar = get_wp_dtype(input_dtype)
+    wp_vec = get_wp_vec_dtype(input_dtype)
+    wp_mat = get_wp_mat_dtype(input_dtype)
+    needs_grad_flag = needs_grad(
+        positions, c6_coefficients, c12_coefficients, cell, beta
+    )
+
+    wp_positions = warp_from_torch(positions, wp_vec, requires_grad=needs_grad_flag)
+    wp_c6 = warp_from_torch(c6_coefficients, wp_scalar, requires_grad=needs_grad_flag)
+    wp_c12 = warp_from_torch(c12_coefficients, wp_scalar, requires_grad=needs_grad_flag)
+    wp_cell = warp_from_torch(cell, wp_mat, requires_grad=needs_grad_flag)
+    wp_nbr = warp_from_torch(neighbor_matrix, wp.int32)
+    wp_nbr_shifts = warp_from_torch(neighbor_matrix_shifts, wp.vec3i)
+    wp_num_nbrs = warp_from_torch(num_neighbors, wp.int32)
+    wp_beta = warp_from_torch(beta, wp_scalar, requires_grad=needs_grad_flag)
+    wp_cutoff = warp_from_torch(cutoff, wp_scalar)
+
+    energies = torch.zeros(num_atoms, dtype=input_dtype, device=positions.device)
+    forces = torch.zeros((num_atoms, 3), dtype=input_dtype, device=positions.device)
+    virial_flat = torch.zeros(9, dtype=input_dtype, device=positions.device)
+    wp_energies = warp_from_torch(energies, wp_scalar, requires_grad=needs_grad_flag)
+    wp_forces = warp_from_torch(forces, wp_vec, requires_grad=needs_grad_flag)
+    wp_virial = warp_from_torch(virial_flat, wp_scalar, requires_grad=needs_grad_flag)
+
+    kernel = _lj_pme_real_space_energy_forces_virial_kernel_overload[wp_scalar]
+    with WarpAutogradContextManager(needs_grad_flag) as tape:
+        wp.launch(
+            kernel,
+            dim=num_atoms,
+            inputs=[
+                wp_positions,
+                wp_c6,
+                wp_c12,
+                wp_cell,
+                wp_nbr,
+                wp_nbr_shifts,
+                wp_num_nbrs,
+                wp_beta,
+                wp_cutoff,
+                wp.int32(mask_value),
+                bool(half_neighbor_list),
+            ],
+            outputs=[wp_energies, wp_forces, wp_virial],
+            device=device,
+        )
+    if needs_grad_flag:
+        attach_for_backward(
+            energies,
+            tape=tape,
+            atomic_energies=wp_energies,
+            atomic_forces=wp_forces,
+            virial=wp_virial,
+            positions=wp_positions,
+            c6_coefficients=wp_c6,
+            c12_coefficients=wp_c12,
+            cell=wp_cell,
+            beta=wp_beta,
+        )
+    return energies, forces, virial_flat
+
+
+def lj_pme_real_space(
+    positions: torch.Tensor,
+    c6_coefficients: torch.Tensor,
+    c12_coefficients: torch.Tensor,
+    cell: torch.Tensor,
+    neighbor_matrix: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor,
+    beta: float | torch.Tensor,
+    cutoff: float,
+    num_neighbors: torch.Tensor | None = None,
+    mask_value: int | None = None,
+    compute_forces: bool = False,
+    compute_virial: bool = False,
+    half_neighbor_list: bool = True,
+) -> torch.Tensor | tuple[torch.Tensor, ...]:
+    """Real-space LJ-PME pair energy (and optionally forces and virial).
+
+    For each pair (i, j) with :math:`r_{ij} < r_{\\text{cut}}` the kernel
+    computes the damped Lennard-Jones pair contribution
+
+    .. math::
+
+        V_{ij} = \\frac{C_{12,ij}}{r_{ij}^{12}}
+                 - \\frac{C_{6,ij}\\, g(\\beta r_{ij})}{r_{ij}^{6}},
+        \\qquad
+        g(x) = e^{-x^2}\\bigl(1 + x^2 + x^4/2\\bigr),
+
+    with geometric combination rules
+    :math:`C_{6,ij} = \\sqrt{C_{6,ii} C_{6,jj}}`,
+    :math:`C_{12,ij} = \\sqrt{C_{12,ii} C_{12,jj}}`. The damping function
+    :math:`g` is the Wennberg complement of the long-range PME term so
+    that :math:`V_{\\text{real}} + V_{\\text{recip}} - V_{\\text{self}}`
+    recovers the bare :math:`r^{-6}` lattice sum.
+
+    Parameters
+    ----------
+    positions : torch.Tensor, shape (N, 3)
+        Atomic coordinates.
+    c6_coefficients : torch.Tensor, shape (N,)
+        Per-atom homoatomic :math:`C_{6,ii}` values.
+    c12_coefficients : torch.Tensor, shape (N,)
+        Per-atom homoatomic :math:`C_{12,ii}` values.
+    cell : torch.Tensor, shape (3, 3) or (1, 3, 3)
+        Unit cell matrix (single-system only in this PR).
+    neighbor_matrix : torch.Tensor, shape (N, max_neighbors), dtype int32
+        Half neighbor matrix: each pair (i, j) appears exactly once.
+        Invalid entries should equal ``mask_value``.
+    neighbor_matrix_shifts : torch.Tensor, shape (N, max_neighbors, 3), dtype int32
+        Periodic image shifts.
+    beta : float or torch.Tensor
+        Dispersion Ewald splitting parameter.
+    cutoff : float
+        Real-space cutoff radius.
+    num_neighbors : torch.Tensor | None, shape (N,), dtype int32
+        Valid neighbor count per atom. If None, inferred from ``neighbor_matrix``.
+    mask_value : int | None
+        Sentinel value marking invalid entries. Defaults to ``num_atoms``.
+    compute_forces : bool, default=False
+        If True, return explicit forces alongside the per-atom energy.
+    compute_virial : bool, default=False
+        If True, return the 3×3 virial tensor
+        :math:`W_{ab} = \\sum_{i<j} r_{ij,a}\\, F_{ij,b}`.
+
+    Returns
+    -------
+    energies : torch.Tensor, shape (N,)
+        Per-atom real-space dispersion energy (half-counted per pair).
+    forces : torch.Tensor, shape (N, 3), optional
+        Per-atom forces. Only returned when ``compute_forces=True``.
+    virial : torch.Tensor, shape (3, 3), optional
+        Virial tensor. Only returned when ``compute_virial=True``; always
+        last in the return tuple.
+    """
+    num_atoms = positions.shape[0]
+    input_dtype = positions.dtype
+    device = positions.device
+
+    if cell.dim() == 2:
+        cell_b = cell.unsqueeze(0)
+    else:
+        cell_b = cell
+    if cell_b.shape[0] != 1:
+        raise ValueError(
+            "lj_pme_real_space currently supports single-system cells; "
+            f"got cell shape {tuple(cell_b.shape)}."
+        )
+
+    c6 = c6_coefficients.to(input_dtype)
+    c12 = c12_coefficients.to(input_dtype)
+    cell_cast = cell_b.to(input_dtype)
+
+    if isinstance(beta, (int, float)):
+        beta_t = torch.tensor([float(beta)], dtype=input_dtype, device=device)
+    else:
+        beta_t = beta.to(input_dtype)
+        if beta_t.dim() == 0:
+            beta_t = beta_t.reshape(1)
+        if beta_t.numel() != 1:
+            raise ValueError(
+                "lj_pme_real_space currently supports a single beta value; "
+                f"got shape {tuple(beta_t.shape)}."
+            )
+
+    cutoff_t = torch.tensor([float(cutoff)], dtype=input_dtype, device=device)
+
+    nbr_mat_i32 = neighbor_matrix.to(torch.int32)
+    nbr_shifts_i32 = neighbor_matrix_shifts.to(torch.int32)
+
+    if mask_value is None:
+        mask_value = num_atoms
+
+    if num_neighbors is None:
+        valid = nbr_mat_i32 != mask_value
+        num_neighbors_t = valid.sum(dim=1).to(torch.int32)
+    else:
+        num_neighbors_t = num_neighbors.to(torch.int32)
+
+    if compute_virial:
+        energies, forces, virial_flat = _lj_pme_real_space_energy_forces_virial_op(
+            positions,
+            c6,
+            c12,
+            cell_cast,
+            nbr_mat_i32,
+            nbr_shifts_i32,
+            num_neighbors_t,
+            beta_t,
+            cutoff_t,
+            int(mask_value),
+            bool(half_neighbor_list),
+        )
+        virial = virial_flat.reshape(3, 3)
+        if compute_forces:
+            return energies, forces, virial
+        return energies, virial
+    elif compute_forces:
+        energies, forces = _lj_pme_real_space_energy_forces_op(
+            positions,
+            c6,
+            c12,
+            cell_cast,
+            nbr_mat_i32,
+            nbr_shifts_i32,
+            num_neighbors_t,
+            beta_t,
+            cutoff_t,
+            int(mask_value),
+            bool(half_neighbor_list),
+        )
+        return energies, forces
+    else:
+        return _lj_pme_real_space_energy_op(
+            positions,
+            c6,
+            c12,
+            cell_cast,
+            nbr_mat_i32,
+            nbr_shifts_i32,
+            num_neighbors_t,
+            beta_t,
+            cutoff_t,
+            int(mask_value),
+            bool(half_neighbor_list),
+        )
+
+
+###########################################################################################
+########################### Top-level LJ-PME orchestrator (PR3) ###########################
+###########################################################################################
+
+
+def lj_pme(
+    positions: torch.Tensor,
+    c6_coefficients: torch.Tensor,
+    c12_coefficients: torch.Tensor,
+    cell: torch.Tensor,
+    neighbor_matrix: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor,
+    beta: float | torch.Tensor | None = None,
+    cutoff: float | None = None,
+    mesh_spacing: float | None = None,
+    mesh_dimensions: tuple[int, int, int] | None = None,
+    spline_order: int = 4,
+    batch_idx: torch.Tensor | None = None,
+    num_neighbors: torch.Tensor | None = None,
+    mask_value: int | None = None,
+    compute_forces: bool = False,
+    accuracy: float = DISPERSION_DEFAULT_ACCURACY,
+    half_neighbor_list: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Complete LJ-PME energy (and optionally forces) for one or more systems.
+
+    Computes :math:`V_{\\text{total}} = V_{\\text{real}} + V_{\\text{recip}} - V_{\\text{self}}`
+    with geometric combination rules:
+
+    * Real-space damped sum (:func:`lj_pme_real_space`)
+    * Reciprocal-space FFT sum (:func:`pme_dispersion_reciprocal_space`)
+    * Self-energy correction (:func:`pme_dispersion_energy_corrections`)
+
+    If ``beta``, ``cutoff``, or ``mesh_dimensions`` are not provided they
+    are estimated jointly from ``accuracy`` (GROMACS-style matched-tail
+    criterion; see :func:`estimate_pme_dispersion_parameters`).
+
+    Parameters
+    ----------
+    positions : torch.Tensor, shape (N, 3)
+    c6_coefficients : torch.Tensor, shape (N,)
+    c12_coefficients : torch.Tensor, shape (N,)
+    cell : torch.Tensor, shape (3, 3) or (B, 3, 3)
+    neighbor_matrix : torch.Tensor, shape (N, max_neighbors), dtype int32
+    neighbor_matrix_shifts : torch.Tensor, shape (N, max_neighbors, 3), dtype int32
+    beta : float | torch.Tensor | None
+    cutoff : float | None
+    mesh_spacing : float | None
+    mesh_dimensions : tuple[int, int, int] | None
+    spline_order : int, default=4
+    batch_idx : torch.Tensor | None
+    num_neighbors : torch.Tensor | None
+    mask_value : int | None
+    compute_forces : bool, default=False
+    accuracy : float, default=1e-3
+
+    Returns
+    -------
+    energy : torch.Tensor
+        Shape (1,) or (B,).
+    forces : torch.Tensor, optional
+        Shape (N, 3) if ``compute_forces=True``.
+    """
+    is_batch = batch_idx is not None
+    if cell.dim() == 2:
+        cell_b = cell.unsqueeze(0)
+    else:
+        cell_b = cell
+    num_systems = cell_b.shape[0]
+    input_dtype = positions.dtype
+    device = positions.device
+
+    if cutoff is None:
+        cutoff = DISPERSION_DEFAULT_CUTOFF
+    if beta is None:
+        beta_scalar = solve_dispersion_beta(cutoff, accuracy)
+        beta_arr = torch.full(
+            (num_systems,), beta_scalar, dtype=input_dtype, device=device
+        )
+    elif isinstance(beta, (int, float)):
+        beta_arr = torch.full(
+            (num_systems,), float(beta), dtype=input_dtype, device=device
+        )
+    else:
+        beta_arr = beta.to(dtype=input_dtype, device=device)
+        if beta_arr.dim() == 0:
+            beta_arr = beta_arr.expand(num_systems).contiguous()
+        elif beta_arr.shape[0] == 1 and num_systems > 1:
+            beta_arr = beta_arr.expand(num_systems).contiguous()
+
+    if mesh_dimensions is None:
+        if mesh_spacing is not None:
+            cell_lengths = torch.linalg.norm(cell_b[0], dim=1)
+            mesh_dimensions = tuple(
+                int(math.ceil(float(length) / mesh_spacing)) for length in cell_lengths
+            )
+        else:
+            mesh_dimensions = estimate_pme_dispersion_mesh_dimensions(
+                cell_b, beta_arr, accuracy
+            )
+
+    # Real-space contribution.
+    if compute_forces:
+        e_real_per_atom, f_real = lj_pme_real_space(
+            positions,
+            c6_coefficients,
+            c12_coefficients,
+            cell_b if is_batch else cell,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            beta=beta_arr if not is_batch else beta_arr[:1],
+            cutoff=cutoff,
+            num_neighbors=num_neighbors,
+            mask_value=mask_value,
+            compute_forces=True,
+            half_neighbor_list=half_neighbor_list,
+        )
+    else:
+        e_real_per_atom = lj_pme_real_space(
+            positions,
+            c6_coefficients,
+            c12_coefficients,
+            cell_b if is_batch else cell,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            beta=beta_arr if not is_batch else beta_arr[:1],
+            cutoff=cutoff,
+            num_neighbors=num_neighbors,
+            mask_value=mask_value,
+            compute_forces=False,
+            half_neighbor_list=half_neighbor_list,
+        )
+        f_real = None
+
+    # Reciprocal-space contribution.
+    if compute_forces:
+        e_recip, f_recip = pme_dispersion_reciprocal_space(
+            positions,
+            c6_coefficients,
+            cell_b if is_batch else cell,
+            beta_arr,
+            mesh_dimensions=mesh_dimensions,
+            spline_order=spline_order,
+            batch_idx=batch_idx,
+            compute_forces=True,
+        )
+    else:
+        e_recip = pme_dispersion_reciprocal_space(
+            positions,
+            c6_coefficients,
+            cell_b if is_batch else cell,
+            beta_arr,
+            mesh_dimensions=mesh_dimensions,
+            spline_order=spline_order,
+            batch_idx=batch_idx,
+        )
+        f_recip = None
+
+    # Self-energy.
+    e_self = pme_dispersion_energy_corrections(
+        c6_coefficients, beta_arr, batch_idx=batch_idx
+    )
+
+    if is_batch:
+        e_real_per_system = torch.zeros(num_systems, dtype=input_dtype, device=device)
+        e_real_per_system.scatter_add_(0, batch_idx.to(torch.int64), e_real_per_atom)
+    else:
+        e_real_per_system = e_real_per_atom.sum().reshape(1)
+
+    energy = e_real_per_system + e_recip - e_self
+
+    if compute_forces:
+        forces = f_real + f_recip
+        return energy, forces
+    return energy

--- a/test/interactions/dispersion/bindings/jax/test_lj_pme.py
+++ b/test/interactions/dispersion/bindings/jax/test_lj_pme.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JAX integration tests for ``lj_pme`` (PR3)."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+pytest.importorskip("jax", reason="No JAX installed.")
+
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from nvalchemiops.jax.interactions.dispersion import (  # noqa: E402
+    estimate_pme_dispersion_parameters,
+    lj_pme,
+)
+from nvalchemiops.jax.interactions.dispersion.parameters import (  # noqa: E402
+    solve_dispersion_beta,
+)
+from nvalchemiops.jax.neighbors import neighbor_list as nbr_list_fn  # noqa: E402
+
+
+def _create_argon_fcc(n_cells: int, lattice_constant: float):
+    fcc = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.5, 0.0],
+            [0.5, 0.0, 0.5],
+            [0.0, 0.5, 0.5],
+        ]
+    )
+
+    # 1. Create a 3D grid of cell indices (i, j, k) with shape (n_cells, n_cells, n_cells, 3)
+    grid = np.stack(
+        np.meshgrid(range(n_cells), range(n_cells), range(n_cells), indexing="ij"),
+        axis=-1,
+    )
+
+    # 2. Reshape to exploit NumPy broadcasting:
+    #    cells shape:   (N_cells_total, 1, 3) where N_cells_total = n_cells^3
+    #    fcc shape:     (1, 4, 3)
+    cells = grid.reshape(-1, 1, 3)
+    fcc_basis = fcc.reshape(1, -1, 3)
+
+    # 3. Add them together (broadcasting creates shape (N_cells_total, 4, 3))
+    #    Then flatten the first two dimensions into (-1, 3) and scale by lattice_constant
+    positions_np = (cells + fcc_basis).reshape(-1, 3) * lattice_constant
+
+    # 4. Convert directly to JAX arrays
+    positions = jnp.array(positions_np, dtype=jnp.float64)
+
+    c6 = jnp.full((positions.shape[0],), 60.0, dtype=jnp.float64)
+    c12 = jnp.full((positions.shape[0],), 5.5e4, dtype=jnp.float64)
+    cell = jnp.eye(3, dtype=jnp.float64) * lattice_constant * n_cells
+
+    return positions, c6, c12, cell
+
+
+def _two_atom_system(r: float, box: float = 20.0):
+    positions = jnp.array([[0.0, 0.0, 0.0], [r, 0.0, 0.0]], dtype=jnp.float64)
+    c6 = jnp.array([60.0, 60.0], dtype=jnp.float64)
+    c12 = jnp.array([5.5e4, 5.5e4], dtype=jnp.float64)
+    cell = jnp.eye(3, dtype=jnp.float64) * box
+    return positions, c6, c12, cell
+
+
+@pytest.mark.gpu
+class TestParameterEstimatorJAX:
+    def test_solve_dispersion_beta(self):
+        for cutoff in [7.0, 9.0, 12.0]:
+            for tol in [1e-3, 1e-5]:
+                b = solve_dispersion_beta(cutoff, tol)
+                x = b * cutoff
+                g = math.exp(-x * x) * (1.0 + x * x + 0.5 * x * x * x * x)
+                assert g == pytest.approx(tol, rel=0.1)
+
+    def test_estimator_returns_dataclass(self, device):  # noqa: ARG002
+        cell = jnp.eye(3, dtype=jnp.float64) * 20.0
+        params = estimate_pme_dispersion_parameters(cell, cutoff=9.0, accuracy=1e-3)
+        assert params.cutoff == 9.0
+        assert params.beta.shape == (1,)
+        assert params.accuracy == 1e-3
+
+
+@pytest.mark.gpu
+class TestLJPMEOrchestratorJAX:
+    def test_auto_parameter_energy(self, device):  # noqa: ARG002
+        positions, c6, c12, cell = _create_argon_fcc(3, 5.26)
+        pbc = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        nm, nn, ns = nbr_list_fn(
+            positions, 9.0, cell=cell[None], pbc=pbc, return_neighbor_list=False
+        )
+        E = lj_pme(positions, c6, c12, cell, nm, ns, num_neighbors=nn)
+        assert E.shape == (1,)
+        assert float(E[0]) < 0.0
+        assert math.isfinite(float(E[0]))
+
+    def test_two_atom_matches_pair_formula(self, device):  # noqa: ARG002
+        r = 3.5
+        positions, c6, c12, cell = _two_atom_system(r)
+        pbc = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        cutoff = 12.0
+        nm, nn, ns = nbr_list_fn(
+            positions, cutoff, cell=cell[None], pbc=pbc, return_neighbor_list=False
+        )
+        beta = solve_dispersion_beta(cutoff, 1e-6)
+        E = lj_pme(
+            positions,
+            c6,
+            c12,
+            cell,
+            nm,
+            ns,
+            num_neighbors=nn,
+            beta=beta,
+            cutoff=cutoff,
+            mesh_dimensions=(128, 128, 128),
+        )
+        ref = 5.5e4 / r**12 - 60.0 / r**6
+        assert float(E[0]) == pytest.approx(ref, rel=0.1)
+
+    def test_momentum_conservation(self, device):  # noqa: ARG002
+        positions, c6, c12, cell = _create_argon_fcc(2, 5.26)
+        pbc = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        nm, nn, ns = nbr_list_fn(
+            positions, 9.0, cell=cell[None], pbc=pbc, return_neighbor_list=False
+        )
+        _, F = lj_pme(
+            positions, c6, c12, cell, nm, ns, num_neighbors=nn, compute_forces=True
+        )
+        np.testing.assert_allclose(np.asarray(F.sum(axis=0)), 0.0, atol=1e-9)
+
+    def test_translation_invariance(self, device):  # noqa: ARG002
+        positions, c6, c12, cell = _create_argon_fcc(2, 5.26)
+        pbc = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        nm, nn, ns = nbr_list_fn(
+            positions, 9.0, cell=cell[None], pbc=pbc, return_neighbor_list=False
+        )
+        E0 = lj_pme(
+            positions,
+            c6,
+            c12,
+            cell,
+            nm,
+            ns,
+            num_neighbors=nn,
+            mesh_dimensions=(48, 48, 48),
+        )
+        shift = jnp.array([0.7, 1.3, 2.1], dtype=jnp.float64)
+        shifted = positions + shift
+        nm2, nn2, ns2 = nbr_list_fn(
+            shifted, 9.0, cell=cell[None], pbc=pbc, return_neighbor_list=False
+        )
+        E1 = lj_pme(
+            shifted,
+            c6,
+            c12,
+            cell,
+            nm2,
+            ns2,
+            num_neighbors=nn2,
+            mesh_dimensions=(48, 48, 48),
+        )
+        assert float(E1[0]) == pytest.approx(float(E0[0]), rel=1e-5)
+
+    def test_dtype_parity(self, device):  # noqa: ARG002
+        positions, c6, c12, cell = _create_argon_fcc(2, 5.26)
+        pbc = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        nm, nn, ns = nbr_list_fn(
+            positions, 9.0, cell=cell[None], pbc=pbc, return_neighbor_list=False
+        )
+        E64 = lj_pme(positions, c6, c12, cell, nm, ns, num_neighbors=nn)
+        E32 = lj_pme(
+            positions.astype(jnp.float32),
+            c6.astype(jnp.float32),
+            c12.astype(jnp.float32),
+            cell.astype(jnp.float32),
+            nm,
+            ns,
+            num_neighbors=nn,
+        )
+        assert E64.dtype == jnp.float64
+        assert E32.dtype == jnp.float32
+        assert float(E32[0]) == pytest.approx(float(E64[0]), rel=1e-3)
+
+    def test_jit_compose(self, device):  # noqa: ARG002
+        """``lj_pme`` composes with ``jax.jit``."""
+        positions, c6, c12, cell = _create_argon_fcc(2, 5.26)
+        pbc = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        nm, nn, ns = nbr_list_fn(
+            positions, 9.0, cell=cell[None], pbc=pbc, return_neighbor_list=False
+        )
+
+        @jax.jit
+        def f(pos):
+            return lj_pme(
+                pos,
+                c6,
+                c12,
+                cell,
+                nm,
+                ns,
+                num_neighbors=nn,
+                beta=0.4,
+                cutoff=9.0,
+                mesh_dimensions=(32, 32, 32),
+            )[0]
+
+        E_jit = float(f(positions))
+        E_eager = float(
+            lj_pme(
+                positions,
+                c6,
+                c12,
+                cell,
+                nm,
+                ns,
+                num_neighbors=nn,
+                beta=0.4,
+                cutoff=9.0,
+                mesh_dimensions=(32, 32, 32),
+            )[0]
+        )
+        assert E_jit == pytest.approx(E_eager, rel=1e-12)

--- a/test/interactions/dispersion/bindings/jax/test_pme_dispersion.py
+++ b/test/interactions/dispersion/bindings/jax/test_pme_dispersion.py
@@ -1,0 +1,359 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JAX binding tests for dispersion PME (LJ-PME reciprocal-space + self-energy).
+
+Covers the same surface as the torch binding tests: self-energy formula,
+isolated-atom convergence, mesh convergence, batched vs single parity,
+and float32 vs float64 parity.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("jax", reason="No JAX installed.")
+
+# import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from nvalchemiops.jax.interactions.dispersion import (  # noqa: E402
+    lj_pme_real_space,
+    pme_dispersion_energy_corrections,
+    pme_dispersion_reciprocal_space,
+)
+
+
+@pytest.mark.gpu
+class TestPMEDispersionEnergyCorrectionsJAX:
+    """V_self = -β⁶ Σ C6_ii / 12 via the JAX binding."""
+
+    def test_single_system_total(self, device):  # noqa: ARG002
+        c6 = jnp.array([1.0, 2.5, 0.5], dtype=jnp.float64)
+        beta = jnp.array([0.4], dtype=jnp.float64)
+        out = pme_dispersion_energy_corrections(c6, beta)
+        expected = -(0.4**6) * (1.0 + 2.5 + 0.5) / 12.0
+        assert out.shape == (1,)
+        assert float(out[0]) == pytest.approx(expected, rel=1e-12)
+
+    def test_batched_per_system_sum(self, device):  # noqa: ARG002
+        c6 = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=jnp.float64)
+        batch_idx = jnp.array([0, 0, 1, 1, 1], dtype=jnp.int32)
+        beta = jnp.array([0.3, 0.5], dtype=jnp.float64)
+        out = pme_dispersion_energy_corrections(c6, beta, batch_idx=batch_idx)
+        exp_0 = -(0.3**6) * (1.0 + 2.0) / 12.0
+        exp_1 = -(0.5**6) * (3.0 + 4.0 + 5.0) / 12.0
+        assert out.shape == (2,)
+        assert float(out[0]) == pytest.approx(exp_0, rel=1e-12)
+        assert float(out[1]) == pytest.approx(exp_1, rel=1e-12)
+
+
+@pytest.mark.gpu
+class TestPMEDispersionReciprocalSpaceJAX:
+    """Reciprocal-space LJ-PME energy via the JAX binding."""
+
+    def test_isolated_atom_converges_to_self_energy(self, device):  # noqa: ARG002
+        """Single atom: V_recip / V_self → 1 as β grows."""
+        positions = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float64)
+        c6 = jnp.array([1.0], dtype=jnp.float64)
+        cell = jnp.eye(3, dtype=jnp.float64) * 20.0
+
+        rel_residuals = []
+        for beta_val in [0.3, 0.5, 0.8]:
+            beta = jnp.array([beta_val], dtype=jnp.float64)
+            E_recip = pme_dispersion_reciprocal_space(
+                positions,
+                c6,
+                cell,
+                beta,
+                mesh_dimensions=(64, 64, 64),
+                spline_order=4,
+            )
+            E_self = pme_dispersion_energy_corrections(c6, beta)
+            rel_residuals.append(
+                abs(float(E_recip[0]) - float(E_self[0])) / abs(float(E_self[0]))
+            )
+
+        assert rel_residuals[0] > rel_residuals[1] > rel_residuals[2]
+        assert rel_residuals[2] < 5e-3
+
+    def test_mesh_convergence(self, device):  # noqa: ARG002
+        positions = jnp.array([[2.0, 3.0, 4.0], [7.0, 6.0, 5.0]], dtype=jnp.float64)
+        c6 = jnp.array([1.0, 1.0], dtype=jnp.float64)
+        cell = jnp.eye(3, dtype=jnp.float64) * 10.0
+        beta = jnp.array([0.5], dtype=jnp.float64)
+
+        E_64 = float(
+            pme_dispersion_reciprocal_space(
+                positions, c6, cell, beta, mesh_dimensions=(64, 64, 64)
+            )[0]
+        )
+        E_96 = float(
+            pme_dispersion_reciprocal_space(
+                positions, c6, cell, beta, mesh_dimensions=(96, 96, 96)
+            )[0]
+        )
+        E_128 = float(
+            pme_dispersion_reciprocal_space(
+                positions, c6, cell, beta, mesh_dimensions=(128, 128, 128)
+            )[0]
+        )
+        err_64 = abs(E_64 - E_128)
+        err_96 = abs(E_96 - E_128)
+        assert err_96 < err_64
+        assert err_96 < 1e-4 * abs(E_128) + 1e-12
+
+    def test_batched_matches_stacked_singles(self, device):  # noqa: ARG002
+        positions = jnp.array(
+            [
+                [0.5, 0.5, 0.5],
+                [3.5, 0.5, 0.5],
+                [0.0, 0.0, 0.0],
+                [4.0, 0.0, 0.0],
+            ],
+            dtype=jnp.float64,
+        )
+        c6 = jnp.array([1.0, 1.0, 2.0, 0.5], dtype=jnp.float64)
+        cell_single = jnp.eye(3, dtype=jnp.float64) * 10.0
+        cell_batch = jnp.stack([cell_single, cell_single])
+        beta_batch = jnp.array([0.4, 0.5], dtype=jnp.float64)
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        mesh = (32, 32, 32)
+
+        E_batch = pme_dispersion_reciprocal_space(
+            positions,
+            c6,
+            cell_batch,
+            beta_batch,
+            mesh_dimensions=mesh,
+            batch_idx=batch_idx,
+        )
+        assert E_batch.shape == (2,)
+
+        E_0 = pme_dispersion_reciprocal_space(
+            positions[:2],
+            c6[:2],
+            cell_single,
+            jnp.array([float(beta_batch[0])], dtype=jnp.float64),
+            mesh_dimensions=mesh,
+        )
+        E_1 = pme_dispersion_reciprocal_space(
+            positions[2:],
+            c6[2:],
+            cell_single,
+            jnp.array([float(beta_batch[1])], dtype=jnp.float64),
+            mesh_dimensions=mesh,
+        )
+        assert float(E_batch[0]) == pytest.approx(float(E_0[0]), rel=1e-10)
+        assert float(E_batch[1]) == pytest.approx(float(E_1[0]), rel=1e-10)
+
+    def test_dtype_parity(self, device):  # noqa: ARG002
+        positions_f64 = jnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=jnp.float64)
+        c6_f64 = jnp.array([1.5, 0.8], dtype=jnp.float64)
+        cell_f64 = jnp.eye(3, dtype=jnp.float64) * 10.0
+        beta_f64 = jnp.array([0.5], dtype=jnp.float64)
+
+        E64 = pme_dispersion_reciprocal_space(
+            positions_f64, c6_f64, cell_f64, beta_f64, mesh_dimensions=(32, 32, 32)
+        )
+        E32 = pme_dispersion_reciprocal_space(
+            positions_f64.astype(jnp.float32),
+            c6_f64.astype(jnp.float32),
+            cell_f64.astype(jnp.float32),
+            beta_f64.astype(jnp.float32),
+            mesh_dimensions=(32, 32, 32),
+        )
+        assert E64.dtype == jnp.float64
+        assert E32.dtype == jnp.float32
+        assert float(E32[0]) == pytest.approx(float(E64[0]), rel=1e-3)
+
+    def test_empty_system_returns_zero(self, device):  # noqa: ARG002
+        positions = jnp.zeros((0, 3), dtype=jnp.float64)
+        c6 = jnp.zeros((0,), dtype=jnp.float64)
+        cell = jnp.eye(3, dtype=jnp.float64) * 10.0
+        beta = jnp.array([0.4], dtype=jnp.float64)
+        out = pme_dispersion_reciprocal_space(
+            positions, c6, cell, beta, mesh_dimensions=(16, 16, 16)
+        )
+        assert out.shape == (1,)
+        assert float(out[0]) == 0.0
+
+
+@pytest.mark.gpu
+class TestLJPMERealSpaceJAX:
+    """JAX binding tests for real-space LJ-PME (PR2)."""
+
+    @staticmethod
+    def _two_atom_pair(r=3.5):
+        positions = jnp.array([[0.0, 0.0, 0.0], [r, 0.0, 0.0]], dtype=jnp.float64)
+        c6 = jnp.array([60.0, 60.0], dtype=jnp.float64)
+        c12 = jnp.array([5e4, 5e4], dtype=jnp.float64)
+        cell = jnp.eye(3, dtype=jnp.float64) * 100.0
+        nbr_mat = jnp.array([[1], [2]], dtype=jnp.int32)
+        nbr_shifts = jnp.zeros((2, 1, 3), dtype=jnp.int32)
+        num_nbrs = jnp.array([1, 0], dtype=jnp.int32)
+        return positions, c6, c12, cell, nbr_mat, nbr_shifts, num_nbrs
+
+    def test_pair_energy_matches_analytical(self, device):  # noqa: ARG002
+        import math
+
+        positions, c6, c12, cell, nbr_mat, nbr_shifts, num_nbrs = self._two_atom_pair()
+        beta = jnp.array([0.35], dtype=jnp.float64)
+        e = lj_pme_real_space(
+            positions,
+            c6,
+            c12,
+            cell,
+            nbr_mat,
+            nbr_shifts,
+            beta=beta,
+            cutoff=10.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+        )
+        r = 3.5
+        x_sq = (0.35 * r) ** 2
+        g = math.exp(-x_sq) * (1 + x_sq + 0.5 * x_sq * x_sq)
+        expected = 5e4 / r**12 - 60.0 * g / r**6
+        assert float(e.sum()) == pytest.approx(expected, rel=1e-12)
+
+    def test_forces_finite_difference(self, device):  # noqa: ARG002
+        positions, c6, c12, cell, nbr_mat, nbr_shifts, num_nbrs = self._two_atom_pair()
+        beta = jnp.array([0.35], dtype=jnp.float64)
+
+        _, f_kernel = lj_pme_real_space(
+            positions,
+            c6,
+            c12,
+            cell,
+            nbr_mat,
+            nbr_shifts,
+            beta=beta,
+            cutoff=10.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+            compute_forces=True,
+        )
+
+        # FD over a 1D move of atom 1 along x.
+        def energy_at(r_val):
+            pos = jnp.array([[0.0, 0.0, 0.0], [r_val, 0.0, 0.0]], dtype=jnp.float64)
+            e = lj_pme_real_space(
+                pos,
+                c6,
+                c12,
+                cell,
+                nbr_mat,
+                nbr_shifts,
+                beta=beta,
+                cutoff=10.0,
+                num_neighbors=num_nbrs,
+                mask_value=2,
+            )
+            return float(e.sum())
+
+        h = 1e-5
+        dE_dr = (energy_at(3.5 + h) - energy_at(3.5 - h)) / (2 * h)
+        assert float(f_kernel[1, 0]) == pytest.approx(-dE_dr, rel=1e-5)
+        assert float(f_kernel[0, 0]) == pytest.approx(dE_dr, rel=1e-5)
+
+    def test_momentum_conservation(self, device):  # noqa: ARG002
+        positions, c6, c12, cell, nbr_mat, nbr_shifts, num_nbrs = self._two_atom_pair()
+        beta = jnp.array([0.35], dtype=jnp.float64)
+        _, f = lj_pme_real_space(
+            positions,
+            c6,
+            c12,
+            cell,
+            nbr_mat,
+            nbr_shifts,
+            beta=beta,
+            cutoff=10.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+            compute_forces=True,
+        )
+        import numpy as np
+
+        np.testing.assert_allclose(f.sum(axis=0), 0.0, atol=1e-12)
+
+    def test_zero_beyond_cutoff(self, device):  # noqa: ARG002
+        positions, c6, c12, cell, nbr_mat, nbr_shifts, num_nbrs = self._two_atom_pair(
+            r=6.0
+        )
+        beta = jnp.array([0.35], dtype=jnp.float64)
+        e = lj_pme_real_space(
+            positions,
+            c6,
+            c12,
+            cell,
+            nbr_mat,
+            nbr_shifts,
+            beta=beta,
+            cutoff=5.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+        )
+        assert float(e.sum()) == 0.0
+
+    def test_virial_finite_difference(self, device):  # noqa: ARG002
+        positions, c6, c12, cell, nbr_mat, nbr_shifts, num_nbrs = self._two_atom_pair()
+        beta = jnp.array([0.35], dtype=jnp.float64)
+
+        def energy_at_strain(eps):
+            I_plus_eps = jnp.eye(3, dtype=jnp.float64) + eps
+            pos_p = positions @ I_plus_eps.T
+            cell_p = cell @ I_plus_eps.T
+            e = lj_pme_real_space(
+                pos_p,
+                c6,
+                c12,
+                cell_p,
+                nbr_mat,
+                nbr_shifts,
+                beta=beta,
+                cutoff=10.0,
+                num_neighbors=num_nbrs,
+                mask_value=2,
+            )
+            return float(e.sum())
+
+        import numpy as np
+
+        h = 1e-5
+        fd = np.zeros((3, 3))
+        for a in range(3):
+            for b in range(3):
+                eps_plus = jnp.zeros((3, 3), dtype=jnp.float64).at[a, b].set(h)
+                eps_minus = jnp.zeros((3, 3), dtype=jnp.float64).at[a, b].set(-h)
+                fd[a, b] = (
+                    energy_at_strain(eps_plus) - energy_at_strain(eps_minus)
+                ) / (2 * h)
+
+        _, _, virial = lj_pme_real_space(
+            positions,
+            c6,
+            c12,
+            cell,
+            nbr_mat,
+            nbr_shifts,
+            beta=beta,
+            cutoff=10.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+            compute_forces=True,
+            compute_virial=True,
+        )
+        np.testing.assert_allclose(np.asarray(virial), -fd, rtol=1e-5, atol=1e-8)

--- a/test/interactions/dispersion/bindings/torch/test_lj_pme.py
+++ b/test/interactions/dispersion/bindings/torch/test_lj_pme.py
@@ -1,0 +1,436 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PyTorch integration tests for the top-level ``lj_pme`` orchestrator (PR3).
+
+Covers parameter estimation, end-to-end energy and forces, translation
+invariance, batch parity, dtype parity, and force consistency with
+autograd.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import torch
+import warp as wp
+
+from nvalchemiops.torch.interactions.dispersion import (
+    estimate_pme_dispersion_parameters,
+    lj_pme,
+)
+from nvalchemiops.torch.interactions.dispersion.parameters import (
+    solve_dispersion_beta,
+)
+from nvalchemiops.torch.neighbors import neighbor_list as nbr_list_fn
+
+
+@pytest.fixture(scope="module")
+def device():
+    if not wp.is_cuda_available():
+        pytest.skip("CUDA not available")
+    return torch.device("cuda")
+
+
+"""
+def _create_argon_fcc(n_cells: int, lattice_constant: float, device):
+    fcc = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.5, 0.0],
+            [0.5, 0.0, 0.5],
+            [0.0, 0.5, 0.5],
+        ]
+    )
+    positions = []
+    for i in range(n_cells):
+        for j in range(n_cells):
+            for k in range(n_cells):
+                for f in fcc:
+                    positions.append((f + np.array([i, j, k])) * lattice_constant)
+    positions = torch.tensor(np.array(positions), dtype=torch.float64, device=device)
+    c6 = torch.full((positions.shape[0],), 60.0, dtype=torch.float64, device=device)
+    c12 = torch.full((positions.shape[0],), 5.5e4, dtype=torch.float64, device=device)
+    cell = torch.eye(3, dtype=torch.float64, device=device) * lattice_constant * n_cells
+    return positions, c6, c12, cell
+"""
+
+
+def _create_argon_fcc(n_cells: int, lattice_constant: float, device):
+    """Argon FCC supercell as torch tensors."""
+    fcc = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.5, 0.0],
+            [0.5, 0.0, 0.5],
+            [0.0, 0.5, 0.5],
+        ]
+    )
+
+    # 1. Create a 3D grid of cell indices (i, j, k) with shape (n_cells, n_cells, n_cells, 3)
+    grid = np.stack(
+        np.meshgrid(range(n_cells), range(n_cells), range(n_cells), indexing="ij"),
+        axis=-1,
+    )
+
+    # 2. Reshape to exploit NumPy broadcasting:
+    #    cells shape:   (N_cells_total, 1, 3) where N_cells_total = n_cells^3
+    #    fcc shape:     (1, 4, 3)
+    cells = grid.reshape(-1, 1, 3)
+    fcc_basis = fcc.reshape(1, -1, 3)
+
+    # 3. Add them together (broadcasting creates shape (N_cells_total, 4, 3))
+    #    Then flatten the dimensions into (-1, 3) and scale by lattice_constant
+    positions_np = (cells + fcc_basis).reshape(-1, 3) * lattice_constant
+
+    # 4. Convert directly to PyTorch tensors on the target device
+    positions = torch.tensor(positions_np, dtype=torch.float64, device=device)
+
+    c6 = torch.full((positions.shape[0],), 60.0, dtype=torch.float64, device=device)
+    c12 = torch.full((positions.shape[0],), 5.5e4, dtype=torch.float64, device=device)
+    cell = torch.eye(3, dtype=torch.float64, device=device) * lattice_constant * n_cells
+
+    return positions, c6, c12, cell
+
+
+def _two_atom_system(r: float, device, box: float = 20.0):
+    positions = torch.tensor(
+        [[0.0, 0.0, 0.0], [r, 0.0, 0.0]], dtype=torch.float64, device=device
+    )
+    c6 = torch.tensor([60.0, 60.0], dtype=torch.float64, device=device)
+    c12 = torch.tensor([5.5e4, 5.5e4], dtype=torch.float64, device=device)
+    cell = torch.eye(3, dtype=torch.float64, device=device) * box
+    return positions, c6, c12, cell
+
+
+@pytest.mark.gpu
+class TestParameterEstimator:
+    """Tests for ``estimate_pme_dispersion_parameters``."""
+
+    def test_solve_dispersion_beta_satisfies_target(self):
+        for cutoff in [7.0, 9.0, 12.0]:
+            for tol in [1e-3, 1e-5]:
+                b = solve_dispersion_beta(cutoff, tol)
+                x = b * cutoff
+                g = math.exp(-x * x) * (1.0 + x * x + 0.5 * x * x * x * x)
+                # g(β·r_c) lands within ~10% of the target threshold
+                assert g == pytest.approx(tol, rel=0.1)
+
+    def test_estimator_returns_consistent_parameters(self, device):
+        cell = torch.eye(3, dtype=torch.float64, device=device) * 20.0
+        params = estimate_pme_dispersion_parameters(cell, cutoff=9.0, accuracy=1e-3)
+        assert params.cutoff == 9.0
+        assert params.beta.shape == (1,)
+        assert params.mesh_dimensions[0] >= 1
+        assert params.mesh_spacing.shape == (1, 3)
+        assert params.accuracy == 1e-3
+
+    def test_estimator_scales_mesh_with_cell(self, device):
+        cell_small = torch.eye(3, dtype=torch.float64, device=device) * 10.0
+        cell_large = torch.eye(3, dtype=torch.float64, device=device) * 30.0
+        p_small = estimate_pme_dispersion_parameters(cell_small, cutoff=9.0)
+        p_large = estimate_pme_dispersion_parameters(cell_large, cutoff=9.0)
+        assert p_large.mesh_dimensions[0] > p_small.mesh_dimensions[0]
+
+
+@pytest.mark.gpu
+class TestLJPMEOrchestrator:
+    """Top-level ``lj_pme()`` API tests."""
+
+    def test_auto_parameter_energy(self, device):
+        """Default-parameter call returns a finite, negative energy."""
+        positions, c6, c12, cell = _create_argon_fcc(3, 5.26, device)
+        pbc = torch.tensor([[True, True, True]], dtype=torch.bool, device=device)
+        cutoff = 9.0
+        nm, nn, ns = nbr_list_fn(
+            positions,
+            cutoff,
+            cell=cell.unsqueeze(0),
+            pbc=pbc,
+            return_neighbor_list=False,
+        )
+        E = lj_pme(positions, c6, c12, cell, nm, ns, num_neighbors=nn)
+        assert E.shape == (1,)
+        assert E.item() < 0.0
+        assert math.isfinite(E.item())
+
+    def test_two_atom_matches_pair_formula(self, device):
+        """Two-atom result matches the bare V_pair = C12/r^12 - C6/r^6."""
+        r = 3.5
+        positions, c6, c12, cell = _two_atom_system(r, device)
+        pbc = torch.tensor([[True, True, True]], dtype=torch.bool, device=device)
+        cutoff = 12.0
+        nm, nn, ns = nbr_list_fn(
+            positions,
+            cutoff,
+            cell=cell.unsqueeze(0),
+            pbc=pbc,
+            return_neighbor_list=False,
+        )
+        # Use a tight matched-tail accuracy and a fine mesh to converge.
+        beta = solve_dispersion_beta(cutoff, 1e-6)
+        E = lj_pme(
+            positions,
+            c6,
+            c12,
+            cell,
+            nm,
+            ns,
+            num_neighbors=nn,
+            beta=beta,
+            cutoff=cutoff,
+            mesh_dimensions=(128, 128, 128),
+        )
+        ref = 5.5e4 / r**12 - 60.0 / r**6
+        # Looser tolerance because matched-tail criterion is approximate;
+        # the answer should be within ~10% of the reference.
+        assert E.item() == pytest.approx(ref, rel=0.1)
+
+    def test_forces_match_real_space_plus_reciprocal(self, device):
+        """End-to-end forces equal the sum of the real- and reciprocal-space pieces."""
+        from nvalchemiops.torch.interactions.dispersion import (
+            lj_pme_real_space,
+            pme_dispersion_reciprocal_space,
+        )
+
+        positions, c6, c12, cell = _create_argon_fcc(2, 5.26, device)
+        pbc = torch.tensor([[True, True, True]], dtype=torch.bool, device=device)
+        cutoff = 8.0
+        beta = solve_dispersion_beta(cutoff, 1e-4)
+        nm, nn, ns = nbr_list_fn(
+            positions,
+            cutoff,
+            cell=cell.unsqueeze(0),
+            pbc=pbc,
+            return_neighbor_list=False,
+        )
+
+        _, F_total = lj_pme(
+            positions,
+            c6,
+            c12,
+            cell,
+            nm,
+            ns,
+            num_neighbors=nn,
+            beta=beta,
+            cutoff=cutoff,
+            mesh_dimensions=(32, 32, 32),
+            compute_forces=True,
+        )
+
+        beta_t = torch.tensor([beta], dtype=torch.float64, device=device)
+        _, F_real = lj_pme_real_space(
+            positions,
+            c6,
+            c12,
+            cell,
+            nm,
+            ns,
+            beta=beta_t,
+            cutoff=cutoff,
+            num_neighbors=nn,
+            compute_forces=True,
+            half_neighbor_list=False,
+        )
+        _, F_recip = pme_dispersion_reciprocal_space(
+            positions,
+            c6,
+            cell,
+            beta_t,
+            mesh_dimensions=(32, 32, 32),
+            compute_forces=True,
+        )
+        torch.testing.assert_close(F_total, F_real + F_recip, rtol=1e-10, atol=1e-12)
+
+    def test_momentum_conservation(self, device):
+        """Σ F = 0 for any system (Newton's 3rd law)."""
+        positions, c6, c12, cell = _create_argon_fcc(2, 5.26, device)
+        pbc = torch.tensor([[True, True, True]], dtype=torch.bool, device=device)
+        nm, nn, ns = nbr_list_fn(
+            positions, 9.0, cell=cell.unsqueeze(0), pbc=pbc, return_neighbor_list=False
+        )
+        _, F = lj_pme(
+            positions, c6, c12, cell, nm, ns, num_neighbors=nn, compute_forces=True
+        )
+        torch.testing.assert_close(
+            F.sum(dim=0),
+            torch.zeros(3, dtype=F.dtype, device=F.device),
+            atol=1e-9,
+            rtol=0,
+        )
+
+    def test_translation_invariance(self, device):
+        """Total energy is invariant under uniform translation of all atoms (modulo PBC)."""
+        positions, c6, c12, cell = _create_argon_fcc(2, 5.26, device)
+        pbc = torch.tensor([[True, True, True]], dtype=torch.bool, device=device)
+        nm, nn, ns = nbr_list_fn(
+            positions, 9.0, cell=cell.unsqueeze(0), pbc=pbc, return_neighbor_list=False
+        )
+        E0 = lj_pme(
+            positions,
+            c6,
+            c12,
+            cell,
+            nm,
+            ns,
+            num_neighbors=nn,
+            mesh_dimensions=(48, 48, 48),
+        )
+        shift = torch.tensor([0.7, 1.3, 2.1], dtype=torch.float64, device=device)
+        nm2, nn2, ns2 = nbr_list_fn(
+            positions + shift,
+            9.0,
+            cell=cell.unsqueeze(0),
+            pbc=pbc,
+            return_neighbor_list=False,
+        )
+        E1 = lj_pme(
+            positions + shift,
+            c6,
+            c12,
+            cell,
+            nm2,
+            ns2,
+            num_neighbors=nn2,
+            mesh_dimensions=(48, 48, 48),
+        )
+        # Discretization-limited; agreement at the 1e-5 level is expected.
+        assert E1.item() == pytest.approx(E0.item(), rel=1e-5)
+
+    def test_dtype_parity(self, device):
+        """float32 and float64 agree within float32 tolerance."""
+        positions, c6, c12, cell = _create_argon_fcc(2, 5.26, device)
+        pbc = torch.tensor([[True, True, True]], dtype=torch.bool, device=device)
+        nm, nn, ns = nbr_list_fn(
+            positions, 9.0, cell=cell.unsqueeze(0), pbc=pbc, return_neighbor_list=False
+        )
+        E64 = lj_pme(positions, c6, c12, cell, nm, ns, num_neighbors=nn)
+        E32 = lj_pme(
+            positions.to(torch.float32),
+            c6.to(torch.float32),
+            c12.to(torch.float32),
+            cell.to(torch.float32),
+            nm,
+            ns,
+            num_neighbors=nn,
+        )
+        assert E64.dtype == torch.float64
+        assert E32.dtype == torch.float32
+        assert E32.item() == pytest.approx(E64.item(), rel=1e-4)
+
+    @pytest.mark.xfail(
+        reason="lj_pme_real_space currently single-system only; "
+        "batched cells require a per-atom-cell kernel (future PR)."
+    )
+    def test_batched_matches_stacked_singles(self, device):
+        """Batched lj_pme matches concatenated single-system calls."""
+        pos_a, c6_a, c12_a, cell_a = _create_argon_fcc(2, 5.20, device)
+        pos_b, c6_b, c12_b, cell_b = _create_argon_fcc(2, 5.45, device)
+        pbc = torch.tensor([[True, True, True]], dtype=torch.bool, device=device)
+        cutoff = 9.0
+        mesh = (32, 32, 32)
+
+        # Batched
+        pos_batch = torch.cat([pos_a, pos_b], dim=0)
+        c6_batch = torch.cat([c6_a, c6_b], dim=0)
+        c12_batch = torch.cat([c12_a, c12_b], dim=0)
+        cell_batch = torch.stack([cell_a, cell_b])
+        batch_idx = torch.cat(
+            [
+                torch.zeros(pos_a.shape[0], dtype=torch.int32, device=device),
+                torch.ones(pos_b.shape[0], dtype=torch.int32, device=device),
+            ]
+        )
+        # Build a single neighbor matrix from per-system batched cell-list.
+        from nvalchemiops.torch.neighbors import batch_cell_list
+
+        nm, nn, ns = batch_cell_list(
+            pos_batch, cutoff, cell_batch, pbc, batch_idx=batch_idx, max_neighbors=128
+        )
+        beta = solve_dispersion_beta(cutoff, 1e-3)
+        E_batch = lj_pme(
+            pos_batch,
+            c6_batch,
+            c12_batch,
+            cell_batch,
+            nm,
+            ns,
+            num_neighbors=nn,
+            batch_idx=batch_idx,
+            beta=beta,
+            cutoff=cutoff,
+            mesh_dimensions=mesh,
+        )
+        assert E_batch.shape == (2,)
+
+        # Single systems
+        nm_a, nn_a, ns_a = nbr_list_fn(
+            pos_a, cutoff, cell=cell_a.unsqueeze(0), pbc=pbc, return_neighbor_list=False
+        )
+        nm_b, nn_b, ns_b = nbr_list_fn(
+            pos_b, cutoff, cell=cell_b.unsqueeze(0), pbc=pbc, return_neighbor_list=False
+        )
+        E_a = lj_pme(
+            pos_a,
+            c6_a,
+            c12_a,
+            cell_a,
+            nm_a,
+            ns_a,
+            num_neighbors=nn_a,
+            beta=beta,
+            cutoff=cutoff,
+            mesh_dimensions=mesh,
+        )
+        E_b = lj_pme(
+            pos_b,
+            c6_b,
+            c12_b,
+            cell_b,
+            nm_b,
+            ns_b,
+            num_neighbors=nn_b,
+            beta=beta,
+            cutoff=cutoff,
+            mesh_dimensions=mesh,
+        )
+        assert E_batch[0].item() == pytest.approx(E_a.item(), rel=1e-9)
+        assert E_batch[1].item() == pytest.approx(E_b.item(), rel=1e-9)
+
+    def test_explicit_beta_overrides_estimator(self, device):
+        """Explicit beta is used (estimator is bypassed)."""
+        positions, c6, c12, cell = _create_argon_fcc(2, 5.26, device)
+        pbc = torch.tensor([[True, True, True]], dtype=torch.bool, device=device)
+        nm, nn, ns = nbr_list_fn(
+            positions, 9.0, cell=cell.unsqueeze(0), pbc=pbc, return_neighbor_list=False
+        )
+        E_auto = lj_pme(positions, c6, c12, cell, nm, ns, num_neighbors=nn)
+        E_explicit = lj_pme(
+            positions,
+            c6,
+            c12,
+            cell,
+            nm,
+            ns,
+            num_neighbors=nn,
+            beta=0.4,
+            cutoff=9.0,
+            mesh_dimensions=(32, 32, 32),
+        )
+        # Different parameters → different result.
+        assert E_auto.item() != E_explicit.item()

--- a/test/interactions/dispersion/bindings/torch/test_pme_dispersion.py
+++ b/test/interactions/dispersion/bindings/torch/test_pme_dispersion.py
@@ -1,0 +1,480 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PyTorch binding tests for dispersion PME (LJ-PME reciprocal-space + self-energy).
+
+Covers:
+- Self-energy formula correctness.
+- Isolated-atom test: V_recip - V_self → 0 in the continuum/large-β limit.
+- Mesh convergence of V_recip.
+- Batched vs stacked-single parity.
+- Float32 vs float64 parity within tolerance.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import warp as wp
+
+from nvalchemiops.torch.interactions.dispersion import (
+    lj_pme_real_space,
+    pme_dispersion_energy_corrections,
+    pme_dispersion_reciprocal_space,
+)
+
+
+@pytest.fixture(scope="module")
+def device():
+    if not wp.is_cuda_available():
+        pytest.skip("CUDA not available")
+    return torch.device("cuda")
+
+
+@pytest.mark.gpu
+class TestPMEDispersionEnergyCorrections:
+    """V_self = -β⁶ Σ C6_ii / 12 via the torch binding."""
+
+    def test_single_system_total(self, device):
+        c6 = torch.tensor([1.0, 2.5, 0.5], dtype=torch.float64, device=device)
+        beta = torch.tensor([0.4], dtype=torch.float64, device=device)
+        out = pme_dispersion_energy_corrections(c6, beta)
+        expected = -(0.4**6) * (1.0 + 2.5 + 0.5) / 12.0
+        assert out.shape == (1,)
+        assert out.item() == pytest.approx(expected, rel=1e-12)
+
+    def test_batched_per_system_sum(self, device):
+        c6 = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], dtype=torch.float64, device=device)
+        batch_idx = torch.tensor([0, 0, 1, 1, 1], dtype=torch.int32, device=device)
+        beta = torch.tensor([0.3, 0.5], dtype=torch.float64, device=device)
+        out = pme_dispersion_energy_corrections(c6, beta, batch_idx=batch_idx)
+        exp_0 = -(0.3**6) * (1.0 + 2.0) / 12.0
+        exp_1 = -(0.5**6) * (3.0 + 4.0 + 5.0) / 12.0
+        assert out.shape == (2,)
+        assert out[0].item() == pytest.approx(exp_0, rel=1e-12)
+        assert out[1].item() == pytest.approx(exp_1, rel=1e-12)
+
+    def test_dtype_parity(self, device):
+        c6_f32 = torch.tensor([1.0, 2.5], dtype=torch.float32, device=device)
+        c6_f64 = c6_f32.to(torch.float64)
+        beta_f32 = torch.tensor([0.4], dtype=torch.float32, device=device)
+        beta_f64 = beta_f32.to(torch.float64)
+        out_f32 = pme_dispersion_energy_corrections(c6_f32, beta_f32)
+        out_f64 = pme_dispersion_energy_corrections(c6_f64, beta_f64)
+        assert out_f32.dtype == torch.float32
+        assert out_f64.dtype == torch.float64
+        assert out_f32.item() == pytest.approx(out_f64.item(), rel=1e-5)
+
+
+@pytest.mark.gpu
+class TestPMEDispersionReciprocalSpace:
+    """Reciprocal-space LJ-PME energy via the torch binding."""
+
+    def test_isolated_atom_converges_to_self_energy(self, device):
+        """Single atom: V_recip / V_self → 1 as β grows (continuum limit).
+
+        For large β the dispersion long-range complement is sharply peaked
+        near r=0 so periodic-image contributions become negligible, and the
+        FFT-evaluated lattice sum should converge to the i=j limit
+        captured by V_self. We track *relative* error since |V_self| grows
+        as β^6 so absolute residuals are not directly comparable.
+        """
+        positions = torch.tensor([[0.0, 0.0, 0.0]], dtype=torch.float64, device=device)
+        c6 = torch.tensor([1.0], dtype=torch.float64, device=device)
+        cell = torch.eye(3, dtype=torch.float64, device=device) * 20.0
+
+        rel_residuals = []
+        for beta_val in [0.3, 0.5, 0.8]:
+            beta = torch.tensor([beta_val], dtype=torch.float64, device=device)
+            E_recip = pme_dispersion_reciprocal_space(
+                positions,
+                c6,
+                cell,
+                beta,
+                mesh_dimensions=(64, 64, 64),
+                spline_order=4,
+            )
+            E_self = pme_dispersion_energy_corrections(c6, beta)
+            rel_residuals.append(
+                abs(E_recip.item() - E_self.item()) / abs(E_self.item())
+            )
+
+        # Relative residual decreases monotonically as β increases.
+        assert rel_residuals[0] > rel_residuals[1] > rel_residuals[2]
+        # At β=0.8 the relative residual is below 0.5%.
+        assert rel_residuals[2] < 5e-3
+
+    def test_mesh_convergence(self, device):
+        """V_recip converges as the mesh becomes finer (fixed β, fixed atoms)."""
+        positions = torch.tensor(
+            [[2.0, 3.0, 4.0], [7.0, 6.0, 5.0]],
+            dtype=torch.float64,
+            device=device,
+        )
+        c6 = torch.tensor([1.0, 1.0], dtype=torch.float64, device=device)
+        cell = torch.eye(3, dtype=torch.float64, device=device) * 10.0
+        beta = torch.tensor([0.5], dtype=torch.float64, device=device)
+
+        E_64 = pme_dispersion_reciprocal_space(
+            positions, c6, cell, beta, mesh_dimensions=(64, 64, 64)
+        ).item()
+        E_96 = pme_dispersion_reciprocal_space(
+            positions, c6, cell, beta, mesh_dimensions=(96, 96, 96)
+        ).item()
+        E_128 = pme_dispersion_reciprocal_space(
+            positions, c6, cell, beta, mesh_dimensions=(128, 128, 128)
+        ).item()
+
+        # Errors decrease as mesh refines (relative to the finest result).
+        err_64 = abs(E_64 - E_128)
+        err_96 = abs(E_96 - E_128)
+        assert err_96 < err_64
+        # Between 96 and 128 we're already well-converged.
+        assert err_96 < 1e-4 * abs(E_128) + 1e-12
+
+    def test_batched_matches_stacked_singles(self, device):
+        """Batched evaluation matches stacked single-system evaluations."""
+        # Two independent two-atom systems in identical 10 Å cubic boxes.
+        positions = torch.tensor(
+            [
+                [0.5, 0.5, 0.5],
+                [3.5, 0.5, 0.5],
+                [0.0, 0.0, 0.0],
+                [4.0, 0.0, 0.0],
+            ],
+            dtype=torch.float64,
+            device=device,
+        )
+        c6 = torch.tensor([1.0, 1.0, 2.0, 0.5], dtype=torch.float64, device=device)
+        cell_single = torch.eye(3, dtype=torch.float64, device=device) * 10.0
+        cell_batch = torch.stack([cell_single, cell_single])
+        beta_batch = torch.tensor([0.4, 0.5], dtype=torch.float64, device=device)
+        batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=device)
+        mesh = (32, 32, 32)
+
+        E_batch = pme_dispersion_reciprocal_space(
+            positions,
+            c6,
+            cell_batch,
+            beta_batch,
+            mesh_dimensions=mesh,
+            batch_idx=batch_idx,
+        )
+        assert E_batch.shape == (2,)
+
+        E_0 = pme_dispersion_reciprocal_space(
+            positions[:2],
+            c6[:2],
+            cell_single,
+            torch.tensor([beta_batch[0].item()], dtype=torch.float64, device=device),
+            mesh_dimensions=mesh,
+        )
+        E_1 = pme_dispersion_reciprocal_space(
+            positions[2:],
+            c6[2:],
+            cell_single,
+            torch.tensor([beta_batch[1].item()], dtype=torch.float64, device=device),
+            mesh_dimensions=mesh,
+        )
+        assert E_batch[0].item() == pytest.approx(E_0.item(), rel=1e-10)
+        assert E_batch[1].item() == pytest.approx(E_1.item(), rel=1e-10)
+
+    def test_dtype_parity(self, device):
+        """float32 and float64 results agree within float32 tolerance."""
+        positions_f64 = torch.tensor(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.float64, device=device
+        )
+        c6_f64 = torch.tensor([1.5, 0.8], dtype=torch.float64, device=device)
+        cell_f64 = torch.eye(3, dtype=torch.float64, device=device) * 10.0
+        beta_f64 = torch.tensor([0.5], dtype=torch.float64, device=device)
+
+        E64 = pme_dispersion_reciprocal_space(
+            positions_f64, c6_f64, cell_f64, beta_f64, mesh_dimensions=(32, 32, 32)
+        )
+        E32 = pme_dispersion_reciprocal_space(
+            positions_f64.to(torch.float32),
+            c6_f64.to(torch.float32),
+            cell_f64.to(torch.float32),
+            beta_f64.to(torch.float32),
+            mesh_dimensions=(32, 32, 32),
+        )
+        assert E64.dtype == torch.float64
+        assert E32.dtype == torch.float32
+        assert E32.item() == pytest.approx(E64.item(), rel=2e-4)
+
+    def test_empty_system_returns_zero(self, device):
+        positions = torch.zeros((0, 3), dtype=torch.float64, device=device)
+        c6 = torch.zeros((0,), dtype=torch.float64, device=device)
+        cell = torch.eye(3, dtype=torch.float64, device=device) * 10.0
+        beta = torch.tensor([0.4], dtype=torch.float64, device=device)
+        out = pme_dispersion_reciprocal_space(
+            positions, c6, cell, beta, mesh_dimensions=(16, 16, 16)
+        )
+        assert out.shape == (1,)
+        assert out.item() == 0.0
+
+    def test_translation_invariance(self, device):
+        """Reciprocal energy is invariant under uniform shifts (modulo PBC).
+
+        Shifting all atoms by the same vector leaves |ρ(k)| unchanged in
+        principle; on the B-spline mesh this holds up to discretization
+        error, which decreases with mesh resolution and spline order.
+        """
+        positions = torch.tensor(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+            dtype=torch.float64,
+            device=device,
+        )
+        c6 = torch.tensor([1.0, 2.0, 0.5], dtype=torch.float64, device=device)
+        cell = torch.eye(3, dtype=torch.float64, device=device) * 10.0
+        beta = torch.tensor([0.4], dtype=torch.float64, device=device)
+        mesh = (64, 64, 64)
+
+        E0 = pme_dispersion_reciprocal_space(
+            positions, c6, cell, beta, mesh_dimensions=mesh
+        )
+        shifted = positions + torch.tensor(
+            [0.7, 1.3, 2.1], dtype=torch.float64, device=device
+        )
+        E1 = pme_dispersion_reciprocal_space(
+            shifted, c6, cell, beta, mesh_dimensions=mesh
+        )
+        # Discretization-limited; expect agreement at the 1e-5 level.
+        assert E1.item() == pytest.approx(E0.item(), rel=1e-5)
+
+
+@pytest.mark.gpu
+class TestLJPMERealSpace:
+    """Real-space LJ-PME binding tests (PR2)."""
+
+    @staticmethod
+    def _two_atom_pair(device, r=3.5):
+        """Two atoms separated by ``r`` along x with a half neighbor list."""
+        positions = torch.tensor(
+            [[0.0, 0.0, 0.0], [r, 0.0, 0.0]], dtype=torch.float64, device=device
+        )
+        c6 = torch.tensor([60.0, 60.0], dtype=torch.float64, device=device)
+        c12 = torch.tensor([5e4, 5e4], dtype=torch.float64, device=device)
+        cell = torch.eye(3, dtype=torch.float64, device=device) * 100.0
+        nbr_mat = torch.tensor([[1], [2]], dtype=torch.int32, device=device)
+        nbr_shifts = torch.zeros((2, 1, 3), dtype=torch.int32, device=device)
+        num_nbrs = torch.tensor([1, 0], dtype=torch.int32, device=device)
+        return positions, c6, c12, cell, nbr_mat, nbr_shifts, num_nbrs
+
+    def test_pair_energy_matches_analytical(self, device):
+        import math
+
+        positions, c6, c12, cell, nbr_mat, nbr_shifts, num_nbrs = self._two_atom_pair(
+            device
+        )
+        beta = torch.tensor([0.35], dtype=torch.float64, device=device)
+        e = lj_pme_real_space(
+            positions,
+            c6,
+            c12,
+            cell,
+            nbr_mat,
+            nbr_shifts,
+            beta=beta,
+            cutoff=10.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+        )
+        r = 3.5
+        x_sq = (0.35 * r) ** 2
+        g = math.exp(-x_sq) * (1 + x_sq + 0.5 * x_sq * x_sq)
+        expected = 5e4 / r**12 - 60.0 * g / r**6
+        assert e.sum().item() == pytest.approx(expected, rel=1e-12)
+
+    def test_forces_match_autograd(self, device):
+        positions, c6, c12, cell, nbr_mat, nbr_shifts, num_nbrs = self._two_atom_pair(
+            device
+        )
+        beta = torch.tensor([0.35], dtype=torch.float64, device=device)
+
+        # Forces from kernel
+        _, f_kernel = lj_pme_real_space(
+            positions,
+            c6,
+            c12,
+            cell,
+            nbr_mat,
+            nbr_shifts,
+            beta=beta,
+            cutoff=10.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+            compute_forces=True,
+        )
+
+        # Forces from autograd: F = -dE/d positions
+        positions_g = positions.clone().requires_grad_(True)
+        e = lj_pme_real_space(
+            positions_g,
+            c6,
+            c12,
+            cell,
+            nbr_mat,
+            nbr_shifts,
+            beta=beta,
+            cutoff=10.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+        )
+        e.sum().backward()
+        f_autograd = -positions_g.grad
+
+        torch.testing.assert_close(f_kernel, f_autograd, rtol=1e-10, atol=1e-12)
+
+    def test_momentum_conservation(self, device):
+        positions, c6, c12, cell, nbr_mat, nbr_shifts, num_nbrs = self._two_atom_pair(
+            device
+        )
+        beta = torch.tensor([0.35], dtype=torch.float64, device=device)
+        _, f = lj_pme_real_space(
+            positions,
+            c6,
+            c12,
+            cell,
+            nbr_mat,
+            nbr_shifts,
+            beta=beta,
+            cutoff=10.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+            compute_forces=True,
+        )
+        torch.testing.assert_close(
+            f.sum(0), torch.zeros(3, dtype=f.dtype, device=f.device), atol=1e-12, rtol=0
+        )
+
+    def test_virial_finite_difference(self, device):
+        """Compare kernel virial against FD over uniform strain (float64).
+
+        Apply x'_i = (I + eps) x_i and cell' = (I + eps) cell. The
+        derivative dE/d(eps_ab) at eps=0 equals the negative virial:
+        ``W_ab = -dE/d(eps_ab)``. The Warp kernel returns
+        :math:`W = \\sum_{i<j} r_{ij} F_{ij}`, which equals
+        :math:`+dE/d(eps)` (sign convention W = -dE/deps means the
+        kernel's positive accumulator measures the "stress" form).
+        Here we just check that the kernel result agrees with FD up to
+        the expected sign.
+        """
+        positions, c6, c12, cell, nbr_mat, nbr_shifts, num_nbrs = self._two_atom_pair(
+            device
+        )
+        beta = torch.tensor([0.35], dtype=torch.float64, device=device)
+
+        def energy_at_strain(eps):
+            I_plus_eps = torch.eye(3, dtype=torch.float64, device=device) + eps
+            pos_p = positions @ I_plus_eps.T
+            cell_p = cell @ I_plus_eps.T
+            e = lj_pme_real_space(
+                pos_p,
+                c6,
+                c12,
+                cell_p,
+                nbr_mat,
+                nbr_shifts,
+                beta=beta,
+                cutoff=10.0,
+                num_neighbors=num_nbrs,
+                mask_value=2,
+            )
+            return float(e.sum())
+
+        h = 1e-5
+        fd = torch.zeros(3, 3, dtype=torch.float64, device=device)
+        for a in range(3):
+            for b in range(3):
+                eps_plus = torch.zeros(3, 3, dtype=torch.float64, device=device)
+                eps_plus[a, b] = h
+                eps_minus = torch.zeros(3, 3, dtype=torch.float64, device=device)
+                eps_minus[a, b] = -h
+                fd[a, b] = (
+                    energy_at_strain(eps_plus) - energy_at_strain(eps_minus)
+                ) / (2 * h)
+
+        _, _, virial = lj_pme_real_space(
+            positions,
+            c6,
+            c12,
+            cell,
+            nbr_mat,
+            nbr_shifts,
+            beta=beta,
+            cutoff=10.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+            compute_forces=True,
+            compute_virial=True,
+        )
+        # Kernel uses W_ab = sum r_ij,a F_ij,b ; dE/deps = -W (so eq with -fd).
+        torch.testing.assert_close(virial, -fd, rtol=1e-5, atol=1e-8)
+
+    def test_zero_beyond_cutoff(self, device):
+        positions, c6, c12, cell, nbr_mat, nbr_shifts, num_nbrs = self._two_atom_pair(
+            device, r=6.0
+        )
+        beta = torch.tensor([0.35], dtype=torch.float64, device=device)
+        e = lj_pme_real_space(
+            positions,
+            c6,
+            c12,
+            cell,
+            nbr_mat,
+            nbr_shifts,
+            beta=beta,
+            cutoff=5.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+        )
+        assert e.sum().item() == 0.0
+
+    def test_dtype_parity(self, device):
+        positions_f64, c6_f64, c12_f64, cell_f64, nbr_mat, nbr_shifts, num_nbrs = (
+            self._two_atom_pair(device)
+        )
+        beta_f64 = torch.tensor([0.35], dtype=torch.float64, device=device)
+        e64, f64 = lj_pme_real_space(
+            positions_f64,
+            c6_f64,
+            c12_f64,
+            cell_f64,
+            nbr_mat,
+            nbr_shifts,
+            beta=beta_f64,
+            cutoff=10.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+            compute_forces=True,
+        )
+        e32, f32 = lj_pme_real_space(
+            positions_f64.to(torch.float32),
+            c6_f64.to(torch.float32),
+            c12_f64.to(torch.float32),
+            cell_f64.to(torch.float32),
+            nbr_mat,
+            nbr_shifts,
+            beta=beta_f64.to(torch.float32),
+            cutoff=10.0,
+            num_neighbors=num_nbrs,
+            mask_value=2,
+            compute_forces=True,
+        )
+        assert e64.dtype == torch.float64
+        assert e32.dtype == torch.float32
+        assert e32.sum().item() == pytest.approx(e64.sum().item(), rel=1e-5)
+        torch.testing.assert_close(f32.to(torch.float64), f64, rtol=1e-4, atol=1e-6)

--- a/test/interactions/dispersion/conftest.py
+++ b/test/interactions/dispersion/conftest.py
@@ -584,6 +584,12 @@ def precision(request):
 # PyTorch binding tests should import D3Parameters from nvalchemiops.torch.interactions.dispersion
 
 
+@pytest.fixture(params=[wp.float32, wp.float64], ids=["float32", "float64"])
+def wp_dtype(request):
+    """Parameterized fixture for Warp scalar dtypes (float32 and float64)."""
+    return request.param
+
+
 # ==============================================================================
 # Reference Output Fixtures
 # ==============================================================================

--- a/test/interactions/dispersion/test_pme_dispersion_kernels.py
+++ b/test/interactions/dispersion/test_pme_dispersion_kernels.py
@@ -1,0 +1,738 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Framework-agnostic tests for the dispersion PME Warp kernels."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import warp as wp
+from scipy.special import erfc as np_erfc
+
+from nvalchemiops.interactions.dispersion.pme_dispersion_kernels import (
+    batch_pme_dispersion_green_structure_factor,
+    batch_pme_dispersion_self_energy,
+    lj_pme_real_space_energy,
+    lj_pme_real_space_energy_forces,
+    lj_pme_real_space_energy_forces_virial,
+    pme_dispersion_green_structure_factor,
+    pme_dispersion_self_energy,
+)
+
+PI = math.pi
+SQRT_PI = math.sqrt(PI)
+PI_3_2 = PI * SQRT_PI
+
+
+def _np_dtype(wp_dtype):
+    return np.float64 if wp_dtype == wp.float64 else np.float32
+
+
+def _rtol(wp_dtype):
+    return 1e-6 if wp_dtype == wp.float64 else 1e-4
+
+
+def _scalar(value, device, wp_dtype):
+    return wp.array([_np_dtype(wp_dtype)(value)], dtype=wp_dtype, device=device)
+
+
+def _f_reference(x):
+    """NumPy reference for f(x) = (1/3)[(1-2x²)e^(-x²) + 2x³√π·erfc(x)]."""
+    x_sq = x * x
+    return (1.0 / 3.0) * (
+        (1.0 - 2.0 * x_sq) * np.exp(-x_sq) + 2.0 * x_sq * x * SQRT_PI * np_erfc(x)
+    )
+
+
+###########################################################################################
+########################### Helper f(x) reference values ##################################
+###########################################################################################
+
+
+class TestDispersionFReference:
+    """f(x) at known points — pure NumPy reference values used elsewhere."""
+
+    def test_f_at_zero(self):
+        """f(0) = 1/3 (erfc(0)=1, exp(0)=1, (1-0)*1 + 0 = 1)."""
+        assert _f_reference(0.0) == pytest.approx(1.0 / 3.0, rel=1e-12)
+
+    def test_f_decays_at_infinity(self):
+        """f(x) → 0 as x → ∞."""
+        assert _f_reference(10.0) == pytest.approx(0.0, abs=1e-10)
+
+    def test_f_is_monotonically_decreasing(self):
+        """f is monotonically decreasing on [0, ∞)."""
+        xs = np.linspace(0.0, 5.0, 50)
+        vals = _f_reference(xs)
+        assert np.all(np.diff(vals) < 0.0)
+
+
+###########################################################################################
+########################### Green's Function Kernel #######################################
+###########################################################################################
+
+
+class TestDispersionGreenStructureFactor:
+    """Tests for _pme_dispersion_green_structure_factor_kernel."""
+
+    def test_shapes(self, device, wp_dtype):
+        mesh_nx, mesh_ny, mesh_nz = 8, 8, 8
+        nz_rfft = mesh_nz // 2 + 1
+
+        k_squared = wp.zeros((mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device)
+        miller_x = wp.zeros(mesh_nx, dtype=wp_dtype, device=device)
+        miller_y = wp.zeros(mesh_ny, dtype=wp_dtype, device=device)
+        miller_z = wp.zeros(nz_rfft, dtype=wp_dtype, device=device)
+        beta = _scalar(0.3, device, wp_dtype)
+        volume = _scalar(1000.0, device, wp_dtype)
+
+        green_function = wp.zeros(
+            (mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device
+        )
+        structure_factor_sq = wp.zeros(
+            (mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device
+        )
+
+        pme_dispersion_green_structure_factor(
+            k_squared=k_squared,
+            miller_x=miller_x,
+            miller_y=miller_y,
+            miller_z=miller_z,
+            beta=beta,
+            volume=volume,
+            mesh_nx=mesh_nx,
+            mesh_ny=mesh_ny,
+            mesh_nz=mesh_nz,
+            spline_order=4,
+            green_function=green_function,
+            structure_factor_sq=structure_factor_sq,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+        assert green_function.shape == (mesh_nx, mesh_ny, nz_rfft)
+        assert structure_factor_sq.shape == (mesh_nx, mesh_ny, nz_rfft)
+
+    def test_green_k0_is_zero(self, device, wp_dtype):
+        """G(k=0) is explicitly set to zero (m=0 mode excluded)."""
+        mesh_nx, mesh_ny, mesh_nz = 4, 4, 4
+        nz_rfft = mesh_nz // 2 + 1
+        np_dtype = _np_dtype(wp_dtype)
+
+        # All k_sq nonzero except (0,0,0)
+        k_sq_np = np.ones((mesh_nx, mesh_ny, nz_rfft), dtype=np_dtype)
+        k_sq_np[0, 0, 0] = 0.0
+        k_squared = wp.array(k_sq_np, dtype=wp_dtype, device=device)
+
+        miller_x = wp.zeros(mesh_nx, dtype=wp_dtype, device=device)
+        miller_y = wp.zeros(mesh_ny, dtype=wp_dtype, device=device)
+        miller_z = wp.zeros(nz_rfft, dtype=wp_dtype, device=device)
+        beta = _scalar(0.3, device, wp_dtype)
+        volume = _scalar(1000.0, device, wp_dtype)
+
+        green_function = wp.zeros(
+            (mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device
+        )
+        structure_factor_sq = wp.zeros(
+            (mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device
+        )
+
+        pme_dispersion_green_structure_factor(
+            k_squared=k_squared,
+            miller_x=miller_x,
+            miller_y=miller_y,
+            miller_z=miller_z,
+            beta=beta,
+            volume=volume,
+            mesh_nx=mesh_nx,
+            mesh_ny=mesh_ny,
+            mesh_nz=mesh_nz,
+            spline_order=4,
+            green_function=green_function,
+            structure_factor_sq=structure_factor_sq,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+        assert green_function.numpy()[0, 0, 0] == 0.0
+
+    def test_green_formula(self, device, wp_dtype):
+        """G(k) = -(π^(3/2) β³ / (2V)) · f(|k|/(2β)) at non-zero k."""
+        mesh_nx, mesh_ny, mesh_nz = 4, 4, 4
+        nz_rfft = mesh_nz // 2 + 1
+        np_dtype = _np_dtype(wp_dtype)
+        beta_val = 0.5
+        volume_val = 100.0
+
+        k_sq_val = 4.0
+        k_sq_np = np.full((mesh_nx, mesh_ny, nz_rfft), k_sq_val, dtype=np_dtype)
+        k_sq_np[0, 0, 0] = 0.0
+        k_squared = wp.array(k_sq_np, dtype=wp_dtype, device=device)
+
+        miller_x = wp.zeros(mesh_nx, dtype=wp_dtype, device=device)
+        miller_y = wp.zeros(mesh_ny, dtype=wp_dtype, device=device)
+        miller_z = wp.zeros(nz_rfft, dtype=wp_dtype, device=device)
+        beta = _scalar(beta_val, device, wp_dtype)
+        volume = _scalar(volume_val, device, wp_dtype)
+
+        green_function = wp.zeros(
+            (mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device
+        )
+        structure_factor_sq = wp.zeros(
+            (mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device
+        )
+
+        pme_dispersion_green_structure_factor(
+            k_squared=k_squared,
+            miller_x=miller_x,
+            miller_y=miller_y,
+            miller_z=miller_z,
+            beta=beta,
+            volume=volume,
+            mesh_nx=mesh_nx,
+            mesh_ny=mesh_ny,
+            mesh_nz=mesh_nz,
+            spline_order=4,
+            green_function=green_function,
+            structure_factor_sq=structure_factor_sq,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+
+        # Expected: G(k) = -(π^(3/2)·β³/(2V))·f(|k|/(2β))
+        x = math.sqrt(k_sq_val) / (2.0 * beta_val)
+        f_val = _f_reference(np.array(x, dtype=np.float64))
+        expected = -PI_3_2 * (beta_val**3) * float(f_val) / (2.0 * volume_val)
+
+        green_np = green_function.numpy()
+        # All non-k=0 points share the same k_squared, so all should match expected
+        for ix in range(mesh_nx):
+            for iy in range(mesh_ny):
+                for iz in range(nz_rfft):
+                    if ix == 0 and iy == 0 and iz == 0:
+                        assert green_np[ix, iy, iz] == 0.0
+                    else:
+                        assert green_np[ix, iy, iz] == pytest.approx(
+                            expected, rel=_rtol(wp_dtype)
+                        )
+
+    def test_green_is_negative_for_nonzero_k(self, device, wp_dtype):
+        """G(k) < 0 for k != 0 (attractive dispersion convention)."""
+        mesh_nx, mesh_ny, mesh_nz = 8, 8, 8
+        nz_rfft = mesh_nz // 2 + 1
+        np_dtype = _np_dtype(wp_dtype)
+
+        rng = np.random.default_rng(0)
+        k_sq_np = rng.uniform(0.1, 10.0, size=(mesh_nx, mesh_ny, nz_rfft)).astype(
+            np_dtype
+        )
+        k_sq_np[0, 0, 0] = 0.0
+        k_squared = wp.array(k_sq_np, dtype=wp_dtype, device=device)
+
+        miller_x = wp.zeros(mesh_nx, dtype=wp_dtype, device=device)
+        miller_y = wp.zeros(mesh_ny, dtype=wp_dtype, device=device)
+        miller_z = wp.zeros(nz_rfft, dtype=wp_dtype, device=device)
+        beta = _scalar(0.5, device, wp_dtype)
+        volume = _scalar(125.0, device, wp_dtype)
+
+        green_function = wp.zeros(
+            (mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device
+        )
+        structure_factor_sq = wp.zeros(
+            (mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device
+        )
+
+        pme_dispersion_green_structure_factor(
+            k_squared=k_squared,
+            miller_x=miller_x,
+            miller_y=miller_y,
+            miller_z=miller_z,
+            beta=beta,
+            volume=volume,
+            mesh_nx=mesh_nx,
+            mesh_ny=mesh_ny,
+            mesh_nz=mesh_nz,
+            spline_order=4,
+            green_function=green_function,
+            structure_factor_sq=structure_factor_sq,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+
+        green_np = green_function.numpy()
+        # k=0 exactly zero, all others strictly negative
+        assert green_np[0, 0, 0] == 0.0
+        assert np.all(green_np[1:] < 0.0) or np.all(green_np.reshape(-1)[1:] < 0.0)
+
+    def test_batched_green_matches_single(self, device, wp_dtype):
+        """Batched kernel result matches stacked single-system result."""
+        mesh_nx, mesh_ny, mesh_nz = 8, 8, 8
+        nz_rfft = mesh_nz // 2 + 1
+        np_dtype = _np_dtype(wp_dtype)
+        num_systems = 3
+
+        rng = np.random.default_rng(42)
+        k_sq_single = rng.uniform(0.1, 10.0, size=(mesh_nx, mesh_ny, nz_rfft)).astype(
+            np_dtype
+        )
+        k_sq_single[0, 0, 0] = 0.0
+        k_sq_batch_np = np.broadcast_to(
+            k_sq_single, (num_systems, mesh_nx, mesh_ny, nz_rfft)
+        ).copy()
+
+        miller_x = wp.zeros(mesh_nx, dtype=wp_dtype, device=device)
+        miller_y = wp.zeros(mesh_ny, dtype=wp_dtype, device=device)
+        miller_z = wp.zeros(nz_rfft, dtype=wp_dtype, device=device)
+
+        betas = np.array([0.3, 0.4, 0.5], dtype=np_dtype)
+        volumes = np.array([100.0, 150.0, 200.0], dtype=np_dtype)
+
+        # Batched run
+        beta_batch = wp.array(betas, dtype=wp_dtype, device=device)
+        volumes_batch = wp.array(volumes, dtype=wp_dtype, device=device)
+        k_sq_batch = wp.array(k_sq_batch_np, dtype=wp_dtype, device=device)
+        green_batch = wp.zeros(
+            (num_systems, mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device
+        )
+        sf_batch = wp.zeros((mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device)
+        batch_pme_dispersion_green_structure_factor(
+            k_squared=k_sq_batch,
+            miller_x=miller_x,
+            miller_y=miller_y,
+            miller_z=miller_z,
+            beta=beta_batch,
+            volumes=volumes_batch,
+            mesh_nx=mesh_nx,
+            mesh_ny=mesh_ny,
+            mesh_nz=mesh_nz,
+            spline_order=4,
+            green_function=green_batch,
+            structure_factor_sq=sf_batch,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+
+        # Single runs
+        for s in range(num_systems):
+            beta_s = _scalar(float(betas[s]), device, wp_dtype)
+            volume_s = _scalar(float(volumes[s]), device, wp_dtype)
+            k_sq_s = wp.array(k_sq_single, dtype=wp_dtype, device=device)
+            green_s = wp.zeros(
+                (mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device
+            )
+            sf_s = wp.zeros((mesh_nx, mesh_ny, nz_rfft), dtype=wp_dtype, device=device)
+            pme_dispersion_green_structure_factor(
+                k_squared=k_sq_s,
+                miller_x=miller_x,
+                miller_y=miller_y,
+                miller_z=miller_z,
+                beta=beta_s,
+                volume=volume_s,
+                mesh_nx=mesh_nx,
+                mesh_ny=mesh_ny,
+                mesh_nz=mesh_nz,
+                spline_order=4,
+                green_function=green_s,
+                structure_factor_sq=sf_s,
+                wp_dtype=wp_dtype,
+                device=device,
+            )
+            np.testing.assert_allclose(
+                green_batch.numpy()[s],
+                green_s.numpy(),
+                rtol=_rtol(wp_dtype),
+            )
+
+
+###########################################################################################
+########################### Self-Energy Kernel ############################################
+###########################################################################################
+
+
+class TestDispersionSelfEnergy:
+    """Tests for _pme_dispersion_self_energy_kernel."""
+
+    def test_per_atom_formula(self, device, wp_dtype):
+        """Per-atom value equals -β⁶ · C6_ii / 12."""
+        np_dtype = _np_dtype(wp_dtype)
+        c6_np = np.array([1.0, 2.5, 0.5, 4.0], dtype=np_dtype)
+        beta_val = 0.4
+
+        c6 = wp.array(c6_np, dtype=wp_dtype, device=device)
+        beta = _scalar(beta_val, device, wp_dtype)
+        out = wp.zeros(len(c6_np), dtype=wp_dtype, device=device)
+
+        pme_dispersion_self_energy(
+            c6_coefficients=c6,
+            beta=beta,
+            energy_correction=out,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+
+        expected = -(beta_val**6) * c6_np / 12.0
+        np.testing.assert_allclose(out.numpy(), expected, rtol=_rtol(wp_dtype))
+
+    def test_zero_c6_gives_zero(self, device, wp_dtype):
+        """Atoms with C6=0 have zero self-energy contribution."""
+        np_dtype = _np_dtype(wp_dtype)
+        c6_np = np.zeros(5, dtype=np_dtype)
+        c6 = wp.array(c6_np, dtype=wp_dtype, device=device)
+        beta = _scalar(0.3, device, wp_dtype)
+        out = wp.zeros(5, dtype=wp_dtype, device=device)
+
+        pme_dispersion_self_energy(
+            c6_coefficients=c6,
+            beta=beta,
+            energy_correction=out,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+        np.testing.assert_array_equal(out.numpy(), np.zeros(5, dtype=np_dtype))
+
+    def test_sign_is_negative_for_positive_c6(self, device, wp_dtype):
+        """Self-energy is negative when C6 > 0 (attractive dispersion)."""
+        np_dtype = _np_dtype(wp_dtype)
+        c6_np = np.array([1.0, 2.0, 3.0], dtype=np_dtype)
+        c6 = wp.array(c6_np, dtype=wp_dtype, device=device)
+        beta = _scalar(0.5, device, wp_dtype)
+        out = wp.zeros(3, dtype=wp_dtype, device=device)
+
+        pme_dispersion_self_energy(
+            c6_coefficients=c6,
+            beta=beta,
+            energy_correction=out,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+        assert np.all(out.numpy() < 0.0)
+
+    def test_batched_self_energy_matches_per_system(self, device, wp_dtype):
+        """Batched kernel respects per-system beta via batch_idx."""
+        np_dtype = _np_dtype(wp_dtype)
+        c6_np = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np_dtype)
+        batch_idx_np = np.array([0, 0, 1, 1, 1], dtype=np.int32)
+        beta_np = np.array([0.3, 0.5], dtype=np_dtype)
+
+        c6 = wp.array(c6_np, dtype=wp_dtype, device=device)
+        batch_idx = wp.array(batch_idx_np, dtype=wp.int32, device=device)
+        beta = wp.array(beta_np, dtype=wp_dtype, device=device)
+        out = wp.zeros(5, dtype=wp_dtype, device=device)
+
+        batch_pme_dispersion_self_energy(
+            c6_coefficients=c6,
+            batch_idx=batch_idx,
+            beta=beta,
+            energy_correction=out,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+
+        expected = np.empty_like(c6_np)
+        for i in range(len(c6_np)):
+            b = beta_np[batch_idx_np[i]]
+            expected[i] = -(b**6) * c6_np[i] / 12.0
+        np.testing.assert_allclose(out.numpy(), expected, rtol=_rtol(wp_dtype))
+
+
+###########################################################################################
+########################### Real-Space LJ-PME Kernels (PR2) ###############################
+###########################################################################################
+
+
+def _lj_pme_pair_energy(r, c6, c12, beta):
+    """Reference V(r) = C12/r^12 - C6 * g(beta*r) / r^6 with g = exp(-x^2)(1+x^2+x^4/2)."""
+    x_sq = (beta * r) ** 2
+    g = np.exp(-x_sq) * (1.0 + x_sq + 0.5 * x_sq * x_sq)
+    return c12 / r**12 - c6 * g / r**6
+
+
+def _make_pair_inputs(r, c6_pair, c12_pair, beta_val, cutoff, device, wp_dtype):
+    """Construct a 2-atom system with one half-neighbor pair separated by ``r``."""
+    np_dtype = _np_dtype(wp_dtype)
+    vec_dtype = wp.vec3d if wp_dtype == wp.float64 else wp.vec3f
+    mat_dtype = wp.mat33d if wp_dtype == wp.float64 else wp.mat33f
+
+    positions_np = np.array([[0.0, 0.0, 0.0], [r, 0.0, 0.0]], dtype=np_dtype)
+    positions = wp.array(positions_np, dtype=vec_dtype, device=device)
+
+    cell_np = (np.eye(3, dtype=np_dtype) * 100.0).reshape(1, 3, 3)
+    cell = wp.array(cell_np, dtype=mat_dtype, device=device)
+
+    c6 = wp.array(
+        np.array([c6_pair, c6_pair], dtype=np_dtype), dtype=wp_dtype, device=device
+    )
+    c12 = wp.array(
+        np.array([c12_pair, c12_pair], dtype=np_dtype), dtype=wp_dtype, device=device
+    )
+
+    nbr_mat_np = np.array([[1], [2]], dtype=np.int32)  # half list: 0->1, 1->padding
+    nbr_mat = wp.array(nbr_mat_np, dtype=wp.int32, device=device)
+    nbr_shifts = wp.array(
+        np.zeros((2, 1, 3), dtype=np.int32), dtype=wp.vec3i, device=device
+    )
+    num_nbrs = wp.array(np.array([1, 0], dtype=np.int32), dtype=wp.int32, device=device)
+
+    beta = _scalar(beta_val, device, wp_dtype)
+    cutoff_arr = _scalar(cutoff, device, wp_dtype)
+    return {
+        "positions": positions,
+        "c6": c6,
+        "c12": c12,
+        "cell": cell,
+        "nbr_mat": nbr_mat,
+        "nbr_shifts": nbr_shifts,
+        "num_nbrs": num_nbrs,
+        "beta": beta,
+        "cutoff": cutoff_arr,
+        "mask_value": 2,
+    }
+
+
+class TestLJPMERealSpaceEnergy:
+    """Pair energy correctness for the real-space LJ-PME kernel."""
+
+    @pytest.mark.parametrize("r", [3.0, 4.0, 5.5])
+    def test_pair_energy_matches_analytical(self, device, wp_dtype, r):
+        c6, c12, beta_val, cutoff = 60.0, 5e4, 0.35, 10.0
+        inp = _make_pair_inputs(r, c6, c12, beta_val, cutoff, device, wp_dtype)
+        energies = wp.zeros(2, dtype=wp_dtype, device=device)
+        lj_pme_real_space_energy(
+            positions=inp["positions"],
+            c6_coefficients=inp["c6"],
+            c12_coefficients=inp["c12"],
+            cell=inp["cell"],
+            neighbor_matrix=inp["nbr_mat"],
+            neighbor_matrix_shifts=inp["nbr_shifts"],
+            num_neighbors=inp["num_nbrs"],
+            beta=inp["beta"],
+            cutoff=inp["cutoff"],
+            mask_value=inp["mask_value"],
+            atomic_energies=energies,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+        total = float(energies.numpy().sum())
+        expected = _lj_pme_pair_energy(r, c6, c12, beta_val)
+        assert total == pytest.approx(expected, rel=_rtol(wp_dtype))
+
+    def test_zero_beta_recovers_full_lj(self, device, wp_dtype):
+        """With beta=0 the damping g(0)=1 and we recover C12/r^12 - C6/r^6."""
+        r, c6, c12 = 3.5, 60.0, 5e4
+        # Note: kernel uses beta>0 in production; use a tiny beta to approximate.
+        inp = _make_pair_inputs(r, c6, c12, 1e-8, 10.0, device, wp_dtype)
+        energies = wp.zeros(2, dtype=wp_dtype, device=device)
+        lj_pme_real_space_energy(
+            positions=inp["positions"],
+            c6_coefficients=inp["c6"],
+            c12_coefficients=inp["c12"],
+            cell=inp["cell"],
+            neighbor_matrix=inp["nbr_mat"],
+            neighbor_matrix_shifts=inp["nbr_shifts"],
+            num_neighbors=inp["num_nbrs"],
+            beta=inp["beta"],
+            cutoff=inp["cutoff"],
+            mask_value=inp["mask_value"],
+            atomic_energies=energies,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+        total = float(energies.numpy().sum())
+        bare_lj = c12 / r**12 - c6 / r**6
+        assert total == pytest.approx(bare_lj, rel=_rtol(wp_dtype))
+
+    def test_pair_beyond_cutoff_is_zero(self, device, wp_dtype):
+        """Pairs with r > cutoff contribute zero."""
+        r, c6, c12, beta_val, cutoff = 6.0, 60.0, 5e4, 0.35, 5.0
+        inp = _make_pair_inputs(r, c6, c12, beta_val, cutoff, device, wp_dtype)
+        energies = wp.zeros(2, dtype=wp_dtype, device=device)
+        lj_pme_real_space_energy(
+            positions=inp["positions"],
+            c6_coefficients=inp["c6"],
+            c12_coefficients=inp["c12"],
+            cell=inp["cell"],
+            neighbor_matrix=inp["nbr_mat"],
+            neighbor_matrix_shifts=inp["nbr_shifts"],
+            num_neighbors=inp["num_nbrs"],
+            beta=inp["beta"],
+            cutoff=inp["cutoff"],
+            mask_value=inp["mask_value"],
+            atomic_energies=energies,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+        assert float(energies.numpy().sum()) == 0.0
+
+    def test_energy_split_equally_per_pair(self, device, wp_dtype):
+        """Half-list: each atom of the pair receives V/2."""
+        r, c6, c12, beta_val = 3.5, 60.0, 5e4, 0.35
+        inp = _make_pair_inputs(r, c6, c12, beta_val, 10.0, device, wp_dtype)
+        energies = wp.zeros(2, dtype=wp_dtype, device=device)
+        lj_pme_real_space_energy(
+            positions=inp["positions"],
+            c6_coefficients=inp["c6"],
+            c12_coefficients=inp["c12"],
+            cell=inp["cell"],
+            neighbor_matrix=inp["nbr_mat"],
+            neighbor_matrix_shifts=inp["nbr_shifts"],
+            num_neighbors=inp["num_nbrs"],
+            beta=inp["beta"],
+            cutoff=inp["cutoff"],
+            mask_value=inp["mask_value"],
+            atomic_energies=energies,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+        e_np = energies.numpy()
+        assert e_np[0] == pytest.approx(e_np[1], rel=_rtol(wp_dtype))
+
+
+class TestLJPMERealSpaceForces:
+    """Force correctness for the real-space LJ-PME kernel."""
+
+    def test_forces_satisfy_newton_third_law(self, device, wp_dtype):
+        r, c6, c12, beta_val = 3.5, 60.0, 5e4, 0.35
+        inp = _make_pair_inputs(r, c6, c12, beta_val, 10.0, device, wp_dtype)
+        vec_dtype = wp.vec3d if wp_dtype == wp.float64 else wp.vec3f
+        energies = wp.zeros(2, dtype=wp_dtype, device=device)
+        forces = wp.zeros(2, dtype=vec_dtype, device=device)
+        lj_pme_real_space_energy_forces(
+            positions=inp["positions"],
+            c6_coefficients=inp["c6"],
+            c12_coefficients=inp["c12"],
+            cell=inp["cell"],
+            neighbor_matrix=inp["nbr_mat"],
+            neighbor_matrix_shifts=inp["nbr_shifts"],
+            num_neighbors=inp["num_nbrs"],
+            beta=inp["beta"],
+            cutoff=inp["cutoff"],
+            mask_value=inp["mask_value"],
+            atomic_energies=energies,
+            atomic_forces=forces,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+        f = forces.numpy()
+        # Forces are equal and opposite.
+        np.testing.assert_allclose(
+            f.sum(axis=0), 0.0, atol=1e-12 if wp_dtype == wp.float64 else 1e-5
+        )
+        np.testing.assert_allclose(f[1], -f[0], rtol=_rtol(wp_dtype))
+
+    @pytest.mark.parametrize("r", [2.8, 3.5, 4.5])
+    def test_forces_match_finite_difference(self, device, wp_dtype, r):
+        """Compare against -dV/dr_i via central differences (float64 only)."""
+        if wp_dtype == wp.float32:
+            pytest.skip("FD test requires float64 precision")
+        c6, c12, beta_val, cutoff = 60.0, 5e4, 0.35, 10.0
+
+        def energy_at(r_val):
+            inp = _make_pair_inputs(r_val, c6, c12, beta_val, cutoff, device, wp_dtype)
+            e = wp.zeros(2, dtype=wp_dtype, device=device)
+            lj_pme_real_space_energy(
+                positions=inp["positions"],
+                c6_coefficients=inp["c6"],
+                c12_coefficients=inp["c12"],
+                cell=inp["cell"],
+                neighbor_matrix=inp["nbr_mat"],
+                neighbor_matrix_shifts=inp["nbr_shifts"],
+                num_neighbors=inp["num_nbrs"],
+                beta=inp["beta"],
+                cutoff=inp["cutoff"],
+                mask_value=inp["mask_value"],
+                atomic_energies=e,
+                wp_dtype=wp_dtype,
+                device=device,
+            )
+            return float(e.numpy().sum())
+
+        h = 1e-5
+        dV_dr = (energy_at(r + h) - energy_at(r - h)) / (2 * h)
+
+        # Force on atom 1 (at +x) is F_1 = -dV/dr * r_hat_1, where r_hat_1 points
+        # along +x (from atom 0 to atom 1 is +x; from atom 1 to atom 0 is -x).
+        # With r_ij = r_i - r_j and F_i = (force_mag/r) * r_ij, atom 1 sees
+        # r_ij = (-r, 0, 0) so F_1.x is negative when force_mag_over_r is positive.
+        inp = _make_pair_inputs(r, c6, c12, beta_val, cutoff, device, wp_dtype)
+        vec_dtype = wp.vec3d
+        e_ = wp.zeros(2, dtype=wp_dtype, device=device)
+        f_ = wp.zeros(2, dtype=vec_dtype, device=device)
+        lj_pme_real_space_energy_forces(
+            positions=inp["positions"],
+            c6_coefficients=inp["c6"],
+            c12_coefficients=inp["c12"],
+            cell=inp["cell"],
+            neighbor_matrix=inp["nbr_mat"],
+            neighbor_matrix_shifts=inp["nbr_shifts"],
+            num_neighbors=inp["num_nbrs"],
+            beta=inp["beta"],
+            cutoff=inp["cutoff"],
+            mask_value=inp["mask_value"],
+            atomic_energies=e_,
+            atomic_forces=f_,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+        f_np = f_.numpy()
+        # Atom 0 is at origin, atom 1 at (r, 0, 0). Pulling atom 1 outward by dr
+        # increases r by dr, so F_1.x = -dV/dr.
+        assert f_np[1, 0] == pytest.approx(-dV_dr, rel=1e-5)
+        assert f_np[0, 0] == pytest.approx(dV_dr, rel=1e-5)
+
+
+class TestLJPMERealSpaceVirial:
+    """Virial correctness for the real-space LJ-PME kernel."""
+
+    def test_virial_matches_pair_outer_product(self, device, wp_dtype):
+        """W_xx = r_ij,x * F_ij,x for a single pair along x-axis."""
+        r, c6, c12, beta_val = 3.5, 60.0, 5e4, 0.35
+        inp = _make_pair_inputs(r, c6, c12, beta_val, 10.0, device, wp_dtype)
+        vec_dtype = wp.vec3d if wp_dtype == wp.float64 else wp.vec3f
+        energies = wp.zeros(2, dtype=wp_dtype, device=device)
+        forces = wp.zeros(2, dtype=vec_dtype, device=device)
+        virial = wp.zeros(9, dtype=wp_dtype, device=device)
+        lj_pme_real_space_energy_forces_virial(
+            positions=inp["positions"],
+            c6_coefficients=inp["c6"],
+            c12_coefficients=inp["c12"],
+            cell=inp["cell"],
+            neighbor_matrix=inp["nbr_mat"],
+            neighbor_matrix_shifts=inp["nbr_shifts"],
+            num_neighbors=inp["num_nbrs"],
+            beta=inp["beta"],
+            cutoff=inp["cutoff"],
+            mask_value=inp["mask_value"],
+            atomic_energies=energies,
+            atomic_forces=forces,
+            virial=virial,
+            wp_dtype=wp_dtype,
+            device=device,
+        )
+        vir = virial.numpy().reshape(3, 3)
+        f_np = forces.numpy()
+        # Single pair along +x: r_ij_0 (= r_i - r_j with i=0, j=1) = (-r, 0, 0).
+        # F_ij is the force on i from this pair (= F_0 = -F_1).
+        # W_ab = r_ij,a * F_ij,b. So W_xx = (-r) * F_0_x = -r * F_0_x.
+        expected_xx = -r * f_np[0, 0]
+        assert vir[0, 0] == pytest.approx(expected_xx, rel=_rtol(wp_dtype))
+        # Off-diagonal entries are exactly zero (single colinear pair).
+        for a in range(3):
+            for b in range(3):
+                if a == 0 and b == 0:
+                    continue
+                assert vir[a, b] == pytest.approx(
+                    0.0, abs=1e-12 if wp_dtype == wp.float64 else 1e-5
+                )


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->
Adding direct, reciprocal and self terms for dispersion PME. 
Added both torch and jax bindings
-
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->
passed pre-commit
- [x] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [ x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [ x] I have performed a self-review of my code
- [ x] I have added docstrings to new functions/classes
- [ x] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
