### PR TITLE
ci: split testmon and coverage caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,18 +219,40 @@ jobs:
       #
       # PR branches use push events to refs/heads/pull-request/*, not the
       # pull_request event. Detect them via the branch name pattern.
-      # Testmon baselines are Python/CUDA-specific because testmon keys its
+      # Testmon databases are Python/CUDA-specific because testmon keys its
       # dependency database by the interpreter version and installed packages.
-      - name: Restore testmon baseline (for PRs)
+      # Coverage baselines are cached separately so stale coverage files do not
+      # replace or mask the testmon dependency database.
+      - name: Restore testmon cache (for PRs)
         if: startsWith(github.ref, 'refs/heads/pull-request/')
         uses: actions/cache/restore@v4
         with:
           path: |
             .testmondata
-            .coverage
-          key: testmon-baseline-main-py${{ matrix.python-version }}-cuda13-${{ github.run_id }}
+            .testmondata-shm
+            .testmondata-wal
+          key: testmon-cache-main-py${{ matrix.python-version }}-cuda13-${{ github.run_id }}
           restore-keys: |
-            testmon-baseline-main-py${{ matrix.python-version }}-cuda13-
+            testmon-cache-main-py${{ matrix.python-version }}-cuda13-
+
+      - name: Restore coverage baseline (for PRs)
+        if: startsWith(github.ref, 'refs/heads/pull-request/')
+        uses: actions/cache/restore@v4
+        with:
+          path: .coverage.baseline
+          key: coverage-baseline-main-py${{ matrix.python-version }}-cuda13-${{ github.run_id }}
+          restore-keys: |
+            coverage-baseline-main-py${{ matrix.python-version }}-cuda13-
+
+      - name: Prepare coverage baseline (for PRs)
+        if: startsWith(github.ref, 'refs/heads/pull-request/')
+        run: |
+          if [ -f .coverage.baseline ]; then
+            echo "Using restored coverage baseline for PR coverage merge"
+            mv .coverage.baseline coverage_main.dat
+          else
+            echo "No coverage baseline restored; reporting PR coverage only"
+          fi
 
       - name: Run tests with testmon and coverage
         run: |
@@ -238,23 +260,38 @@ jobs:
           IS_PR=${{ startsWith(github.ref, 'refs/heads/pull-request/') }}
           if [[ "$IS_PR" == "true" ]]; then
             # PR: testmon selects affected tests, coverage traces them
-            make testmon-coverage
+            make testmon-coverage COVERAGE_BASELINE_FILE=coverage_main.dat
           else
             # Main/Schedule: build testmon DB, then full coverage without testmon
+            rm -f .testmondata .testmondata-shm .testmondata-wal
+            rm -f .coverage .coverage.* coverage_main.dat
             make testmon-collect
             make testmon-coverage PYTEST_TESTMON_FLAGS=""
           fi
 
-      # Save one baseline per Python version from main/schedule runs. PR runs
-      # restore the newest matching baseline for their matrix interpreter.
-      - name: Save testmon baseline
+      # Save one testmon DB and one coverage baseline per Python/CUDA version
+      # from main/schedule runs. PR runs restore the newest matching pair.
+      - name: Save testmon cache
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule')
         uses: actions/cache/save@v4
         with:
           path: |
             .testmondata
-            .coverage
-          key: testmon-baseline-main-py${{ matrix.python-version }}-cuda13-${{ github.run_id }}
+            .testmondata-shm
+            .testmondata-wal
+          key: testmon-cache-main-py${{ matrix.python-version }}-cuda13-${{ github.run_id }}
+
+      - name: Prepare coverage baseline
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule')
+        run: |
+          cp .coverage .coverage.baseline
+
+      - name: Save coverage baseline
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule')
+        uses: actions/cache/save@v4
+        with:
+          path: .coverage.baseline
+          key: coverage-baseline-main-py${{ matrix.python-version }}-cuda13-${{ github.run_id }}
 
       - name: Upload coverage to Codecov
         if: github.event_name != 'merge_group' && github.event_name != 'schedule'
@@ -321,16 +358,29 @@ jobs:
       - name: Run tests with testmon and coverage
         run: |
           export PATH="$HOME/.local/bin:$PATH"
+          rm -f .testmondata .testmondata-shm .testmondata-wal
+          rm -f .coverage .coverage.* coverage_main.dat
           make testmon-collect
           make testmon-coverage PYTEST_TESTMON_FLAGS=""
 
-      - name: Save testmon baseline
+      - name: Save testmon cache
         uses: actions/cache/save@v4
         with:
           path: |
             .testmondata
-            .coverage
-          key: testmon-baseline-main-py${{ matrix.python-version }}-cuda12-${{ github.run_id }}
+            .testmondata-shm
+            .testmondata-wal
+          key: testmon-cache-main-py${{ matrix.python-version }}-cuda12-${{ github.run_id }}
+
+      - name: Prepare coverage baseline
+        run: |
+          cp .coverage .coverage.baseline
+
+      - name: Save coverage baseline
+        uses: actions/cache/save@v4
+        with:
+          path: .coverage.baseline
+          key: coverage-baseline-main-py${{ matrix.python-version }}-cuda12-${{ github.run_id }}
 
       - name: Upload coverage report artifact
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ testmon-collect:  ## Build testmon dependency database (no coverage)
 
 .PHONY: testmon-coverage
 testmon-coverage:  ## Run tests with coverage (testmon selects by default)
-	rm -f .coverage
+	rm -f .coverage $(COVERAGE_DATA_FILES) $(addsuffix .*, $(COVERAGE_DATA_FILES))
 	$(foreach mod,$(TEST_MODULES),\
 		COVERAGE_FILE=.coverage.$(firstword $(subst :, ,$(mod))) \
 		uv run coverage run -m pytest $(PYTEST_TESTMON_FLAGS) $(lastword $(subst :, ,$(mod))); \
@@ -101,13 +101,20 @@ testmon-coverage:  ## Run tests with coverage (testmon selects by default)
 	if [ -n "$(COVERAGE_BASELINE_FILE)" ] && [ -f "$(COVERAGE_BASELINE_FILE)" ]; then \
 		coverage_files="$$coverage_files $(COVERAGE_BASELINE_FILE)"; \
 	fi; \
-	for coverage_file in $(COVERAGE_DATA_FILES); do \
-		if [ -f "$$coverage_file" ]; then \
-			coverage_files="$$coverage_files $$coverage_file"; \
-		fi; \
+	for coverage_prefix in $(COVERAGE_DATA_FILES); do \
+		for coverage_file in "$$coverage_prefix" "$$coverage_prefix".*; do \
+			if [ -f "$$coverage_file" ]; then \
+				coverage_files="$$coverage_files $$coverage_file"; \
+			fi; \
+		done; \
 	done; \
 	if [ -n "$$coverage_files" ]; then \
 		uv run coverage combine --data-file=.coverage $$coverage_files || true; \
+	else \
+		coverage_files=$$(find . -maxdepth 1 -name ".coverage.*" ! -name ".coverage.baseline" -print); \
+		if [ -n "$$coverage_files" ]; then \
+			uv run coverage combine --data-file=.coverage $$coverage_files || true; \
+		fi; \
 	fi
 	uv run coverage report --show-missing --fail-under=70
 	uv run coverage xml -o nvalchemiops.coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,8 @@ pytest:  ## Run pytest with coverage
 
 PYTEST_TESTMON_FLAGS ?= --testmon --testmon-nocollect
 TEST_MODULES := types:test/test_types.py math:test/math neighbors:test/neighbors interactions:test/interactions
+COVERAGE_DATA_FILES := $(foreach mod,$(TEST_MODULES),.coverage.$(firstword $(subst :, ,$(mod))))
+COVERAGE_BASELINE_FILE ?=
 
 .PHONY: testmon-collect
 testmon-collect:  ## Build testmon dependency database (no coverage)
@@ -90,11 +92,23 @@ testmon-collect:  ## Build testmon dependency database (no coverage)
 
 .PHONY: testmon-coverage
 testmon-coverage:  ## Run tests with coverage (testmon selects by default)
+	rm -f .coverage
 	$(foreach mod,$(TEST_MODULES),\
 		COVERAGE_FILE=.coverage.$(firstword $(subst :, ,$(mod))) \
 		uv run coverage run -m pytest $(PYTEST_TESTMON_FLAGS) $(lastword $(subst :, ,$(mod))); \
 		RET=$$?; if [ $$RET -ne 0 ] && [ $$RET -ne 5 ]; then exit $$RET; fi;) true
-	uv run coverage combine --append || true
+	@coverage_files=""; \
+	if [ -n "$(COVERAGE_BASELINE_FILE)" ] && [ -f "$(COVERAGE_BASELINE_FILE)" ]; then \
+		coverage_files="$$coverage_files $(COVERAGE_BASELINE_FILE)"; \
+	fi; \
+	for coverage_file in $(COVERAGE_DATA_FILES); do \
+		if [ -f "$$coverage_file" ]; then \
+			coverage_files="$$coverage_files $$coverage_file"; \
+		fi; \
+	done; \
+	if [ -n "$$coverage_files" ]; then \
+		uv run coverage combine --data-file=.coverage $$coverage_files || true; \
+	fi
 	uv run coverage report --show-missing --fail-under=70
 	uv run coverage xml -o nvalchemiops.coverage.xml
 


### PR DESCRIPTION
# ALCHEMI Toolkit-Ops Pull Request

## Description

Split the testmon and coverage caches used by CI so each Python/CUDA baseline can drift independently. This addresses the PR #97 behavior where Python 3.14 reused a useful testmon cache and finished quickly, while the other Python versions restored stale or empty testmon state and reran much more of the suite.

This follows the toolkit CI pattern of keeping the test-selection cache scoped to the Python environment instead of bundling it with coverage output.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

Relates to #97.

## Changes Made

- Cache `.testmondata` separately from coverage baselines for CUDA 12 and CUDA 13 CI.
- Restore coverage baselines as `.coverage.baseline` and merge them explicitly during PR test runs.
- Make `testmon-coverage` combine only the restored baseline and per-module coverage files that exist.

## Testing

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

Validation performed:

- `git diff --check`
- YAML parse of `.github/workflows/ci.yml`
- `make -n testmon-coverage COVERAGE_BASELINE_FILE=coverage_main.dat`
- `make -n testmon-coverage PYTEST_TESTMON_FLAGS=""`

GPU tests were not run locally.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

No changelog, docstring, or documentation updates are needed for this CI-only change.
