### PR TITLE
Release GPU memory between tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
       - get-pr-labels
       - changed-files
     runs-on: linux-amd64-gpu-h100-latest-1
-    timeout-minutes: 60
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,8 @@ jobs:
       #
       # PR branches use push events to refs/heads/pull-request/*, not the
       # pull_request event. Detect them via the branch name pattern.
+      # Testmon baselines are Python-version-specific because testmon keys its
+      # dependency database by the interpreter version and installed packages.
       - name: Restore testmon baseline (for PRs)
         if: startsWith(github.ref, 'refs/heads/pull-request/')
         uses: actions/cache/restore@v4
@@ -225,9 +227,9 @@ jobs:
           path: |
             .testmondata
             .coverage
-          key: testmon-baseline-main-${{ github.run_id }}
+          key: testmon-baseline-main-py${{ matrix.python-version }}-${{ github.run_id }}
           restore-keys: |
-            testmon-baseline-main-
+            testmon-baseline-main-py${{ matrix.python-version }}-
 
       - name: Run tests with testmon and coverage
         run: |
@@ -242,15 +244,8 @@ jobs:
             make testmon-coverage PYTEST_TESTMON_FLAGS=""
           fi
 
-      # Cache baseline (only from main/schedule runs)
-      - name: Delete old testmon cache
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh cache list --key testmon-baseline-main- --json id,key --jq '.[].key' | \
-            xargs -I{} gh cache delete "{}" || true
-
+      # Save one baseline per Python version from main/schedule runs. PR runs
+      # restore the newest matching baseline for their matrix interpreter.
       - name: Save testmon baseline
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule')
         uses: actions/cache/save@v4
@@ -258,7 +253,7 @@ jobs:
           path: |
             .testmondata
             .coverage
-          key: testmon-baseline-main-${{ github.run_id }}
+          key: testmon-baseline-main-py${{ matrix.python-version }}-${{ github.run_id }}
 
       - name: Upload coverage to Codecov
         if: github.event_name != 'merge_group' && github.event_name != 'schedule'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
       - get-pr-labels
       - changed-files
     runs-on: linux-amd64-gpu-h100-latest-1
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -26,24 +26,35 @@ os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
 
 
 def _framework_sort_key(item: pytest.Item) -> tuple[int, str, str]:
-    """Sort framework binding suites so JAX runs before Torch."""
+    """Sort framework suites so JAX runs before Warp and Torch CUDA tests."""
     item_path = str(getattr(item, "path", None) or getattr(item, "fspath", ""))
     item_path = item_path.replace(os.sep, "/")
 
     if "/bindings/jax/" in item_path:
-        framework_rank = 1
+        framework_rank = 0
     elif "/bindings/torch/" in item_path:
         framework_rank = 2
     else:
-        framework_rank = 0
+        framework_rank = 1
 
     return framework_rank, item_path, item.name
 
 
+def _sort_items_by_framework(items: list[pytest.Item]) -> None:
+    """Sort pytest items in place by framework execution order."""
+    items.sort(key=_framework_sort_key)
+
+
 @pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(config, items):
-    """Group JAX binding tests before Torch binding tests within each run."""
-    items.sort(key=_framework_sort_key)
+    """Group JAX binding tests before Torch binding tests during collection."""
+    _sort_items_by_framework(items)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_collection_finish(session):
+    """Re-apply framework ordering after collection plugins finish deselection."""
+    _sort_items_by_framework(session.items)
 
 
 @pytest.fixture(autouse=True)
@@ -55,10 +66,28 @@ def _release_gpu_memory():
 
 def _release_framework_gpu_memory() -> None:
     """Drop Python references and framework caches between tests."""
+    _synchronize_jax_devices()
+    _synchronize_torch_cuda()
     gc.collect()
     _clear_jax_caches()
     _clear_torch_cuda_cache()
     gc.collect()
+
+
+def _synchronize_jax_devices() -> None:
+    """Wait for pending JAX work before clearing JAX caches."""
+    jax = sys.modules.get("jax")
+    if jax is None:
+        return
+
+    effects_barrier = getattr(jax, "effects_barrier", None)
+    if effects_barrier is not None:
+        effects_barrier()
+
+    for device in jax.devices():
+        synchronize = getattr(device, "synchronize_all_activity", None)
+        if synchronize is not None:
+            synchronize()
 
 
 def _clear_jax_caches() -> None:
@@ -70,6 +99,16 @@ def _clear_jax_caches() -> None:
     clear_caches = getattr(jax, "clear_caches", None)
     if clear_caches is not None:
         clear_caches()
+
+
+def _synchronize_torch_cuda() -> None:
+    """Wait for pending PyTorch CUDA work before releasing allocator caches."""
+    torch = sys.modules.get("torch")
+    if torch is None:
+        return
+
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
 
 
 def _clear_torch_cuda_cache() -> None:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -25,14 +25,32 @@ os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
 os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
 
 
+def _item_path(item: pytest.Item) -> str:
+    """Return a normalized path for a pytest item."""
+    item_path = str(getattr(item, "path", None) or getattr(item, "fspath", ""))
+    return item_path.replace(os.sep, "/")
+
+
+def _item_framework(item: pytest.Item | None) -> str | None:
+    """Classify framework binding tests by path."""
+    if item is None:
+        return None
+
+    item_path = _item_path(item)
+    if "/bindings/jax/" in item_path:
+        return "jax"
+    if "/bindings/torch/" in item_path:
+        return "torch"
+    return None
+
+
 def _framework_sort_key(item: pytest.Item) -> tuple[int, str, str]:
     """Sort framework suites so JAX runs before Warp and Torch CUDA tests."""
-    item_path = str(getattr(item, "path", None) or getattr(item, "fspath", ""))
-    item_path = item_path.replace(os.sep, "/")
-
-    if "/bindings/jax/" in item_path:
+    item_path = _item_path(item)
+    framework = _item_framework(item)
+    if framework == "jax":
         framework_rank = 0
-    elif "/bindings/torch/" in item_path:
+    elif framework == "torch":
         framework_rank = 2
     else:
         framework_rank = 1
@@ -57,29 +75,64 @@ def pytest_collection_finish(session):
     _sort_items_by_framework(session.items)
 
 
-@pytest.fixture(autouse=True)
-def _release_gpu_memory():
-    """Release framework-owned GPU caches after each test."""
-    yield
-    _release_framework_gpu_memory()
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_teardown(item, nextitem):
+    """Release framework GPU memory only after leaving framework blocks."""
+    framework = _item_framework(item)
+    if framework is None:
+        return
+
+    next_framework = _item_framework(nextitem)
+    if framework == next_framework:
+        return
+
+    _write_cleanup_log(
+        item.config,
+        f"GPU cleanup: leaving {framework} before {_cleanup_destination(nextitem)}",
+    )
+    _release_framework_gpu_memory(framework, item.config)
 
 
-def _release_framework_gpu_memory() -> None:
-    """Drop Python references and framework caches between tests."""
-    _call_cleanup(_synchronize_jax_devices)
-    _call_cleanup(_synchronize_torch_cuda)
+def _cleanup_destination(nextitem: pytest.Item | None) -> str:
+    """Describe where execution is headed after a cleanup boundary."""
+    if nextitem is None:
+        return "end of pytest run"
+
+    next_framework = _item_framework(nextitem)
+    if next_framework is None:
+        return "base tests"
+    return f"{next_framework} tests"
+
+
+def _release_framework_gpu_memory(framework: str, config: pytest.Config) -> None:
+    """Drop caches for the framework block that just finished."""
+    if framework == "jax":
+        _call_cleanup(_synchronize_jax_devices, framework, config)
+        _call_cleanup(_clear_jax_caches, framework, config)
+    elif framework == "torch":
+        _call_cleanup(_synchronize_torch_cuda, framework, config)
+        _call_cleanup(_clear_torch_cuda_cache, framework, config)
     gc.collect()
-    _call_cleanup(_clear_jax_caches)
-    _call_cleanup(_clear_torch_cuda_cache)
-    gc.collect()
 
 
-def _call_cleanup(cleanup):
+def _call_cleanup(cleanup, framework: str, config: pytest.Config) -> None:
     """Run cleanup best-effort so teardown does not mask test failures."""
     try:
         cleanup()
-    except Exception:
-        return
+    except Exception as exc:
+        message = str(exc).splitlines()[0]
+        _write_cleanup_log(
+            config,
+            f"GPU cleanup: {framework} {cleanup.__name__} failed: "
+            f"{type(exc).__name__}: {message}",
+        )
+
+
+def _write_cleanup_log(config: pytest.Config, message: str) -> None:
+    """Write a concise cleanup message to pytest terminal output."""
+    terminal_reporter = config.pluginmanager.get_plugin("terminalreporter")
+    if terminal_reporter is not None:
+        terminal_reporter.write_line(message)
 
 
 def _synchronize_jax_devices() -> None:
@@ -127,4 +180,3 @@ def _clear_torch_cuda_cache() -> None:
 
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
-        torch.cuda.ipc_collect()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,17 +12,72 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Top-level pytest coordination for CI GPU memory stability.
+
+This file owns test-session behavior that must apply to every pytest process.
+CI runs pytest once per top-level test module group via ``make testmon-coverage``,
+so each process imports this file before collecting one of ``test/test_types.py``,
+``test/math``, ``test/neighbors``, or ``test/interactions``.
+
+The hooks here do three things:
+
+* configure JAX's allocator before any test imports JAX,
+* order framework binding tests as JAX -> framework-neutral Warp -> Torch, and
+* release framework-owned GPU caches when leaving a JAX or Torch test block.
+
+Framework detection is intentionally path based. Collection ordering and teardown
+must not import JAX or Torch just to decide where a test belongs. Cleanup is also
+best effort: a cache-release failure should be visible in the log, but should not
+mask the original test result.
+
+Keep broad pytest/session plumbing here. Put domain-specific fixtures near their
+tests unless they truly need to affect every pytest invocation.
+"""
+
 import gc
 import os
 import sys
+from collections.abc import Callable
+from typing import Literal
 
 import pytest
 
-# These must be set before any test module imports JAX. The previous autouse
-# fixture set them after collection-time imports, which is too late for XLA's
-# allocator configuration.
-os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
-os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+FrameworkName = Literal["jax", "torch"]
+
+_JAX_ALLOCATOR_ENVIRONMENT = {
+    "XLA_PYTHON_CLIENT_ALLOCATOR": "platform",
+    "XLA_PYTHON_CLIENT_PREALLOCATE": "false",
+}
+
+_FRAMEWORK_PATH_MARKERS: tuple[tuple[str, FrameworkName], ...] = (
+    ("/bindings/jax/", "jax"),
+    ("/bindings/torch/", "torch"),
+)
+
+_FRAMEWORK_SORT_RANK: dict[FrameworkName | None, int] = {
+    "jax": 0,
+    None: 1,
+    "torch": 2,
+}
+
+
+# ==============================================================================
+# Import-Time Environment
+# ==============================================================================
+
+
+def _configure_jax_allocator_environment() -> None:
+    """Set XLA allocator variables before collection-time imports can load JAX."""
+    for name, value in _JAX_ALLOCATOR_ENVIRONMENT.items():
+        os.environ[name] = value
+
+
+_configure_jax_allocator_environment()
+
+
+# ==============================================================================
+# Framework Classification
+# ==============================================================================
 
 
 def _item_path(item: pytest.Item) -> str:
@@ -31,31 +86,27 @@ def _item_path(item: pytest.Item) -> str:
     return item_path.replace(os.sep, "/")
 
 
-def _item_framework(item: pytest.Item | None) -> str | None:
-    """Classify framework binding tests by path."""
+def _item_framework(item: pytest.Item | None) -> FrameworkName | None:
+    """Classify framework binding tests by path; None means framework-neutral."""
     if item is None:
         return None
 
     item_path = _item_path(item)
-    if "/bindings/jax/" in item_path:
-        return "jax"
-    if "/bindings/torch/" in item_path:
-        return "torch"
+    for path_marker, framework in _FRAMEWORK_PATH_MARKERS:
+        if path_marker in item_path:
+            return framework
     return None
 
 
-def _framework_sort_key(item: pytest.Item) -> tuple[int, str, str]:
-    """Sort framework suites so JAX runs before Warp and Torch CUDA tests."""
-    item_path = _item_path(item)
-    framework = _item_framework(item)
-    if framework == "jax":
-        framework_rank = 0
-    elif framework == "torch":
-        framework_rank = 2
-    else:
-        framework_rank = 1
+# ==============================================================================
+# Collection Ordering
+# ==============================================================================
 
-    return framework_rank, item_path, item.name
+
+def _framework_sort_key(item: pytest.Item) -> tuple[int, str, str]:
+    """Return a stable JAX -> neutral -> Torch ordering key."""
+    item_path = _item_path(item)
+    return _FRAMEWORK_SORT_RANK[_item_framework(item)], item_path, item.name
 
 
 def _sort_items_by_framework(items: list[pytest.Item]) -> None:
@@ -75,8 +126,13 @@ def pytest_collection_finish(session):
     _sort_items_by_framework(session.items)
 
 
+# ==============================================================================
+# Framework Boundary Cleanup
+# ==============================================================================
+
+
 @pytest.hookimpl(trylast=True)
-def pytest_runtest_teardown(item, nextitem):
+def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> None:
     """Release framework GPU memory only after leaving framework blocks."""
     framework = _item_framework(item)
     if framework is None:
@@ -104,8 +160,11 @@ def _cleanup_destination(nextitem: pytest.Item | None) -> str:
     return f"{next_framework} tests"
 
 
-def _release_framework_gpu_memory(framework: str, config: pytest.Config) -> None:
-    """Drop caches for the framework block that just finished."""
+def _release_framework_gpu_memory(
+    framework: FrameworkName,
+    config: pytest.Config,
+) -> None:
+    """Synchronize and drop caches for the framework block that just finished."""
     if framework == "jax":
         _call_cleanup(_synchronize_jax_devices, framework, config)
         _call_cleanup(_clear_jax_caches, framework, config)
@@ -115,7 +174,11 @@ def _release_framework_gpu_memory(framework: str, config: pytest.Config) -> None
     gc.collect()
 
 
-def _call_cleanup(cleanup, framework: str, config: pytest.Config) -> None:
+def _call_cleanup(
+    cleanup: Callable[[], None],
+    framework: FrameworkName,
+    config: pytest.Config,
+) -> None:
     """Run cleanup best-effort so teardown does not mask test failures."""
     try:
         cleanup()
@@ -133,6 +196,11 @@ def _write_cleanup_log(config: pytest.Config, message: str) -> None:
     terminal_reporter = config.pluginmanager.get_plugin("terminalreporter")
     if terminal_reporter is not None:
         terminal_reporter.write_line(message)
+
+
+# ==============================================================================
+# Framework-Specific Cleanup Helpers
+# ==============================================================================
 
 
 def _synchronize_jax_devices() -> None:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,24 +12,72 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import gc
 import os
+import sys
 
 import pytest
 
+# These must be set before any test module imports JAX. The previous autouse
+# fixture set them after collection-time imports, which is too late for XLA's
+# allocator configuration.
+os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
+os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
 
-@pytest.fixture(scope="module", autouse=True)
-def set_env_vars():
-    """Set JAX specific environment variables"""
-    if "XLA_PYTHON_CLIENT_PREALLOCATE" in os.environ:
-        old_preallocate = os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"]
+
+def _framework_sort_key(item: pytest.Item) -> tuple[int, str, str]:
+    """Sort framework binding suites so JAX runs before Torch."""
+    item_path = str(getattr(item, "path", None) or getattr(item, "fspath", ""))
+    item_path = item_path.replace(os.sep, "/")
+
+    if "/bindings/jax/" in item_path:
+        framework_rank = 1
+    elif "/bindings/torch/" in item_path:
+        framework_rank = 2
     else:
-        old_preallocate = ""
-    if "XLA_PYTHON_CLIENT_PREALLOCATE" in os.environ:
-        old_allocator = os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"]
-    else:
-        old_allocator = ""
-    os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
-    os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+        framework_rank = 0
+
+    return framework_rank, item_path, item.name
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(config, items):
+    """Group JAX binding tests before Torch binding tests within each run."""
+    items.sort(key=_framework_sort_key)
+
+
+@pytest.fixture(autouse=True)
+def _release_gpu_memory():
+    """Release framework-owned GPU caches after each test."""
     yield
-    os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = old_allocator
-    os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = old_preallocate
+    _release_framework_gpu_memory()
+
+
+def _release_framework_gpu_memory() -> None:
+    """Drop Python references and framework caches between tests."""
+    gc.collect()
+    _clear_jax_caches()
+    _clear_torch_cuda_cache()
+    gc.collect()
+
+
+def _clear_jax_caches() -> None:
+    """Clear JAX compilation caches if JAX was imported by the test."""
+    jax = sys.modules.get("jax")
+    if jax is None:
+        return
+
+    clear_caches = getattr(jax, "clear_caches", None)
+    if clear_caches is not None:
+        clear_caches()
+
+
+def _clear_torch_cuda_cache() -> None:
+    """Clear PyTorch CUDA allocator caches if Torch was imported by the test."""
+    torch = sys.modules.get("torch")
+    if torch is None:
+        return
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        torch.cuda.ipc_collect()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -66,12 +66,20 @@ def _release_gpu_memory():
 
 def _release_framework_gpu_memory() -> None:
     """Drop Python references and framework caches between tests."""
-    _synchronize_jax_devices()
-    _synchronize_torch_cuda()
+    _call_cleanup(_synchronize_jax_devices)
+    _call_cleanup(_synchronize_torch_cuda)
     gc.collect()
-    _clear_jax_caches()
-    _clear_torch_cuda_cache()
+    _call_cleanup(_clear_jax_caches)
+    _call_cleanup(_clear_torch_cuda_cache)
     gc.collect()
+
+
+def _call_cleanup(cleanup):
+    """Run cleanup best-effort so teardown does not mask test failures."""
+    try:
+        cleanup()
+    except Exception:
+        return
 
 
 def _synchronize_jax_devices() -> None:

--- a/test/interactions/electrostatics/bindings/torch/test_coulomb.py
+++ b/test/interactions/electrostatics/bindings/torch/test_coulomb.py
@@ -62,7 +62,7 @@ def simple_pair_system(device):
         device=device,
     )
     neighbor_list = torch.tensor([[0], [1]], dtype=torch.int32, device=device)
-    neighbor_ptr = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    neighbor_ptr = torch.tensor([0, 1, 1], dtype=torch.int32, device=device)
     neighbor_shifts = torch.zeros((1, 3), dtype=torch.int32, device=device)
     return positions, charges, cell, neighbor_list, neighbor_ptr, neighbor_shifts
 


### PR DESCRIPTION
# ALCHEMI Toolkit-Ops Pull Request

## Description

Expands the scope of `test/conftest.py` to define clearer boundaries between frameworks. Pytest now groups framework binding tests in the order `jax` -> `warp` -> `torch`, then releases framework-owned GPU caches only when leaving a JAX or Torch block.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

- Added path-based framework ordering and boundary GPU cleanup in `test/conftest.py`.
- Kept JAX allocator environment configuration active before collection-time imports.
- Split testmon baseline caches by Python version so PR jobs restore a baseline compatible with testmon's interpreter/package environment key.
- Fixed one Coulomb test fixture with an invalid CSR `neighbor_ptr`.
- Bumped CI timeout to 45 minutes.

## Testing

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

Local checks: `py_compile`, `ruff check`, and `ruff format --check` for targeted files. GPU tests need CI.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

Testmon treats Python version as part of its environment fingerprint. The CI cache keys now include `matrix.python-version`, so nightly/main runs publish one baseline per interpreter and PR runs consume the matching baseline instead of accidentally restoring another matrix lane's cache.
