### PR TITLE
fix(neighbors): reject unbatched methods with batch metadata

### DIFF
--- a/docs/userguide/components/neighborlist.md
+++ b/docs/userguide/components/neighborlist.md
@@ -402,6 +402,12 @@ batched inputs.
 | `"naive_dual_cutoff"` | \(O(N^2)\) with two cutoffs | Two-cutoff queries |
 | `"batch_*"` | Per-system batched form of any of the above (e.g. `"batch_cell_list"`, `"batch_cluster_tile"`, `"batch_naive_dual_cutoff"`) | Batched systems |
 
+Method names that do not start with `batch_` refer to single-system algorithms.
+When `batch_idx` or `batch_ptr` (batch metadata) is supplied, those explicit
+method names are treated as aliases for the corresponding `batch_*` methods.
+For example, `method="naive"` is dispatched as `method="batch_naive"` when batch
+metadata is provided.
+
 Override automatic selection by passing the `method` parameter:
 
 ::::{tab-set}

--- a/nvalchemiops/jax/neighbors/__init__.py
+++ b/nvalchemiops/jax/neighbors/__init__.py
@@ -176,7 +176,13 @@ def neighbor_list(
         comparing estimated work from per-system atom counts and cell (or
         bounding-box) volumes and can select cluster-tile when the CUDA,
         float32, fully-periodic, contiguous-batch, and output-option guards
-        allow it. When only ``batch_idx`` is provided (no ``batch_ptr`` or 3-D ``cell``),
+        allow it. Method names that do not start with ``batch_`` refer to
+        single-system algorithms. When ``batch_idx`` or ``batch_ptr`` (batch
+        metadata) is supplied, those explicit method names are treated as aliases
+        for the corresponding ``batch_*`` methods. For example,
+        ``method="naive"`` is dispatched as ``method="batch_naive"`` when batch
+        metadata is provided. When only ``batch_idx`` is provided (no
+        ``batch_ptr`` or 3-D ``cell``),
         auto-selection computes ``batch_idx.max() + 1`` (and a ``bincount``)
         which triggers a device-to-host
         synchronization. To avoid this, pass ``batch_ptr``, a 3-D ``cell``
@@ -419,6 +425,11 @@ def neighbor_list(
         if has_batch_inputs:
             method = "batch_" + method
     else:
+        if batch_idx is not None or batch_ptr is not None:
+            # Route explicit single-system method names through the matching
+            # batch method when batch metadata is provided.
+            if not method.startswith("batch_"):
+                method = "batch_" + method
         base = method[len("batch_") :] if method.startswith("batch_") else method
         if base in NEIGHBOR_LIST_STRATEGIES:
             # Fine-grained strategy name (e.g. from suggest/report): decompose to

--- a/nvalchemiops/torch/neighbors/__init__.py
+++ b/nvalchemiops/torch/neighbors/__init__.py
@@ -150,7 +150,13 @@ def neighbor_list(
         comparing estimated work from per-system atom counts and cell (or
         bounding-box) volumes and can select cluster-tile when the CUDA,
         float32, fully-periodic, contiguous-batch, and output-option guards
-        allow it. When only ``batch_idx`` is provided (no ``batch_ptr`` or 3-D ``cell``),
+        allow it. Method names that do not start with ``batch_`` refer to
+        single-system algorithms. When ``batch_idx`` or ``batch_ptr`` (batch
+        metadata) is supplied, those explicit method names are treated as aliases
+        for the corresponding ``batch_*`` methods. For example,
+        ``method="naive"`` is dispatched as ``method="batch_naive"`` when batch
+        metadata is provided. When only ``batch_idx`` is provided (no
+        ``batch_ptr`` or 3-D ``cell``),
         auto-selection computes ``batch_idx.max() + 1`` (and a ``bincount``)
         which triggers a device-to-host
         synchronization. To avoid this, pass ``batch_ptr``, a 3-D ``cell``
@@ -394,6 +400,11 @@ def neighbor_list(
         elif has_batch_inputs:
             cell, pbc = _squeeze_single_system_cell_pbc(cell, pbc)
     else:
+        if batch_idx is not None or batch_ptr is not None:
+            # Route explicit single-system method names through the matching
+            # batch method when batch metadata is provided.
+            if not method.startswith("batch_"):
+                method = "batch_" + method
         base = method[len("batch_") :] if method.startswith("batch_") else method
         if base in NEIGHBOR_LIST_STRATEGIES:
             # Fine-grained strategy name (e.g. from suggest/report): decompose

--- a/test/neighbors/bindings/jax/test_neighborlist.py
+++ b/test/neighbors/bindings/jax/test_neighborlist.py
@@ -448,6 +448,224 @@ class TestNeighborListExplicitMethod:
         assert len(wrapper_result) == len(direct_result)
         assert_neighbor_matrix_equal_jax(wrapper_result, direct_result)
 
+    @pytest.mark.parametrize(
+        ("method", "expected_route", "expected_options"),
+        [
+            ("naive", "batch_naive", {"native_strategy": "auto"}),
+            ("cell_list", "batch_cell_list", {"strategy": "auto"}),
+            ("cluster_tile", "batch_cluster_tile", {}),
+            ("naive_dual_cutoff", "batch_naive_dual_cutoff", {}),
+            ("naive_scalar", "batch_naive", {"native_strategy": "scalar"}),
+            ("naive_tile", "batch_naive", {"native_strategy": "tile"}),
+            (
+                "cell_list_atom_centric",
+                "batch_cell_list",
+                {"strategy": "atom_centric", "atom_centric_path": "direct"},
+            ),
+            (
+                "cell_list_pair_centric",
+                "batch_cell_list",
+                {"strategy": "pair_centric", "atom_centric_path": "sorted"},
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("batch_arg", ["batch_idx", "batch_ptr", "both"])
+    def test_explicit_unbatched_method_promotes_with_batch_metadata(
+        self, method, expected_route, expected_options, batch_arg, monkeypatch
+    ):
+        """Explicit single-system methods route to their batch equivalents."""
+        positions = jnp.zeros((6, 3), dtype=jnp.float32)
+        cell = jnp.repeat(jnp.eye(3, dtype=jnp.float32)[None, :, :] * 8.0, 2, axis=0)
+        pbc = jnp.ones((2, 3), dtype=bool)
+        kwargs = {
+            "batch_idx": jnp.array([0, 0, 0, 1, 1, 1], dtype=jnp.int32),
+            "batch_ptr": jnp.array([0, 3, 6], dtype=jnp.int32),
+        }
+        if batch_arg == "batch_idx":
+            kwargs.pop("batch_ptr")
+        elif batch_arg == "batch_ptr":
+            kwargs.pop("batch_idx")
+
+        seen = {}
+
+        def fake_batch_naive(*args, **call_kwargs):
+            seen["route"] = "batch_naive"
+            seen["kwargs"] = call_kwargs
+            return "batch_naive"
+
+        def fake_batch_cell_list(*args, **call_kwargs):
+            seen["route"] = "batch_cell_list"
+            seen["args"] = args
+            seen["kwargs"] = call_kwargs
+            return "batch_cell_list"
+
+        def fake_batch_cluster_tile(*args, **call_kwargs):
+            seen["route"] = "batch_cluster_tile"
+            seen["args"] = args
+            seen["kwargs"] = call_kwargs
+            return "batch_cluster_tile"
+
+        def fake_batch_naive_dual_cutoff(*args, **call_kwargs):
+            seen["route"] = "batch_naive_dual_cutoff"
+            seen["kwargs"] = call_kwargs
+            return "batch_naive_dual_cutoff"
+
+        monkeypatch.setattr(
+            neighbor_module, "batch_naive_neighbor_list", fake_batch_naive
+        )
+        monkeypatch.setattr(neighbor_module, "batch_cell_list", fake_batch_cell_list)
+        monkeypatch.setattr(
+            neighbor_module,
+            "batch_cluster_tile_neighbor_list",
+            fake_batch_cluster_tile,
+        )
+        monkeypatch.setattr(
+            neighbor_module,
+            "batch_naive_neighbor_list_dual_cutoff",
+            fake_batch_naive_dual_cutoff,
+        )
+
+        result = neighbor_list(
+            positions,
+            2.0,
+            cutoff2=3.0 if method == "naive_dual_cutoff" else None,
+            cell=cell,
+            pbc=pbc,
+            method=method,
+            **kwargs,
+        )
+
+        assert result == expected_route
+        assert seen["route"] == expected_route
+        for key, expected in expected_options.items():
+            assert seen["kwargs"][key] == expected
+
+    @pytest.mark.parametrize("method", ["naive", "cell_list"])
+    def test_explicit_unbatched_method_without_batch_metadata_stays_unbatched(
+        self, method, monkeypatch
+    ):
+        """A 3D cell alone is not batch metadata for explicit methods."""
+        positions = jnp.zeros((6, 3), dtype=jnp.float32)
+        cell = jnp.repeat(jnp.eye(3, dtype=jnp.float32)[None, :, :] * 8.0, 2, axis=0)
+        pbc = jnp.zeros((2, 3), dtype=bool)
+
+        def fake_unbatched(*args, **kwargs):
+            return "unbatched"
+
+        def fail_batched(*args, **kwargs):
+            raise AssertionError("batch method should not be selected")
+
+        monkeypatch.setattr(neighbor_module, "batch_naive_neighbor_list", fail_batched)
+        monkeypatch.setattr(neighbor_module, "batch_cell_list", fail_batched)
+        monkeypatch.setattr(neighbor_module, "naive_neighbor_list", fake_unbatched)
+        monkeypatch.setattr(neighbor_module, "cell_list", fake_unbatched)
+
+        assert (
+            neighbor_list(positions, 2.0, cell=cell, pbc=pbc, method=method)
+            == "unbatched"
+        )
+
+    @pytest.mark.parametrize(
+        ("method", "expected_route"),
+        [("naive", "batch_naive"), ("cell_list", "batch_cell_list")],
+    )
+    @pytest.mark.parametrize("batch_arg", ["batch_idx", "batch_ptr", "both"])
+    def test_explicit_unbatched_method_promotes_single_system_batch_metadata(
+        self, method, expected_route, batch_arg, monkeypatch
+    ):
+        """Even one-system batch metadata is still explicit batch metadata."""
+        positions = jnp.zeros((6, 3), dtype=jnp.float32)
+        cell = jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3) * 8.0
+        pbc = jnp.zeros((1, 3), dtype=bool)
+        kwargs = {
+            "batch_idx": jnp.zeros(6, dtype=jnp.int32),
+            "batch_ptr": jnp.array([0, 6], dtype=jnp.int32),
+        }
+        if batch_arg == "batch_idx":
+            kwargs.pop("batch_ptr")
+        elif batch_arg == "batch_ptr":
+            kwargs.pop("batch_idx")
+
+        def fake_batch_naive(*args, **call_kwargs):
+            return "batch_naive"
+
+        def fake_batch_cell_list(*args, **call_kwargs):
+            return "batch_cell_list"
+
+        monkeypatch.setattr(
+            neighbor_module, "batch_naive_neighbor_list", fake_batch_naive
+        )
+        monkeypatch.setattr(neighbor_module, "batch_cell_list", fake_batch_cell_list)
+
+        assert (
+            neighbor_list(positions, 2.0, cell=cell, pbc=pbc, method=method, **kwargs)
+            == expected_route
+        )
+
+    def test_invalid_method_with_batch_metadata_stays_invalid(self):
+        """Unknown method names are not promoted into generated batch names."""
+        positions = jnp.zeros((6, 3), dtype=jnp.float32)
+        batch_idx = jnp.array([0, 0, 0, 1, 1, 1], dtype=jnp.int32)
+
+        with pytest.raises(ValueError, match="Invalid method"):
+            neighbor_list(positions, 2.0, method="not_a_method", batch_idx=batch_idx)
+
+    def test_promoted_naive_does_not_cross_batch_boundaries(self):
+        """Promoted naive honors batch boundaries for overlapping coordinates."""
+        molecule = jnp.array(
+            [[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [-0.24, 0.93, 0.0]],
+            dtype=jnp.float32,
+        )
+        positions = jnp.concatenate([molecule, molecule], axis=0)
+        batch_idx = jnp.array([0, 0, 0, 1, 1, 1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 3, 6], dtype=jnp.int32)
+
+        pairs, _ptr = neighbor_list(
+            positions,
+            1.1,
+            method="naive",
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            return_neighbor_list=True,
+            max_neighbors=4,
+        )
+
+        assert pairs.shape[1] == 8
+        np.testing.assert_array_equal(
+            np.asarray(batch_idx[pairs[0]]), np.asarray(batch_idx[pairs[1]])
+        )
+
+    def test_method_none_and_batch_method_accept_batch_metadata(self):
+        """Auto and explicit batch methods accept batch metadata."""
+        positions = jnp.zeros((6, 3), dtype=jnp.float32)
+        cell = jnp.repeat(jnp.eye(3, dtype=jnp.float32)[None, :, :], 2, axis=0)
+        pbc = jnp.zeros((2, 3), dtype=bool)
+        batch_idx = jnp.array([0, 0, 0, 1, 1, 1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 3, 6], dtype=jnp.int32)
+
+        auto_result = neighbor_list(
+            positions,
+            2.0,
+            cell=cell,
+            pbc=pbc,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=8,
+        )
+        batch_result = neighbor_list(
+            positions,
+            2.0,
+            cell=cell,
+            pbc=pbc,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            method="batch_naive",
+            max_neighbors=8,
+        )
+
+        assert auto_result[0].shape == (6, 8)
+        assert batch_result[0].shape == (6, 8)
+
 
 # ==============================================================================
 # Tests: Fine-Grained Method Equivalence

--- a/test/neighbors/bindings/torch/test_neighborlist.py
+++ b/test/neighbors/bindings/torch/test_neighborlist.py
@@ -858,6 +858,225 @@ class TestNeighborListExplicitMethod:
         assert len(wrapper_result) == len(direct_result)
         assert_neighbor_matrix_equal(wrapper_result, direct_result)
 
+    @pytest.mark.parametrize(
+        ("method", "expected_route", "expected_options"),
+        [
+            ("naive", "batch_naive", {"native_strategy": "auto"}),
+            ("cell_list", "batch_cell_list", {"strategy": "auto"}),
+            ("cluster_tile", "batch_cluster_tile", {}),
+            ("naive_dual_cutoff", "batch_naive_dual_cutoff", {}),
+            ("naive_scalar", "batch_naive", {"native_strategy": "scalar"}),
+            ("naive_tile", "batch_naive", {"native_strategy": "tile"}),
+            (
+                "cell_list_atom_centric",
+                "batch_cell_list",
+                {"strategy": "atom_centric", "atom_centric_path": "direct"},
+            ),
+            (
+                "cell_list_pair_centric",
+                "batch_cell_list",
+                {"strategy": "pair_centric", "atom_centric_path": "sorted"},
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("batch_arg", ["batch_idx", "batch_ptr", "both"])
+    def test_explicit_unbatched_method_promotes_with_batch_metadata(
+        self, method, expected_route, expected_options, batch_arg, device, monkeypatch
+    ):
+        """Explicit single-system methods route to their batch equivalents."""
+        positions = torch.zeros(6, 3, dtype=torch.float32, device=device)
+        cell = torch.eye(3, dtype=torch.float32, device=device).repeat(2, 1, 1) * 8.0
+        pbc = torch.ones(2, 3, dtype=torch.bool, device=device)
+        kwargs = {
+            "batch_idx": torch.tensor(
+                [0, 0, 0, 1, 1, 1], dtype=torch.int32, device=device
+            ),
+            "batch_ptr": torch.tensor([0, 3, 6], dtype=torch.int32, device=device),
+        }
+        if batch_arg == "batch_idx":
+            kwargs.pop("batch_ptr")
+        elif batch_arg == "batch_ptr":
+            kwargs.pop("batch_idx")
+
+        seen = {}
+
+        def fake_batch_naive(*args, **call_kwargs):
+            seen["route"] = "batch_naive"
+            seen["kwargs"] = call_kwargs
+            return "batch_naive"
+
+        def fake_batch_cell_list(*args, **call_kwargs):
+            seen["route"] = "batch_cell_list"
+            seen["args"] = args
+            seen["kwargs"] = call_kwargs
+            return "batch_cell_list"
+
+        def fake_batch_cluster_tile(*args, **call_kwargs):
+            seen["route"] = "batch_cluster_tile"
+            seen["args"] = args
+            seen["kwargs"] = call_kwargs
+            return "batch_cluster_tile"
+
+        def fake_batch_naive_dual_cutoff(*args, **call_kwargs):
+            seen["route"] = "batch_naive_dual_cutoff"
+            seen["kwargs"] = call_kwargs
+            return "batch_naive_dual_cutoff"
+
+        monkeypatch.setattr(
+            neighbor_module, "batch_naive_neighbor_list", fake_batch_naive
+        )
+        monkeypatch.setattr(neighbor_module, "batch_cell_list", fake_batch_cell_list)
+        monkeypatch.setattr(
+            neighbor_module,
+            "batch_cluster_tile_neighbor_list",
+            fake_batch_cluster_tile,
+        )
+        monkeypatch.setattr(
+            neighbor_module,
+            "batch_naive_neighbor_list_dual_cutoff",
+            fake_batch_naive_dual_cutoff,
+        )
+
+        result = neighbor_list(
+            positions,
+            2.0,
+            cutoff2=3.0 if method == "naive_dual_cutoff" else None,
+            cell=cell,
+            pbc=pbc,
+            method=method,
+            **kwargs,
+        )
+
+        assert result == expected_route
+        assert seen["route"] == expected_route
+        for key, expected in expected_options.items():
+            assert seen["kwargs"][key] == expected
+
+    @pytest.mark.parametrize("method", ["naive", "cell_list"])
+    def test_explicit_unbatched_method_without_batch_metadata_stays_unbatched(
+        self, method, device, monkeypatch
+    ):
+        """A 3D cell alone is not batch metadata for explicit methods."""
+        positions = torch.zeros(6, 3, dtype=torch.float32, device=device)
+        cell = torch.eye(3, dtype=torch.float32, device=device).repeat(2, 1, 1) * 8.0
+        pbc = torch.zeros(2, 3, dtype=torch.bool, device=device)
+
+        def fake_unbatched(*args, **kwargs):
+            return "unbatched"
+
+        def fail_batched(*args, **kwargs):
+            raise AssertionError("batch method should not be selected")
+
+        monkeypatch.setattr(neighbor_module, "batch_naive_neighbor_list", fail_batched)
+        monkeypatch.setattr(neighbor_module, "batch_cell_list", fail_batched)
+        monkeypatch.setattr(neighbor_module, "naive_neighbor_list", fake_unbatched)
+        monkeypatch.setattr(neighbor_module, "cell_list", fake_unbatched)
+
+        assert (
+            neighbor_list(positions, 2.0, cell=cell, pbc=pbc, method=method)
+            == "unbatched"
+        )
+
+    @pytest.mark.parametrize(
+        ("method", "expected_route"),
+        [("naive", "batch_naive"), ("cell_list", "batch_cell_list")],
+    )
+    @pytest.mark.parametrize("batch_arg", ["batch_idx", "batch_ptr", "both"])
+    def test_explicit_unbatched_method_promotes_single_system_batch_metadata(
+        self, method, expected_route, batch_arg, device, monkeypatch
+    ):
+        """Even one-system batch metadata is still explicit batch metadata."""
+        positions = torch.zeros(6, 3, dtype=torch.float32, device=device)
+        cell = torch.eye(3, dtype=torch.float32, device=device).reshape(1, 3, 3) * 8.0
+        pbc = torch.zeros(1, 3, dtype=torch.bool, device=device)
+        kwargs = {
+            "batch_idx": torch.zeros(6, dtype=torch.int32, device=device),
+            "batch_ptr": torch.tensor([0, 6], dtype=torch.int32, device=device),
+        }
+        if batch_arg == "batch_idx":
+            kwargs.pop("batch_ptr")
+        elif batch_arg == "batch_ptr":
+            kwargs.pop("batch_idx")
+
+        def fake_batch_naive(*args, **call_kwargs):
+            return "batch_naive"
+
+        def fake_batch_cell_list(*args, **call_kwargs):
+            return "batch_cell_list"
+
+        monkeypatch.setattr(
+            neighbor_module, "batch_naive_neighbor_list", fake_batch_naive
+        )
+        monkeypatch.setattr(neighbor_module, "batch_cell_list", fake_batch_cell_list)
+
+        assert (
+            neighbor_list(positions, 2.0, cell=cell, pbc=pbc, method=method, **kwargs)
+            == expected_route
+        )
+
+    def test_invalid_method_with_batch_metadata_stays_invalid(self, device):
+        """Unknown method names are not promoted into generated batch names."""
+        positions = torch.zeros(6, 3, dtype=torch.float32, device=device)
+        batch_idx = torch.tensor([0, 0, 0, 1, 1, 1], dtype=torch.int32, device=device)
+
+        with pytest.raises(ValueError, match="Invalid method"):
+            neighbor_list(positions, 2.0, method="not_a_method", batch_idx=batch_idx)
+
+    def test_promoted_naive_does_not_cross_batch_boundaries(self, device):
+        """Promoted naive honors batch boundaries for overlapping coordinates."""
+        molecule = torch.tensor(
+            [[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [-0.24, 0.93, 0.0]],
+            dtype=torch.float32,
+            device=device,
+        )
+        positions = torch.cat([molecule, molecule], dim=0)
+        batch_idx = torch.tensor([0, 0, 0, 1, 1, 1], dtype=torch.int32, device=device)
+        batch_ptr = torch.tensor([0, 3, 6], dtype=torch.int32, device=device)
+
+        pairs, _ptr = neighbor_list(
+            positions,
+            1.1,
+            method="naive",
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            return_neighbor_list=True,
+            max_neighbors=4,
+        )
+
+        assert pairs.shape[1] == 8
+        assert torch.all(batch_idx[pairs[0].long()] == batch_idx[pairs[1].long()])
+
+    def test_method_none_and_batch_method_accept_batch_metadata(self, device):
+        """Auto and explicit batch methods accept batch metadata."""
+        positions = torch.zeros(6, 3, dtype=torch.float32, device=device)
+        cell = torch.eye(3, dtype=torch.float32, device=device).repeat(2, 1, 1)
+        pbc = torch.zeros(2, 3, dtype=torch.bool, device=device)
+        batch_idx = torch.tensor([0, 0, 0, 1, 1, 1], dtype=torch.int32, device=device)
+        batch_ptr = torch.tensor([0, 3, 6], dtype=torch.int32, device=device)
+
+        auto_result = neighbor_list(
+            positions,
+            2.0,
+            cell=cell,
+            pbc=pbc,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=8,
+        )
+        batch_result = neighbor_list(
+            positions,
+            2.0,
+            cell=cell,
+            pbc=pbc,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            method="batch_naive",
+            max_neighbors=8,
+        )
+
+        assert auto_result[0].shape == (6, 8)
+        assert batch_result[0].shape == (6, 8)
+
 
 class TestNeighborListBatchProcessing:
     """Test batch processing with batch_idx."""


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# nvalchemi-toolkit-ops Pull Request

## Description

Reject explicit single-system neighbor-list methods when batched metadata is
provided. Calls such as `method="naive"` or `method="cell_list"` with
`batch_idx` / `batch_ptr` previously treated the concatenated batch as one
system, which could produce cross-system neighbor edges.

The public API signature is unchanged. `method=None` remains the official
auto-dispatch path, and explicit `batch_*` methods remain allowed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Changes Made

- Added a fail-fast guard in Torch `neighbor_list` for explicit non-`batch_*`
  methods when `batch_idx` or `batch_ptr` is supplied.
- Added the same guard in JAX `neighbor_list`.
- Documented that explicit non-`batch_*` methods are single-system only.
- Added Torch/JAX regression tests covering `batch_idx`, `batch_ptr`, and both
  forms of batch metadata for explicit non-batched method names, including
  fine-grained methods such as `naive_tile`, `cell_list_pair_centric`, and
  `cluster_tile`.
- Added positive coverage that `method=None` and explicit `batch_naive` still
  accept batched metadata.

## Testing

- [ ] Full unit test suite passes locally
- [x] Focused unit tests pass locally
- [x] Linting passes locally

Ran locally:

```bash
ruff check \
  nvalchemiops/torch/neighbors/__init__.py \
  nvalchemiops/jax/neighbors/__init__.py \
  test/neighbors/bindings/torch/test_neighborlist.py \
  test/neighbors/bindings/jax/test_neighborlist.py
```

Result: `All checks passed!`

```bash
git diff --check
```

Result: no whitespace errors.

```bash
WARP_CACHE_PATH=/tmp/warp-cache \
python -m pytest test/neighbors/bindings/torch/test_neighborlist.py::TestNeighborListExplicitMethod -q
```

Result: `58 passed, 15 warnings`.

JAX targeted tests were not runnable in this local venv because `jax` is not
installed:

```text
Skipped: No JAX installed.
```

## Additional Notes

This intentionally does not add a broad `batch_idx`/`batch_ptr` consistency
validator. It only prevents the known silent failure mode where a single-system
method accepts batch metadata and builds neighbor edges across graph boundaries.
