### PR TITLE
ci: avoid duplicate testmon runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,13 +218,14 @@ jobs:
       # CONDITIONAL LOGIC BASED ON EVENT TYPE
       #
       # PR branches use push events to refs/heads/pull-request/*, not the
-      # pull_request event. Detect them via the branch name pattern.
+      # pull_request event. Merge queue runs use merge_group events on
+      # gh-readonly-queue refs, but should use the same testmon-selected path.
       # Testmon databases are Python/CUDA-specific because testmon keys its
       # dependency database by the interpreter version and installed packages.
       # Coverage baselines are cached separately so stale coverage files do not
       # replace or mask the testmon dependency database.
-      - name: Restore testmon cache (for PRs)
-        if: startsWith(github.ref, 'refs/heads/pull-request/')
+      - name: Restore testmon cache (for PRs and merge queue)
+        if: startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'merge_group'
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -235,8 +236,8 @@ jobs:
           restore-keys: |
             testmon-cache-main-py${{ matrix.python-version }}-cuda13-
 
-      - name: Restore coverage baseline (for PRs)
-        if: startsWith(github.ref, 'refs/heads/pull-request/')
+      - name: Restore coverage baseline (for PRs and merge queue)
+        if: startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'merge_group'
         uses: actions/cache/restore@v4
         with:
           path: .coverage.baseline
@@ -244,8 +245,8 @@ jobs:
           restore-keys: |
             coverage-baseline-main-py${{ matrix.python-version }}-cuda13-
 
-      - name: Prepare coverage baseline (for PRs)
-        if: startsWith(github.ref, 'refs/heads/pull-request/')
+      - name: Prepare coverage baseline (for PRs and merge queue)
+        if: startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'merge_group'
         run: |
           if [ -f .coverage.baseline ]; then
             echo "Using restored coverage baseline for PR coverage merge"
@@ -257,20 +258,20 @@ jobs:
       - name: Run tests with testmon and coverage
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          IS_PR=${{ startsWith(github.ref, 'refs/heads/pull-request/') }}
-          if [[ "$IS_PR" == "true" ]]; then
-            # PR: testmon selects affected tests, coverage traces them
+          USE_TESTMON_SELECTION=${{ startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'merge_group' }}
+          if [[ "$USE_TESTMON_SELECTION" == "true" ]]; then
+            # PR/Merge queue: testmon selects affected tests, coverage traces them
             make testmon-coverage COVERAGE_BASELINE_FILE=coverage_main.dat
           else
-            # Main/Schedule: build testmon DB, then full coverage without testmon
+            # Main/Schedule: refresh testmon DB and coverage baseline in one full pass.
             rm -f .testmondata .testmondata-shm .testmondata-wal
             rm -f .coverage .coverage.* coverage_main.dat
-            make testmon-collect
-            make testmon-coverage PYTEST_TESTMON_FLAGS=""
+            make testmon-coverage PYTEST_TESTMON_FLAGS="--testmon"
           fi
 
       # Save one testmon DB and one coverage baseline per Python/CUDA version
-      # from main/schedule runs. PR runs restore the newest matching pair.
+      # from main/schedule runs. PR and merge queue runs restore the newest
+      # matching pair.
       - name: Save testmon cache
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule')
         uses: actions/cache/save@v4
@@ -360,8 +361,7 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           rm -f .testmondata .testmondata-shm .testmondata-wal
           rm -f .coverage .coverage.* coverage_main.dat
-          make testmon-collect
-          make testmon-coverage PYTEST_TESTMON_FLAGS=""
+          make testmon-coverage PYTEST_TESTMON_FLAGS="--testmon"
 
       - name: Save testmon cache
         uses: actions/cache/save@v4


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

This PR updates CI so merge queue runs use the same testmon-selected path as PR runs. It also refreshes scheduled/main testmon data and coverage in a single pass, avoiding the duplicate full test run that has been causing long jobs and timeouts.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

Relates to recent merge queue CI timeouts from duplicate testmon/coverage execution.

## Changes Made

- Restore testmon and coverage caches for merge queue runs.
- Run merge queue checks through the PR-style testmon selection path.
- Use one coverage-backed testmon pass for main and scheduled cache refreshes.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

Validated locally with workflow syntax and make dry-runs:

- `git diff --check`
- Ruby YAML parse for `.github/workflows/ci.yml`
- `make -n testmon-coverage PYTEST_TESTMON_FLAGS="--testmon"`
- `make -n testmon-coverage COVERAGE_BASELINE_FILE=coverage_main.dat`

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

No local GPU test run was performed; this change only updates GitHub Actions workflow behavior.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
