### PR TITLE
fix(coverage): tolerate stale testmon baselines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,9 @@ omit = [
 ]
 show_missing = true
 fail_under = 70
+# Warn instead of aborting on missing source files (e.g. stale cached
+# testmon/coverage baselines referencing files deleted in the current PR).
+ignore_errors = true
 
 [tool.coverage.xml]
 output = "nvalchemiops.coverage.xml"


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

PR #95 is failing CUDA 13 test jobs after the tests pass because `coverage report`
aborts on a missing source file from a cached testmon/coverage baseline:
`nvalchemiops/neighbors/cell_list.py`.

This mirrors the stale baseline issue fixed in `NVIDIA/nvalchemi-toolkit` PR #78.
The same coverage setting lets CI warn about missing stale-cache sources instead
of failing after a successful test run.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

Relates to #95

## Changes Made

- Added `ignore_errors = true` under `[tool.coverage.report]`
- Documented that this is for stale cached testmon/coverage baselines
- Kept the change scoped to coverage reporting configuration

## Testing

- [ ] Unit tests pass locally (`make pytest`) - not run; config-only change and local machine has no GPU
- [ ] Linting passes (`make lint`) - not run; config-only change
- [ ] New tests added for new functionality meets coverage expectations? - N/A

Verified locally:

- `git diff --check`
- Parsed `pyproject.toml` and confirmed `tool.coverage.report.ignore_errors` is `true`

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md) - not applicable; CI config fix
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes - N/A
- [ ] I have updated the documentation (if applicable) - N/A

## Additional Notes

This follows the same fix pattern as `NVIDIA/nvalchemi-toolkit` PR #78:
`fix(coverage): tolerate missing source files in report`.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
