### PR TITLE
docs(dynamics): clarify NPT velocity thermostat drag

### DIFF
--- a/docs/userguide/components/dynamics.md
+++ b/docs/userguide/components/dynamics.md
@@ -290,8 +290,10 @@ $$
 
 ### NPT (Isothermal-Isobaric)
 
-Constant temperature and pressure simulations using Martyna-Tobias-Klein (MTK) equations
-with coupled Nosé-Hoover chains for thermostat and barostat:
+Constant temperature and pressure simulations using Martyna-Tobias-Klein (MTK)
+equations. The convenience `run_npt_step` applies particle thermostat friction
+inside its NPT velocity half-steps; it is not a drop-in primitive for integrator
+splits that apply particle Nosé-Hoover velocity scaling separately.
 
 ```python
 from nvalchemiops.dynamics.integrators import run_npt_step
@@ -310,7 +312,8 @@ run_npt_step(
 
 - Maintains constant temperature and pressure
 - Supports isotropic (scalar), orthorhombic (3 components), and fully anisotropic (9 components) pressure control
-- Uses Nosé-Hoover chains for both thermostat and barostat
+- Uses an NPT velocity primitive that includes particle thermostat drag
+- Use `nph_velocity_half_step` or another no-thermostat velocity primitive when composing a separate particle NHC Trotter scaling step
 
 ### NPH (Isenthalpic-Isobaric)
 

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -2258,7 +2258,11 @@ def npt_velocity_half_step(
         ``v ← v · exp(-Δt · (ε̇ + Tr(ε̇)/(3·N_atoms) · I + η̇₁ · I))``
 
     where ``ε̇ = cell_velocities = p_g/W`` and ``η̇₁`` is the first
-    thermostat-chain velocity.
+    thermostat-chain velocity.  This primitive already applies particle
+    thermostat drag through ``eta_dots[:, 0]``; callers that apply particle
+    NHC velocity scaling as a separate Trotter operator should use
+    :func:`nph_velocity_half_step` or another no-thermostat velocity primitive
+    instead.
 
     Parameters
     ----------
@@ -2366,7 +2370,9 @@ def npt_velocity_half_step_out(
     Perform half-step velocity update for NPT (non-mutating).
 
     Non-mutating version of :func:`npt_velocity_half_step` that returns
-    a new array instead of modifying in-place.
+    a new array instead of modifying in-place.  Like the in-place variant,
+    this includes particle thermostat drag through ``eta_dots[:, 0]`` and
+    should not be combined with separate particle NHC velocity scaling.
 
     Parameters
     ----------
@@ -2692,6 +2698,12 @@ def run_npt_step(
     7. Velocity half-step
     8. Barostat half-step
     9. Thermostat half-step
+
+    Particle thermostat friction is applied inside the two
+    :func:`npt_velocity_half_step` calls via ``eta_dot[:, 0]``.  The
+    :func:`npt_thermostat_half_step` calls update the chain state; callers
+    using a different split with explicit particle velocity scaling should
+    not also use ``npt_velocity_half_step`` for those particle half-steps.
 
     Parameters
     ----------


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Clarify NPT dynamics documentation around particle thermostat drag in `npt_velocity_half_step` and `run_npt_step`, including guidance for callers composing separate particle NHC scaling steps.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

https://github.com/NVIDIA/nvalchemi-toolkit/issues/95
https://github.com/NVIDIA/nvalchemi-toolkit/pull/96

## Changes Made

- Document that `npt_velocity_half_step` applies particle thermostat drag through `eta_dots[:, 0]`.
- Clarify that `run_npt_step` applies particle thermostat friction inside its NPT velocity half-steps.
- Point split integrator callers toward `nph_velocity_half_step` or another no-thermostat velocity primitive when particle NHC velocity scaling is applied separately.

## Testing

- [ ] Unit tests pass locally (`make pytest`) - Not run; staged changes are documentation-only.
- [ ] Linting passes (`make lint`) - Not run.
- [ ] New tests added for new functionality meets coverage expectations? N/A; no new functionality is staged.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
