### PR TITLE
Add JAX Slab Correction Bindings

### DIFF
--- a/benchmarks/interactions/electrostatics/benchmark_electrostatics.py
+++ b/benchmarks/interactions/electrostatics/benchmark_electrostatics.py
@@ -104,6 +104,11 @@ except ImportError:
     _jax_neighbors = None
 
 
+SLAB_AXIS = 2
+SLAB_VACUUM_FACTOR = 3.0
+SLAB_METHODS = ("ewald_slab", "pme_slab")
+
+
 def _get_backend_modules(
     backend: str,
 ) -> tuple:
@@ -319,6 +324,24 @@ def prepare_system_numpy(
         }
 
 
+def prepare_slab_system_numpy(
+    supercell_size: int,
+    batch_size: int = 1,
+    vacuum_factor: float = SLAB_VACUUM_FACTOR,
+    slab_axis: int = SLAB_AXIS,
+) -> dict:
+    """Create a slab benchmark system with vacuum and mixed periodicity."""
+    np_data = prepare_system_numpy(supercell_size, batch_size=batch_size)
+
+    cell = np_data["cell"].copy()
+    cell[:, slab_axis, :] *= vacuum_factor
+
+    pbc = np_data["pbc"].copy()
+    pbc[..., slab_axis] = False
+
+    return {**np_data, "cell": cell, "pbc": pbc}
+
+
 def convert_to_backend(
     np_data: dict,
     backend: str,
@@ -501,6 +524,7 @@ def prepare_single_system(
     supercell_size: int,
     device: str,
     dtype: torch.dtype,
+    np_data: dict | None = None,
 ) -> dict:
     """Prepare a single system for benchmarking.
 
@@ -525,7 +549,8 @@ def prepare_single_system(
     """
     dtype_str = str(dtype).split(".")[-1]
 
-    np_data = prepare_system_numpy(supercell_size, batch_size=1)
+    if np_data is None:
+        np_data = prepare_system_numpy(supercell_size, batch_size=1)
 
     backend_data = convert_to_backend(
         np_data, "torch", device=device, dtype_str=dtype_str
@@ -542,7 +567,7 @@ def prepare_single_system(
         pbc = pbc.squeeze(0)
 
     pbc_slab = backend_data["pbc"].clone()
-    pbc_slab[..., 2] = False
+    pbc_slab[..., SLAB_AXIS] = False
 
     mesh_spacing = params["mesh_spacing"]
     if hasattr(mesh_spacing, "tolist"):
@@ -575,6 +600,7 @@ def prepare_batch_system(
     batch_size: int,
     device: str,
     dtype: torch.dtype,
+    np_data: dict | None = None,
 ) -> dict:
     """Prepare a batched system for benchmarking.
 
@@ -601,7 +627,8 @@ def prepare_batch_system(
     """
     dtype_str = str(dtype).split(".")[-1]
 
-    np_data = prepare_system_numpy(supercell_size, batch_size=batch_size)
+    if np_data is None:
+        np_data = prepare_system_numpy(supercell_size, batch_size=batch_size)
 
     backend_data = convert_to_backend(
         np_data, "torch", device=device, dtype_str=dtype_str
@@ -614,7 +641,7 @@ def prepare_batch_system(
     )
 
     pbc_slab = backend_data["pbc"].clone()
-    pbc_slab[..., 2] = False
+    pbc_slab[..., SLAB_AXIS] = False
 
     return {
         "positions": backend_data["positions"],
@@ -646,7 +673,7 @@ def prepare_jax_ewald_pme_system(np_data: dict, dtype_str: str) -> dict:
     nl_matrix, nl_num_neighbors, nl_matrix_shifts = compute_neighbor_list(
         backend_data, "jax", params_data["cutoff"]
     )
-    pbc_slab = backend_data["pbc"].at[..., 2].set(False)
+    pbc_slab = backend_data["pbc"].at[..., SLAB_AXIS].set(False)
 
     system_data = {
         "positions": backend_data["positions"],
@@ -2289,33 +2316,45 @@ def main():
                                 traceback.print_exc()
                                 system_data_cache["dsf"] = None
                     else:
-                        if "ewald_pme" not in system_data_cache:
+                        cache_key = (
+                            "ewald_pme_slab" if method in SLAB_METHODS else "ewald_pme"
+                        )
+                        if cache_key not in system_data_cache:
                             try:
+                                np_data = (
+                                    prepare_slab_system_numpy(size, batch_size=1)
+                                    if method in SLAB_METHODS
+                                    else prepare_system_numpy(size, batch_size=1)
+                                )
                                 if args.backend == "jax":
-                                    np_data = prepare_system_numpy(size, batch_size=1)
-                                    system_data_cache["ewald_pme"] = (
+                                    system_data_cache[cache_key] = (
                                         prepare_jax_ewald_pme_system(np_data, dtype_str)
                                     )
                                 else:
-                                    system_data_cache["ewald_pme"] = (
-                                        prepare_single_system(size, device, dtype)
+                                    system_data_cache[cache_key] = (
+                                        prepare_single_system(
+                                            size, device, dtype, np_data=np_data
+                                        )
                                     )
                             except Exception as e:
                                 print(f"    Failed to prepare system: {e}")
                                 traceback.print_exc()
-                                system_data_cache["ewald_pme"] = None
+                                system_data_cache[cache_key] = None
 
                 for method in methods:
                     backends = get_backends_for_method(method)
+                    cache_key = (
+                        "ewald_pme_slab" if method in SLAB_METHODS else "ewald_pme"
+                    )
                     system_data = system_data_cache.get(
-                        "dsf" if method == "dsf" else "ewald_pme"
+                        "dsf" if method == "dsf" else cache_key
                     )
                     if system_data is None:
                         continue
 
                     method_components = (
                         ["full"]
-                        if method in ("dsf", "ewald_slab", "pme_slab")
+                        if method == "dsf" or method in SLAB_METHODS
                         else components
                     )
                     for backend in backends:
@@ -2413,37 +2452,51 @@ def main():
                                 traceback.print_exc()
                                 system_data_cache["dsf"] = None
                     else:
-                        if "ewald_pme" not in system_data_cache:
+                        cache_key = (
+                            "ewald_pme_slab" if method in SLAB_METHODS else "ewald_pme"
+                        )
+                        if cache_key not in system_data_cache:
                             try:
-                                if args.backend == "jax":
-                                    np_data = prepare_system_numpy(
+                                np_data = (
+                                    prepare_slab_system_numpy(
                                         base_size, batch_size=batch_size
                                     )
-                                    system_data_cache["ewald_pme"] = (
+                                    if method in SLAB_METHODS
+                                    else prepare_system_numpy(
+                                        base_size, batch_size=batch_size
+                                    )
+                                )
+                                if args.backend == "jax":
+                                    system_data_cache[cache_key] = (
                                         prepare_jax_ewald_pme_system(np_data, dtype_str)
                                     )
                                 else:
-                                    system_data_cache["ewald_pme"] = (
-                                        prepare_batch_system(
-                                            base_size, batch_size, device, dtype
-                                        )
+                                    system_data_cache[cache_key] = prepare_batch_system(
+                                        base_size,
+                                        batch_size,
+                                        device,
+                                        dtype,
+                                        np_data=np_data,
                                     )
                             except Exception as e:
                                 print(f"    Failed to prepare system: {e}")
                                 traceback.print_exc()
-                                system_data_cache["ewald_pme"] = None
+                                system_data_cache[cache_key] = None
 
                 for method in methods:
                     backends = get_backends_for_method(method)
+                    cache_key = (
+                        "ewald_pme_slab" if method in SLAB_METHODS else "ewald_pme"
+                    )
                     system_data = system_data_cache.get(
-                        "dsf" if method == "dsf" else "ewald_pme"
+                        "dsf" if method == "dsf" else cache_key
                     )
                     if system_data is None:
                         continue
 
                     method_components = (
                         ["full"]
-                        if method in ("dsf", "ewald_slab", "pme_slab")
+                        if method == "dsf" or method in SLAB_METHODS
                         else components
                     )
                     for backend in backends:

--- a/benchmarks/interactions/electrostatics/benchmark_electrostatics.py
+++ b/benchmarks/interactions/electrostatics/benchmark_electrostatics.py
@@ -43,6 +43,8 @@ Usage:
     python benchmark_electrostatics.py --config benchmark_config.yaml --backend torchpme --method ewald
     python benchmark_electrostatics.py --config benchmark_config.yaml --backend torch --method ewald_slab
     python benchmark_electrostatics.py --config benchmark_config.yaml --backend torch --method pme_slab
+    python benchmark_electrostatics.py --config benchmark_config.yaml --backend jax --method ewald_slab
+    python benchmark_electrostatics.py --config benchmark_config.yaml --backend jax --method pme_slab
     python benchmark_electrostatics.py --config benchmark_config.yaml --method dsf --backend both
 """
 
@@ -637,6 +639,41 @@ def prepare_batch_system(
     }
 
 
+def prepare_jax_ewald_pme_system(np_data: dict, dtype_str: str) -> dict:
+    """Prepare a JAX system dictionary for Ewald and PME benchmarks."""
+    backend_data = convert_to_backend(np_data, "jax", dtype_str=dtype_str)
+    params_data = compute_electrostatics_params(backend_data, "jax")
+    nl_matrix, nl_num_neighbors, nl_matrix_shifts = compute_neighbor_list(
+        backend_data, "jax", params_data["cutoff"]
+    )
+    pbc_slab = backend_data["pbc"].at[..., 2].set(False)
+
+    system_data = {
+        "positions": backend_data["positions"],
+        "charges": backend_data["charges"],
+        "cell": backend_data["cell"],
+        "pbc": backend_data["pbc"],
+        "pbc_slab": pbc_slab,
+        "neighbor_matrix": nl_matrix,
+        "num_neighbors": nl_num_neighbors,
+        "neighbor_matrix_shifts": nl_matrix_shifts,
+        "total_atoms": backend_data["total_atoms"],
+        "num_atoms_per_system": backend_data["num_atoms_per_system"],
+        "batch_idx": backend_data["batch_idx"],
+        "alpha": params_data["alpha"],
+        "k_cutoff": params_data["k_cutoff"],
+        "cutoff": params_data["cutoff"],
+        "mesh_dimensions": params_data["mesh_dimensions"],
+        "mesh_spacing": params_data["mesh_spacing"],
+        "spline_order": 4,
+        "k_vectors_pme": params_data["k_vectors_pme"],
+        "k_squared_pme": params_data["k_squared_pme"],
+    }
+    if backend_data["batch_idx"] is not None:
+        system_data["batch_size"] = int(backend_data["cell"].shape[0])
+    return system_data
+
+
 # ==============================================================================
 # DSF System Preparation
 # ==============================================================================
@@ -1107,6 +1144,7 @@ def prepare_jax_ewald(
     component: Literal["real", "reciprocal", "full"],
     compute_forces: bool,
     compute_virial: bool = False,
+    slab_correction: bool = False,
 ):
     """Prepare a JIT-compiled Ewald callable for benchmarking.
 
@@ -1124,6 +1162,8 @@ def prepare_jax_ewald(
         Whether to compute forces.
     compute_virial : bool, optional
         Whether to compute virial tensor, by default False.
+    slab_correction : bool, optional
+        Whether to run the full Ewald wrapper with slab correction enabled.
 
     Returns
     -------
@@ -1137,6 +1177,7 @@ def prepare_jax_ewald(
     alpha = system_data.get("alpha")
     k_cutoff = system_data.get("k_cutoff")
     num_atoms_per_system = system_data.get("num_atoms_per_system")
+    pbc_slab = system_data.get("pbc_slab")
 
     neighbor_matrix_data = system_data.get("neighbor_matrix")
     neighbor_matrix_shifts = system_data.get("neighbor_matrix_shifts")
@@ -1148,6 +1189,7 @@ def prepare_jax_ewald(
     _compute_forces = compute_forces
     _compute_virial = compute_virial
     _k_cutoff = k_cutoff
+    _slab_correction = slab_correction
 
     if component == "real":
 
@@ -1217,6 +1259,7 @@ def prepare_jax_ewald(
             neighbor_matrix,
             neighbor_matrix_shifts,
             batch_idx,
+            pbc_slab,
         ):
             return _jax_electrostatics.ewald_summation(
                 positions=positions,
@@ -1232,6 +1275,8 @@ def prepare_jax_ewald(
                 neighbor_matrix_shifts=neighbor_matrix_shifts,
                 compute_forces=_compute_forces,
                 compute_virial=_compute_virial,
+                pbc=pbc_slab,
+                slab_correction=_slab_correction,
             )
 
         def call():
@@ -1243,6 +1288,7 @@ def prepare_jax_ewald(
                 neighbor_matrix_data,
                 neighbor_matrix_shifts,
                 batch_idx,
+                pbc_slab,
             )
 
     return call
@@ -1253,6 +1299,7 @@ def prepare_jax_pme(
     component: Literal["real", "reciprocal", "full"],
     compute_forces: bool,
     compute_virial: bool = False,
+    slab_correction: bool = False,
 ):
     """Prepare a JIT-compiled PME callable for benchmarking.
 
@@ -1269,6 +1316,8 @@ def prepare_jax_pme(
         Whether to compute forces.
     compute_virial : bool, optional
         Whether to compute virial tensor, by default False.
+    slab_correction : bool, optional
+        Whether to run the full PME wrapper with slab correction enabled.
 
     Returns
     -------
@@ -1282,6 +1331,7 @@ def prepare_jax_pme(
     alpha = system_data.get("alpha")
     mesh_dimensions = system_data.get("mesh_dimensions")
     spline_order = system_data.get("spline_order")
+    pbc_slab = system_data.get("pbc_slab")
 
     neighbor_matrix_data = system_data.get("neighbor_matrix")
     neighbor_matrix_shifts = system_data.get("neighbor_matrix_shifts")
@@ -1290,6 +1340,7 @@ def prepare_jax_pme(
     _compute_virial = compute_virial
     _spline_order = spline_order
     _mesh_dimensions = mesh_dimensions
+    _slab_correction = slab_correction
 
     if component == "real":
 
@@ -1370,6 +1421,7 @@ def prepare_jax_pme(
             neighbor_matrix,
             neighbor_matrix_shifts,
             batch_idx,
+            pbc_slab,
         ):
             return _jax_electrostatics.particle_mesh_ewald(
                 positions=positions,
@@ -1385,6 +1437,8 @@ def prepare_jax_pme(
                 neighbor_matrix_shifts=neighbor_matrix_shifts,
                 compute_forces=_compute_forces,
                 compute_virial=_compute_virial,
+                pbc=pbc_slab,
+                slab_correction=_slab_correction,
             )
 
         def call():
@@ -1396,6 +1450,7 @@ def prepare_jax_pme(
                 neighbor_matrix_data,
                 neighbor_matrix_shifts,
                 batch_idx,
+                pbc_slab,
             )
 
     return call
@@ -1880,12 +1935,13 @@ def run_benchmark(
                         slab_correction=method == "pme_slab",
                     )
         elif backend == "jax":
-            if method == "ewald":
+            if method in ("ewald", "ewald_slab"):
                 bench_fn = prepare_jax_ewald(
                     system_data,
                     component,
                     compute_forces,
                     effective_virial,
+                    slab_correction=method == "ewald_slab",
                 )
             else:  # pme
                 bench_fn = prepare_jax_pme(
@@ -1893,6 +1949,7 @@ def run_benchmark(
                     component,
                     compute_forces,
                     effective_virial,
+                    slab_correction=method == "pme_slab",
                 )
         elif backend == "torchpme":
             if system_data.get("batch_idx") is not None:
@@ -2136,7 +2193,7 @@ def main():
         elif args.backend == "torch":
             return ["torch"]
         elif args.backend == "jax":
-            if method in ("ewald", "pme"):
+            if method in ("ewald", "ewald_slab", "pme", "pme_slab"):
                 return ["jax"]
             return []
         elif args.backend == "torchpme":
@@ -2236,41 +2293,9 @@ def main():
                             try:
                                 if args.backend == "jax":
                                     np_data = prepare_system_numpy(size, batch_size=1)
-                                    backend_data = convert_to_backend(
-                                        np_data, "jax", dtype_str=dtype_str
+                                    system_data_cache["ewald_pme"] = (
+                                        prepare_jax_ewald_pme_system(np_data, dtype_str)
                                     )
-                                    params_data = compute_electrostatics_params(
-                                        backend_data, "jax"
-                                    )
-                                    nl_matrix, nl_num_neighbors, nl_matrix_shifts = (
-                                        compute_neighbor_list(
-                                            backend_data, "jax", params_data["cutoff"]
-                                        )
-                                    )
-                                    system_data_cache["ewald_pme"] = {
-                                        "positions": backend_data["positions"],
-                                        "charges": backend_data["charges"],
-                                        "cell": backend_data["cell"],
-                                        "pbc": backend_data["pbc"],
-                                        "neighbor_matrix": nl_matrix,
-                                        "num_neighbors": nl_num_neighbors,
-                                        "neighbor_matrix_shifts": nl_matrix_shifts,
-                                        "total_atoms": backend_data["total_atoms"],
-                                        "num_atoms_per_system": backend_data[
-                                            "num_atoms_per_system"
-                                        ],
-                                        "batch_idx": None,
-                                        "alpha": params_data["alpha"],
-                                        "k_cutoff": params_data["k_cutoff"],
-                                        "cutoff": params_data["cutoff"],
-                                        "mesh_dimensions": params_data[
-                                            "mesh_dimensions"
-                                        ],
-                                        "mesh_spacing": params_data["mesh_spacing"],
-                                        "spline_order": 4,
-                                        "k_vectors_pme": params_data["k_vectors_pme"],
-                                        "k_squared_pme": params_data["k_squared_pme"],
-                                    }
                                 else:
                                     system_data_cache["ewald_pme"] = (
                                         prepare_single_system(size, device, dtype)
@@ -2394,42 +2419,9 @@ def main():
                                     np_data = prepare_system_numpy(
                                         base_size, batch_size=batch_size
                                     )
-                                    backend_data = convert_to_backend(
-                                        np_data, "jax", dtype_str=dtype_str
+                                    system_data_cache["ewald_pme"] = (
+                                        prepare_jax_ewald_pme_system(np_data, dtype_str)
                                     )
-                                    params_data = compute_electrostatics_params(
-                                        backend_data, "jax"
-                                    )
-                                    nl_matrix, nl_num_neighbors, nl_matrix_shifts = (
-                                        compute_neighbor_list(
-                                            backend_data, "jax", params_data["cutoff"]
-                                        )
-                                    )
-                                    system_data_cache["ewald_pme"] = {
-                                        "positions": backend_data["positions"],
-                                        "charges": backend_data["charges"],
-                                        "cell": backend_data["cell"],
-                                        "pbc": backend_data["pbc"],
-                                        "neighbor_matrix": nl_matrix,
-                                        "num_neighbors": nl_num_neighbors,
-                                        "neighbor_matrix_shifts": nl_matrix_shifts,
-                                        "total_atoms": backend_data["total_atoms"],
-                                        "num_atoms_per_system": backend_data[
-                                            "num_atoms_per_system"
-                                        ],
-                                        "batch_idx": backend_data["batch_idx"],
-                                        "batch_size": batch_size,
-                                        "alpha": params_data["alpha"],
-                                        "k_cutoff": params_data["k_cutoff"],
-                                        "cutoff": params_data["cutoff"],
-                                        "mesh_dimensions": params_data[
-                                            "mesh_dimensions"
-                                        ],
-                                        "mesh_spacing": params_data["mesh_spacing"],
-                                        "spline_order": 4,
-                                        "k_vectors_pme": params_data["k_vectors_pme"],
-                                        "k_squared_pme": params_data["k_squared_pme"],
-                                    }
                                 else:
                                     system_data_cache["ewald_pme"] = (
                                         prepare_batch_system(

--- a/docs/benchmarks/electrostatics.md
+++ b/docs/benchmarks/electrostatics.md
@@ -390,7 +390,8 @@ python benchmark_electrostatics.py \
 
 `--backend {torch,jax,torchpme,torch_dsf,both}`
 : Computational backend (default: `torch`). `both` dispatches per-method:
-  `torch` + `torchpme` for Ewald/PME, `torch` + `torch_dsf` for DSF.
+  `torch` + `torchpme` for Ewald/PME, `torch` for Ewald/PME slab
+  methods, and `torch` + `torch_dsf` for DSF.
 
 `--method {ewald,ewald_slab,pme,pme_slab,dsf,both,all}`
 : Electrostatics method (default: `both`). `both` = Ewald + PME.
@@ -421,16 +422,28 @@ python benchmark_electrostatics.py \
 #### Slab Benchmarks
 
 ```bash
-# Ewald slab
+# Ewald slab (PyTorch)
 python benchmark_electrostatics.py \
     --config benchmark_config.yaml \
     --backend torch \
     --method ewald_slab
 
-# PME slab
+# Ewald slab (JAX)
+python benchmark_electrostatics.py \
+    --config benchmark_config.yaml \
+    --backend jax \
+    --method ewald_slab
+
+# PME slab (PyTorch)
 python benchmark_electrostatics.py \
     --config benchmark_config.yaml \
     --backend torch \
+    --method pme_slab
+
+# PME slab (JAX)
+python benchmark_electrostatics.py \
+    --config benchmark_config.yaml \
+    --backend jax \
     --method pme_slab
 ```
 

--- a/docs/modules/jax/electrostatics.rst
+++ b/docs/modules/jax/electrostatics.rst
@@ -46,6 +46,16 @@ Individual components of the Particle Mesh Ewald method.
 .. autofunction:: pme_energy_corrections
 .. autofunction:: pme_energy_corrections_with_charge_grad
 
+Slab Correction
+---------------
+
+Explicit-output Yeh-Berkowitz/Ballenegger slab correction for systems with two
+periodic directions. JAX slab bindings are forward-only; request energies,
+forces, charge gradients, and virials with the same flags used by the Ewald and
+PME wrappers.
+
+.. autofunction:: compute_slab_correction
+
 K-Vector Generation
 -------------------
 

--- a/docs/userguide/components/electrostatics.md
+++ b/docs/userguide/components/electrostatics.md
@@ -1587,7 +1587,7 @@ from nvalchemiops.jax.interactions.electrostatics import ewald_summation
 
 # Define energy function for differentiation
 def energy_fn(positions):
-    energies, _ = ewald_summation(
+    energies = ewald_summation(
         positions, charges, cell, alpha=0.3, k_cutoff=8.0,
         neighbor_list=nl, neighbor_ptr=nl_ptr, neighbor_shifts=shifts,
         compute_forces=False,

--- a/docs/userguide/components/electrostatics.md
+++ b/docs/userguide/components/electrostatics.md
@@ -505,14 +505,13 @@ from nvalchemiops.torch.neighbors import neighbor_list
 
 pbc_slab = torch.tensor([[True, True, False]], dtype=torch.bool, device=positions.device)
 
-# The neighbor list controls the real-space 3D Ewald images. For a slab setup,
-# use a cell with enough vacuum in the non-periodic direction.
-pbc_neighbor = torch.tensor([[True, True, True]], dtype=torch.bool, device=positions.device)
+# The neighbor list controls real-space periodic images. For this slab setup,
+# use the same T/T/F periodicity and a cell with enough vacuum along z.
 neighbor_list_coo, neighbor_ptr, neighbor_shifts = neighbor_list(
     positions,
     cutoff=5.0,
     cell=cell,
-    pbc=pbc_neighbor,
+    pbc=pbc_slab,
     return_neighbor_list=True,
 )
 
@@ -548,14 +547,13 @@ from nvalchemiops.jax.neighbors import neighbor_list
 
 pbc_slab = jnp.array([[True, True, False]], dtype=jnp.bool_)
 
-# The neighbor list controls the real-space 3D Ewald images. For a slab setup,
-# use a cell with enough vacuum in the non-periodic direction.
-pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+# The neighbor list controls real-space periodic images. For this slab setup,
+# use the same T/T/F periodicity and a cell with enough vacuum along z.
 neighbor_list_coo, neighbor_ptr, neighbor_shifts = neighbor_list(
     positions,
     cutoff=5.0,
     cell=cell,
-    pbc=pbc_neighbor,
+    pbc=pbc_slab,
     return_neighbor_list=True,
 )
 
@@ -920,14 +918,13 @@ from nvalchemiops.torch.neighbors import neighbor_list
 
 pbc_slab = torch.tensor([[True, True, False]], dtype=torch.bool, device=positions.device)
 
-# The neighbor list controls the real-space 3D images. For a slab setup,
-# use a cell with enough vacuum in the non-periodic direction.
-pbc_neighbor = torch.tensor([[True, True, True]], dtype=torch.bool, device=positions.device)
+# The neighbor list controls real-space periodic images. For this slab setup,
+# use the same T/T/F periodicity and a cell with enough vacuum along z.
 neighbor_list_coo, neighbor_ptr, neighbor_shifts = neighbor_list(
     positions,
     cutoff=5.0,
     cell=cell,
-    pbc=pbc_neighbor,
+    pbc=pbc_slab,
     return_neighbor_list=True,
 )
 
@@ -1009,14 +1006,13 @@ from nvalchemiops.jax.neighbors import neighbor_list
 
 pbc_slab = jnp.array([[True, True, False]], dtype=jnp.bool_)
 
-# The neighbor list controls the real-space 3D images. For a slab setup,
-# use a cell with enough vacuum in the non-periodic direction.
-pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+# The neighbor list controls real-space periodic images. For this slab setup,
+# use the same T/T/F periodicity and a cell with enough vacuum along z.
 neighbor_list_coo, neighbor_ptr, neighbor_shifts = neighbor_list(
     positions,
     cutoff=5.0,
     cell=cell,
-    pbc=pbc_neighbor,
+    pbc=pbc_slab,
     return_neighbor_list=True,
 )
 

--- a/docs/userguide/components/electrostatics.md
+++ b/docs/userguide/components/electrostatics.md
@@ -9,10 +9,9 @@ In periodic systems, the $1/r$ potential decays slowly, requiring special techni
 to handle the conditionally convergent lattice sum. ALCHEMI Toolkit-Ops provides
 GPU-accelerated implementations of Ewald summation, two-dimensional slab
 correction, Particle Mesh Ewald (PME), and Damped Shifted Force (DSF) electrostatics
-via [NVIDIA Warp](https://nvidia.github.io/warp/), with PyTorch and JAX autograd support
-for machine learning applications (Ewald and PME support full position/charge/cell
-autograd; DSF provides charge gradients via autograd and computes forces/virials
-analytically).
+via [NVIDIA Warp](https://nvidia.github.io/warp/). PyTorch bindings support autograd
+where documented; JAX electrostatics bindings expose explicit energies, forces,
+charge gradients, and virials via flags.
 
 ```{tip}
 For periodic systems, start with
@@ -24,7 +23,7 @@ systems or large-scale simulations, consider approximate
 {func}`~nvalchemiops.torch.interactions.electrostatics.dsf_coulomb` (PyTorch only) which provides $O(N)$ scaling
 with smooth force continuity at the cutoff.
 For slab-like systems with two periodic directions, use Ewald or PME with
-`slab_correction=True` and `pbc=...` in PyTorch.
+`slab_correction=True` and `pbc=...` in PyTorch or JAX.
 ```
 
 ## Overview of Available Methods
@@ -532,6 +531,44 @@ For batched slab simulations, pass `pbc` as an explicit contiguous `(B, 3)`
 tensor so each system carries its own slab geometry.
 ```
 
+#### 2D Slab Correction (JAX)
+
+JAX Ewald supports the same explicit-output slab correction. Pass
+`slab_correction=True` and request forces, charge gradients, or virials with the
+usual flags:
+
+```python
+import jax.numpy as jnp
+
+from nvalchemiops.jax.interactions.electrostatics import ewald_summation
+from nvalchemiops.jax.neighbors import neighbor_list
+
+pbc_slab = jnp.array([[True, True, False]], dtype=jnp.bool_)
+pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+neighbor_list_coo, neighbor_ptr, neighbor_shifts = neighbor_list(
+    positions,
+    cutoff=5.0,
+    cell=cell,
+    pbc=pbc_neighbor,
+    return_neighbor_list=True,
+)
+
+energies, forces, charge_grads = ewald_summation(
+    positions=positions,
+    charges=charges,
+    cell=cell,
+    alpha=0.3,
+    k_cutoff=8.0,
+    neighbor_list=neighbor_list_coo,
+    neighbor_ptr=neighbor_ptr,
+    neighbor_shifts=neighbor_shifts,
+    pbc=pbc_slab,
+    slab_correction=True,
+    compute_forces=True,
+    compute_charge_gradients=True,
+)
+```
+
 For an orthorhombic slab with non-periodic $z$ direction, total charge
 $Q = \sum_i q_i$, dipole moment $M_z = \sum_i q_i z_i$, second moment
 $M_{z^2} = \sum_i q_i z_i^2$, box length $L_z$, and volume $V$, the correction is:
@@ -542,7 +579,7 @@ E_\mathrm{slab}
 \left(M_z^2 - Q M_{z^2} - \frac{Q^2 L_z^2}{12}\right)
 ```
 
-The per-atom contribution used by the PyTorch kernels is:
+The per-atom contribution used by the slab kernels is:
 
 ```{math}
 e_i
@@ -632,6 +669,11 @@ When using the Ewald component functions for slab-like systems, add the slab
 correction explicitly after computing the 3D-periodic real- and reciprocal-space
 parts:
 
+::::{tab-set}
+
+:::{tab-item} PyTorch
+:sync: pytorch
+
 ```python
 from nvalchemiops.torch.interactions.electrostatics import compute_slab_correction
 
@@ -646,6 +688,30 @@ slab_energies, slab_forces = compute_slab_correction(
 ewald_slab_energies = real_energies + recip_energies + slab_energies
 ewald_slab_forces = real_forces + recip_forces + slab_forces
 ```
+
+:::
+
+:::{tab-item} JAX
+:sync: jax
+
+```python
+from nvalchemiops.jax.interactions.electrostatics import compute_slab_correction
+
+slab_energies, slab_forces = compute_slab_correction(
+    positions=positions,
+    charges=charges,
+    cell=cell,
+    pbc=pbc_slab,
+    compute_forces=True,
+)
+
+ewald_slab_energies = real_energies + recip_energies + slab_energies
+ewald_slab_forces = real_forces + recip_forces + slab_forces
+```
+
+:::
+
+::::
 
 ## Particle Mesh Ewald (PME)
 
@@ -908,6 +974,46 @@ slab_energies, slab_forces = compute_slab_correction(
 pme_slab_energies = real_energies + pme_reciprocal_energies + slab_energies
 pme_slab_forces = real_forces + pme_reciprocal_forces + slab_forces
 ```
+
+#### 2D Slab Correction with PME (JAX)
+
+Full JAX PME supports the same slab correction and explicit-output flags:
+
+```python
+import jax.numpy as jnp
+
+from nvalchemiops.jax.interactions.electrostatics import particle_mesh_ewald
+from nvalchemiops.jax.neighbors import neighbor_list
+
+pbc_slab = jnp.array([[True, True, False]], dtype=jnp.bool_)
+pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+neighbor_list_coo, neighbor_ptr, neighbor_shifts = neighbor_list(
+    positions,
+    cutoff=5.0,
+    cell=cell,
+    pbc=pbc_neighbor,
+    return_neighbor_list=True,
+)
+
+energies, forces, charge_grads = particle_mesh_ewald(
+    positions=positions,
+    charges=charges,
+    cell=cell,
+    alpha=0.3,
+    mesh_dimensions=(32, 32, 32),
+    neighbor_list=neighbor_list_coo,
+    neighbor_ptr=neighbor_ptr,
+    neighbor_shifts=neighbor_shifts,
+    pbc=pbc_slab,
+    slab_correction=True,
+    compute_forces=True,
+    compute_charge_gradients=True,
+)
+```
+
+The full JAX PME interface adds the same slab correction described in the Ewald
+section; component-wise PME composition uses `compute_slab_correction(...)` in
+the same way as the PyTorch snippet above.
 
 ### PME vs Ewald: When to Use Each
 

--- a/docs/userguide/components/electrostatics.md
+++ b/docs/userguide/components/electrostatics.md
@@ -485,7 +485,12 @@ k_{\text{cutoff}} = \sqrt{-2 \ln \varepsilon} / \eta
 Refer to the [Parameter Estimation](parameter-estimation) section for API usage.
 ```
 
-#### 2D Slab Correction (PyTorch)
+#### 2D Slab Correction
+
+::::{tab-set}
+
+:::{tab-item} PyTorch
+:sync: pytorch
 
 For slab-like systems with two periodic directions and one non-periodic direction,
 PyTorch Ewald can add the Yeh-Berkowitz / Ballenegger-Arnold-Cerdà slab
@@ -526,12 +531,10 @@ energies, forces = ewald_summation(
 )
 ```
 
-```{tip}
-For batched slab simulations, pass `pbc` as an explicit contiguous `(B, 3)`
-tensor so each system carries its own slab geometry.
-```
+:::
 
-#### 2D Slab Correction (JAX)
+:::{tab-item} JAX
+:sync: jax
 
 JAX Ewald supports the same explicit-output slab correction. Pass
 `slab_correction=True` and request forces, charge gradients, or virials with the
@@ -544,6 +547,9 @@ from nvalchemiops.jax.interactions.electrostatics import ewald_summation
 from nvalchemiops.jax.neighbors import neighbor_list
 
 pbc_slab = jnp.array([[True, True, False]], dtype=jnp.bool_)
+
+# The neighbor list controls the real-space 3D Ewald images. For a slab setup,
+# use a cell with enough vacuum in the non-periodic direction.
 pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
 neighbor_list_coo, neighbor_ptr, neighbor_shifts = neighbor_list(
     positions,
@@ -567,6 +573,15 @@ energies, forces, charge_grads = ewald_summation(
     compute_forces=True,
     compute_charge_gradients=True,
 )
+```
+
+:::
+
+::::
+
+```{tip}
+For batched slab simulations, pass `pbc` as an explicit contiguous `(B, 3)`
+tensor so each system carries its own slab geometry.
 ```
 
 For an orthorhombic slab with non-periodic $z$ direction, total charge
@@ -639,9 +654,9 @@ recip_energies, recip_forces = ewald_reciprocal_space(
 :sync: jax
 
 ```python
-import jax
-import jax.numpy as jnp
-from nvalchemiops.jax.interactions.electrostatics import ewald_real_space, ewald_reciprocal_space
+from nvalchemiops.jax.interactions.electrostatics import (
+    ewald_real_space, ewald_reciprocal_space
+)
 
 # Real-space only (short-range, damped Coulomb)
 real_energies, real_forces = ewald_real_space(
@@ -768,8 +783,6 @@ energies, forces = particle_mesh_ewald(
 :sync: jax
 
 ```python
-import jax
-import jax.numpy as jnp
 from nvalchemiops.jax.interactions.electrostatics import particle_mesh_ewald
 
 energies, forces = particle_mesh_ewald(
@@ -888,7 +901,12 @@ the value of `accuracy` the more precise, at the cost of higher
 computational requirements.
 ```
 
-#### 2D Slab Correction with PME (PyTorch)
+#### 2D Slab Correction with PME
+
+::::{tab-set}
+
+:::{tab-item} PyTorch
+:sync: pytorch
 
 For slab-like systems with two periodic directions, full PyTorch PME supports the
 same slab correction as Ewald. Pass `slab_correction=True` and a boolean `pbc`
@@ -975,17 +993,24 @@ pme_slab_energies = real_energies + pme_reciprocal_energies + slab_energies
 pme_slab_forces = real_forces + pme_reciprocal_forces + slab_forces
 ```
 
-#### 2D Slab Correction with PME (JAX)
+:::
+
+:::{tab-item} JAX
+:sync: jax
 
 Full JAX PME supports the same slab correction and explicit-output flags:
 
 ```python
+import jax
 import jax.numpy as jnp
 
 from nvalchemiops.jax.interactions.electrostatics import particle_mesh_ewald
 from nvalchemiops.jax.neighbors import neighbor_list
 
 pbc_slab = jnp.array([[True, True, False]], dtype=jnp.bool_)
+
+# The neighbor list controls the real-space 3D images. For a slab setup,
+# use a cell with enough vacuum in the non-periodic direction.
 pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
 neighbor_list_coo, neighbor_ptr, neighbor_shifts = neighbor_list(
     positions,
@@ -1014,6 +1039,10 @@ energies, forces, charge_grads = particle_mesh_ewald(
 The full JAX PME interface adds the same slab correction described in the Ewald
 section; component-wise PME composition uses `compute_slab_correction(...)` in
 the same way as the PyTorch snippet above.
+
+:::
+
+::::
 
 ### PME vs Ewald: When to Use Each
 

--- a/examples/electrostatics/05_slab_correction_example.py
+++ b/examples/electrostatics/05_slab_correction_example.py
@@ -111,13 +111,8 @@ print(f"  Total charge: {charges.sum().item():.1f}")
 # %%
 # Build the Real-Space Neighbor List
 # ----------------------------------
-# The slab correction modifies the long-range Ewald result after computing a
-# standard 3D Ewald sum in a cell with vacuum padding. The neighbor list controls
-# the real-space periodic images used by that 3D Ewald calculation.
-#
-# For this demonstration we use full 3D periodicity for the neighbor list and a
-# cutoff smaller than the vacuum gap, so no short-range neighbors cross the slab
-# normal.
+# The neighbor list controls real-space periodic images. For this slab setup,
+# use the same T/T/F periodicity and a cell with enough vacuum along z.
 
 alpha = 0.3
 real_space_cutoff = 5.0
@@ -125,12 +120,11 @@ k_cutoff = 2.5
 mesh_dimensions = (16, 16, 16)
 alpha_tensor = torch.tensor([alpha], dtype=torch.float64, device=device)
 
-pbc_neighbor = torch.tensor([[True, True, True]], dtype=torch.bool, device=device)
 neighbor_list, neighbor_ptr, neighbor_shifts = neighbor_list_fn(
     positions,
     real_space_cutoff,
     cell=cell,
-    pbc=pbc_neighbor,
+    pbc=pbc_slab,
     return_neighbor_list=True,
 )
 

--- a/examples/electrostatics/06_jax_slab_correction_example.py
+++ b/examples/electrostatics/06_jax_slab_correction_example.py
@@ -1,0 +1,544 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+2D Slab Correction for Ewald and PME with JAX
+=============================================
+
+This example demonstrates how to apply the Yeh-Berkowitz / Ballenegger
+two-dimensional slab correction to JAX Ewald and Particle Mesh Ewald (PME)
+electrostatics. The correction is used for slab-like systems with two periodic
+directions and one non-periodic direction, such as interfaces with vacuum
+padding.
+
+In this example you will learn:
+
+- How to run ``ewald_summation(..., slab_correction=True)`` in JAX
+- How to run ``particle_mesh_ewald(..., slab_correction=True)`` in JAX
+- How to pass slab periodicity with a boolean ``pbc`` array
+- How to compute the standalone slab correction with ``compute_slab_correction``
+- How the standalone correction equals the integrated Ewald energy/force delta
+- How to compose total Ewald and PME component workflows with slab
+- How triclinic slab cells use the normal to the periodic plane
+- How to use ``jax.jit`` with a full neighbor list + PME slab pipeline
+
+.. important::
+    This script is intended as an API demonstration. Do not use this script
+    for performance benchmarking; refer to the `benchmarks` folder instead.
+"""
+
+# %%
+# Setup and Imports
+# -----------------
+# The slab correction is available through the high-level JAX Ewald and PME
+# APIs, and as a standalone helper. The standalone helper is useful for
+# debugging, validation, and adding the correction when composing total
+# component workflows.
+
+from __future__ import annotations
+
+import sys
+
+try:
+    import jax
+    import jax.numpy as jnp
+except ImportError:
+    print(
+        "This example requires JAX. Install with: pip install 'nvalchemi-toolkit-ops[jax]'"
+    )
+    sys.exit(0)
+
+try:
+    from nvalchemiops.jax.interactions.electrostatics import (
+        compute_slab_correction,
+        ewald_real_space,
+        ewald_reciprocal_space,
+        ewald_summation,
+        generate_k_vectors_ewald_summation,
+        particle_mesh_ewald,
+        pme_reciprocal_space,
+    )
+    from nvalchemiops.jax.neighbors import neighbor_list as neighbor_list_fn
+    from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
+    from nvalchemiops.jax.neighbors.neighbor_utils import compute_naive_num_shifts
+except Exception as exc:
+    print(
+        f"JAX/Warp backend unavailable ({exc}). This example requires a CUDA-backed runtime."
+    )
+    sys.exit(0)
+
+# %%
+# Check Device
+# ------------
+
+print("=" * 70)
+print("JAX 2D SLAB CORRECTION EXAMPLE")
+print("=" * 70)
+
+devices = jax.devices()
+print(f"\nJAX devices: {devices}")
+print(f"Default backend: {jax.default_backend()}")
+
+# %%
+# Create a Small Slab System
+# --------------------------
+# We use a two-ion CsCl-like system in a cell with a long z direction. The
+# long cell vector represents vacuum padding normal to the slab.
+#
+# ``pbc_slab`` marks x and y as periodic and z as non-periodic. Batched slab
+# simulations should pass an explicit ``(B, 3)`` array so each system carries
+# its own slab geometry.
+
+
+def create_cscl_slab_system() -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    """Create a small T/T/F slab system with vacuum along z."""
+    positions = jnp.array(
+        [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]],
+        dtype=jnp.float64,
+    )
+    charges = jnp.array([1.0, -1.0], dtype=jnp.float64)
+    cell = jnp.diag(jnp.array([10.0, 10.0, 30.0], dtype=jnp.float64))[None, :, :]
+    pbc_slab = jnp.array([[True, True, False]], dtype=jnp.bool_)
+    return positions, charges, cell, pbc_slab
+
+
+positions, charges, cell, pbc_slab = create_cscl_slab_system()
+
+print("Slab system:")
+print(f"  Number of atoms: {positions.shape[0]}")
+print(f"  Cell rows:\n{jax.device_get(cell[0])}")
+print(f"  Slab pbc: {jax.device_get(pbc_slab[0])}")
+print(f"  Total charge: {float(charges.sum()):.1f}")
+
+# %%
+# Build the Real-Space Neighbor List
+# ----------------------------------
+# The slab correction modifies the long-range Ewald result after computing a
+# standard 3D Ewald sum in a cell with vacuum padding. The neighbor list controls
+# the real-space periodic images used by that 3D Ewald calculation.
+#
+# For this demonstration we use full 3D periodicity for the neighbor list and a
+# cutoff smaller than the vacuum gap, so no short-range neighbors cross the slab
+# normal.
+
+alpha = 0.3
+real_space_cutoff = 5.0
+k_cutoff = 2.5
+mesh_dimensions = (16, 16, 16)
+alpha_array = jnp.array([alpha], dtype=jnp.float64)
+
+pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+neighbor_list, neighbor_ptr, neighbor_shifts = neighbor_list_fn(
+    positions,
+    real_space_cutoff,
+    cell=cell,
+    pbc=pbc_neighbor,
+    return_neighbor_list=True,
+)
+
+print("\nNeighbor list:")
+print(f"  Number of neighbor entries: {neighbor_list.shape[1]}")
+print(f"  Real-space cutoff: {real_space_cutoff:.1f} Å")
+
+# %%
+# Standard 3D Ewald
+# -----------------
+# First compute the uncorrected 3D-periodic Ewald result. This is the quantity
+# that will receive the slab correction.
+
+energies_3d, forces_3d, charge_grads_3d, virial_3d = ewald_summation(
+    positions=positions,
+    charges=charges,
+    cell=cell,
+    alpha=alpha,
+    k_cutoff=k_cutoff,
+    neighbor_list=neighbor_list,
+    neighbor_ptr=neighbor_ptr,
+    neighbor_shifts=neighbor_shifts,
+    compute_forces=True,
+    compute_charge_gradients=True,
+    compute_virial=True,
+)
+
+print("\nStandard 3D Ewald:")
+print(f"  Total energy: {float(energies_3d.sum()): .8f}")
+print(f"  Max force magnitude: {float(jnp.linalg.norm(forces_3d, axis=1).max()): .8f}")
+print(f"  Charge gradients: {jax.device_get(charge_grads_3d)}")
+print(f"  Virial trace: {float(jnp.trace(virial_3d[0])): .8f}")
+
+# %%
+# Ewald with Slab Correction
+# --------------------------
+# Set ``slab_correction=True`` and pass the slab periodicity. The output tuple
+# follows the same ordering as ordinary Ewald: energies, forces, charge
+# gradients, and virial when all optional quantities are requested.
+
+energies_slab, forces_slab, charge_grads_slab, virial_slab = ewald_summation(
+    positions=positions,
+    charges=charges,
+    cell=cell,
+    alpha=alpha,
+    k_cutoff=k_cutoff,
+    neighbor_list=neighbor_list,
+    neighbor_ptr=neighbor_ptr,
+    neighbor_shifts=neighbor_shifts,
+    compute_forces=True,
+    compute_charge_gradients=True,
+    compute_virial=True,
+    pbc=pbc_slab,
+    slab_correction=True,
+)
+
+print("\nEwald with slab correction:")
+print(f"  Total energy: {float(energies_slab.sum()): .8f}")
+print(f"  Energy delta: {float((energies_slab - energies_3d).sum()): .8f}")
+print(
+    f"  Max force magnitude: {float(jnp.linalg.norm(forces_slab, axis=1).max()): .8f}"
+)
+print(f"  Charge gradients: {jax.device_get(charge_grads_slab)}")
+print(f"  Virial trace: {float(jnp.trace(virial_slab[0])): .8f}")
+
+# %%
+# Standalone Slab Correction
+# --------------------------
+# The same correction can be computed directly. The standalone result equals
+# the difference between the slab-corrected and uncorrected Ewald outputs.
+
+correction_energy, correction_forces, correction_charge_grads, correction_virial = (
+    compute_slab_correction(
+        positions=positions,
+        charges=charges,
+        cell=cell,
+        pbc=pbc_slab,
+        compute_forces=True,
+        compute_charge_gradients=True,
+        compute_virial=True,
+    )
+)
+
+energy_delta_error = jnp.max(jnp.abs((energies_slab - energies_3d) - correction_energy))
+force_delta_error = jnp.max(jnp.abs((forces_slab - forces_3d) - correction_forces))
+charge_grad_delta_error = jnp.max(
+    jnp.abs((charge_grads_slab - charge_grads_3d) - correction_charge_grads)
+)
+virial_delta_error = jnp.max(jnp.abs((virial_slab - virial_3d) - correction_virial))
+
+print("\nStandalone correction:")
+print(f"  Correction energy: {float(correction_energy.sum()): .8f}")
+print(f"  Max energy delta error: {float(energy_delta_error):.2e}")
+print(f"  Max force delta error: {float(force_delta_error):.2e}")
+print(f"  Max charge-gradient delta error: {float(charge_grad_delta_error):.2e}")
+print(f"  Max virial delta error: {float(virial_delta_error):.2e}")
+
+# %%
+# Total Ewald Component Composition
+# ---------------------------------
+# If you need the Ewald real-space, Ewald reciprocal-space, and slab terms
+# separately, compute the three pieces explicitly and add matching outputs.
+
+ewald_component_real_energy, ewald_component_real_forces = ewald_real_space(
+    positions=positions,
+    charges=charges,
+    cell=cell,
+    alpha=alpha_array,
+    neighbor_list=neighbor_list,
+    neighbor_ptr=neighbor_ptr,
+    neighbor_shifts=neighbor_shifts,
+    compute_forces=True,
+)
+ewald_k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff)
+ewald_component_reciprocal_energy, ewald_component_reciprocal_forces = (
+    ewald_reciprocal_space(
+        positions=positions,
+        charges=charges,
+        cell=cell,
+        k_vectors=ewald_k_vectors,
+        alpha=alpha_array,
+        compute_forces=True,
+    )
+)
+ewald_component_slab_energy, ewald_component_slab_forces = compute_slab_correction(
+    positions=positions,
+    charges=charges,
+    cell=cell,
+    pbc=pbc_slab,
+    compute_forces=True,
+)
+
+total_ewald_energy = (
+    ewald_component_real_energy
+    + ewald_component_reciprocal_energy
+    + ewald_component_slab_energy
+)
+total_ewald_forces = (
+    ewald_component_real_forces
+    + ewald_component_reciprocal_forces
+    + ewald_component_slab_forces
+)
+
+print("\nTotal Ewald composition from components:")
+print(
+    f"  Max energy error: {float(jnp.max(jnp.abs(total_ewald_energy - energies_slab))):.2e}"
+)
+print(
+    f"  Max force error: {float(jnp.max(jnp.abs(total_ewald_forces - forces_slab))):.2e}"
+)
+
+# %%
+# PME with Slab Correction
+# ------------------------
+# Full PME accepts the same slab correction arguments as Ewald. The reciprocal
+# PME component itself remains a 3D-periodic reciprocal-space calculation; the
+# slab term is added by the high-level ``particle_mesh_ewald`` wrapper.
+
+pme_3d_energy, pme_3d_forces = particle_mesh_ewald(
+    positions=positions,
+    charges=charges,
+    cell=cell,
+    alpha=alpha,
+    mesh_dimensions=mesh_dimensions,
+    neighbor_list=neighbor_list,
+    neighbor_ptr=neighbor_ptr,
+    neighbor_shifts=neighbor_shifts,
+    compute_forces=True,
+)
+
+pme_slab_energy, pme_slab_forces = particle_mesh_ewald(
+    positions=positions,
+    charges=charges,
+    cell=cell,
+    alpha=alpha,
+    mesh_dimensions=mesh_dimensions,
+    neighbor_list=neighbor_list,
+    neighbor_ptr=neighbor_ptr,
+    neighbor_shifts=neighbor_shifts,
+    compute_forces=True,
+    pbc=pbc_slab,
+    slab_correction=True,
+)
+
+print("\nPME with slab correction:")
+print(f"  Standard PME energy: {float(pme_3d_energy.sum()): .8f}")
+print(f"  Slab PME energy: {float(pme_slab_energy.sum()): .8f}")
+print(f"  Energy delta: {float((pme_slab_energy - pme_3d_energy).sum()): .8f}")
+print(
+    f"  Max force magnitude: {float(jnp.linalg.norm(pme_slab_forces, axis=1).max()): .8f}"
+)
+
+# %%
+# Total PME Component Composition
+# -------------------------------
+# If you need real-space, PME reciprocal-space, and slab terms separately,
+# compute the three pieces explicitly and add matching outputs.
+
+real_energy, real_forces = ewald_real_space(
+    positions=positions,
+    charges=charges,
+    cell=cell,
+    alpha=alpha_array,
+    neighbor_list=neighbor_list,
+    neighbor_ptr=neighbor_ptr,
+    neighbor_shifts=neighbor_shifts,
+    compute_forces=True,
+)
+reciprocal_energy, reciprocal_forces = pme_reciprocal_space(
+    positions=positions,
+    charges=charges,
+    cell=cell,
+    alpha=alpha_array,
+    mesh_dimensions=mesh_dimensions,
+    compute_forces=True,
+)
+slab_energy_correction, slab_forces_correction = compute_slab_correction(
+    positions=positions,
+    charges=charges,
+    cell=cell,
+    pbc=pbc_slab,
+    compute_forces=True,
+)
+
+total_pme_energy = real_energy + reciprocal_energy + slab_energy_correction
+total_pme_forces = real_forces + reciprocal_forces + slab_forces_correction
+
+print("\nTotal PME composition from components:")
+print(
+    f"  Max energy error: {float(jnp.max(jnp.abs(total_pme_energy - pme_slab_energy))):.2e}"
+)
+print(
+    f"  Max force error: {float(jnp.max(jnp.abs(total_pme_forces - pme_slab_forces))):.2e}"
+)
+
+# %%
+# Triclinic Slab Cells
+# --------------------
+# Triclinic cells are also supported. The slab normal follows the plane spanned
+# by the two periodic cell vectors; it is not locked to a Cartesian axis.
+#
+# Here we reuse the same positions and charges with a tilted cell and compute
+# the standalone correction.
+
+triclinic_cell = jnp.array(
+    [[[10.0, 0.0, 0.0], [1.5, 9.0, 0.8], [0.2, 0.4, 30.0]]],
+    dtype=jnp.float64,
+)
+
+triclinic_energy, triclinic_forces = compute_slab_correction(
+    positions=positions,
+    charges=charges,
+    cell=triclinic_cell,
+    pbc=pbc_slab,
+    compute_forces=True,
+)
+
+print("\nTriclinic standalone correction:")
+print(f"  Cell rows:\n{jax.device_get(triclinic_cell[0])}")
+print(f"  Correction energy: {float(triclinic_energy.sum()): .8f}")
+print(f"  Forces:\n{jax.device_get(triclinic_forces)}")
+
+# %%
+# JIT Compilation
+# ---------------
+# Demonstrate combining the neighbor list build and PME slab calculation into a
+# single ``jax.jit``-compiled function. This allows JAX to fuse the entire
+# pipeline into one optimized computation.
+#
+# For JIT compatibility:
+#
+# - ``max_neighbors`` must be specified (static array shapes)
+# - ``mesh_dimensions`` must be a concrete tuple (static FFT sizes)
+# - ``alpha`` can be a traced JAX array
+# - ``compute_forces`` and other boolean flags must be static
+# - Periodic shift metadata (``shift_range``, ``num_shifts_per_system``,
+#   ``max_shifts_per_system``) must be pre-computed outside jit using
+#   ``compute_naive_num_shifts``, since the launch dimensions must be concrete
+
+print("\n" + "=" * 70)
+print("JIT COMPILATION")
+print("=" * 70)
+
+jit_positions, jit_charges, jit_cell, jit_pbc_slab = create_cscl_slab_system()
+jit_pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+jit_alpha = jnp.array([alpha], dtype=jnp.float64)
+jit_max_neighbors = 16
+jit_mask_value = jit_positions.shape[0]
+
+shift_range, num_shifts_per_system, max_shifts_per_system = compute_naive_num_shifts(
+    jit_cell,
+    real_space_cutoff,
+    jit_pbc_neighbor,
+)
+
+
+def compute_pme_slab_energy_forces(
+    positions_in: jax.Array,
+    charges_in: jax.Array,
+    cell_in: jax.Array,
+    pbc_slab_in: jax.Array,
+    pbc_neighbor_in: jax.Array,
+    alpha_in: jax.Array,
+    shift_range_per_dimension: jax.Array = shift_range,
+    num_shifts: jax.Array = num_shifts_per_system,
+    cutoff: float = real_space_cutoff,
+    max_neighbors: int = jit_max_neighbors,
+    max_shifts: int = max_shifts_per_system,
+    mask_value: int = jit_mask_value,
+    mesh_dims: tuple[int, int, int] = mesh_dimensions,
+) -> tuple[jax.Array, jax.Array]:
+    """JIT-compatible neighbor matrix + PME slab pipeline."""
+    neighbor_matrix, _, neighbor_matrix_shifts = naive_neighbor_list(
+        positions_in,
+        cutoff,
+        cell=cell_in,
+        pbc=pbc_neighbor_in,
+        max_neighbors=max_neighbors,
+        fill_value=mask_value,
+        shift_range_per_dimension=shift_range_per_dimension,
+        num_shifts_per_system=num_shifts,
+        max_shifts_per_system=max_shifts,
+    )
+
+    energies, forces = particle_mesh_ewald(
+        positions=positions_in,
+        charges=charges_in,
+        cell=cell_in,
+        alpha=alpha_in,
+        mesh_dimensions=mesh_dims,
+        neighbor_matrix=neighbor_matrix,
+        neighbor_matrix_shifts=neighbor_matrix_shifts,
+        mask_value=mask_value,
+        compute_forces=True,
+        pbc=pbc_slab_in,
+        slab_correction=True,
+    )
+
+    return energies, forces
+
+
+jit_compute_pme_slab_energy_forces = jax.jit(compute_pme_slab_energy_forces)
+
+energies_nonjit, forces_nonjit = compute_pme_slab_energy_forces(
+    jit_positions,
+    jit_charges,
+    jit_cell,
+    jit_pbc_slab,
+    jit_pbc_neighbor,
+    jit_alpha,
+)
+energies_nonjit.block_until_ready()
+forces_nonjit.block_until_ready()
+
+print("  Non-jitted PME slab:")
+print(f"    Total energy: {float(energies_nonjit.sum()): .8f}")
+print(
+    f"    Max force magnitude: {float(jnp.linalg.norm(forces_nonjit, axis=1).max()): .8f}"
+)
+
+print("\nCompiling and running jitted PME slab pipeline...")
+energies_jit, forces_jit = jit_compute_pme_slab_energy_forces(
+    jit_positions,
+    jit_charges,
+    jit_cell,
+    jit_pbc_slab,
+    jit_pbc_neighbor,
+    jit_alpha,
+)
+energies_jit.block_until_ready()
+forces_jit.block_until_ready()
+
+print("  JIT PME slab:")
+print(f"    Total energy: {float(energies_jit.sum()): .8f}")
+print(
+    f"    Max force magnitude: {float(jnp.linalg.norm(forces_jit, axis=1).max()): .8f}"
+)
+print(
+    f"    Max energy error vs non-jit: {float(jnp.max(jnp.abs(energies_jit - energies_nonjit))):.2e}"
+)
+print(
+    f"    Max force error vs non-jit: {float(jnp.max(jnp.abs(forces_jit - forces_nonjit))):.2e}"
+)
+
+# %%
+# Summary
+# -------
+# Use ``ewald_summation(..., slab_correction=True, pbc=pbc_slab)`` or
+# ``particle_mesh_ewald(..., slab_correction=True, pbc=pbc_slab)`` when you want
+# the correction included in the total outputs. Use ``compute_slab_correction``
+# directly when you need the correction term alone or when composing
+# ``ewald_real_space`` with ``ewald_reciprocal_space`` or
+# ``pme_reciprocal_space``.
+#
+# For ``jax.jit`` workflows, keep shape-determining values outside the jitted
+# function: neighbor capacity, shift metadata, FFT mesh dimensions, and output
+# flags should all be static.

--- a/examples/electrostatics/06_jax_slab_correction_example.py
+++ b/examples/electrostatics/06_jax_slab_correction_example.py
@@ -125,13 +125,8 @@ print(f"  Total charge: {float(charges.sum()):.1f}")
 # %%
 # Build the Real-Space Neighbor List
 # ----------------------------------
-# The slab correction modifies the long-range Ewald result after computing a
-# standard 3D Ewald sum in a cell with vacuum padding. The neighbor list controls
-# the real-space periodic images used by that 3D Ewald calculation.
-#
-# For this demonstration we use full 3D periodicity for the neighbor list and a
-# cutoff smaller than the vacuum gap, so no short-range neighbors cross the slab
-# normal.
+# The neighbor list controls real-space periodic images. For this slab setup,
+# use the same T/T/F periodicity and a cell with enough vacuum along z.
 
 alpha = 0.3
 real_space_cutoff = 5.0
@@ -139,12 +134,11 @@ k_cutoff = 2.5
 mesh_dimensions = (16, 16, 16)
 alpha_array = jnp.array([alpha], dtype=jnp.float64)
 
-pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
 neighbor_list, neighbor_ptr, neighbor_shifts = neighbor_list_fn(
     positions,
     real_space_cutoff,
     cell=cell,
-    pbc=pbc_neighbor,
+    pbc=pbc_slab,
     return_neighbor_list=True,
 )
 
@@ -429,7 +423,6 @@ print("JIT COMPILATION")
 print("=" * 70)
 
 jit_positions, jit_charges, jit_cell, jit_pbc_slab = create_cscl_slab_system()
-jit_pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
 jit_alpha = jnp.array([alpha], dtype=jnp.float64)
 jit_max_neighbors = 16
 jit_mask_value = jit_positions.shape[0]
@@ -437,7 +430,7 @@ jit_mask_value = jit_positions.shape[0]
 shift_range, num_shifts_per_system, max_shifts_per_system = compute_naive_num_shifts(
     jit_cell,
     real_space_cutoff,
-    jit_pbc_neighbor,
+    jit_pbc_slab,
 )
 
 
@@ -446,7 +439,6 @@ def compute_pme_slab_energy_forces(
     charges_in: jax.Array,
     cell_in: jax.Array,
     pbc_slab_in: jax.Array,
-    pbc_neighbor_in: jax.Array,
     alpha_in: jax.Array,
     shift_range_per_dimension: jax.Array = shift_range,
     num_shifts: jax.Array = num_shifts_per_system,
@@ -461,7 +453,7 @@ def compute_pme_slab_energy_forces(
         positions_in,
         cutoff,
         cell=cell_in,
-        pbc=pbc_neighbor_in,
+        pbc=pbc_slab_in,
         max_neighbors=max_neighbors,
         fill_value=mask_value,
         shift_range_per_dimension=shift_range_per_dimension,
@@ -493,7 +485,6 @@ energies_nonjit, forces_nonjit = compute_pme_slab_energy_forces(
     jit_charges,
     jit_cell,
     jit_pbc_slab,
-    jit_pbc_neighbor,
     jit_alpha,
 )
 energies_nonjit.block_until_ready()
@@ -511,7 +502,6 @@ energies_jit, forces_jit = jit_compute_pme_slab_energy_forces(
     jit_charges,
     jit_cell,
     jit_pbc_slab,
-    jit_pbc_neighbor,
     jit_alpha,
 )
 energies_jit.block_until_ready()

--- a/nvalchemiops/jax/interactions/electrostatics/__init__.py
+++ b/nvalchemiops/jax/interactions/electrostatics/__init__.py
@@ -58,12 +58,17 @@ from nvalchemiops.jax.interactions.electrostatics.pme import (
     pme_green_structure_factor,
     pme_reciprocal_space,
 )
+from nvalchemiops.jax.interactions.electrostatics.slab import (
+    compute_slab_correction,
+)
 
 __all__ = [
     # Coulomb
     "coulomb_energy",
     "coulomb_forces",
     "coulomb_energy_forces",
+    # Slab correction
+    "compute_slab_correction",
     # Ewald
     "ewald_real_space",
     "ewald_reciprocal_space",

--- a/nvalchemiops/jax/interactions/electrostatics/_utils.py
+++ b/nvalchemiops/jax/interactions/electrostatics/_utils.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared utilities for JAX electrostatics bindings."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+import warp as wp
+from warp.jax_experimental import jax_kernel
+
+
+class ElectrostaticOutputs(NamedTuple):
+    """Named electrostatic outputs used for internal composition."""
+
+    energies: jax.Array
+    forces: jax.Array | None = None
+    charge_grads: jax.Array | None = None
+    virial: jax.Array | None = None
+
+
+def _normalize_dtype(dtype):
+    """Normalize dtype for kernel dictionary lookup.
+
+    Parameters
+    ----------
+    dtype : dtype-like
+        Input dtype from a JAX array.
+
+    Returns
+    -------
+    jnp.float32 or jnp.float64
+        Normalized JAX dtype for kernel lookup.
+    """
+    if dtype == jnp.float32 or str(dtype) == "float32":
+        return jnp.float32
+    if dtype == jnp.float64 or str(dtype) == "float64":
+        return jnp.float64
+    raise ValueError(f"Unsupported dtype: {dtype}")
+
+
+def _make_jax_kernels(
+    wp_overload_dict: dict,
+    num_outputs: int,
+    in_out_argnames: list[str],
+) -> dict:
+    """Maps a ``jax`` data type to ``warp``.
+
+    Parameters
+    ----------
+    wp_overload_dict : dict
+        Warp kernel overload dictionary keyed by wp.float32/wp.float64.
+    num_outputs : int
+        Number of output arrays returned by the kernel.
+    in_out_argnames : list of str
+        Names of in-place output arguments.
+
+    Returns
+    -------
+    dict
+        Dictionary mapping jnp.float32/jnp.float64 to jax_kernel instances.
+    """
+    jax_to_wp = {jnp.float32: wp.float32, jnp.float64: wp.float64}
+    return {
+        jax_dtype: jax_kernel(
+            wp_overload_dict[wp_dtype],
+            num_outputs=num_outputs,
+            in_out_argnames=in_out_argnames,
+            enable_backward=False,
+        )
+        for jax_dtype, wp_dtype in jax_to_wp.items()
+    }
+
+
+def _prepare_cell(cell: jax.Array) -> tuple[jax.Array, int]:
+    """Normalize a cell array to shape ``(B, 3, 3)``."""
+    if cell.ndim == 2:
+        cell = cell[jnp.newaxis, :, :]
+    if cell.ndim != 3 or cell.shape[1:] != (3, 3):
+        raise ValueError(f"cell must have shape (3, 3) or (B, 3, 3), got {cell.shape}")
+    return cell, cell.shape[0]
+
+
+def _build_electrostatic_result(
+    outputs: ElectrostaticOutputs,
+    compute_forces: bool,
+    compute_charge_gradients: bool,
+    compute_virial: bool,
+) -> jax.Array | tuple[jax.Array, ...]:
+    """Build an output tuple in electrostatics API order."""
+    result = [outputs.energies]
+    if compute_forces and outputs.forces is not None:
+        result.append(outputs.forces)
+    if compute_charge_gradients and outputs.charge_grads is not None:
+        result.append(outputs.charge_grads)
+    if compute_virial and outputs.virial is not None:
+        result.append(outputs.virial)
+    return tuple(result) if len(result) > 1 else result[0]
+
+
+def _unpack_electrostatic_outputs(
+    outputs: jax.Array | tuple[jax.Array, ...],
+    compute_forces: bool,
+    compute_charge_gradients: bool,
+    compute_virial: bool,
+) -> ElectrostaticOutputs:
+    """Unpack electrostatics outputs by flag combination without cursor logic."""
+    output_tuple = outputs if isinstance(outputs, tuple) else (outputs,)
+
+    if compute_forces and compute_charge_gradients and compute_virial:
+        energies, forces, charge_grads, virial = output_tuple
+    elif compute_forces and compute_charge_gradients:
+        energies, forces, charge_grads = output_tuple
+        virial = None
+    elif compute_forces and compute_virial:
+        energies, forces, virial = output_tuple
+        charge_grads = None
+    elif compute_charge_gradients and compute_virial:
+        energies, charge_grads, virial = output_tuple
+        forces = None
+    elif compute_forces:
+        energies, forces = output_tuple
+        charge_grads = None
+        virial = None
+    elif compute_charge_gradients:
+        energies, charge_grads = output_tuple
+        forces = None
+        virial = None
+    elif compute_virial:
+        energies, virial = output_tuple
+        forces = None
+        charge_grads = None
+    else:
+        (energies,) = output_tuple
+        forces = None
+        charge_grads = None
+        virial = None
+
+    return ElectrostaticOutputs(
+        energies=energies,
+        forces=forces,
+        charge_grads=charge_grads,
+        virial=virial,
+    )
+
+
+def _combine_electrostatic_outputs(
+    real_outputs: jax.Array | tuple[jax.Array, ...],
+    reciprocal_outputs: jax.Array | tuple[jax.Array, ...],
+    slab_outputs: jax.Array | tuple[jax.Array, ...] | None,
+    compute_forces: bool,
+    compute_charge_gradients: bool,
+    compute_virial: bool,
+) -> jax.Array | tuple[jax.Array, ...]:
+    """Combine real, reciprocal, and optional slab outputs by named fields."""
+    real = _unpack_electrostatic_outputs(
+        real_outputs,
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
+    )
+    reciprocal = _unpack_electrostatic_outputs(
+        reciprocal_outputs,
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
+    )
+
+    energies = real.energies + reciprocal.energies
+    forces = (
+        real.forces + reciprocal.forces
+        if compute_forces and real.forces is not None and reciprocal.forces is not None
+        else None
+    )
+    charge_grads = (
+        real.charge_grads + reciprocal.charge_grads
+        if compute_charge_gradients
+        and real.charge_grads is not None
+        and reciprocal.charge_grads is not None
+        else None
+    )
+    virial = (
+        real.virial + reciprocal.virial
+        if compute_virial and real.virial is not None and reciprocal.virial is not None
+        else None
+    )
+    combined = ElectrostaticOutputs(
+        energies=energies,
+        forces=forces,
+        charge_grads=charge_grads,
+        virial=virial,
+    )
+
+    if slab_outputs is not None:
+        slab = _unpack_electrostatic_outputs(
+            slab_outputs,
+            compute_forces,
+            compute_charge_gradients,
+            compute_virial,
+        )
+        combined = ElectrostaticOutputs(
+            energies=combined.energies + slab.energies,
+            forces=(
+                combined.forces + slab.forces
+                if compute_forces
+                and combined.forces is not None
+                and slab.forces is not None
+                else combined.forces
+            ),
+            charge_grads=(
+                combined.charge_grads + slab.charge_grads
+                if compute_charge_gradients
+                and combined.charge_grads is not None
+                and slab.charge_grads is not None
+                else combined.charge_grads
+            ),
+            virial=(
+                combined.virial + slab.virial
+                if compute_virial
+                and combined.virial is not None
+                and slab.virial is not None
+                else combined.virial
+            ),
+        )
+
+    return _build_electrostatic_result(
+        combined,
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
+    )

--- a/nvalchemiops/jax/interactions/electrostatics/_utils.py
+++ b/nvalchemiops/jax/interactions/electrostatics/_utils.py
@@ -17,21 +17,10 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple
-
 import jax
 import jax.numpy as jnp
 import warp as wp
 from warp.jax_experimental import jax_kernel
-
-
-class ElectrostaticOutputs(NamedTuple):
-    """Named electrostatic outputs used for internal composition."""
-
-    energies: jax.Array
-    forces: jax.Array | None = None
-    charge_grads: jax.Array | None = None
-    virial: jax.Array | None = None
 
 
 def _normalize_dtype(dtype):
@@ -97,19 +86,22 @@ def _prepare_cell(cell: jax.Array) -> tuple[jax.Array, int]:
 
 
 def _build_electrostatic_result(
-    outputs: ElectrostaticOutputs,
+    energies: jax.Array,
+    forces: jax.Array | None,
+    charge_grads: jax.Array | None,
+    virial: jax.Array | None,
     compute_forces: bool,
     compute_charge_gradients: bool,
     compute_virial: bool,
 ) -> jax.Array | tuple[jax.Array, ...]:
     """Build an output tuple in electrostatics API order."""
-    result = [outputs.energies]
-    if compute_forces and outputs.forces is not None:
-        result.append(outputs.forces)
-    if compute_charge_gradients and outputs.charge_grads is not None:
-        result.append(outputs.charge_grads)
-    if compute_virial and outputs.virial is not None:
-        result.append(outputs.virial)
+    result = [energies]
+    if compute_forces and forces is not None:
+        result.append(forces)
+    if compute_charge_gradients and charge_grads is not None:
+        result.append(charge_grads)
+    if compute_virial and virial is not None:
+        result.append(virial)
     return tuple(result) if len(result) > 1 else result[0]
 
 
@@ -118,7 +110,7 @@ def _unpack_electrostatic_outputs(
     compute_forces: bool,
     compute_charge_gradients: bool,
     compute_virial: bool,
-) -> ElectrostaticOutputs:
+) -> tuple[jax.Array, jax.Array | None, jax.Array | None, jax.Array | None]:
     """Unpack electrostatics outputs by flag combination without cursor logic."""
     output_tuple = outputs if isinstance(outputs, tuple) else (outputs,)
 
@@ -151,12 +143,7 @@ def _unpack_electrostatic_outputs(
         charge_grads = None
         virial = None
 
-    return ElectrostaticOutputs(
-        energies=energies,
-        forces=forces,
-        charge_grads=charge_grads,
-        virial=virial,
-    )
+    return energies, forces, charge_grads, virial
 
 
 def _combine_electrostatic_outputs(
@@ -168,78 +155,78 @@ def _combine_electrostatic_outputs(
     compute_virial: bool,
 ) -> jax.Array | tuple[jax.Array, ...]:
     """Combine real, reciprocal, and optional slab outputs by named fields."""
-    real = _unpack_electrostatic_outputs(
-        real_outputs,
-        compute_forces,
-        compute_charge_gradients,
-        compute_virial,
+    real_energies, real_forces, real_charge_grads, real_virial = (
+        _unpack_electrostatic_outputs(
+            real_outputs,
+            compute_forces,
+            compute_charge_gradients,
+            compute_virial,
+        )
     )
-    reciprocal = _unpack_electrostatic_outputs(
+    (
+        reciprocal_energies,
+        reciprocal_forces,
+        reciprocal_charge_grads,
+        reciprocal_virial,
+    ) = _unpack_electrostatic_outputs(
         reciprocal_outputs,
         compute_forces,
         compute_charge_gradients,
         compute_virial,
     )
 
-    energies = real.energies + reciprocal.energies
+    energies = real_energies + reciprocal_energies
     forces = (
-        real.forces + reciprocal.forces
-        if compute_forces and real.forces is not None and reciprocal.forces is not None
+        real_forces + reciprocal_forces
+        if compute_forces and real_forces is not None and reciprocal_forces is not None
         else None
     )
     charge_grads = (
-        real.charge_grads + reciprocal.charge_grads
+        real_charge_grads + reciprocal_charge_grads
         if compute_charge_gradients
-        and real.charge_grads is not None
-        and reciprocal.charge_grads is not None
+        and real_charge_grads is not None
+        and reciprocal_charge_grads is not None
         else None
     )
     virial = (
-        real.virial + reciprocal.virial
-        if compute_virial and real.virial is not None and reciprocal.virial is not None
+        real_virial + reciprocal_virial
+        if compute_virial and real_virial is not None and reciprocal_virial is not None
         else None
-    )
-    combined = ElectrostaticOutputs(
-        energies=energies,
-        forces=forces,
-        charge_grads=charge_grads,
-        virial=virial,
     )
 
     if slab_outputs is not None:
-        slab = _unpack_electrostatic_outputs(
-            slab_outputs,
-            compute_forces,
-            compute_charge_gradients,
-            compute_virial,
+        slab_energies, slab_forces, slab_charge_grads, slab_virial = (
+            _unpack_electrostatic_outputs(
+                slab_outputs,
+                compute_forces,
+                compute_charge_gradients,
+                compute_virial,
+            )
         )
-        combined = ElectrostaticOutputs(
-            energies=combined.energies + slab.energies,
-            forces=(
-                combined.forces + slab.forces
-                if compute_forces
-                and combined.forces is not None
-                and slab.forces is not None
-                else combined.forces
-            ),
-            charge_grads=(
-                combined.charge_grads + slab.charge_grads
-                if compute_charge_gradients
-                and combined.charge_grads is not None
-                and slab.charge_grads is not None
-                else combined.charge_grads
-            ),
-            virial=(
-                combined.virial + slab.virial
-                if compute_virial
-                and combined.virial is not None
-                and slab.virial is not None
-                else combined.virial
-            ),
+        energies = energies + slab_energies
+        forces = (
+            forces + slab_forces
+            if compute_forces and forces is not None and slab_forces is not None
+            else forces
+        )
+        charge_grads = (
+            charge_grads + slab_charge_grads
+            if compute_charge_gradients
+            and charge_grads is not None
+            and slab_charge_grads is not None
+            else charge_grads
+        )
+        virial = (
+            virial + slab_virial
+            if compute_virial and virial is not None and slab_virial is not None
+            else virial
         )
 
     return _build_electrostatic_result(
-        combined,
+        energies,
+        forces,
+        charge_grads,
+        virial,
         compute_forces,
         compute_charge_gradients,
         compute_virial,

--- a/nvalchemiops/jax/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/jax/interactions/electrostatics/ewald.py
@@ -57,7 +57,6 @@ from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     _ewald_subtract_self_energy_kernel_overload,
 )
 from nvalchemiops.jax.interactions.electrostatics._utils import (
-    ElectrostaticOutputs,
     _build_electrostatic_result,
     _combine_electrostatic_outputs,
     _make_jax_kernels,
@@ -702,7 +701,10 @@ def ewald_real_space(
         virial = None
 
     return _build_electrostatic_result(
-        ElectrostaticOutputs(energies, forces, charge_grads, virial),
+        energies,
+        forces,
+        charge_grads,
+        virial,
         compute_forces,
         compute_charge_gradients,
         compute_virial,
@@ -1064,7 +1066,10 @@ def ewald_reciprocal_space(
         charge_grads = None
 
     return _build_electrostatic_result(
-        ElectrostaticOutputs(energies, forces, charge_grads, virial),
+        energies,
+        forces,
+        charge_grads,
+        virial,
         compute_forces,
         compute_charge_gradients,
         compute_virial,

--- a/nvalchemiops/jax/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/jax/interactions/electrostatics/ewald.py
@@ -28,8 +28,6 @@ import math
 
 import jax
 import jax.numpy as jnp
-import warp as wp
-from warp.jax_experimental import jax_kernel
 
 from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     BATCH_BLOCK_SIZE,
@@ -58,11 +56,25 @@ from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     _ewald_reciprocal_space_virial_kernel_overload,
     _ewald_subtract_self_energy_kernel_overload,
 )
+from nvalchemiops.jax.interactions.electrostatics._utils import (
+    ElectrostaticOutputs,
+    _build_electrostatic_result,
+    _combine_electrostatic_outputs,
+    _make_jax_kernels,
+    _normalize_dtype,
+    _prepare_cell,
+)
 from nvalchemiops.jax.interactions.electrostatics.k_vectors import (
     generate_k_vectors_ewald_summation,
 )
 from nvalchemiops.jax.interactions.electrostatics.parameters import (
     estimate_ewald_parameters,
+)
+from nvalchemiops.jax.interactions.electrostatics.slab import (
+    _prepare_pbc_for_slab,
+)
+from nvalchemiops.jax.interactions.electrostatics.slab import (
+    compute_slab_correction as _compute_slab_correction,
 )
 
 __all__ = [
@@ -72,72 +84,6 @@ __all__ = [
 ]
 
 PI = math.pi
-
-# ==============================================================================
-# Helper for Creating JAX Kernel Dictionaries
-# ==============================================================================
-
-# Dtype normalization for kernel lookup
-_DTYPE_MAP = {
-    jnp.float32: jnp.float32,
-    jnp.float64: jnp.float64,
-}
-
-
-def _normalize_dtype(dtype):
-    """Normalize dtype for kernel dictionary lookup.
-
-    Parameters
-    ----------
-    dtype : dtype-like
-        Input dtype from a JAX array.
-
-    Returns
-    -------
-    jnp.float32 or jnp.float64
-        Normalized JAX dtype for kernel lookup.
-    """
-    # Convert to JAX dtype if needed
-    if dtype == jnp.float32 or str(dtype) == "float32":
-        return jnp.float32
-    elif dtype == jnp.float64 or str(dtype) == "float64":
-        return jnp.float64
-    else:
-        raise ValueError(f"Unsupported dtype: {dtype}")
-
-
-def _make_jax_kernels(
-    wp_overload_dict: dict,
-    num_outputs: int,
-    in_out_argnames: list[str],
-) -> dict:
-    """Maps a ``jax`` data type to ``warp``.
-
-    Parameters
-    ----------
-    wp_overload_dict : dict
-        Warp kernel overload dictionary keyed by wp.float32/wp.float64.
-    num_outputs : int
-        Number of output arrays returned by the kernel.
-    in_out_argnames : list of str
-        Names of in-place output arguments.
-
-    Returns
-    -------
-    dict
-        Dictionary mapping jnp.float32/jnp.float64 to jax_kernel instances.
-    """
-    _JAX_TO_WP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
-    return {
-        jax_dtype: jax_kernel(
-            wp_overload_dict[wp_dtype],
-            num_outputs=num_outputs,
-            in_out_argnames=in_out_argnames,
-            enable_backward=False,
-        )
-        for jax_dtype, wp_dtype in _JAX_TO_WP.items()
-    }
-
 
 # ==============================================================================
 # JAX Kernel Wrappers - Real Space
@@ -306,7 +252,6 @@ _jax_batch_ewald_reciprocal_virial = _make_jax_kernels(
     1,
     ["virial"],
 )
-
 
 # ==============================================================================
 # Helper Functions
@@ -746,18 +691,6 @@ def ewald_real_space(
                     launch_dims=(num_atoms,),
                 )
 
-    # Return results (energies and charge_grads are float64, forces match input dtype)
-    # Virial is always last in the return tuple when requested
-    def _build_result():
-        result = [energies]
-        if compute_forces and forces is not None:
-            result.append(forces)
-        if compute_charge_gradients and charge_grads is not None:
-            result.append(charge_grads)
-        if compute_virial and virial is not None:
-            result.append(virial)
-        return tuple(result) if len(result) > 1 else result[0]
-
     # Initialize optional variables to None if not computed
     if not (compute_forces or compute_virial or compute_charge_gradients):
         forces = None
@@ -768,7 +701,12 @@ def ewald_real_space(
     if not compute_virial:
         virial = None
 
-    return _build_result()
+    return _build_electrostatic_result(
+        ElectrostaticOutputs(energies, forces, charge_grads, virial),
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
+    )
 
 
 def ewald_reciprocal_space(
@@ -1118,18 +1056,6 @@ def ewald_reciprocal_space(
 
         charge_grads = charge_grads - self_energy_grad - background_grad
 
-    # Return results (energies and charge_grads are float64, forces match input dtype)
-    # Virial is always last in the return tuple when requested
-    def _build_result():
-        result = [energies]
-        if compute_forces and forces is not None:
-            result.append(forces)
-        if compute_charge_gradients and charge_grads is not None:
-            result.append(charge_grads)
-        if compute_virial and virial is not None:
-            result.append(virial)
-        return tuple(result) if len(result) > 1 else result[0]
-
     # Initialize optional variables to None if not computed
     if not (compute_forces or compute_charge_gradients):
         forces = None
@@ -1137,7 +1063,12 @@ def ewald_reciprocal_space(
     elif not compute_charge_gradients:
         charge_grads = None
 
-    return _build_result()
+    return _build_electrostatic_result(
+        ElectrostaticOutputs(energies, forces, charge_grads, virial),
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
+    )
 
 
 def ewald_summation(
@@ -1157,8 +1088,11 @@ def ewald_summation(
     neighbor_matrix_shifts: jax.Array | None = None,
     mask_value: int | None = None,
     compute_forces: bool = False,
+    compute_charge_gradients: bool = False,
     compute_virial: bool = False,
     accuracy: float = 1e-6,
+    pbc: jax.Array | None = None,
+    slab_correction: bool = False,
 ) -> jax.Array | tuple[jax.Array, ...]:
     """Compute complete Ewald summation (real + reciprocal space).
 
@@ -1206,10 +1140,19 @@ def ewald_summation(
         Value indicating invalid entries in neighbor_matrix.
     compute_forces : bool, default=False
         Whether to compute forces.
+    compute_charge_gradients : bool, default=False
+        Whether to compute charge gradients dE/dq_i.
     compute_virial : bool, default=False
         Whether to compute the virial tensor.
     accuracy : float, default=1e-6
         Target accuracy for automatic parameter estimation.
+    pbc : jax.Array, shape (3,) or (B, 3), dtype=bool, optional
+        Per-system periodic boundary conditions. Required when
+        ``slab_correction=True``. True marks periodic directions and False
+        marks the non-periodic slab direction.
+    slab_correction : bool, default=False
+        If True, add the Yeh-Berkowitz/Ballenegger slab correction to the
+        3D-periodic Ewald outputs.
 
     Returns
     -------
@@ -1217,6 +1160,8 @@ def ewald_summation(
         Per-atom total Ewald energy.
     forces : jax.Array, shape (N, 3), optional
         Forces (if compute_forces=True).
+    charge_gradients : jax.Array, shape (N,), optional
+        Charge gradients (if compute_charge_gradients=True).
     virial : jax.Array, shape (1, 3, 3) or (B, 3, 3), optional
         Virial tensor (if compute_virial=True). Always last in the return tuple.
 
@@ -1230,14 +1175,17 @@ def ewald_summation(
     ...     compute_forces=True,
     ... )
     """
+    cell, num_systems = _prepare_cell(cell)
+    if batch_idx is not None:
+        batch_idx = batch_idx.astype(jnp.int32)
+    if slab_correction:
+        pbc = _prepare_pbc_for_slab(pbc, num_systems)
+
     # Auto-estimate alpha and k_cutoff if not provided
     if alpha is None or k_cutoff is None:
-        # Ensure cell is (B, 3, 3) for parameter estimation
-        cell_3d = cell if cell.ndim == 3 else cell[jnp.newaxis, :, :]
-
         params = estimate_ewald_parameters(
             positions=positions,
-            cell=cell_3d,
+            cell=cell,
             batch_idx=batch_idx,
             accuracy=accuracy,
         )
@@ -1249,15 +1197,12 @@ def ewald_summation(
 
     # Generate k_vectors if not provided
     if k_vectors is None:
-        # Ensure cell is (B, 3, 3)
-        cell_3d = cell if cell.ndim == 3 else cell[jnp.newaxis, :, :]
-
         # Ensure k_cutoff is defined
         if k_cutoff is None:
             raise ValueError("k_cutoff must be provided if k_vectors is None")
 
         k_vectors = generate_k_vectors_ewald_summation(
-            cell=cell_3d,
+            cell=cell,
             k_cutoff=k_cutoff,
             miller_bounds=miller_bounds,
         )
@@ -1276,7 +1221,7 @@ def ewald_summation(
         mask_value=mask_value,
         batch_idx=batch_idx,
         compute_forces=compute_forces,
-        compute_charge_gradients=False,
+        compute_charge_gradients=compute_charge_gradients,
         compute_virial=compute_virial,
     )
 
@@ -1290,34 +1235,28 @@ def ewald_summation(
         batch_idx=batch_idx,
         max_atoms_per_system=max_atoms_per_system,
         compute_forces=compute_forces,
-        compute_charge_gradients=False,
+        compute_charge_gradients=compute_charge_gradients,
         compute_virial=compute_virial,
     )
 
-    # Sum contributions
-    # Both real_result and recip_result have matching tuple structure based on flags
-    # The order is: (energies, [forces], [virial]) - virial always last when present
-    if compute_forces and compute_virial:
-        real_energies, real_forces, real_virial = real_result  # type: ignore[misc]
-        recip_energies, recip_forces, recip_virial = recip_result  # type: ignore[misc]
-        total_energies = real_energies + recip_energies
-        total_forces = real_forces + recip_forces
-        total_virial = real_virial + recip_virial
-        return total_energies, total_forces, total_virial
-    elif compute_forces:
-        real_energies, real_forces = real_result  # type: ignore[misc]
-        recip_energies, recip_forces = recip_result  # type: ignore[misc]
-        total_energies = real_energies + recip_energies
-        total_forces = real_forces + recip_forces
-        return total_energies, total_forces
-    elif compute_virial:
-        real_energies, real_virial = real_result  # type: ignore[misc]
-        recip_energies, recip_virial = recip_result  # type: ignore[misc]
-        total_energies = real_energies + recip_energies
-        total_virial = real_virial + recip_virial
-        return total_energies, total_virial
-    else:
-        real_energies = real_result  # type: ignore[assignment]
-        recip_energies = recip_result  # type: ignore[assignment]
-        total_energies = real_energies + recip_energies
-        return total_energies
+    slab_result = None
+    if slab_correction:
+        slab_result = _compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            batch_idx=batch_idx,
+            compute_forces=compute_forces,
+            compute_charge_gradients=compute_charge_gradients,
+            compute_virial=compute_virial,
+        )
+
+    return _combine_electrostatic_outputs(
+        real_result,
+        recip_result,
+        slab_result,
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
+    )

--- a/nvalchemiops/jax/interactions/electrostatics/pme.py
+++ b/nvalchemiops/jax/interactions/electrostatics/pme.py
@@ -53,7 +53,15 @@ from nvalchemiops.interactions.electrostatics.pme_kernels import (
     _pme_energy_corrections_with_charge_grad_kernel_overload,
     _pme_green_structure_factor_kernel_overload,
 )
-from nvalchemiops.jax.interactions.electrostatics.ewald import ewald_real_space
+from nvalchemiops.jax.interactions.electrostatics._utils import (
+    ElectrostaticOutputs,
+    _build_electrostatic_result,
+    _combine_electrostatic_outputs,
+    _prepare_cell,
+)
+from nvalchemiops.jax.interactions.electrostatics.ewald import (
+    ewald_real_space,
+)
 from nvalchemiops.jax.interactions.electrostatics.k_vectors import (
     generate_k_vectors_pme,
 )
@@ -61,6 +69,12 @@ from nvalchemiops.jax.interactions.electrostatics.parameters import (
     estimate_pme_mesh_dimensions,
     estimate_pme_parameters,
     mesh_spacing_to_dimensions,
+)
+from nvalchemiops.jax.interactions.electrostatics.slab import (
+    _prepare_pbc_for_slab,
+)
+from nvalchemiops.jax.interactions.electrostatics.slab import (
+    compute_slab_correction as _compute_slab_correction,
 )
 from nvalchemiops.jax.spline import (
     spline_gather,
@@ -785,17 +799,12 @@ def pme_reciprocal_space(
             if compute_virial
             else None
         )
-        # Build return tuple based on flags
-        result = [energies]
-        if compute_forces:
-            result.append(forces)
-        if compute_charge_gradients:
-            result.append(charge_grads)
-        if compute_virial:
-            result.append(virial)
-        if len(result) == 1:
-            return result[0]
-        return tuple(result)
+        return _build_electrostatic_result(
+            ElectrostaticOutputs(energies, forces, charge_grads, virial),
+            compute_forces,
+            compute_charge_gradients,
+            compute_virial,
+        )
 
     # Determine mesh dimensions
     if mesh_dimensions is None:
@@ -932,24 +941,12 @@ def pme_reciprocal_space(
         # Compute forces: F = 2 * q * E
         forces = 2.0 * interpolated_field
 
-    # Build return tuple based on flags
-    # Order: energies, [forces], [charge_grads], [virial] (virial always last)
-    if compute_forces and compute_charge_gradients and compute_virial:
-        return energies, forces, charge_grads, virial
-    elif compute_forces and compute_charge_gradients:
-        return energies, forces, charge_grads
-    elif compute_forces and compute_virial:
-        return energies, forces, virial
-    elif compute_charge_gradients and compute_virial:
-        return energies, charge_grads, virial
-    elif compute_forces:
-        return energies, forces
-    elif compute_charge_gradients:
-        return energies, charge_grads
-    elif compute_virial:
-        return energies, virial
-    else:
-        return energies
+    return _build_electrostatic_result(
+        ElectrostaticOutputs(energies, forces, charge_grads, virial),
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
+    )
 
 
 def particle_mesh_ewald(
@@ -973,6 +970,8 @@ def particle_mesh_ewald(
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
     accuracy: float = 1e-6,
+    pbc: jax.Array | None = None,
+    slab_correction: bool = False,
 ) -> (
     jax.Array
     | tuple[jax.Array, jax.Array]
@@ -1040,6 +1039,13 @@ def particle_mesh_ewald(
         Stress = virial / volume.
     accuracy : float, default=1e-6
         Target accuracy for automatic parameter estimation.
+    pbc : jax.Array, shape (3,) or (B, 3), dtype=bool, optional
+        Per-system periodic boundary conditions. Required when
+        ``slab_correction=True``. True marks periodic directions and False
+        marks the non-periodic slab direction.
+    slab_correction : bool, default=False
+        If True, add the Yeh-Berkowitz/Ballenegger slab correction to the
+        3D-periodic PME outputs.
 
     Returns
     -------
@@ -1093,10 +1099,12 @@ def particle_mesh_ewald(
     """
     num_atoms = positions.shape[0]
 
-    # Prepare cell
-    if cell.ndim == 2:
-        cell = cell[jnp.newaxis, :, :]
-    num_systems = cell.shape[0]
+    # Prepare cell and slab pbc
+    cell, num_systems = _prepare_cell(cell)
+    if batch_idx is not None:
+        batch_idx = batch_idx.astype(jnp.int32)
+    if slab_correction:
+        pbc = _prepare_pbc_for_slab(pbc, num_systems)
 
     # Estimate parameters if not provided
     if alpha is None:
@@ -1157,16 +1165,24 @@ def particle_mesh_ewald(
         k_squared=k_squared,
     )
 
-    # Normalize return tuples for easy combination
-    # Both rs and rec return: energies, [forces], [charge_grads], [virial]
-    # where virial is always last if present
-    rs_tuple = rs if isinstance(rs, tuple) else (rs,)
-    rec_tuple = rec if isinstance(rec, tuple) else (rec,)
+    slab = None
+    if slab_correction:
+        slab = _compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            batch_idx=batch_idx,
+            compute_forces=compute_forces,
+            compute_charge_gradients=compute_charge_gradients,
+            compute_virial=compute_virial,
+        )
 
-    # The number of outputs should match between rs and rec
-    # Combine element-wise
-    results = tuple(r + s for r, s in zip(rs_tuple, rec_tuple))
-
-    if len(results) == 1:
-        return results[0]
-    return results
+    return _combine_electrostatic_outputs(
+        rs,
+        rec,
+        slab,
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
+    )

--- a/nvalchemiops/jax/interactions/electrostatics/pme.py
+++ b/nvalchemiops/jax/interactions/electrostatics/pme.py
@@ -54,7 +54,6 @@ from nvalchemiops.interactions.electrostatics.pme_kernels import (
     _pme_green_structure_factor_kernel_overload,
 )
 from nvalchemiops.jax.interactions.electrostatics._utils import (
-    ElectrostaticOutputs,
     _build_electrostatic_result,
     _combine_electrostatic_outputs,
     _prepare_cell,
@@ -800,7 +799,10 @@ def pme_reciprocal_space(
             else None
         )
         return _build_electrostatic_result(
-            ElectrostaticOutputs(energies, forces, charge_grads, virial),
+            energies,
+            forces,
+            charge_grads,
+            virial,
             compute_forces,
             compute_charge_gradients,
             compute_virial,
@@ -942,7 +944,10 @@ def pme_reciprocal_space(
         forces = 2.0 * interpolated_field
 
     return _build_electrostatic_result(
-        ElectrostaticOutputs(energies, forces, charge_grads, virial),
+        energies,
+        forces,
+        charge_grads,
+        virial,
         compute_forces,
         compute_charge_gradients,
         compute_virial,

--- a/nvalchemiops/jax/interactions/electrostatics/slab.py
+++ b/nvalchemiops/jax/interactions/electrostatics/slab.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JAX two-dimensional slab correction bindings."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from nvalchemiops.interactions.electrostatics.slab_kernels import (
+    _slab_correction_energy_forces_charge_grad_kernel_overload,
+    _slab_correction_energy_forces_kernel_overload,
+    _slab_correction_energy_kernel_overload,
+    _slab_reduce_moments_kernel_overload,
+)
+from nvalchemiops.jax.interactions.electrostatics._utils import (
+    ElectrostaticOutputs,
+    _build_electrostatic_result,
+    _make_jax_kernels,
+    _normalize_dtype,
+    _prepare_cell,
+)
+
+__all__ = ["compute_slab_correction"]
+
+
+_jax_slab_reduce_moments = _make_jax_kernels(
+    _slab_reduce_moments_kernel_overload,
+    3,
+    ["mz", "mz2", "qtotal"],
+)
+
+_jax_slab_correction_energy = _make_jax_kernels(
+    _slab_correction_energy_kernel_overload,
+    1,
+    ["energy_out"],
+)
+
+_jax_slab_correction_energy_forces = _make_jax_kernels(
+    _slab_correction_energy_forces_kernel_overload,
+    3,
+    ["energy_out", "forces", "virial"],
+)
+
+_jax_slab_correction_energy_forces_charge_grad = _make_jax_kernels(
+    _slab_correction_energy_forces_charge_grad_kernel_overload,
+    4,
+    ["energy_out", "forces", "charge_grads", "virial"],
+)
+
+
+def _prepare_pbc_for_slab(pbc: jax.Array | None, num_systems: int) -> jax.Array:
+    """Normalize and validate slab pbc as ``(B, 3)``."""
+    if pbc is None:
+        raise ValueError(
+            "slab_correction=True requires an explicit `pbc` argument. "
+            "Use a boolean array with shape (3,) for a single system or "
+            "(B, 3) for batched systems."
+        )
+
+    pbc = jnp.asarray(pbc)
+    if pbc.dtype != jnp.bool_:
+        raise ValueError(f"pbc must be a bool array, got dtype={pbc.dtype}")
+
+    if pbc.ndim == 1:
+        if pbc.shape != (3,):
+            raise ValueError(f"pbc must have shape (3,) or (B, 3), got {pbc.shape}")
+        if num_systems != 1:
+            raise ValueError(
+                "batched slab correction requires pbc with shape (B, 3); "
+                "shape (3,) is only valid for single-system calls"
+            )
+        return pbc[jnp.newaxis, :]
+
+    if pbc.ndim != 2 or pbc.shape[1] != 3:
+        raise ValueError(f"pbc must have shape (3,) or (B, 3), got {pbc.shape}")
+
+    if pbc.shape[0] != num_systems:
+        raise ValueError(
+            f"pbc has {pbc.shape[0]} rows but cell describes {num_systems} systems"
+        )
+
+    return pbc
+
+
+def compute_slab_correction(
+    positions: jax.Array,
+    charges: jax.Array,
+    cell: jax.Array,
+    pbc: jax.Array,
+    batch_idx: jax.Array | None = None,
+    compute_forces: bool = False,
+    compute_charge_gradients: bool = False,
+    compute_virial: bool = False,
+) -> jax.Array | tuple[jax.Array, ...]:
+    """Yeh-Berkowitz/Ballenegger slab correction for 2D periodic systems.
+
+    Returns the standalone slab correction contribution for JAX electrostatics
+    APIs. The caller can add the returned energy, force, charge-gradient, and
+    virial terms to 3D-periodic Ewald or PME component outputs. This JAX binding
+    is forward-only and exposes explicit outputs via flags.
+
+    Parameters
+    ----------
+    positions : jax.Array, shape (N, 3)
+        Atomic coordinates.
+    charges : jax.Array, shape (N,)
+        Atomic charges.
+    cell : jax.Array, shape (3, 3) or (B, 3, 3)
+        Unit cell matrices.
+    pbc : jax.Array, shape (3,) or (B, 3), dtype=bool
+        Per-system periodic boundary conditions. True marks periodic directions
+        and False marks the non-periodic slab direction. Systems whose pbc row
+        is not slab-like contribute zero. A shape (3,) array is accepted only
+        for single-system calls.
+    batch_idx : jax.Array, shape (N,), dtype=int32, optional
+        System index for each atom. Defaults to all zeros for a single system.
+    compute_forces : bool, default=False
+        If True, return per-atom slab forces.
+    compute_charge_gradients : bool, default=False
+        If True, return per-atom slab charge gradients dE_slab/dq_i.
+    compute_virial : bool, default=False
+        If True, return per-system slab virial tensors.
+
+    Returns
+    -------
+    energies : jax.Array, shape (N,)
+        Per-atom slab correction energy.
+    forces : jax.Array, shape (N, 3), optional
+        Per-atom slab force.
+    charge_gradients : jax.Array, shape (N,), optional
+        Per-atom slab charge gradient.
+    virial : jax.Array, shape (B, 3, 3), optional
+        Per-system slab virial tensor.
+    """
+    dtype = _normalize_dtype(positions.dtype)
+    positions_cast = positions.astype(dtype)
+    charges_cast = charges.astype(dtype)
+    cell_cast, num_systems = _prepare_cell(cell.astype(dtype))
+    pbc_cast = _prepare_pbc_for_slab(pbc, num_systems)
+    num_atoms = positions_cast.shape[0]
+
+    if batch_idx is None:
+        batch_idx_i32 = jnp.zeros(num_atoms, dtype=jnp.int32)
+    else:
+        batch_idx_i32 = batch_idx.astype(jnp.int32)
+
+    if num_atoms == 0:
+        return _build_electrostatic_result(
+            ElectrostaticOutputs(
+                energies=jnp.zeros((0,), dtype=jnp.float64),
+                forces=jnp.zeros((0, 3), dtype=dtype) if compute_forces else None,
+                charge_grads=(
+                    jnp.zeros((0,), dtype=jnp.float64)
+                    if compute_charge_gradients
+                    else None
+                ),
+                virial=(
+                    jnp.zeros((num_systems, 3, 3), dtype=dtype)
+                    if compute_virial
+                    else None
+                ),
+            ),
+            compute_forces,
+            compute_charge_gradients,
+            compute_virial,
+        )
+
+    mz = jnp.zeros((num_systems, 3), dtype=jnp.float64)
+    mz2 = jnp.zeros((num_systems, 3), dtype=jnp.float64)
+    qtotal = jnp.zeros(num_systems, dtype=jnp.float64)
+    mz, mz2, qtotal = _jax_slab_reduce_moments[dtype](
+        positions_cast,
+        charges_cast,
+        batch_idx_i32,
+        pbc_cast,
+        cell_cast,
+        mz,
+        mz2,
+        qtotal,
+        launch_dims=(num_atoms,),
+    )
+
+    energy_in = jnp.zeros(num_atoms, dtype=jnp.float64)
+    energy_out = jnp.zeros(num_atoms, dtype=jnp.float64)
+
+    if compute_charge_gradients:
+        forces = jnp.zeros((num_atoms, 3), dtype=dtype)
+        charge_grads = jnp.zeros(num_atoms, dtype=jnp.float64)
+        virial = jnp.zeros((num_systems, 3, 3), dtype=dtype)
+        energy_out, forces, charge_grads, virial = (
+            _jax_slab_correction_energy_forces_charge_grad[dtype](
+                positions_cast,
+                charges_cast,
+                batch_idx_i32,
+                pbc_cast,
+                cell_cast,
+                mz,
+                mz2,
+                qtotal,
+                energy_in,
+                energy_out,
+                int(compute_virial),
+                forces,
+                charge_grads,
+                virial,
+                launch_dims=(num_atoms,),
+            )
+        )
+        return _build_electrostatic_result(
+            ElectrostaticOutputs(
+                energies=energy_out,
+                forces=forces,
+                charge_grads=charge_grads,
+                virial=virial,
+            ),
+            compute_forces,
+            compute_charge_gradients,
+            compute_virial,
+        )
+
+    if compute_forces or compute_virial:
+        forces = jnp.zeros((num_atoms, 3), dtype=dtype)
+        virial = jnp.zeros((num_systems, 3, 3), dtype=dtype)
+        energy_out, forces, virial = _jax_slab_correction_energy_forces[dtype](
+            positions_cast,
+            charges_cast,
+            batch_idx_i32,
+            pbc_cast,
+            cell_cast,
+            mz,
+            mz2,
+            qtotal,
+            energy_in,
+            energy_out,
+            int(compute_virial),
+            forces,
+            virial,
+            launch_dims=(num_atoms,),
+        )
+        return _build_electrostatic_result(
+            ElectrostaticOutputs(
+                energies=energy_out,
+                forces=forces,
+                charge_grads=None,
+                virial=virial,
+            ),
+            compute_forces,
+            compute_charge_gradients,
+            compute_virial,
+        )
+
+    (energy_out,) = _jax_slab_correction_energy[dtype](
+        positions_cast,
+        charges_cast,
+        batch_idx_i32,
+        pbc_cast,
+        cell_cast,
+        mz,
+        mz2,
+        qtotal,
+        energy_in,
+        energy_out,
+        launch_dims=(num_atoms,),
+    )
+    return energy_out

--- a/nvalchemiops/jax/interactions/electrostatics/slab.py
+++ b/nvalchemiops/jax/interactions/electrostatics/slab.py
@@ -27,7 +27,6 @@ from nvalchemiops.interactions.electrostatics.slab_kernels import (
     _slab_reduce_moments_kernel_overload,
 )
 from nvalchemiops.jax.interactions.electrostatics._utils import (
-    ElectrostaticOutputs,
     _build_electrostatic_result,
     _make_jax_kernels,
     _normalize_dtype,
@@ -160,20 +159,10 @@ def compute_slab_correction(
 
     if num_atoms == 0:
         return _build_electrostatic_result(
-            ElectrostaticOutputs(
-                energies=jnp.zeros((0,), dtype=jnp.float64),
-                forces=jnp.zeros((0, 3), dtype=dtype) if compute_forces else None,
-                charge_grads=(
-                    jnp.zeros((0,), dtype=jnp.float64)
-                    if compute_charge_gradients
-                    else None
-                ),
-                virial=(
-                    jnp.zeros((num_systems, 3, 3), dtype=dtype)
-                    if compute_virial
-                    else None
-                ),
-            ),
+            jnp.zeros((0,), dtype=jnp.float64),
+            jnp.zeros((0, 3), dtype=dtype) if compute_forces else None,
+            (jnp.zeros((0,), dtype=jnp.float64) if compute_charge_gradients else None),
+            (jnp.zeros((num_systems, 3, 3), dtype=dtype) if compute_virial else None),
             compute_forces,
             compute_charge_gradients,
             compute_virial,
@@ -221,12 +210,10 @@ def compute_slab_correction(
             )
         )
         return _build_electrostatic_result(
-            ElectrostaticOutputs(
-                energies=energy_out,
-                forces=forces,
-                charge_grads=charge_grads,
-                virial=virial,
-            ),
+            energy_out,
+            forces,
+            charge_grads,
+            virial,
             compute_forces,
             compute_charge_gradients,
             compute_virial,
@@ -252,12 +239,10 @@ def compute_slab_correction(
             launch_dims=(num_atoms,),
         )
         return _build_electrostatic_result(
-            ElectrostaticOutputs(
-                energies=energy_out,
-                forces=forces,
-                charge_grads=None,
-                virial=virial,
-            ),
+            energy_out,
+            forces,
+            None,
+            virial,
             compute_forces,
             compute_charge_gradients,
             compute_virial,

--- a/nvalchemiops/torch/interactions/electrostatics/_util.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_util.py
@@ -17,27 +17,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple
-
 import torch
 
 __all__ = [
-    "ElectrostaticOutputs",
     "_InjectChargeGrad",
     "_build_electrostatic_result",
     "_combine_electrostatic_outputs",
     "_sum_charge_gradients",
     "_unpack_electrostatic_outputs",
 ]
-
-
-class ElectrostaticOutputs(NamedTuple):
-    """Named electrostatics outputs in public API order."""
-
-    energies: torch.Tensor
-    forces: torch.Tensor | None = None
-    charge_grads: torch.Tensor | None = None
-    virial: torch.Tensor | None = None
 
 
 @torch.compiler.disable
@@ -50,19 +38,22 @@ def _sum_charge_gradients(
 
 
 def _build_electrostatic_result(
-    outputs: ElectrostaticOutputs,
+    energies: torch.Tensor,
+    forces: torch.Tensor | None,
+    charge_grads: torch.Tensor | None,
+    virial: torch.Tensor | None,
     compute_forces: bool,
     compute_charge_gradients: bool,
     compute_virial: bool,
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     """Build an output tuple in electrostatics API order."""
-    result = [outputs.energies]
-    if compute_forces and outputs.forces is not None:
-        result.append(outputs.forces)
-    if compute_charge_gradients and outputs.charge_grads is not None:
-        result.append(outputs.charge_grads)
-    if compute_virial and outputs.virial is not None:
-        result.append(outputs.virial)
+    result = [energies]
+    if compute_forces and forces is not None:
+        result.append(forces)
+    if compute_charge_gradients and charge_grads is not None:
+        result.append(charge_grads)
+    if compute_virial and virial is not None:
+        result.append(virial)
     return tuple(result) if len(result) > 1 else result[0]
 
 
@@ -71,7 +62,7 @@ def _unpack_electrostatic_outputs(
     compute_forces: bool,
     compute_charge_gradients: bool,
     compute_virial: bool,
-) -> ElectrostaticOutputs:
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
     """Unpack electrostatics outputs by flag combination without cursor logic."""
     output_tuple = outputs if isinstance(outputs, tuple) else (outputs,)
 
@@ -104,7 +95,7 @@ def _unpack_electrostatic_outputs(
         charge_grads = None
         virial = None
 
-    return ElectrostaticOutputs(energies, forces, charge_grads, virial)
+    return energies, forces, charge_grads, virial
 
 
 def _combine_electrostatic_outputs(
@@ -116,58 +107,79 @@ def _combine_electrostatic_outputs(
     compute_virial: bool,
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     """Combine real, reciprocal, and optional slab outputs by named fields."""
-    real = _unpack_electrostatic_outputs(
-        real_outputs, compute_forces, compute_charge_gradients, compute_virial
+    real_energies, real_forces, real_charge_grads, real_virial = (
+        _unpack_electrostatic_outputs(
+            real_outputs,
+            compute_forces,
+            compute_charge_gradients,
+            compute_virial,
+        )
     )
-    reciprocal = _unpack_electrostatic_outputs(
-        reciprocal_outputs, compute_forces, compute_charge_gradients, compute_virial
+    (
+        reciprocal_energies,
+        reciprocal_forces,
+        reciprocal_charge_grads,
+        reciprocal_virial,
+    ) = _unpack_electrostatic_outputs(
+        reciprocal_outputs,
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
     )
 
-    energies = real.energies + reciprocal.energies
+    energies = real_energies + reciprocal_energies
     forces = (
-        real.forces + reciprocal.forces
-        if compute_forces and real.forces is not None and reciprocal.forces is not None
+        real_forces + reciprocal_forces
+        if compute_forces and real_forces is not None and reciprocal_forces is not None
         else None
     )
 
     if (
         compute_charge_gradients
-        and real.charge_grads is not None
-        and reciprocal.charge_grads is not None
+        and real_charge_grads is not None
+        and reciprocal_charge_grads is not None
     ):
         if torch.compiler.is_compiling():
             charge_grads = _sum_charge_gradients(
-                real.charge_grads, reciprocal.charge_grads
+                real_charge_grads, reciprocal_charge_grads
             )
         else:
-            charge_grads = real.charge_grads + reciprocal.charge_grads
+            charge_grads = real_charge_grads + reciprocal_charge_grads
     else:
         charge_grads = None
 
     virial = (
-        real.virial + reciprocal.virial
-        if compute_virial and real.virial is not None and reciprocal.virial is not None
+        real_virial + reciprocal_virial
+        if compute_virial and real_virial is not None and reciprocal_virial is not None
         else None
     )
 
     if slab_outputs is not None:
-        slab = _unpack_electrostatic_outputs(
-            slab_outputs, compute_forces, compute_charge_gradients, compute_virial
+        slab_energies, slab_forces, slab_charge_grads, slab_virial = (
+            _unpack_electrostatic_outputs(
+                slab_outputs,
+                compute_forces,
+                compute_charge_gradients,
+                compute_virial,
+            )
         )
-        energies = energies + slab.energies
-        if compute_forces and forces is not None and slab.forces is not None:
-            forces = forces + slab.forces
+        energies = energies + slab_energies
+        if compute_forces and forces is not None and slab_forces is not None:
+            forces = forces + slab_forces
         if (
             compute_charge_gradients
             and charge_grads is not None
-            and slab.charge_grads is not None
+            and slab_charge_grads is not None
         ):
-            charge_grads = charge_grads + slab.charge_grads
-        if compute_virial and virial is not None and slab.virial is not None:
-            virial = virial + slab.virial
+            charge_grads = charge_grads + slab_charge_grads
+        if compute_virial and virial is not None and slab_virial is not None:
+            virial = virial + slab_virial
 
     return _build_electrostatic_result(
-        ElectrostaticOutputs(energies, forces, charge_grads, virial),
+        energies,
+        forces,
+        charge_grads,
+        virial,
         compute_forces,
         compute_charge_gradients,
         compute_virial,

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -106,7 +106,6 @@ from nvalchemiops.torch.autograd import (
     warp_from_torch,
 )
 from nvalchemiops.torch.interactions.electrostatics._util import (
-    ElectrostaticOutputs,
     _build_electrostatic_result,
     _combine_electrostatic_outputs,
     _InjectChargeGrad,
@@ -2722,7 +2721,10 @@ def ewald_real_space(
             )
 
         return _build_electrostatic_result(
-            ElectrostaticOutputs(energies, forces, charge_grads, virial),
+            energies,
+            forces,
+            charge_grads,
+            virial,
             compute_forces,
             compute_charge_gradients,
             compute_virial,
@@ -2793,7 +2795,10 @@ def ewald_real_space(
             raise ValueError("Either neighbor_list or neighbor_matrix must be provided")
 
         return _build_electrostatic_result(
-            ElectrostaticOutputs(energies, forces, charge_grads, virial),
+            energies,
+            forces,
+            charge_grads,
+            virial,
             compute_forces,
             compute_charge_gradients,
             compute_virial,
@@ -2816,8 +2821,12 @@ def ewald_real_space(
                     neighbor_shifts,
                     compute_virial=compute_virial,
                 )
+                charge_grads = None
                 return _build_electrostatic_result(
-                    ElectrostaticOutputs(energies, forces, virial=virial),
+                    energies,
+                    forces,
+                    charge_grads,
+                    virial,
                     compute_forces,
                     compute_charge_gradients,
                     compute_virial,
@@ -2833,8 +2842,14 @@ def ewald_real_space(
                     neighbor_ptr,
                     neighbor_shifts,
                 )
+                forces = None
+                charge_grads = None
+                virial = None
                 return _build_electrostatic_result(
-                    ElectrostaticOutputs(energies),
+                    energies,
+                    forces,
+                    charge_grads,
+                    virial,
                     compute_forces,
                     compute_charge_gradients,
                     compute_virial,
@@ -2851,8 +2866,12 @@ def ewald_real_space(
                     neighbor_shifts,
                     compute_virial=compute_virial,
                 )
+                charge_grads = None
                 return _build_electrostatic_result(
-                    ElectrostaticOutputs(energies, forces, virial=virial),
+                    energies,
+                    forces,
+                    charge_grads,
+                    virial,
                     compute_forces,
                     compute_charge_gradients,
                     compute_virial,
@@ -2867,8 +2886,14 @@ def ewald_real_space(
                     neighbor_ptr,
                     neighbor_shifts,
                 )
+                forces = None
+                charge_grads = None
+                virial = None
                 return _build_electrostatic_result(
-                    ElectrostaticOutputs(energies),
+                    energies,
+                    forces,
+                    charge_grads,
+                    virial,
                     compute_forces,
                     compute_charge_gradients,
                     compute_virial,
@@ -2887,8 +2912,12 @@ def ewald_real_space(
                     mask_value,
                     compute_virial=compute_virial,
                 )
+                charge_grads = None
                 return _build_electrostatic_result(
-                    ElectrostaticOutputs(energies, forces, virial=virial),
+                    energies,
+                    forces,
+                    charge_grads,
+                    virial,
                     compute_forces,
                     compute_charge_gradients,
                     compute_virial,
@@ -2904,8 +2933,14 @@ def ewald_real_space(
                     neighbor_matrix_shifts,
                     mask_value,
                 )
+                forces = None
+                charge_grads = None
+                virial = None
                 return _build_electrostatic_result(
-                    ElectrostaticOutputs(energies),
+                    energies,
+                    forces,
+                    charge_grads,
+                    virial,
                     compute_forces,
                     compute_charge_gradients,
                     compute_virial,
@@ -2922,8 +2957,12 @@ def ewald_real_space(
                     mask_value,
                     compute_virial=compute_virial,
                 )
+                charge_grads = None
                 return _build_electrostatic_result(
-                    ElectrostaticOutputs(energies, forces, virial=virial),
+                    energies,
+                    forces,
+                    charge_grads,
+                    virial,
                     compute_forces,
                     compute_charge_gradients,
                     compute_virial,
@@ -2938,8 +2977,14 @@ def ewald_real_space(
                     neighbor_matrix_shifts,
                     mask_value,
                 )
+                forces = None
+                charge_grads = None
+                virial = None
                 return _build_electrostatic_result(
-                    ElectrostaticOutputs(energies),
+                    energies,
+                    forces,
+                    charge_grads,
+                    virial,
                     compute_forces,
                     compute_charge_gradients,
                     compute_virial,
@@ -3052,7 +3097,10 @@ def ewald_reciprocal_space(
             )
 
         return _build_electrostatic_result(
-            ElectrostaticOutputs(energies, forces, charge_grads, virial),
+            energies,
+            forces,
+            charge_grads,
+            virial,
             compute_forces,
             compute_charge_gradients,
             compute_virial,
@@ -3084,7 +3132,10 @@ def ewald_reciprocal_space(
             )
 
         return _build_electrostatic_result(
-            ElectrostaticOutputs(energies, forces, charge_grads, virial),
+            energies,
+            forces,
+            charge_grads,
+            virial,
             compute_forces,
             compute_charge_gradients,
             compute_virial,
@@ -3102,8 +3153,12 @@ def ewald_reciprocal_space(
                 batch_idx,
                 compute_virial=compute_virial,
             )
+            charge_grads = None
             return _build_electrostatic_result(
-                ElectrostaticOutputs(energies, forces, virial=virial),
+                energies,
+                forces,
+                charge_grads,
+                virial,
                 compute_forces,
                 compute_charge_gradients,
                 compute_virial,
@@ -3118,8 +3173,13 @@ def ewald_reciprocal_space(
                 batch_idx,
                 compute_virial=compute_virial,
             )
+            forces = None
+            charge_grads = None
             return _build_electrostatic_result(
-                ElectrostaticOutputs(energies, virial=virial),
+                energies,
+                forces,
+                charge_grads,
+                virial,
                 compute_forces,
                 compute_charge_gradients,
                 compute_virial,
@@ -3134,8 +3194,12 @@ def ewald_reciprocal_space(
                 alpha,
                 compute_virial=compute_virial,
             )
+            charge_grads = None
             return _build_electrostatic_result(
-                ElectrostaticOutputs(energies, forces, virial=virial),
+                energies,
+                forces,
+                charge_grads,
+                virial,
                 compute_forces,
                 compute_charge_gradients,
                 compute_virial,
@@ -3149,8 +3213,13 @@ def ewald_reciprocal_space(
                 alpha,
                 compute_virial=compute_virial,
             )
+            forces = None
+            charge_grads = None
             return _build_electrostatic_result(
-                ElectrostaticOutputs(energies, virial=virial),
+                energies,
+                forces,
+                charge_grads,
+                virial,
                 compute_forces,
                 compute_charge_gradients,
                 compute_virial,
@@ -3362,26 +3431,25 @@ def ewald_summation(
                 compute_charge_gradients=True,
                 compute_virial=compute_virial,
             )
-            slab = _unpack_electrostatic_outputs(
-                slab_out,
-                compute_forces,
-                compute_charge_gradients=True,
-                compute_virial=compute_virial,
+            slab_energies, slab_forces, slab_charge_grads, slab_virial = (
+                _unpack_electrostatic_outputs(
+                    slab_out,
+                    compute_forces,
+                    compute_charge_gradients=True,
+                    compute_virial=compute_virial,
+                )
             )
-            slab_energies = slab.energies
 
             if charges.requires_grad:
                 slab_energies = _InjectChargeGrad.apply(
-                    slab_energies, charges, slab.charge_grads, batch_idx
+                    slab_energies, charges, slab_charge_grads, batch_idx
                 )
 
             slab_result = _build_electrostatic_result(
-                ElectrostaticOutputs(
-                    slab_energies,
-                    slab.forces,
-                    slab.charge_grads,
-                    slab.virial,
-                ),
+                slab_energies,
+                slab_forces,
+                slab_charge_grads,
+                slab_virial,
                 compute_forces,
                 compute_charge_gradients,
                 compute_virial,

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -180,7 +180,6 @@ from nvalchemiops.torch.autograd import (
     warp_from_torch,
 )
 from nvalchemiops.torch.interactions.electrostatics._util import (
-    ElectrostaticOutputs,
     _build_electrostatic_result,
     _combine_electrostatic_outputs,
     _InjectChargeGrad,
@@ -2372,26 +2371,25 @@ def particle_mesh_ewald(
                 compute_charge_gradients=True,
                 compute_virial=compute_virial,
             )
-            slab = _unpack_electrostatic_outputs(
-                slab_out,
-                compute_forces,
-                compute_charge_gradients=True,
-                compute_virial=compute_virial,
+            slab_energies, slab_forces, slab_charge_grads, slab_virial = (
+                _unpack_electrostatic_outputs(
+                    slab_out,
+                    compute_forces,
+                    compute_charge_gradients=True,
+                    compute_virial=compute_virial,
+                )
             )
-            slab_energies = slab.energies
 
             if charges.requires_grad:
                 slab_energies = _InjectChargeGrad.apply(
-                    slab_energies, charges, slab.charge_grads, batch_idx
+                    slab_energies, charges, slab_charge_grads, batch_idx
                 )
 
             slab_result = _build_electrostatic_result(
-                ElectrostaticOutputs(
-                    slab_energies,
-                    slab.forces,
-                    slab.charge_grads,
-                    slab.virial,
-                ),
+                slab_energies,
+                slab_forces,
+                slab_charge_grads,
+                slab_virial,
                 compute_forces,
                 compute_charge_gradients,
                 compute_virial,

--- a/nvalchemiops/torch/interactions/electrostatics/slab.py
+++ b/nvalchemiops/torch/interactions/electrostatics/slab.py
@@ -33,7 +33,6 @@ from nvalchemiops.torch.autograd import (
     warp_from_torch,
 )
 from nvalchemiops.torch.interactions.electrostatics._util import (
-    ElectrostaticOutputs,
     _build_electrostatic_result,
 )
 from nvalchemiops.torch.types import get_wp_dtype, get_wp_mat_dtype, get_wp_vec_dtype
@@ -453,7 +452,10 @@ def compute_slab_correction(
             )
         )
         return _build_electrostatic_result(
-            ElectrostaticOutputs(energies, forces, charge_grads, virial),
+            energies,
+            forces,
+            charge_grads,
+            virial,
             compute_forces,
             compute_charge_gradients,
             compute_virial,
@@ -468,8 +470,12 @@ def compute_slab_correction(
             batch_idx,
             compute_virial=compute_virial,
         )
+        charge_grads = None
         return _build_electrostatic_result(
-            ElectrostaticOutputs(energies, forces, virial=virial),
+            energies,
+            forces,
+            charge_grads,
+            virial,
             compute_forces,
             compute_charge_gradients,
             compute_virial,

--- a/test/interactions/electrostatics/bindings/jax/test_slab.py
+++ b/test/interactions/electrostatics/bindings/jax/test_slab.py
@@ -1,0 +1,1057 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for explicit-output JAX slab electrostatics bindings."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from nvalchemiops.jax.interactions.electrostatics import compute_slab_correction
+from nvalchemiops.jax.interactions.electrostatics.ewald import (
+    ewald_real_space,
+    ewald_reciprocal_space,
+    ewald_summation,
+)
+from nvalchemiops.jax.interactions.electrostatics.k_vectors import (
+    generate_k_vectors_ewald_summation,
+)
+from nvalchemiops.jax.interactions.electrostatics.pme import (
+    particle_mesh_ewald,
+    pme_reciprocal_space,
+)
+from nvalchemiops.jax.neighbors import batch_cell_list, cell_list
+
+EWALD_ALPHA = 0.35
+EWALD_K_CUTOFF = 8.0
+PME_MESH = (8, 8, 8)
+REAL_SPACE_CUTOFF = 6.0
+SLAB_STRICT_RTOL = 1e-12
+SLAB_STRICT_ATOL = 1e-14
+OUTPUT_CASES = [
+    (False, False, False, ("energies",)),
+    (True, False, False, ("energies", "forces")),
+    (False, True, False, ("energies", "charge_grads")),
+    (False, False, True, ("energies", "virial")),
+    (True, True, False, ("energies", "forces", "charge_grads")),
+    (True, False, True, ("energies", "forces", "virial")),
+    (False, True, True, ("energies", "charge_grads", "virial")),
+    (True, True, True, ("energies", "forces", "charge_grads", "virial")),
+]
+
+
+def _make_slab_system(dtype=jnp.float64):
+    """Return a small triclinic single-system slab fixture."""
+    positions = jnp.array(
+        [
+            [2.0, 2.0, 4.0],
+            [4.0, 5.0, 9.0],
+            [7.0, 3.0, 15.0],
+        ],
+        dtype=dtype,
+    )
+    charges = jnp.array([1.0, -1.0, 0.5], dtype=dtype)
+    cell = jnp.array(
+        [[[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [1.0, 0.5, 30.0]]],
+        dtype=dtype,
+    )
+    pbc_slab = jnp.array([[True, True, False]], dtype=jnp.bool_)
+    return positions, charges, cell, pbc_slab
+
+
+def _make_batched_system(dtype=jnp.float64):
+    """Return one slab system batched with one 3D-periodic system."""
+    slab_positions, slab_charges, slab_cell, _ = _make_slab_system(dtype)
+    other_positions = jnp.array(
+        [[1.0, 1.0, 2.0], [3.0, 4.0, 8.0]],
+        dtype=dtype,
+    )
+    other_charges = jnp.array([1.0, -1.0], dtype=dtype)
+    other_cell = jnp.eye(3, dtype=dtype) * 12.0
+    positions = jnp.concatenate([slab_positions, other_positions], axis=0)
+    charges = jnp.concatenate([slab_charges, other_charges], axis=0)
+    cell = jnp.concatenate([slab_cell, other_cell[jnp.newaxis, :, :]], axis=0)
+    batch_idx = jnp.array([0, 0, 0, 1, 1], dtype=jnp.int32)
+    pbc = jnp.array(
+        [[True, True, False], [True, True, True]],
+        dtype=jnp.bool_,
+    )
+    return positions, charges, cell, batch_idx, pbc
+
+
+def _reference_slab_correction(positions, charges, cell, pbc, batch_idx=None):
+    """Compute slab corrections using an independent reference formula."""
+    input_dtype = positions.dtype
+    positions_f64 = positions.astype(jnp.float64)
+    charges_f64 = charges.astype(jnp.float64)
+    cell_f64 = cell.astype(jnp.float64)
+    if cell_f64.ndim == 2:
+        cell_f64 = cell_f64[jnp.newaxis, :, :]
+    pbc_array = jnp.asarray(pbc)
+    if pbc_array.ndim == 1:
+        pbc_array = pbc_array[jnp.newaxis, :]
+    if batch_idx is None:
+        batch_idx_i32 = jnp.zeros(positions_f64.shape[0], dtype=jnp.int32)
+    else:
+        batch_idx_i32 = batch_idx.astype(jnp.int32)
+
+    num_systems = cell_f64.shape[0]
+    axis_order_a = jnp.array([1, 2, 0])
+    axis_order_b = jnp.array([2, 0, 1])
+    periodic_a = cell_f64[:, axis_order_a, :]
+    periodic_b = cell_f64[:, axis_order_b, :]
+    normals = jnp.cross(periodic_a, periodic_b)
+    normals = normals / jnp.linalg.norm(normals, axis=-1, keepdims=True)
+    nonperiodic_vectors = cell_f64
+    volume = jnp.abs(jnp.linalg.det(cell_f64))
+    height_sq = jnp.sum(nonperiodic_vectors * normals, axis=-1) ** 2
+    slab_axis_mask = jnp.logical_and(
+        ~pbc_array,
+        jnp.sum(~pbc_array, axis=1, keepdims=True) == 1,
+    ).astype(jnp.float64)
+
+    normal_atoms = normals[batch_idx_i32]
+    z_values = jnp.einsum("nd,nad->na", positions_f64, normal_atoms)
+    charge_column = charges_f64[:, jnp.newaxis]
+    moments = jnp.zeros((num_systems, 3), dtype=jnp.float64)
+    projected_moment = moments.at[batch_idx_i32].add(charge_column * z_values)
+    projected_second_moment = moments.at[batch_idx_i32].add(
+        charge_column * z_values * z_values
+    )
+    total_charge = (
+        jnp.zeros((num_systems,), dtype=jnp.float64).at[batch_idx_i32].add(charges_f64)
+    )
+
+    projected_moment_atoms = projected_moment[batch_idx_i32]
+    projected_second_moment_atoms = projected_second_moment[batch_idx_i32]
+    total_charge_atoms = total_charge[batch_idx_i32, jnp.newaxis]
+    volume_atoms = volume[batch_idx_i32, jnp.newaxis]
+    height_sq_atoms = height_sq[batch_idx_i32]
+    slab_axis_mask_atoms = slab_axis_mask[batch_idx_i32]
+    bracket = (
+        z_values * projected_moment_atoms
+        - 0.5
+        * (projected_second_moment_atoms + total_charge_atoms * z_values * z_values)
+        - total_charge_atoms * height_sq_atoms / 12.0
+    )
+    axis_energies = (
+        (2.0 * jnp.pi / volume_atoms) * charge_column * bracket * slab_axis_mask_atoms
+    )
+    energies = jnp.sum(axis_energies, axis=1)
+    force_magnitudes = (
+        -(4.0 * jnp.pi / volume_atoms)
+        * charge_column
+        * (projected_moment_atoms - total_charge_atoms * z_values)
+        * slab_axis_mask_atoms
+    )
+    forces = jnp.sum(force_magnitudes[:, :, jnp.newaxis] * normal_atoms, axis=1)
+    charge_grads = jnp.sum(
+        (4.0 * jnp.pi / volume_atoms) * bracket * slab_axis_mask_atoms,
+        axis=1,
+    )
+    system_axis_energies = jnp.zeros((num_systems, 3), dtype=jnp.float64)
+    system_axis_energies = system_axis_energies.at[batch_idx_i32].add(axis_energies)
+    identity = jnp.eye(3, dtype=jnp.float64)
+    virial_axes = system_axis_energies[:, :, jnp.newaxis, jnp.newaxis] * (
+        identity[jnp.newaxis, jnp.newaxis, :, :]
+        - 2.0 * normals[:, :, :, jnp.newaxis] * normals[:, :, jnp.newaxis, :]
+    )
+    virial = jnp.sum(virial_axes, axis=1)
+
+    return (
+        energies,
+        forces.astype(input_dtype),
+        charge_grads,
+        virial.astype(input_dtype),
+    )
+
+
+def _assert_close(actual, expected, rtol=1e-10, atol=1e-12):
+    """Assert two JAX-compatible arrays are numerically close."""
+    actual_array = jnp.asarray(actual)
+    expected_array = jnp.asarray(expected)
+    assert actual_array.shape == expected_array.shape
+    assert bool(jnp.allclose(actual_array, expected_array, rtol=rtol, atol=atol))
+
+
+def _as_named_outputs(output, compute_forces, compute_charge_gradients, compute_virial):
+    """Convert an electrostatics output tuple into a name-to-array mapping."""
+    output_tuple = output if isinstance(output, tuple) else (output,)
+    cursor = 0
+    named = {"energies": output_tuple[cursor]}
+    cursor += 1
+    if compute_forces:
+        named["forces"] = output_tuple[cursor]
+        cursor += 1
+    if compute_charge_gradients:
+        named["charge_grads"] = output_tuple[cursor]
+        cursor += 1
+    if compute_virial:
+        named["virial"] = output_tuple[cursor]
+    return named
+
+
+def _component_sum(
+    real_outputs,
+    reciprocal_outputs,
+    slab_outputs,
+    compute_forces,
+    compute_charge_gradients,
+    compute_virial,
+):
+    """Return named real + reciprocal + slab component sums."""
+    real_named = _as_named_outputs(
+        real_outputs, compute_forces, compute_charge_gradients, compute_virial
+    )
+    reciprocal_named = _as_named_outputs(
+        reciprocal_outputs, compute_forces, compute_charge_gradients, compute_virial
+    )
+    slab_named = _as_named_outputs(
+        slab_outputs, compute_forces, compute_charge_gradients, compute_virial
+    )
+    return {
+        name: real_named[name] + reciprocal_named[name] + slab_named[name]
+        for name in real_named
+    }
+
+
+def _expected_by_name(outputs):
+    """Return a name-to-array mapping for full slab reference outputs."""
+    return {
+        "energies": outputs[0],
+        "forces": outputs[1],
+        "charge_grads": outputs[2],
+        "virial": outputs[3],
+    }
+
+
+class TestStandaloneSlabCorrection:
+    """Standalone JAX slab correction API behavior."""
+
+    @pytest.mark.parametrize(
+        (
+            "compute_forces",
+            "compute_charge_gradients",
+            "compute_virial",
+            "output_names",
+        ),
+        OUTPUT_CASES,
+    )
+    def test_output_subsets_match_reference(
+        self,
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
+        output_names,
+        device,  # noqa: ARG002
+    ):
+        """Standalone output tuple ordering and values follow enabled flags."""
+        positions, charges, cell, pbc = _make_slab_system()
+
+        result = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            compute_forces=compute_forces,
+            compute_charge_gradients=compute_charge_gradients,
+            compute_virial=compute_virial,
+        )
+        expected = _expected_by_name(
+            _reference_slab_correction(positions, charges, cell, pbc)
+        )
+
+        if len(output_names) == 1:
+            assert not isinstance(result, tuple)
+        else:
+            assert isinstance(result, tuple)
+        result_tuple = result if isinstance(result, tuple) else (result,)
+
+        assert len(result_tuple) == len(output_names)
+        for output, name in zip(result_tuple, output_names, strict=True):
+            _assert_close(output, expected[name])
+
+    def test_outputs_match_reference(self, device):  # noqa: ARG002
+        """Standalone slab outputs match the analytical reference formula."""
+        positions, charges, cell, pbc = _make_slab_system()
+
+        outputs = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+        expected = _reference_slab_correction(positions, charges, cell, pbc)
+
+        for actual, reference in zip(outputs, expected):
+            _assert_close(actual, reference)
+
+    def test_explicit_outputs_match_jax_autograd_reference(self, device):  # noqa: ARG002
+        """Standalone explicit outputs match pure-JAX autodiff derivatives."""
+        positions, charges, cell, pbc = _make_slab_system()
+
+        def reference_energy(positions_in, charges_in, cell_in):
+            return _reference_slab_correction(positions_in, charges_in, cell_in, pbc)[
+                0
+            ].sum()
+
+        grad_positions, grad_charges = jax.grad(
+            reference_energy,
+            argnums=(0, 1),
+        )(positions, charges, cell)
+        eps = jnp.zeros((3, 3), dtype=positions.dtype)
+
+        def strained_reference_energy(eps_in):
+            deformation = jnp.eye(3, dtype=positions.dtype) + eps_in
+            return reference_energy(
+                positions @ deformation.T,
+                charges,
+                cell @ deformation.T,
+            )
+
+        autograd_virial = -jax.grad(strained_reference_energy)(eps)
+        _, forces, charge_grads, virial = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+
+        _assert_close(forces, -grad_positions)
+        _assert_close(charge_grads, grad_charges)
+        _assert_close(virial[0], autograd_virial, rtol=1e-9, atol=1e-10)
+
+    def test_translation_invariance_non_neutral(self, device):  # noqa: ARG002
+        """Non-neutral triclinic slab outputs are translation invariant."""
+        positions, charges, cell, pbc = _make_slab_system()
+        shift = jnp.array([1.3, -0.7, 2.1], dtype=positions.dtype)
+
+        energies_0, forces_0, charge_grads_0 = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            compute_forces=True,
+            compute_charge_gradients=True,
+        )
+        energies_1, forces_1, charge_grads_1 = compute_slab_correction(
+            positions + shift,
+            charges,
+            cell,
+            pbc,
+            compute_forces=True,
+            compute_charge_gradients=True,
+        )
+
+        _assert_close(energies_1.sum(), energies_0.sum())
+        _assert_close(forces_1, forces_0)
+        _assert_close(charge_grads_1, charge_grads_0)
+
+    def test_output_dtypes(self, device):  # noqa: ARG002
+        """Energy and charge gradients use float64; vector outputs use input dtype."""
+        positions, charges, cell, pbc = _make_slab_system(dtype=jnp.float32)
+
+        energies, forces, charge_grads, virial = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+
+        assert energies.dtype == jnp.float64
+        assert forces.dtype == positions.dtype
+        assert charge_grads.dtype == jnp.float64
+        assert virial.dtype == positions.dtype
+
+    def test_3d_periodic_system_is_noop(self, device):  # noqa: ARG002
+        """A fully 3D periodic pbc row contributes zero slab correction."""
+        positions, charges, cell, _ = _make_slab_system()
+        pbc_3d = jnp.array([[True, True, True]], dtype=jnp.bool_)
+
+        outputs = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc_3d,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+
+        _assert_close(outputs[0], jnp.zeros_like(outputs[0]), rtol=0, atol=0)
+        _assert_close(outputs[1], jnp.zeros_like(outputs[1]), rtol=0, atol=0)
+        _assert_close(outputs[2], jnp.zeros_like(outputs[2]), rtol=0, atol=0)
+        _assert_close(outputs[3], jnp.zeros_like(outputs[3]), rtol=0, atol=0)
+
+    def test_mixed_pbc_batch_zeroes_3d_system(self, device):  # noqa: ARG002
+        """Batched standalone slab applies only to slab-like pbc rows."""
+        positions, charges, cell, batch_idx, pbc = _make_batched_system()
+
+        outputs = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            batch_idx=batch_idx,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+        expected = _reference_slab_correction(
+            positions, charges, cell, pbc, batch_idx=batch_idx
+        )
+
+        for actual, reference in zip(outputs, expected):
+            _assert_close(actual, reference)
+        _assert_close(outputs[0][3:], jnp.zeros_like(outputs[0][3:]), rtol=0, atol=0)
+        _assert_close(outputs[1][3:], jnp.zeros_like(outputs[1][3:]), rtol=0, atol=0)
+        _assert_close(outputs[2][3:], jnp.zeros_like(outputs[2][3:]), rtol=0, atol=0)
+        _assert_close(outputs[3][1], jnp.zeros_like(outputs[3][1]), rtol=0, atol=0)
+
+    def test_single_atom_non_neutral(self, device):  # noqa: ARG002
+        """Single charged slabs keep finite background terms."""
+        dtype = jnp.float64
+        positions = jnp.array([[1.2, -0.4, 3.5]], dtype=dtype)
+        charges = jnp.array([0.7], dtype=dtype)
+        cell = jnp.diag(jnp.array([8.0, 9.0, 24.0], dtype=dtype))[jnp.newaxis, :, :]
+        pbc = jnp.array([True, True, False], dtype=jnp.bool_)
+
+        outputs = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+        expected = _reference_slab_correction(positions, charges, cell, pbc)
+
+        for actual, reference in zip(outputs, expected):
+            _assert_close(actual, reference)
+
+    def test_empty_standalone_system(self, device):  # noqa: ARG002
+        """Empty standalone slab calls return empty outputs and zero virial."""
+        dtype = jnp.float64
+        positions = jnp.empty((0, 3), dtype=dtype)
+        charges = jnp.empty((0,), dtype=dtype)
+        cell = jnp.diag(jnp.array([8.0, 9.0, 24.0], dtype=dtype))[jnp.newaxis, :, :]
+        pbc = jnp.array([True, True, False], dtype=jnp.bool_)
+
+        energies, forces, charge_grads, virial = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+
+        assert energies.shape == (0,)
+        assert forces.shape == (0, 3)
+        assert charge_grads.shape == (0,)
+        assert virial.shape == (1, 3, 3)
+        _assert_close(virial, jnp.zeros_like(virial), rtol=0, atol=0)
+
+
+class TestJaxSlabPbcShapeContracts:
+    """Public slab APIs validate pbc shape contracts."""
+
+    def test_single_system_accepts_1d_pbc(self, device):  # noqa: ARG002
+        """A single-system (3,) pbc is equivalent to explicit (1, 3) pbc."""
+        positions, charges, cell, pbc = _make_slab_system()
+
+        energy_1d = compute_slab_correction(positions, charges, cell, pbc[0])
+        energy_2d = compute_slab_correction(positions, charges, cell, pbc)
+
+        _assert_close(energy_1d, energy_2d, rtol=0, atol=0)
+
+    def test_single_system_pme_accepts_1d_pbc(self, device):  # noqa: ARG002
+        """A single-system PME slab call accepts either (3,) or (1, 3) pbc."""
+        positions, charges, cell, pbc = _make_slab_system()
+        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_neighbor,
+        )
+
+        energies_1d = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            alpha=EWALD_ALPHA,
+            mesh_dimensions=PME_MESH,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            pbc=pbc[0],
+            slab_correction=True,
+        )
+        energies_2d = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            alpha=EWALD_ALPHA,
+            mesh_dimensions=PME_MESH,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            pbc=pbc,
+            slab_correction=True,
+        )
+
+        _assert_close(
+            energies_1d,
+            energies_2d,
+            rtol=SLAB_STRICT_RTOL,
+            atol=SLAB_STRICT_ATOL,
+        )
+
+    def test_batched_standalone_rejects_1d_pbc(self, device):  # noqa: ARG002
+        """Batched standalone calls require explicit per-system pbc rows."""
+        positions, charges, cell, batch_idx, pbc = _make_batched_system()
+
+        with pytest.raises(ValueError, match="batched.*pbc"):
+            compute_slab_correction(
+                positions, charges, cell, pbc[0], batch_idx=batch_idx
+            )
+
+    def test_standalone_rejects_non_bool_pbc(self, device):  # noqa: ARG002
+        """Standalone slab calls require boolean pbc arrays."""
+        positions, charges, cell, _ = _make_slab_system()
+        pbc = jnp.array([1, 1, 0], dtype=jnp.int32)
+
+        with pytest.raises(ValueError, match="bool"):
+            compute_slab_correction(positions, charges, cell, pbc)
+
+    def test_standalone_rejects_bad_pbc_shape(self, device):  # noqa: ARG002
+        """Standalone slab calls reject pbc arrays that are not (3,) or (B, 3)."""
+        positions, charges, cell, _ = _make_slab_system()
+        pbc = jnp.array([True, False], dtype=jnp.bool_)
+
+        with pytest.raises(ValueError, match="shape"):
+            compute_slab_correction(positions, charges, cell, pbc)
+
+    def test_full_ewald_slab_requires_pbc(self, device):  # noqa: ARG002
+        """Ewald slab correction requires explicit slab periodicity."""
+        positions, charges, cell, _ = _make_slab_system()
+
+        with pytest.raises(ValueError, match="pbc"):
+            ewald_summation(
+                positions,
+                charges,
+                cell,
+                alpha=EWALD_ALPHA,
+                k_cutoff=EWALD_K_CUTOFF,
+                slab_correction=True,
+            )
+
+    def test_full_pme_slab_requires_pbc(self, device):  # noqa: ARG002
+        """PME slab correction requires explicit slab periodicity."""
+        positions, charges, cell, _ = _make_slab_system()
+
+        with pytest.raises(ValueError, match="pbc"):
+            particle_mesh_ewald(
+                positions,
+                charges,
+                cell,
+                alpha=EWALD_ALPHA,
+                mesh_dimensions=PME_MESH,
+                slab_correction=True,
+            )
+
+    def test_single_system_ewald_accepts_1d_pbc(self, device):  # noqa: ARG002
+        """A single-system Ewald slab call accepts either (3,) or (1, 3) pbc."""
+        positions, charges, cell, pbc = _make_slab_system()
+        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_neighbor,
+        )
+        common_kwargs = {
+            "alpha": EWALD_ALPHA,
+            "k_cutoff": EWALD_K_CUTOFF,
+            "neighbor_matrix": neighbor_matrix,
+            "neighbor_matrix_shifts": neighbor_matrix_shifts,
+            "compute_forces": True,
+            "compute_charge_gradients": True,
+            "compute_virial": True,
+            "slab_correction": True,
+        }
+
+        outputs_1d = ewald_summation(
+            positions,
+            charges,
+            cell,
+            pbc=pbc[0],
+            **common_kwargs,
+        )
+        outputs_2d = ewald_summation(
+            positions,
+            charges,
+            cell,
+            pbc=pbc,
+            **common_kwargs,
+        )
+
+        for actual, expected in zip(outputs_1d, outputs_2d, strict=True):
+            _assert_close(
+                actual,
+                expected,
+                rtol=SLAB_STRICT_RTOL,
+                atol=SLAB_STRICT_ATOL,
+            )
+
+    def test_batched_ewald_rejects_1d_pbc(self, device):  # noqa: ARG002
+        """Batched Ewald slab calls require explicit per-system pbc rows."""
+        positions, charges, cell, batch_idx, pbc = _make_batched_system()
+
+        with pytest.raises(ValueError, match="batched.*pbc"):
+            ewald_summation(
+                positions,
+                charges,
+                cell,
+                alpha=jnp.array([EWALD_ALPHA, EWALD_ALPHA], dtype=positions.dtype),
+                k_cutoff=EWALD_K_CUTOFF,
+                batch_idx=batch_idx,
+                pbc=pbc[0],
+                slab_correction=True,
+            )
+
+    def test_batched_pme_rejects_1d_pbc(self, device):  # noqa: ARG002
+        """Batched PME slab calls require explicit per-system pbc rows."""
+        positions, charges, cell, batch_idx, pbc = _make_batched_system()
+
+        with pytest.raises(ValueError, match="batched.*pbc"):
+            particle_mesh_ewald(
+                positions,
+                charges,
+                cell,
+                alpha=jnp.array([EWALD_ALPHA, EWALD_ALPHA], dtype=positions.dtype),
+                mesh_dimensions=PME_MESH,
+                batch_idx=batch_idx,
+                pbc=pbc[0],
+                slab_correction=True,
+            )
+
+
+class TestJaxEwaldSlabIntegration:
+    """Full JAX Ewald slab wrapper composition."""
+
+    def test_full_ewald_3d_pbc_noop(self, device):  # noqa: ARG002
+        """3D periodic Ewald slab mode matches standard Ewald."""
+        positions, charges, cell, _ = _make_slab_system()
+        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_neighbor,
+        )
+        common_kwargs = {
+            "alpha": EWALD_ALPHA,
+            "k_cutoff": EWALD_K_CUTOFF,
+            "neighbor_matrix": neighbor_matrix,
+            "neighbor_matrix_shifts": neighbor_matrix_shifts,
+            "compute_forces": True,
+            "compute_charge_gradients": True,
+            "compute_virial": True,
+        }
+
+        outputs_off = ewald_summation(positions, charges, cell, **common_kwargs)
+        outputs_3d = ewald_summation(
+            positions,
+            charges,
+            cell,
+            pbc=jnp.array([True, True, True], dtype=jnp.bool_),
+            slab_correction=True,
+            **common_kwargs,
+        )
+
+        for actual, expected in zip(outputs_3d, outputs_off, strict=True):
+            _assert_close(
+                actual,
+                expected,
+                rtol=SLAB_STRICT_RTOL,
+                atol=SLAB_STRICT_ATOL,
+            )
+
+    @pytest.mark.parametrize(
+        (
+            "compute_forces",
+            "compute_charge_gradients",
+            "compute_virial",
+            "output_names",
+        ),
+        OUTPUT_CASES,
+    )
+    def test_full_ewald_matches_component_sum(
+        self,
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
+        output_names,
+        device,  # noqa: ARG002
+    ):
+        """Every Ewald slab flag combination preserves tuple order and values."""
+        positions, charges, cell, pbc = _make_slab_system()
+        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_neighbor,
+        )
+        k_vectors = generate_k_vectors_ewald_summation(cell, EWALD_K_CUTOFF)
+
+        full_outputs = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=EWALD_ALPHA,
+            k_vectors=k_vectors,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            pbc=pbc,
+            slab_correction=True,
+            compute_forces=compute_forces,
+            compute_charge_gradients=compute_charge_gradients,
+            compute_virial=compute_virial,
+        )
+        real_outputs = ewald_real_space(
+            positions,
+            charges,
+            cell,
+            alpha=EWALD_ALPHA,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            compute_forces=compute_forces,
+            compute_charge_gradients=compute_charge_gradients,
+            compute_virial=compute_virial,
+        )
+        reciprocal_outputs = ewald_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            k_vectors,
+            EWALD_ALPHA,
+            compute_forces=compute_forces,
+            compute_charge_gradients=compute_charge_gradients,
+            compute_virial=compute_virial,
+        )
+        slab_outputs = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            compute_forces=compute_forces,
+            compute_charge_gradients=compute_charge_gradients,
+            compute_virial=compute_virial,
+        )
+
+        expected = _component_sum(
+            real_outputs,
+            reciprocal_outputs,
+            slab_outputs,
+            compute_forces,
+            compute_charge_gradients,
+            compute_virial,
+        )
+        full_named = _as_named_outputs(
+            full_outputs,
+            compute_forces,
+            compute_charge_gradients,
+            compute_virial,
+        )
+
+        assert tuple(full_named) == tuple(output_names)
+        for name, expected_value in expected.items():
+            _assert_close(full_named[name], expected_value)
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    def test_full_ewald_slab_output_dtypes(self, dtype, device):  # noqa: ARG002
+        """Ewald slab energies/charge gradients are fp64; vectors match input dtype."""
+        positions, charges, cell, pbc = _make_slab_system(dtype=dtype)
+        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_neighbor,
+        )
+
+        energies, forces, charge_grads, virial = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=EWALD_ALPHA,
+            k_cutoff=EWALD_K_CUTOFF,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            pbc=pbc,
+            slab_correction=True,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+
+        assert positions.dtype == dtype
+        assert charges.dtype == dtype
+        assert cell.dtype == dtype
+        assert energies.dtype == jnp.float64
+        assert forces.dtype == dtype
+        assert charge_grads.dtype == jnp.float64
+        assert virial.dtype == dtype
+
+
+class TestJaxPMESlabIntegration:
+    """Full JAX PME slab wrapper composition and output order."""
+
+    @pytest.mark.parametrize(
+        (
+            "compute_forces",
+            "compute_charge_gradients",
+            "compute_virial",
+            "output_names",
+        ),
+        OUTPUT_CASES,
+    )
+    def test_full_pme_outputs_match_component_sum(
+        self,
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
+        output_names,
+        device,  # noqa: ARG002
+    ):
+        """Every PME slab flag combination preserves tuple order and values."""
+        positions, charges, cell, pbc = _make_slab_system()
+        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_neighbor,
+        )
+
+        full_outputs = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            alpha=EWALD_ALPHA,
+            mesh_dimensions=PME_MESH,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            pbc=pbc,
+            slab_correction=True,
+            compute_forces=compute_forces,
+            compute_charge_gradients=compute_charge_gradients,
+            compute_virial=compute_virial,
+        )
+        real_outputs = ewald_real_space(
+            positions,
+            charges,
+            cell,
+            alpha=EWALD_ALPHA,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            compute_forces=compute_forces,
+            compute_charge_gradients=compute_charge_gradients,
+            compute_virial=compute_virial,
+        )
+        reciprocal_outputs = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=jnp.array([EWALD_ALPHA], dtype=positions.dtype),
+            mesh_dimensions=PME_MESH,
+            compute_forces=compute_forces,
+            compute_charge_gradients=compute_charge_gradients,
+            compute_virial=compute_virial,
+        )
+        slab_outputs = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            compute_forces=compute_forces,
+            compute_charge_gradients=compute_charge_gradients,
+            compute_virial=compute_virial,
+        )
+
+        expected = _component_sum(
+            real_outputs,
+            reciprocal_outputs,
+            slab_outputs,
+            compute_forces,
+            compute_charge_gradients,
+            compute_virial,
+        )
+        full_named = _as_named_outputs(
+            full_outputs,
+            compute_forces,
+            compute_charge_gradients,
+            compute_virial,
+        )
+
+        assert tuple(full_named) == tuple(output_names)
+        for name, expected_value in expected.items():
+            _assert_close(full_named[name], expected_value, rtol=1e-9, atol=1e-10)
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    def test_full_pme_slab_output_dtypes(self, dtype, device):  # noqa: ARG002
+        """PME slab energies/charge gradients are fp64; vectors match input dtype."""
+        positions, charges, cell, pbc = _make_slab_system(dtype=dtype)
+        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_neighbor,
+        )
+
+        energies, forces, charge_grads, virial = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            alpha=EWALD_ALPHA,
+            mesh_dimensions=PME_MESH,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            pbc=pbc,
+            slab_correction=True,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+
+        assert positions.dtype == dtype
+        assert charges.dtype == dtype
+        assert cell.dtype == dtype
+        assert energies.dtype == jnp.float64
+        assert forces.dtype == dtype
+        assert charge_grads.dtype == jnp.float64
+        assert virial.dtype == dtype
+
+    def test_full_pme_slab_3d_pbc_noop(self, device):  # noqa: ARG002
+        """3D periodic PME slab mode matches standard PME."""
+        positions, charges, cell, _ = _make_slab_system()
+        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_neighbor,
+        )
+        common_kwargs = {
+            "alpha": EWALD_ALPHA,
+            "mesh_dimensions": PME_MESH,
+            "neighbor_matrix": neighbor_matrix,
+            "neighbor_matrix_shifts": neighbor_matrix_shifts,
+            "compute_forces": True,
+            "compute_charge_gradients": True,
+            "compute_virial": True,
+        }
+
+        outputs_off = particle_mesh_ewald(positions, charges, cell, **common_kwargs)
+        outputs_3d = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            pbc=jnp.array([True, True, True], dtype=jnp.bool_),
+            slab_correction=True,
+            **common_kwargs,
+        )
+
+        for actual, expected in zip(outputs_3d, outputs_off, strict=True):
+            _assert_close(actual, expected, rtol=1e-9, atol=1e-10)
+
+    def test_mixed_pbc_batch_matches_component_sum(self, device):  # noqa: ARG002
+        """Batched PME slab applies correction only to slab-like systems."""
+        positions, charges, cell, batch_idx, pbc = _make_batched_system()
+        pbc_neighbor = jnp.array(
+            [[True, True, True], [True, True, True]],
+            dtype=jnp.bool_,
+        )
+        neighbor_matrix, _, neighbor_matrix_shifts = batch_cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_neighbor,
+            batch_idx=batch_idx,
+            max_neighbors=32,
+        )
+        alpha = jnp.array([EWALD_ALPHA, EWALD_ALPHA], dtype=positions.dtype)
+
+        full_outputs = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            alpha=alpha,
+            mesh_dimensions=PME_MESH,
+            batch_idx=batch_idx,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            pbc=pbc,
+            slab_correction=True,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+        pme_3d_outputs = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            alpha=alpha,
+            mesh_dimensions=PME_MESH,
+            batch_idx=batch_idx,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+        slab_outputs = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            batch_idx=batch_idx,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+
+        for actual, pme_3d, slab in zip(full_outputs, pme_3d_outputs, slab_outputs):
+            _assert_close(actual, pme_3d + slab, rtol=1e-9, atol=1e-10)
+
+        _assert_close(slab_outputs[0][3:], jnp.zeros_like(slab_outputs[0][3:]))
+        _assert_close(slab_outputs[1][3:], jnp.zeros_like(slab_outputs[1][3:]))
+        _assert_close(slab_outputs[2][3:], jnp.zeros_like(slab_outputs[2][3:]))
+        _assert_close(slab_outputs[3][1], jnp.zeros_like(slab_outputs[3][1]))

--- a/test/interactions/electrostatics/bindings/jax/test_slab.py
+++ b/test/interactions/electrostatics/bindings/jax/test_slab.py
@@ -493,12 +493,11 @@ class TestJaxSlabPbcShapeContracts:
     def test_single_system_pme_accepts_1d_pbc(self, device):  # noqa: ARG002
         """A single-system PME slab call accepts either (3,) or (1, 3) pbc."""
         positions, charges, cell, pbc = _make_slab_system()
-        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
         neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
             positions,
             REAL_SPACE_CUTOFF,
             cell,
-            pbc_neighbor,
+            pbc,
         )
 
         energies_1d = particle_mesh_ewald(
@@ -587,12 +586,11 @@ class TestJaxSlabPbcShapeContracts:
     def test_single_system_ewald_accepts_1d_pbc(self, device):  # noqa: ARG002
         """A single-system Ewald slab call accepts either (3,) or (1, 3) pbc."""
         positions, charges, cell, pbc = _make_slab_system()
-        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
         neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
             positions,
             REAL_SPACE_CUTOFF,
             cell,
-            pbc_neighbor,
+            pbc,
         )
         common_kwargs = {
             "alpha": EWALD_ALPHA,
@@ -664,15 +662,65 @@ class TestJaxSlabPbcShapeContracts:
 class TestJaxEwaldSlabIntegration:
     """Full JAX Ewald slab wrapper composition."""
 
+    def test_neighbor_pbc_ttf_matches_ttt_with_vacuum(self, device):  # noqa: ARG002
+        """Ewald slab outputs are unchanged by T/T/F vs T/T/T vacuum neighbors."""
+        positions, charges, cell, pbc = _make_slab_system()
+        pbc_3d = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        neighbor_matrix_slab, _, neighbor_matrix_shifts_slab = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc,
+        )
+        neighbor_matrix_3d, _, neighbor_matrix_shifts_3d = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_3d,
+        )
+        common_kwargs = {
+            "alpha": EWALD_ALPHA,
+            "k_cutoff": EWALD_K_CUTOFF,
+            "compute_forces": True,
+            "compute_charge_gradients": True,
+            "compute_virial": True,
+            "pbc": pbc,
+            "slab_correction": True,
+        }
+
+        outputs_slab = ewald_summation(
+            positions,
+            charges,
+            cell,
+            neighbor_matrix=neighbor_matrix_slab,
+            neighbor_matrix_shifts=neighbor_matrix_shifts_slab,
+            **common_kwargs,
+        )
+        outputs_3d = ewald_summation(
+            positions,
+            charges,
+            cell,
+            neighbor_matrix=neighbor_matrix_3d,
+            neighbor_matrix_shifts=neighbor_matrix_shifts_3d,
+            **common_kwargs,
+        )
+
+        for actual, expected in zip(outputs_slab, outputs_3d, strict=True):
+            _assert_close(
+                actual,
+                expected,
+                rtol=SLAB_STRICT_RTOL,
+                atol=SLAB_STRICT_ATOL,
+            )
+
     def test_full_ewald_3d_pbc_noop(self, device):  # noqa: ARG002
         """3D periodic Ewald slab mode matches standard Ewald."""
-        positions, charges, cell, _ = _make_slab_system()
-        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        positions, charges, cell, pbc = _make_slab_system()
         neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
             positions,
             REAL_SPACE_CUTOFF,
             cell,
-            pbc_neighbor,
+            pbc,
         )
         common_kwargs = {
             "alpha": EWALD_ALPHA,
@@ -721,12 +769,11 @@ class TestJaxEwaldSlabIntegration:
     ):
         """Every Ewald slab flag combination preserves tuple order and values."""
         positions, charges, cell, pbc = _make_slab_system()
-        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
         neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
             positions,
             REAL_SPACE_CUTOFF,
             cell,
-            pbc_neighbor,
+            pbc,
         )
         k_vectors = generate_k_vectors_ewald_summation(cell, EWALD_K_CUTOFF)
 
@@ -798,12 +845,11 @@ class TestJaxEwaldSlabIntegration:
     def test_full_ewald_slab_output_dtypes(self, dtype, device):  # noqa: ARG002
         """Ewald slab energies/charge gradients are fp64; vectors match input dtype."""
         positions, charges, cell, pbc = _make_slab_system(dtype=dtype)
-        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
         neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
             positions,
             REAL_SPACE_CUTOFF,
             cell,
-            pbc_neighbor,
+            pbc,
         )
 
         energies, forces, charge_grads, virial = ewald_summation(
@@ -833,6 +879,52 @@ class TestJaxEwaldSlabIntegration:
 class TestJaxPMESlabIntegration:
     """Full JAX PME slab wrapper composition and output order."""
 
+    def test_neighbor_pbc_ttf_matches_ttt_with_vacuum(self, device):  # noqa: ARG002
+        """PME slab outputs are unchanged by T/T/F vs T/T/T vacuum neighbors."""
+        positions, charges, cell, pbc = _make_slab_system()
+        pbc_3d = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        neighbor_matrix_slab, _, neighbor_matrix_shifts_slab = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc,
+        )
+        neighbor_matrix_3d, _, neighbor_matrix_shifts_3d = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_3d,
+        )
+        common_kwargs = {
+            "alpha": EWALD_ALPHA,
+            "mesh_dimensions": PME_MESH,
+            "compute_forces": True,
+            "compute_charge_gradients": True,
+            "compute_virial": True,
+            "pbc": pbc,
+            "slab_correction": True,
+        }
+
+        outputs_slab = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            neighbor_matrix=neighbor_matrix_slab,
+            neighbor_matrix_shifts=neighbor_matrix_shifts_slab,
+            **common_kwargs,
+        )
+        outputs_3d = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            neighbor_matrix=neighbor_matrix_3d,
+            neighbor_matrix_shifts=neighbor_matrix_shifts_3d,
+            **common_kwargs,
+        )
+
+        for actual, expected in zip(outputs_slab, outputs_3d, strict=True):
+            _assert_close(actual, expected, rtol=1e-9, atol=1e-10)
+
     @pytest.mark.parametrize(
         (
             "compute_forces",
@@ -852,12 +944,11 @@ class TestJaxPMESlabIntegration:
     ):
         """Every PME slab flag combination preserves tuple order and values."""
         positions, charges, cell, pbc = _make_slab_system()
-        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
         neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
             positions,
             REAL_SPACE_CUTOFF,
             cell,
-            pbc_neighbor,
+            pbc,
         )
 
         full_outputs = particle_mesh_ewald(
@@ -928,12 +1019,11 @@ class TestJaxPMESlabIntegration:
     def test_full_pme_slab_output_dtypes(self, dtype, device):  # noqa: ARG002
         """PME slab energies/charge gradients are fp64; vectors match input dtype."""
         positions, charges, cell, pbc = _make_slab_system(dtype=dtype)
-        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
         neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
             positions,
             REAL_SPACE_CUTOFF,
             cell,
-            pbc_neighbor,
+            pbc,
         )
 
         energies, forces, charge_grads, virial = particle_mesh_ewald(
@@ -961,13 +1051,12 @@ class TestJaxPMESlabIntegration:
 
     def test_full_pme_slab_3d_pbc_noop(self, device):  # noqa: ARG002
         """3D periodic PME slab mode matches standard PME."""
-        positions, charges, cell, _ = _make_slab_system()
-        pbc_neighbor = jnp.array([[True, True, True]], dtype=jnp.bool_)
+        positions, charges, cell, pbc = _make_slab_system()
         neighbor_matrix, _, neighbor_matrix_shifts = cell_list(
             positions,
             REAL_SPACE_CUTOFF,
             cell,
-            pbc_neighbor,
+            pbc,
         )
         common_kwargs = {
             "alpha": EWALD_ALPHA,
@@ -995,15 +1084,11 @@ class TestJaxPMESlabIntegration:
     def test_mixed_pbc_batch_matches_component_sum(self, device):  # noqa: ARG002
         """Batched PME slab applies correction only to slab-like systems."""
         positions, charges, cell, batch_idx, pbc = _make_batched_system()
-        pbc_neighbor = jnp.array(
-            [[True, True, True], [True, True, True]],
-            dtype=jnp.bool_,
-        )
         neighbor_matrix, _, neighbor_matrix_shifts = batch_cell_list(
             positions,
             REAL_SPACE_CUTOFF,
             cell,
-            pbc_neighbor,
+            pbc,
             batch_idx=batch_idx,
             max_neighbors=32,
         )

--- a/test/interactions/electrostatics/bindings/torch/test_slab.py
+++ b/test/interactions/electrostatics/bindings/torch/test_slab.py
@@ -107,31 +107,26 @@ def _make_triclinic_slab_system(dtype=torch.float64, device="cpu"):
 
 
 def _make_cscl_ewald_inputs(dtype=torch.float64, device="cpu"):
-    """Create CsCl slab inputs plus the full-3D real-space neighbor list."""
+    """Create CsCl slab inputs plus a T/T/F real-space neighbor list."""
     positions, charges, cell, pbc = _make_cscl_slab_system(dtype, device)
     neighbor_list, neighbor_ptr, neighbor_shifts = _build_neighbor_list(
-        positions, cell, REAL_SPACE_CUTOFF, [True, True, True], device
+        positions, cell, REAL_SPACE_CUTOFF, [True, True, False], device
     )
     return positions, charges, cell, pbc, neighbor_list, neighbor_ptr, neighbor_shifts
 
 
 def _make_triclinic_ewald_inputs(dtype=torch.float64, device="cpu"):
-    """Create triclinic slab inputs plus the full-3D real-space neighbor list."""
+    """Create triclinic slab inputs plus a T/T/F real-space neighbor list."""
     positions, charges, cell, pbc = _make_triclinic_slab_system(dtype, device)
     neighbor_list, neighbor_ptr, neighbor_shifts = _build_neighbor_list(
-        positions, cell, REAL_SPACE_CUTOFF, [True, True, True], device
+        positions, cell, REAL_SPACE_CUTOFF, [True, True, False], device
     )
     return positions, charges, cell, pbc, neighbor_list, neighbor_ptr, neighbor_shifts
 
 
-def _build_neighbor_list(positions, cell, cutoff, pbc_full3d, device="cpu"):
-    """Build neighbor list using cell_list with full 3D pbc.
-
-    The slab correction handles the 2D periodicity separately; for the
-    real-space neighbor list we use full 3D periodicity (the vacuum gap
-    in z guarantees no real-space neighbors leak across).
-    """
-    pbc_tensor = torch.tensor(pbc_full3d, dtype=torch.bool, device=device).unsqueeze(0)
+def _build_neighbor_list(positions, cell, cutoff, pbc, device="cpu"):
+    """Build neighbor list using cell_list with explicit pbc."""
+    pbc_tensor = torch.tensor(pbc, dtype=torch.bool, device=device).unsqueeze(0)
     neighbor_list, neighbor_ptr, unit_shifts = cell_list(
         positions, cutoff, cell, pbc_tensor, return_neighbor_list=True
     )
@@ -635,6 +630,126 @@ class TestTriclinicCells:
         torch.testing.assert_close(cg1, cg0, rtol=1e-12, atol=1e-15)
 
 
+class TestSlabNeighborPbc:
+    """Vacuum slab neighbor lists should agree for T/T/F and T/T/T pbc."""
+
+    def test_ewald_neighbor_pbc_ttf_matches_ttt_with_vacuum(self, device):
+        """Ewald slab outputs are unchanged by T/T/F vs T/T/T vacuum neighbors."""
+        dtype = torch.float64
+        positions, charges, cell, pbc = _make_cscl_slab_system(dtype, device)
+        pbc_slab = pbc.unsqueeze(0)
+        pbc_3d = torch.tensor([[True, True, True]], dtype=torch.bool, device=device)
+
+        nl_slab, ptr_slab, shifts_slab = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_slab,
+            return_neighbor_list=True,
+        )
+        nl_3d, ptr_3d, shifts_3d = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_3d,
+            return_neighbor_list=True,
+        )
+        common_kwargs = {
+            "alpha": EWALD_ALPHA,
+            "k_cutoff": EWALD_K_CUTOFF,
+            "compute_forces": True,
+            "compute_charge_gradients": True,
+            "compute_virial": True,
+            "pbc": pbc,
+            "slab_correction": True,
+        }
+
+        outputs_slab = ewald_summation(
+            positions,
+            charges,
+            cell,
+            neighbor_list=nl_slab,
+            neighbor_ptr=ptr_slab,
+            neighbor_shifts=shifts_slab,
+            **common_kwargs,
+        )
+        outputs_3d = ewald_summation(
+            positions,
+            charges,
+            cell,
+            neighbor_list=nl_3d,
+            neighbor_ptr=ptr_3d,
+            neighbor_shifts=shifts_3d,
+            **common_kwargs,
+        )
+
+        for actual, expected in zip(outputs_slab, outputs_3d, strict=True):
+            torch.testing.assert_close(
+                actual,
+                expected,
+                rtol=SLAB_STRICT_RTOL,
+                atol=SLAB_STRICT_ATOL,
+            )
+
+    def test_pme_neighbor_pbc_ttf_matches_ttt_with_vacuum(self, device):
+        """PME slab outputs are unchanged by T/T/F vs T/T/T vacuum neighbors."""
+        dtype = torch.float64
+        positions, charges, cell, pbc = _make_cscl_slab_system(dtype, device)
+        pbc_slab = pbc.unsqueeze(0)
+        pbc_3d = torch.tensor([[True, True, True]], dtype=torch.bool, device=device)
+
+        nl_slab, ptr_slab, shifts_slab = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_slab,
+            return_neighbor_list=True,
+        )
+        nl_3d, ptr_3d, shifts_3d = cell_list(
+            positions,
+            REAL_SPACE_CUTOFF,
+            cell,
+            pbc_3d,
+            return_neighbor_list=True,
+        )
+        common_kwargs = {
+            "alpha": torch.tensor([EWALD_ALPHA], dtype=dtype, device=device),
+            "mesh_dimensions": (16, 16, 16),
+            "compute_forces": True,
+            "compute_charge_gradients": True,
+            "compute_virial": True,
+            "pbc": pbc,
+            "slab_correction": True,
+        }
+
+        outputs_slab = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            neighbor_list=nl_slab,
+            neighbor_ptr=ptr_slab,
+            neighbor_shifts=shifts_slab,
+            **common_kwargs,
+        )
+        outputs_3d = particle_mesh_ewald(
+            positions,
+            charges,
+            cell,
+            neighbor_list=nl_3d,
+            neighbor_ptr=ptr_3d,
+            neighbor_shifts=shifts_3d,
+            **common_kwargs,
+        )
+
+        for actual, expected in zip(outputs_slab, outputs_3d, strict=True):
+            torch.testing.assert_close(
+                actual,
+                expected,
+                rtol=SLAB_STRICT_RTOL,
+                atol=SLAB_STRICT_ATOL,
+            )
+
+
 # ==============================================================================
 # Ewald slab dtype behavior
 # ==============================================================================
@@ -688,7 +803,7 @@ class TestPbcNoneHandling:
 
         positions, charges, cell, _ = _make_cscl_slab_system(dtype, device)
         nl, ptr, shifts = _build_neighbor_list(
-            positions, cell, 5.0, [True, True, True], device
+            positions, cell, 5.0, [True, True, False], device
         )
 
         with pytest.raises(ValueError, match="pbc"):
@@ -870,7 +985,7 @@ class TestSlabHybridForces:
             positions.detach(),
             cell.detach(),
             REAL_SPACE_CUTOFF,
-            [True, True, True],
+            [True, True, False],
             device,
         )
         k_vectors = generate_k_vectors_ewald_summation(cell.detach(), EWALD_K_CUTOFF)
@@ -1534,11 +1649,6 @@ class TestPMESlabIntegration:
             dtype=torch.int32,
             device=device,
         )
-        pbc_3d = torch.tensor(
-            [[True, True, True], [True, True, True]],
-            dtype=torch.bool,
-            device=device,
-        )
         pbc_slab_mixed = torch.tensor(
             [[True, True, False], [True, True, True]],
             dtype=torch.bool,
@@ -1548,7 +1658,7 @@ class TestPMESlabIntegration:
             positions,
             cutoff=REAL_SPACE_CUTOFF,
             cell=cell,
-            pbc=pbc_3d,
+            pbc=pbc_slab_mixed,
             batch_idx=batch_idx,
             return_neighbor_list=True,
         )


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Adds explicit-output JAX support for 2D electrostatic slab corrections, matching the Torch Ewald/PME slab semantics. JAX autograd is not enabled to maintain consistency with Ewald/PME bindings. 

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- Added JAX `compute_slab_correction(...)` with explicit energies, forces, charge gradients, and virials.
- Extended JAX Ewald and PME wrappers with `pbc` / `slab_correction` support and shared output-composition helpers.
- Added JAX slab tests covering standalone correction, Ewald/PME composition, output ordering, dtype behavior, and `pbc` shape contracts.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
