### PR TITLE
perf(electrostatics): accelerate reciprocal Ewald fill

### DIFF
--- a/nvalchemiops/interactions/electrostatics/ewald_kernels.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_kernels.py
@@ -164,7 +164,6 @@ __all__ = [
     "ewald_reciprocal_space_fill_structure_factors",
     "ewald_subtract_self_energy",
     "can_tile_ewald_recip_on_device",
-    "should_tile_ewald_recip_compute",
     "should_tile_ewald_recip_fill",
 ]
 
@@ -215,18 +214,6 @@ def should_tile_ewald_recip_fill(num_atoms: int) -> bool:
     if override is not None:
         return override
     return num_atoms >= _env_int("NVALCHEMIOPS_EWALD_RECIP_MIN_ATOMS", 1024)
-
-
-def should_tile_ewald_recip_compute(num_atoms: int, num_k: int) -> bool:
-    """Return whether reciprocal atom-major compute should use a tiled launch."""
-    override = _recip_tiling_override()
-    if override is False:
-        return False
-    if override is True:
-        return True
-    min_atoms = _env_int("NVALCHEMIOPS_EWALD_RECIP_MIN_ATOMS", 1024)
-    max_k = _env_int("NVALCHEMIOPS_EWALD_RECIP_COMPUTE_MAX_K", 512)
-    return num_atoms >= min_atoms and num_k <= max_k
 
 
 def can_tile_ewald_recip_on_device(device: object) -> bool:

--- a/nvalchemiops/interactions/electrostatics/ewald_kernels.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_kernels.py
@@ -163,6 +163,9 @@ __all__ = [
     "ewald_reciprocal_space_energy_forces_charge_grad",
     "ewald_reciprocal_space_fill_structure_factors",
     "ewald_subtract_self_energy",
+    "can_tile_ewald_recip_on_device",
+    "should_tile_ewald_recip_compute",
+    "should_tile_ewald_recip_fill",
 ]
 
 # Mathematical constants
@@ -184,6 +187,51 @@ BATCH_BLOCK_SIZE = BATCH_BLOCK_SIZE if BATCH_BLOCK_SIZE > 0 else 16
 # result. On CPU warp clamps block_dim to 1 and the tile primitives degrade to
 # scalar passthrough.
 REAL_SPACE_TILED_BLOCK_DIM = 64
+
+
+def _env_int(name: str, default: int) -> int:
+    """Return a positive integer env override or ``default``."""
+    try:
+        value = int(os.environ.get(name, default))
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+RECIP_TILED_BLOCK_DIM = _env_int("NVALCHEMIOPS_EWALD_RECIP_TILE_DIM", 128)
+
+
+def _recip_tiling_override() -> bool | None:
+    """Return the reciprocal tiling override, or ``None`` for auto mode."""
+    value = os.environ.get("NVALCHEMIOPS_EWALD_RECIP_TILED")
+    if value is None or value == "":
+        return None
+    return value not in {"0", "false", "False", "off", "OFF"}
+
+
+def should_tile_ewald_recip_fill(num_atoms: int) -> bool:
+    """Return whether reciprocal fill should use a tiled launch."""
+    override = _recip_tiling_override()
+    if override is not None:
+        return override
+    return num_atoms >= _env_int("NVALCHEMIOPS_EWALD_RECIP_MIN_ATOMS", 1024)
+
+
+def should_tile_ewald_recip_compute(num_atoms: int, num_k: int) -> bool:
+    """Return whether reciprocal atom-major compute should use a tiled launch."""
+    override = _recip_tiling_override()
+    if override is False:
+        return False
+    if override is True:
+        return True
+    min_atoms = _env_int("NVALCHEMIOPS_EWALD_RECIP_MIN_ATOMS", 1024)
+    max_k = _env_int("NVALCHEMIOPS_EWALD_RECIP_COMPUTE_MAX_K", 512)
+    return num_atoms >= min_atoms and num_k <= max_k
+
+
+def can_tile_ewald_recip_on_device(device: object) -> bool:
+    """Return whether reciprocal tiled kernels can run on ``device``."""
+    return str(device).startswith("cuda")
 
 
 ###########################################################################################
@@ -554,6 +602,196 @@ def _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad(
     cellgrad_cache[k_idx, 5] = rb_x
     cellgrad_cache[k_idx, 6] = rb_y
     cellgrad_cache[k_idx, 7] = rb_z
+
+
+@wp.kernel
+def _ewald_reciprocal_space_energy_kernel_fill_structure_factors_tiled(
+    positions: wp.array(dtype=Any),
+    charges: wp.array(dtype=Any),
+    k_vectors: wp.array(dtype=Any),
+    cell: wp.array(dtype=Any),
+    alpha: wp.array(dtype=Any),
+    total_charge: wp.array(dtype=wp.float64),
+    cos_k_dot_r: wp.array2d(dtype=wp.float64),
+    sin_k_dot_r: wp.array2d(dtype=wp.float64),
+    real_structure_factors: wp.array(dtype=wp.float64),
+    imag_structure_factors: wp.array(dtype=wp.float64),
+):
+    """Cooperative tiled single-system reciprocal structure-factor fill.
+
+    Thread launch
+    -------------
+    ``wp.launch_tiled(dim=K, block_dim=RECIP_TILED_BLOCK_DIM)``. One block owns
+    one k-vector and its lanes cooperate over all atoms.
+
+    Modifies
+    --------
+    ``total_charge``, ``cos_k_dot_r``, ``sin_k_dot_r``,
+    ``real_structure_factors``, and ``imag_structure_factors``.
+    """
+    k_idx, lane = wp.tid()
+    num_atoms = positions.shape[0]
+
+    alpha_ = wp.float64(alpha[0])
+    exp_factor = wp.float64(0.25) / (alpha_ * alpha_)
+    volume = wp.float64(wp.abs(wp.determinant(cell[0])))
+    inv_volume = wp.float64(1.0) / volume
+
+    k_vector = k_vectors[k_idx]
+    kx = wp.float64(k_vector[0])
+    ky = wp.float64(k_vector[1])
+    kz = wp.float64(k_vector[2])
+    k_squared = kx * kx + ky * ky + kz * kz
+
+    green_function = wp.float64(0.0)
+    if k_squared >= wp.float64(1e-10):
+        green_function = (
+            wp_exp_kernel(k_squared, exp_factor) * wp.float64(EIGHTPI) * inv_volume
+        )
+
+    real_sum = wp.float64(0.0)
+    imag_sum = wp.float64(0.0)
+    charge_sum = wp.float64(0.0)
+
+    for atom_start in range(0, num_atoms, RECIP_TILED_BLOCK_DIM):
+        atom_idx = atom_start + lane
+        if atom_idx < num_atoms:
+            position = positions[atom_idx]
+            charge = wp.float64(charges[atom_idx])
+            if k_idx == 0:
+                charge_sum += charge * inv_volume
+
+            cos_kr = wp.float64(0.0)
+            sin_kr = wp.float64(0.0)
+            if k_squared >= wp.float64(1e-10):
+                k_dot_r = (
+                    kx * wp.float64(position[0])
+                    + ky * wp.float64(position[1])
+                    + kz * wp.float64(position[2])
+                )
+                cos_kr = wp.cos(k_dot_r)
+                sin_kr = wp.sin(k_dot_r)
+                real_sum += charge * cos_kr
+                imag_sum += charge * sin_kr
+
+            cos_k_dot_r[k_idx, atom_idx] = cos_kr
+            sin_k_dot_r[k_idx, atom_idx] = sin_kr
+
+    real_tile = wp.tile_reduce(wp.add, wp.tile(real_sum))
+    imag_tile = wp.tile_reduce(wp.add, wp.tile(imag_sum))
+    charge_tile = wp.tile_reduce(wp.add, wp.tile(charge_sum))
+
+    wp.tile_store(real_structure_factors, real_tile * green_function, k_idx)
+    wp.tile_store(imag_structure_factors, imag_tile * green_function, k_idx)
+    if k_idx == 0:
+        wp.tile_store(total_charge, charge_tile, 0)
+
+
+@wp.kernel
+def _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled(
+    positions: wp.array(dtype=Any),
+    charges: wp.array(dtype=Any),
+    k_vectors: wp.array(dtype=Any),
+    cell: wp.array(dtype=Any),
+    alpha: wp.array(dtype=Any),
+    total_charge: wp.array(dtype=wp.float64),
+    cos_k_dot_r: wp.array2d(dtype=wp.float64),
+    sin_k_dot_r: wp.array2d(dtype=wp.float64),
+    real_structure_factors: wp.array(dtype=wp.float64),
+    imag_structure_factors: wp.array(dtype=wp.float64),
+    cellgrad_cache: wp.array2d(dtype=wp.float64),
+):
+    """Cooperative tiled fill plus first-order cell-gradient cache."""
+    k_idx, lane = wp.tid()
+    num_atoms = positions.shape[0]
+
+    alpha_ = wp.float64(alpha[0])
+    exp_factor = wp.float64(0.25) / (alpha_ * alpha_)
+    volume = wp.float64(wp.abs(wp.determinant(cell[0])))
+    inv_volume = wp.float64(1.0) / volume
+
+    k_vector = k_vectors[k_idx]
+    kx = wp.float64(k_vector[0])
+    ky = wp.float64(k_vector[1])
+    kz = wp.float64(k_vector[2])
+    k_squared = kx * kx + ky * ky + kz * kz
+
+    green_function = wp.float64(0.0)
+    if k_squared >= wp.float64(1e-10):
+        green_function = (
+            wp_exp_kernel(k_squared, exp_factor) * wp.float64(EIGHTPI) * inv_volume
+        )
+
+    real_sum = wp.float64(0.0)
+    imag_sum = wp.float64(0.0)
+    charge_sum = wp.float64(0.0)
+    a_sum = wp.float64(0.0)
+    b_sum = wp.float64(0.0)
+    ra_x = wp.float64(0.0)
+    ra_y = wp.float64(0.0)
+    ra_z = wp.float64(0.0)
+    rb_x = wp.float64(0.0)
+    rb_y = wp.float64(0.0)
+    rb_z = wp.float64(0.0)
+
+    for atom_start in range(0, num_atoms, RECIP_TILED_BLOCK_DIM):
+        atom_idx = atom_start + lane
+        if atom_idx < num_atoms:
+            position = positions[atom_idx]
+            charge = wp.float64(charges[atom_idx])
+            if k_idx == 0:
+                charge_sum += charge * inv_volume
+
+            rx = wp.float64(position[0])
+            ry = wp.float64(position[1])
+            rz = wp.float64(position[2])
+            cos_kr = wp.float64(0.0)
+            sin_kr = wp.float64(0.0)
+            if k_squared >= wp.float64(1e-10):
+                k_dot_r = kx * rx + ky * ry + kz * rz
+                cos_kr = wp.cos(k_dot_r)
+                sin_kr = wp.sin(k_dot_r)
+                qc = charge * cos_kr
+                qs = charge * sin_kr
+                real_sum += qc
+                imag_sum += qs
+                a_sum += qc
+                b_sum += qs
+                ra_x += qc * rx
+                ra_y += qc * ry
+                ra_z += qc * rz
+                rb_x += qs * rx
+                rb_y += qs * ry
+                rb_z += qs * rz
+
+            cos_k_dot_r[k_idx, atom_idx] = cos_kr
+            sin_k_dot_r[k_idx, atom_idx] = sin_kr
+
+    real_tile = wp.tile_reduce(wp.add, wp.tile(real_sum))
+    imag_tile = wp.tile_reduce(wp.add, wp.tile(imag_sum))
+    charge_tile = wp.tile_reduce(wp.add, wp.tile(charge_sum))
+    a_tile = wp.tile_reduce(wp.add, wp.tile(a_sum))
+    b_tile = wp.tile_reduce(wp.add, wp.tile(b_sum))
+    ra_x_tile = wp.tile_reduce(wp.add, wp.tile(ra_x))
+    ra_y_tile = wp.tile_reduce(wp.add, wp.tile(ra_y))
+    ra_z_tile = wp.tile_reduce(wp.add, wp.tile(ra_z))
+    rb_x_tile = wp.tile_reduce(wp.add, wp.tile(rb_x))
+    rb_y_tile = wp.tile_reduce(wp.add, wp.tile(rb_y))
+    rb_z_tile = wp.tile_reduce(wp.add, wp.tile(rb_z))
+
+    wp.tile_store(real_structure_factors, real_tile * green_function, k_idx)
+    wp.tile_store(imag_structure_factors, imag_tile * green_function, k_idx)
+    if k_idx == 0:
+        wp.tile_store(total_charge, charge_tile, 0)
+    if lane == 0:
+        cellgrad_cache[k_idx, 0] = wp.tile_extract(a_tile, 0)
+        cellgrad_cache[k_idx, 1] = wp.tile_extract(b_tile, 0)
+        cellgrad_cache[k_idx, 2] = wp.tile_extract(ra_x_tile, 0)
+        cellgrad_cache[k_idx, 3] = wp.tile_extract(ra_y_tile, 0)
+        cellgrad_cache[k_idx, 4] = wp.tile_extract(ra_z_tile, 0)
+        cellgrad_cache[k_idx, 5] = wp.tile_extract(rb_x_tile, 0)
+        cellgrad_cache[k_idx, 6] = wp.tile_extract(rb_y_tile, 0)
+        cellgrad_cache[k_idx, 7] = wp.tile_extract(rb_z_tile, 0)
 
 
 @wp.kernel
@@ -1380,6 +1618,207 @@ def _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad(
 
     if k_idx == 0:
         wp.atomic_add(total_charges, system_id, local_charge)
+
+
+@wp.kernel
+def _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_tiled(
+    positions: wp.array(dtype=Any),
+    charges: wp.array(dtype=Any),
+    k_vectors: wp.array2d(dtype=Any),
+    cell: wp.array(dtype=Any),
+    alpha: wp.array(dtype=Any),
+    atom_start: wp.array(dtype=wp.int32),
+    atom_end: wp.array(dtype=wp.int32),
+    total_charges: wp.array(dtype=wp.float64),
+    cos_k_dot_r: wp.array2d(dtype=wp.float64),
+    sin_k_dot_r: wp.array2d(dtype=wp.float64),
+    real_structure_factors: wp.array2d(dtype=wp.float64),
+    imag_structure_factors: wp.array2d(dtype=wp.float64),
+):
+    """Cooperative tiled batched reciprocal structure-factor fill."""
+    k_idx, system_id, lane = wp.tid()
+
+    system_cell = cell[system_id]
+    system_alpha = wp.float64(alpha[system_id])
+    a_start = atom_start[system_id]
+    a_end = atom_end[system_id]
+
+    exp_factor = wp.float64(0.25) / (system_alpha * system_alpha)
+    volume = wp.float64(wp.abs(wp.determinant(system_cell)))
+    inv_volume = wp.float64(1.0) / volume
+
+    k_vector = k_vectors[system_id, k_idx]
+    kx = wp.float64(k_vector[0])
+    ky = wp.float64(k_vector[1])
+    kz = wp.float64(k_vector[2])
+    k_squared = kx * kx + ky * ky + kz * kz
+
+    green_function = wp.float64(0.0)
+    if k_squared >= wp.float64(1e-10):
+        green_function = (
+            wp_exp_kernel(k_squared, exp_factor) * wp.float64(EIGHTPI) * inv_volume
+        )
+
+    real_sum = wp.float64(0.0)
+    imag_sum = wp.float64(0.0)
+    charge_sum = wp.float64(0.0)
+
+    for atom_tile_start in range(a_start, a_end, RECIP_TILED_BLOCK_DIM):
+        atom_idx = atom_tile_start + lane
+        if atom_idx < a_end:
+            position = positions[atom_idx]
+            charge = wp.float64(charges[atom_idx])
+            if k_idx == 0:
+                charge_sum += charge * inv_volume
+
+            cos_kr = wp.float64(0.0)
+            sin_kr = wp.float64(0.0)
+            if k_squared >= wp.float64(1e-10):
+                k_dot_r = (
+                    kx * wp.float64(position[0])
+                    + ky * wp.float64(position[1])
+                    + kz * wp.float64(position[2])
+                )
+                cos_kr = wp.cos(k_dot_r)
+                sin_kr = wp.sin(k_dot_r)
+                real_sum += charge * cos_kr
+                imag_sum += charge * sin_kr
+
+            cos_k_dot_r[k_idx, atom_idx] = cos_kr
+            sin_k_dot_r[k_idx, atom_idx] = sin_kr
+
+    real_tile = wp.tile_reduce(wp.add, wp.tile(real_sum))
+    imag_tile = wp.tile_reduce(wp.add, wp.tile(imag_sum))
+    charge_tile = wp.tile_reduce(wp.add, wp.tile(charge_sum))
+
+    if lane == 0:
+        real_structure_factors[system_id, k_idx] = (
+            wp.tile_extract(real_tile, 0) * green_function
+        )
+        imag_structure_factors[system_id, k_idx] = (
+            wp.tile_extract(imag_tile, 0) * green_function
+        )
+    if k_idx == 0:
+        wp.tile_store(total_charges, charge_tile, system_id)
+
+
+@wp.kernel
+def _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled(
+    positions: wp.array(dtype=Any),
+    charges: wp.array(dtype=Any),
+    k_vectors: wp.array2d(dtype=Any),
+    cell: wp.array(dtype=Any),
+    alpha: wp.array(dtype=Any),
+    atom_start: wp.array(dtype=wp.int32),
+    atom_end: wp.array(dtype=wp.int32),
+    total_charges: wp.array(dtype=wp.float64),
+    cos_k_dot_r: wp.array2d(dtype=wp.float64),
+    sin_k_dot_r: wp.array2d(dtype=wp.float64),
+    real_structure_factors: wp.array2d(dtype=wp.float64),
+    imag_structure_factors: wp.array2d(dtype=wp.float64),
+    cellgrad_cache: wp.array2d(dtype=wp.float64),
+):
+    """Cooperative tiled batched fill plus first-order cell-gradient cache."""
+    k_idx, system_id, lane = wp.tid()
+
+    system_cell = cell[system_id]
+    system_alpha = wp.float64(alpha[system_id])
+    a_start = atom_start[system_id]
+    a_end = atom_end[system_id]
+
+    exp_factor = wp.float64(0.25) / (system_alpha * system_alpha)
+    volume = wp.float64(wp.abs(wp.determinant(system_cell)))
+    inv_volume = wp.float64(1.0) / volume
+
+    k_vector = k_vectors[system_id, k_idx]
+    kx = wp.float64(k_vector[0])
+    ky = wp.float64(k_vector[1])
+    kz = wp.float64(k_vector[2])
+    k_squared = kx * kx + ky * ky + kz * kz
+
+    green_function = wp.float64(0.0)
+    if k_squared >= wp.float64(1e-10):
+        green_function = (
+            wp_exp_kernel(k_squared, exp_factor) * wp.float64(EIGHTPI) * inv_volume
+        )
+
+    real_sum = wp.float64(0.0)
+    imag_sum = wp.float64(0.0)
+    charge_sum = wp.float64(0.0)
+    a_sum = wp.float64(0.0)
+    b_sum = wp.float64(0.0)
+    ra_x = wp.float64(0.0)
+    ra_y = wp.float64(0.0)
+    ra_z = wp.float64(0.0)
+    rb_x = wp.float64(0.0)
+    rb_y = wp.float64(0.0)
+    rb_z = wp.float64(0.0)
+
+    for atom_tile_start in range(a_start, a_end, RECIP_TILED_BLOCK_DIM):
+        atom_idx = atom_tile_start + lane
+        if atom_idx < a_end:
+            position = positions[atom_idx]
+            charge = wp.float64(charges[atom_idx])
+            if k_idx == 0:
+                charge_sum += charge * inv_volume
+
+            rx = wp.float64(position[0])
+            ry = wp.float64(position[1])
+            rz = wp.float64(position[2])
+            cos_kr = wp.float64(0.0)
+            sin_kr = wp.float64(0.0)
+            if k_squared >= wp.float64(1e-10):
+                k_dot_r = kx * rx + ky * ry + kz * rz
+                cos_kr = wp.cos(k_dot_r)
+                sin_kr = wp.sin(k_dot_r)
+                qc = charge * cos_kr
+                qs = charge * sin_kr
+                real_sum += qc
+                imag_sum += qs
+                a_sum += qc
+                b_sum += qs
+                ra_x += qc * rx
+                ra_y += qc * ry
+                ra_z += qc * rz
+                rb_x += qs * rx
+                rb_y += qs * ry
+                rb_z += qs * rz
+
+            cos_k_dot_r[k_idx, atom_idx] = cos_kr
+            sin_k_dot_r[k_idx, atom_idx] = sin_kr
+
+    real_tile = wp.tile_reduce(wp.add, wp.tile(real_sum))
+    imag_tile = wp.tile_reduce(wp.add, wp.tile(imag_sum))
+    charge_tile = wp.tile_reduce(wp.add, wp.tile(charge_sum))
+    a_tile = wp.tile_reduce(wp.add, wp.tile(a_sum))
+    b_tile = wp.tile_reduce(wp.add, wp.tile(b_sum))
+    ra_x_tile = wp.tile_reduce(wp.add, wp.tile(ra_x))
+    ra_y_tile = wp.tile_reduce(wp.add, wp.tile(ra_y))
+    ra_z_tile = wp.tile_reduce(wp.add, wp.tile(ra_z))
+    rb_x_tile = wp.tile_reduce(wp.add, wp.tile(rb_x))
+    rb_y_tile = wp.tile_reduce(wp.add, wp.tile(rb_y))
+    rb_z_tile = wp.tile_reduce(wp.add, wp.tile(rb_z))
+
+    if lane == 0:
+        real_structure_factors[system_id, k_idx] = (
+            wp.tile_extract(real_tile, 0) * green_function
+        )
+        imag_structure_factors[system_id, k_idx] = (
+            wp.tile_extract(imag_tile, 0) * green_function
+        )
+    if k_idx == 0:
+        wp.tile_store(total_charges, charge_tile, system_id)
+
+    row = system_id * k_vectors.shape[1] + k_idx
+    if lane == 0:
+        cellgrad_cache[row, 0] = wp.tile_extract(a_tile, 0)
+        cellgrad_cache[row, 1] = wp.tile_extract(b_tile, 0)
+        cellgrad_cache[row, 2] = wp.tile_extract(ra_x_tile, 0)
+        cellgrad_cache[row, 3] = wp.tile_extract(ra_y_tile, 0)
+        cellgrad_cache[row, 4] = wp.tile_extract(ra_z_tile, 0)
+        cellgrad_cache[row, 5] = wp.tile_extract(rb_x_tile, 0)
+        cellgrad_cache[row, 6] = wp.tile_extract(rb_y_tile, 0)
+        cellgrad_cache[row, 7] = wp.tile_extract(rb_z_tile, 0)
 
 
 @wp.kernel
@@ -2968,6 +3407,7 @@ def _get_ewald_recip_component_factory_kernel(
     *,
     component: str,
     batched: bool = False,
+    tiled: bool = False,
 ) -> wp.Kernel:
     """Return an Ewald reciprocal factory kernel without a module import cycle."""
     from nvalchemiops.interactions.electrostatics.ewald_recip_factory import (
@@ -2975,7 +3415,7 @@ def _get_ewald_recip_component_factory_kernel(
     )
 
     return get_ewald_recip_component_kernel(
-        wp_dtype, component=component, batched=batched
+        wp_dtype, component=component, batched=batched, tiled=tiled
     )
 
 
@@ -3023,26 +3463,42 @@ def ewald_reciprocal_space_fill_structure_factors(
         Warp device.
     """
     num_k = k_vectors.shape[0]
+    num_atoms = positions.shape[0]
     if device is None:
         device = str(positions.device)
 
-    wp.launch(
-        _get_ewald_recip_component_factory_kernel(wp_dtype, component="fill"),
-        dim=num_k,
-        inputs=[
-            positions,
-            charges,
-            k_vectors,
-            cell,
-            alpha,
-            total_charge,
-            cos_k_dot_r,
-            sin_k_dot_r,
-            real_structure_factors,
-            imag_structure_factors,
-        ],
-        device=device,
+    inputs = [
+        positions,
+        charges,
+        k_vectors,
+        cell,
+        alpha,
+        total_charge,
+        cos_k_dot_r,
+        sin_k_dot_r,
+        real_structure_factors,
+        imag_structure_factors,
+    ]
+    tiled = can_tile_ewald_recip_on_device(device) and should_tile_ewald_recip_fill(
+        num_atoms
     )
+    if tiled:
+        wp.launch_tiled(
+            _get_ewald_recip_component_factory_kernel(
+                wp_dtype, component="fill", tiled=True
+            ),
+            dim=num_k,
+            inputs=inputs,
+            device=device,
+            block_dim=RECIP_TILED_BLOCK_DIM,
+        )
+    else:
+        wp.launch(
+            _get_ewald_recip_component_factory_kernel(wp_dtype, component="fill"),
+            dim=num_k,
+            inputs=inputs,
+            device=device,
+        )
 
 
 def ewald_reciprocal_space_compute_energy(
@@ -3434,27 +3890,43 @@ def batch_ewald_reciprocal_space_fill_structure_factors(
     if device is None:
         device = str(positions.device)
 
-    wp.launch(
-        _get_ewald_recip_component_factory_kernel(
-            wp_dtype, component="fill", batched=True
-        ),
-        dim=(num_k, num_systems, max_blocks_per_system),
-        inputs=[
-            positions,
-            charges,
-            k_vectors,
-            cell,
-            alpha,
-            atom_start,
-            atom_end,
-            total_charges,
-            cos_k_dot_r,
-            sin_k_dot_r,
-            real_structure_factors,
-            imag_structure_factors,
-        ],
-        device=device,
+    inputs = [
+        positions,
+        charges,
+        k_vectors,
+        cell,
+        alpha,
+        atom_start,
+        atom_end,
+        total_charges,
+        cos_k_dot_r,
+        sin_k_dot_r,
+        real_structure_factors,
+        imag_structure_factors,
+    ]
+    max_atoms = max_blocks_per_system * BATCH_BLOCK_SIZE
+    tiled = can_tile_ewald_recip_on_device(device) and should_tile_ewald_recip_fill(
+        max_atoms
     )
+    if tiled:
+        wp.launch_tiled(
+            _get_ewald_recip_component_factory_kernel(
+                wp_dtype, component="fill", batched=True, tiled=True
+            ),
+            dim=(num_k, num_systems),
+            inputs=inputs,
+            device=device,
+            block_dim=RECIP_TILED_BLOCK_DIM,
+        )
+    else:
+        wp.launch(
+            _get_ewald_recip_component_factory_kernel(
+                wp_dtype, component="fill", batched=True
+            ),
+            dim=(num_k, num_systems, max_blocks_per_system),
+            inputs=inputs,
+            device=device,
+        )
 
 
 def batch_ewald_reciprocal_space_compute_energy(

--- a/nvalchemiops/interactions/electrostatics/ewald_recip_factory.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_recip_factory.py
@@ -106,6 +106,7 @@ from nvalchemiops.interactions.electrostatics._factory_common import (
 )
 from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     EIGHTPI,
+    RECIP_TILED_BLOCK_DIM,
     _batch_ewald_energy_corrections_backward_kernel,
     _batch_ewald_energy_corrections_double_backward_kernel,
     _batch_ewald_energy_corrections_kernel,
@@ -113,6 +114,7 @@ from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     _batch_ewald_reciprocal_space_energy_forces_kernel,
     _batch_ewald_reciprocal_space_energy_kernel_compute_energy,
     _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors,
+    _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_tiled,
     _batch_ewald_reciprocal_space_virial_kernel,
     _batch_ewald_subtract_self_energy_kernel,
     _ewald_energy_corrections_backward_kernel,
@@ -122,6 +124,7 @@ from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     _ewald_reciprocal_space_energy_forces_kernel,
     _ewald_reciprocal_space_energy_kernel_compute_energy,
     _ewald_reciprocal_space_energy_kernel_fill_structure_factors,
+    _ewald_reciprocal_space_energy_kernel_fill_structure_factors_tiled,
     _ewald_reciprocal_space_virial_kernel,
     _ewald_subtract_self_energy_kernel,
 )
@@ -306,6 +309,7 @@ def make_ewald_recip_kernel(
     deriv_state: _DerivState = _DerivState.E,
     cell_grad: bool = False,
     order: str = "forward",
+    tiled: bool = False,
 ) -> _RecipKernels:
     """Return a cached, specialized ``ewald_recip`` kernel bundle.
 
@@ -336,7 +340,9 @@ def make_ewald_recip_kernel(
     _validate_axes(wp_dtype, batched, neighbor_input, deriv_state, cell_grad, order)
 
     if order == "double_backward":
-        return _make_double_backward_kernels(wp_dtype, batched, deriv_state, cell_grad)
+        return _make_double_backward_kernels(
+            wp_dtype, batched, deriv_state, cell_grad, tiled=tiled
+        )
 
     fill = get_ewald_recip_component_kernel(wp_dtype, component="fill", batched=batched)
     compute = _make_compute_kernel(wp_dtype, batched, deriv_state, order)
@@ -369,6 +375,7 @@ def get_ewald_recip_kernel(
     cell_grad: bool = False,
     order: str = "forward",
     component: str = "ewald_recip",
+    tiled: bool = False,
 ) -> _RecipKernels:
     """Return a cached ``ewald_recip`` kernel bundle, validating dtype + component.
 
@@ -387,6 +394,7 @@ def get_ewald_recip_kernel(
         deriv_state=deriv_state,
         cell_grad=cell_grad,
         order=order,
+        tiled=tiled,
     )
 
 
@@ -396,6 +404,7 @@ def get_ewald_recip_component_kernel(
     *,
     component: str,
     batched: bool = False,
+    tiled: bool = False,
 ) -> wp.Kernel:
     """Return a typed low-level Ewald reciprocal kernel.
 
@@ -414,13 +423,22 @@ def get_ewald_recip_component_kernel(
         "f64_2d": wp.array2d(dtype=wp.float64),
         "v_2d": wp.array2d(dtype=info.vec),
     }
+    fill_kernel = (
+        _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_tiled
+        if batched and tiled
+        else _ewald_reciprocal_space_energy_kernel_fill_structure_factors_tiled
+        if tiled
+        else _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors
+        if batched
+        else _ewald_reciprocal_space_energy_kernel_fill_structure_factors
+    )
     specs = {
         ("fill", False): (
-            _ewald_reciprocal_space_energy_kernel_fill_structure_factors,
+            fill_kernel,
             ("v", "f", "v", "m", "f", "f64", "f64_2d", "f64_2d", "f64", "f64"),
         ),
         ("fill", True): (
-            _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors,
+            fill_kernel,
             (
                 "v",
                 "f",
@@ -1036,6 +1054,7 @@ def _make_double_backward_kernels(
     batched: bool,
     deriv_state: _DerivState,
     cell_grad: bool = False,
+    tiled: bool = False,
 ) -> _RecipKernels:
     """Build the second-derivative node (recompute mode).
 
@@ -1422,6 +1441,129 @@ def _make_double_backward_kernels(
         # grad_grad_energy[isys] += Phi_k (= dL/d(grad_energy), NOT scaled by ge).
         wp.atomic_add(grad_grad_energy, isys, g_k * phi_k)
 
+    @wp.kernel(module=reduce_module)
+    def _ewald_recip_dbwd_reduce_tiled(
+        positions: wp.array(dtype=vec_dtype),
+        charges: wp.array(dtype=wp_dtype),
+        k_vectors: wp.array2d(dtype=vec_dtype),
+        cell: wp.array(dtype=info.mat),
+        alpha: wp.array(dtype=wp_dtype),
+        batch_id: wp.array(dtype=wp.int32),
+        atom_start: wp.array(dtype=wp.int32),
+        atom_end: wp.array(dtype=wp.int32),
+        v_pos: wp.array(dtype=vec_dtype),
+        v_charge: wp.array(dtype=wp.float64),
+        grad_energy: wp.array(dtype=wp.float64),
+        deriv_dq: wp.int32,
+        gA: wp.array2d(dtype=wp.float64),
+        gB: wp.array2d(dtype=wp.float64),
+        gC: wp.array2d(dtype=wp.float64),
+        gD: wp.array2d(dtype=wp.float64),
+        gP: wp.array2d(dtype=wp.float64),
+        gQ: wp.array2d(dtype=wp.float64),
+        grad_grad_energy: wp.array(dtype=wp.float64),
+        cell_grad: wp.int32,
+        volume: wp.array(dtype=wp.float64),
+        v_kvectors: wp.array2d(dtype=vec_dtype),
+        v_volume: wp.array(dtype=wp.float64),
+        gPu: wp.array2d(dtype=wp.float64),
+        gQu: wp.array2d(dtype=wp.float64),
+        grad_kvectors: wp.array2d(dtype=vec_dtype),
+        grad_volume: wp.array(dtype=wp.float64),
+    ) -> None:
+        """Cooperative tiled k-major reduce for non-cell reciprocal HVP."""
+        if BATCHED:
+            k_idx, isys, lane = wp.tid()
+        else:
+            k_idx, lane = wp.tid()
+            isys = wp.int32(0)
+
+        alpha_ = wp.float64(alpha[isys])
+        exp_factor = wp.float64(0.25) / (alpha_ * alpha_)
+        vol = wp.float64(wp.abs(wp.determinant(cell[isys])))
+
+        k_vector = k_vectors[isys, k_idx]
+        kx = wp.float64(k_vector[0])
+        ky = wp.float64(k_vector[1])
+        kz = wp.float64(k_vector[2])
+        k_squared = kx * kx + ky * ky + kz * kz
+        if k_squared < wp.float64(_K_SQUARED_EPSILON):
+            return
+
+        g_k = wp_exp_kernel(k_squared, exp_factor) * wp.float64(EIGHTPI) / vol
+
+        a_start = wp.int32(0)
+        a_end = positions.shape[0]
+        if BATCHED:
+            a_start = atom_start[isys]
+            a_end = atom_end[isys]
+
+        a_sum = wp.float64(0.0)
+        b_sum = wp.float64(0.0)
+        c_sum = wp.float64(0.0)
+        d_sum = wp.float64(0.0)
+        p_sum = wp.float64(0.0)
+        q_sum = wp.float64(0.0)
+
+        for atom_tile_start in range(a_start, a_end, RECIP_TILED_BLOCK_DIM):
+            atom_idx = atom_tile_start + lane
+            if atom_idx < a_end:
+                position = positions[atom_idx]
+                rx = wp.float64(position[0])
+                ry = wp.float64(position[1])
+                rz = wp.float64(position[2])
+                qi = wp.float64(charges[atom_idx])
+                k_dot_r = kx * rx + ky * ry + kz * rz
+                cos_kr = wp.cos(k_dot_r)
+                sin_kr = wp.sin(k_dot_r)
+                qc = qi * cos_kr
+                qs = qi * sin_kr
+
+                a_sum += qc
+                b_sum += qs
+
+                vp = v_pos[atom_idx]
+                w_i = (
+                    wp.float64(vp[0]) * kx
+                    + wp.float64(vp[1]) * ky
+                    + wp.float64(vp[2]) * kz
+                )
+                p_sum += w_i * qc
+                q_sum += w_i * qs
+
+                if DERIV_DQ:
+                    vq = v_charge[atom_idx]
+                    c_sum += vq * cos_kr
+                    d_sum += vq * sin_kr
+
+        a_red = wp.tile_reduce(wp.add, wp.tile(a_sum))
+        b_red = wp.tile_reduce(wp.add, wp.tile(b_sum))
+        c_red = wp.tile_reduce(wp.add, wp.tile(c_sum))
+        d_red = wp.tile_reduce(wp.add, wp.tile(d_sum))
+        p_red = wp.tile_reduce(wp.add, wp.tile(p_sum))
+        q_red = wp.tile_reduce(wp.add, wp.tile(q_sum))
+
+        if lane == 0:
+            a_val = wp.tile_extract(a_red, 0)
+            b_val = wp.tile_extract(b_red, 0)
+            c_val = wp.tile_extract(c_red, 0)
+            d_val = wp.tile_extract(d_red, 0)
+            p_val = wp.tile_extract(p_red, 0)
+            q_val = wp.tile_extract(q_red, 0)
+
+            gA[isys, k_idx] = g_k * a_val
+            gB[isys, k_idx] = g_k * b_val
+            gP[isys, k_idx] = g_k * p_val
+            gQ[isys, k_idx] = g_k * q_val
+            if DERIV_DQ:
+                gC[isys, k_idx] = g_k * c_val
+                gD[isys, k_idx] = g_k * d_val
+
+            phi_k = b_val * p_val - a_val * q_val
+            if DERIV_DQ:
+                phi_k += a_val * c_val + b_val * d_val
+            wp.atomic_add(grad_grad_energy, isys, g_k * phi_k)
+
     @wp.kernel(module=compute_module)
     def _ewald_recip_dbwd_compute(
         positions: wp.array(dtype=vec_dtype),
@@ -1582,6 +1724,10 @@ def _make_double_backward_kernels(
     for kernel, base in (
         (_ewald_recip_dbwd_reduce, "ewald_recip_double_backward_reduce"),
         (
+            _ewald_recip_dbwd_reduce_tiled,
+            "ewald_recip_double_backward_reduce_tiled",
+        ),
+        (
             _ewald_recip_dbwd_compute,
             "ewald_recip_double_backward_compute",
         ),
@@ -1596,5 +1742,7 @@ def _make_double_backward_kernels(
             order="double_backward",
         )
     return _RecipKernels(
-        fill=_ewald_recip_dbwd_reduce, compute=_ewald_recip_dbwd_compute, virial=None
+        fill=_ewald_recip_dbwd_reduce_tiled if tiled else _ewald_recip_dbwd_reduce,
+        compute=_ewald_recip_dbwd_compute,
+        virial=None,
     )

--- a/nvalchemiops/jax/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/jax/interactions/electrostatics/ewald.py
@@ -30,12 +30,19 @@ import warnings
 
 import jax
 import jax.numpy as jnp
+import warp as wp
 from jax.interpreters import ad as jax_ad
 from jax.scipy.special import erfc
+from warp.jax_experimental import GraphMode, jax_callable
 
 from nvalchemiops.interactions.electrostatics._factory_common import _DerivState
 from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     BATCH_BLOCK_SIZE,
+    batch_ewald_reciprocal_space_fill_structure_factors,
+    should_tile_ewald_recip_fill,
+)
+from nvalchemiops.interactions.electrostatics.ewald_kernels import (
+    ewald_reciprocal_space_fill_structure_factors as _wp_ewald_recip_fill,
 )
 from nvalchemiops.interactions.electrostatics.ewald_real_factory import (
     get_ewald_real_kernel,
@@ -83,6 +90,15 @@ PI = math.pi
 # ``_make_jax_kernel_factory`` returns lazy dtype mappings whose entries
 # materialize their ``jax_kernel`` wrappers on first ``__getitem__``. Module import
 # is therefore free of FFI work; warp NVRTC compile defers to first launch.
+
+
+def _jax_can_tile_ewald_recip() -> bool:
+    """Return whether JAX reciprocal tiled callbacks should be used."""
+    # ``jax_callable`` + nested ``wp.launch_tiled`` is not stable under the
+    # current JAX/Warp stack for jitted reciprocal calls. Keep JAX on the
+    # existing ``jax_kernel`` path until Warp exposes tiled launch metadata
+    # through that wrapper.
+    return False
 
 
 # ==============================================================================
@@ -183,6 +199,190 @@ _jax_batch_ewald_reciprocal_fill_structure_factors = _jax_ewald_recip_component(
     ],
     batched=True,
 )
+
+
+def _ewald_recip_fill_tiled_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    charges: wp.array(dtype=wp.float32),
+    k_vectors: wp.array(dtype=wp.vec3f),
+    cell: wp.array(dtype=wp.mat33f),
+    alpha: wp.array(dtype=wp.float32),
+    total_charge: wp.array(dtype=wp.float64),
+    cos_k_dot_r: wp.array(dtype=wp.float64, ndim=2),
+    sin_k_dot_r: wp.array(dtype=wp.float64, ndim=2),
+    real_structure_factors: wp.array(dtype=wp.float64),
+    imag_structure_factors: wp.array(dtype=wp.float64),
+) -> None:
+    _wp_ewald_recip_fill(
+        positions,
+        charges,
+        k_vectors,
+        cell,
+        alpha,
+        total_charge,
+        cos_k_dot_r,
+        sin_k_dot_r,
+        real_structure_factors,
+        imag_structure_factors,
+        wp.float32,
+        str(positions.device),
+    )
+
+
+def _ewald_recip_fill_tiled_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    charges: wp.array(dtype=wp.float64),
+    k_vectors: wp.array(dtype=wp.vec3d),
+    cell: wp.array(dtype=wp.mat33d),
+    alpha: wp.array(dtype=wp.float64),
+    total_charge: wp.array(dtype=wp.float64),
+    cos_k_dot_r: wp.array(dtype=wp.float64, ndim=2),
+    sin_k_dot_r: wp.array(dtype=wp.float64, ndim=2),
+    real_structure_factors: wp.array(dtype=wp.float64),
+    imag_structure_factors: wp.array(dtype=wp.float64),
+) -> None:
+    _wp_ewald_recip_fill(
+        positions,
+        charges,
+        k_vectors,
+        cell,
+        alpha,
+        total_charge,
+        cos_k_dot_r,
+        sin_k_dot_r,
+        real_structure_factors,
+        imag_structure_factors,
+        wp.float64,
+        str(positions.device),
+    )
+
+
+def _batch_ewald_recip_fill_tiled_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    charges: wp.array(dtype=wp.float32),
+    k_vectors: wp.array(dtype=wp.vec3f, ndim=2),
+    cell: wp.array(dtype=wp.mat33f),
+    alpha: wp.array(dtype=wp.float32),
+    atom_start: wp.array(dtype=wp.int32),
+    atom_end: wp.array(dtype=wp.int32),
+    total_charges: wp.array(dtype=wp.float64),
+    cos_k_dot_r: wp.array(dtype=wp.float64, ndim=2),
+    sin_k_dot_r: wp.array(dtype=wp.float64, ndim=2),
+    real_structure_factors: wp.array(dtype=wp.float64, ndim=2),
+    imag_structure_factors: wp.array(dtype=wp.float64, ndim=2),
+    max_blocks_per_system: wp.int32,
+) -> None:
+    batch_ewald_reciprocal_space_fill_structure_factors(
+        positions,
+        charges,
+        k_vectors,
+        cell,
+        alpha,
+        atom_start,
+        atom_end,
+        total_charges,
+        cos_k_dot_r,
+        sin_k_dot_r,
+        real_structure_factors,
+        imag_structure_factors,
+        int(k_vectors.shape[1]),
+        int(cell.shape[0]),
+        int(max_blocks_per_system),
+        wp.float32,
+        str(positions.device),
+    )
+
+
+def _batch_ewald_recip_fill_tiled_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    charges: wp.array(dtype=wp.float64),
+    k_vectors: wp.array(dtype=wp.vec3d, ndim=2),
+    cell: wp.array(dtype=wp.mat33d),
+    alpha: wp.array(dtype=wp.float64),
+    atom_start: wp.array(dtype=wp.int32),
+    atom_end: wp.array(dtype=wp.int32),
+    total_charges: wp.array(dtype=wp.float64),
+    cos_k_dot_r: wp.array(dtype=wp.float64, ndim=2),
+    sin_k_dot_r: wp.array(dtype=wp.float64, ndim=2),
+    real_structure_factors: wp.array(dtype=wp.float64, ndim=2),
+    imag_structure_factors: wp.array(dtype=wp.float64, ndim=2),
+    max_blocks_per_system: wp.int32,
+) -> None:
+    batch_ewald_reciprocal_space_fill_structure_factors(
+        positions,
+        charges,
+        k_vectors,
+        cell,
+        alpha,
+        atom_start,
+        atom_end,
+        total_charges,
+        cos_k_dot_r,
+        sin_k_dot_r,
+        real_structure_factors,
+        imag_structure_factors,
+        int(k_vectors.shape[1]),
+        int(cell.shape[0]),
+        int(max_blocks_per_system),
+        wp.float64,
+        str(positions.device),
+    )
+
+
+_JAX_EWALD_RECIP_FILL_TILED = {
+    jnp.dtype(jnp.float32): jax_callable(
+        _ewald_recip_fill_tiled_f32,
+        num_outputs=5,
+        in_out_argnames=[
+            "total_charge",
+            "cos_k_dot_r",
+            "sin_k_dot_r",
+            "real_structure_factors",
+            "imag_structure_factors",
+        ],
+        graph_mode=GraphMode.NONE,
+    ),
+    jnp.dtype(jnp.float64): jax_callable(
+        _ewald_recip_fill_tiled_f64,
+        num_outputs=5,
+        in_out_argnames=[
+            "total_charge",
+            "cos_k_dot_r",
+            "sin_k_dot_r",
+            "real_structure_factors",
+            "imag_structure_factors",
+        ],
+        graph_mode=GraphMode.NONE,
+    ),
+}
+
+
+_JAX_BATCH_EWALD_RECIP_FILL_TILED = {
+    jnp.dtype(jnp.float32): jax_callable(
+        _batch_ewald_recip_fill_tiled_f32,
+        num_outputs=5,
+        in_out_argnames=[
+            "total_charges",
+            "cos_k_dot_r",
+            "sin_k_dot_r",
+            "real_structure_factors",
+            "imag_structure_factors",
+        ],
+        graph_mode=GraphMode.NONE,
+    ),
+    jnp.dtype(jnp.float64): jax_callable(
+        _batch_ewald_recip_fill_tiled_f64,
+        num_outputs=5,
+        in_out_argnames=[
+            "total_charges",
+            "cos_k_dot_r",
+            "sin_k_dot_r",
+            "real_structure_factors",
+            "imag_structure_factors",
+        ],
+        graph_mode=GraphMode.NONE,
+    ),
+}
 
 # --- Energy Computation ---
 
@@ -860,39 +1060,76 @@ def _ewald_reciprocal_space_impl(
             max_atoms_per_system + BATCH_BLOCK_SIZE - 1
         ) // BATCH_BLOCK_SIZE
 
-        (_fill_total_charge, cos_k_dot_r, sin_k_dot_r, real_sf, imag_sf) = (
-            _jax_batch_ewald_reciprocal_fill_structure_factors[dtype](
-                positions_cast,
-                charges_cast,
-                k_vectors_cast,
-                cell_cast,
-                alpha_arr,
-                atom_start,
-                atom_end,
-                fill_total_charge,
-                cos_k_dot_r,
-                sin_k_dot_r,
-                real_sf,
-                imag_sf,
-                launch_dims=(num_k, num_systems, max_blocks_per_system),
+        if _jax_can_tile_ewald_recip() and should_tile_ewald_recip_fill(
+            int(max_atoms_per_system)
+        ):
+            (_fill_total_charge, cos_k_dot_r, sin_k_dot_r, real_sf, imag_sf) = (
+                _JAX_BATCH_EWALD_RECIP_FILL_TILED[jnp.dtype(dtype)](
+                    positions_cast,
+                    charges_cast,
+                    k_vectors_cast,
+                    cell_cast,
+                    alpha_arr,
+                    atom_start,
+                    atom_end,
+                    fill_total_charge,
+                    cos_k_dot_r,
+                    sin_k_dot_r,
+                    real_sf,
+                    imag_sf,
+                    max_blocks_per_system,
+                )
             )
-        )
+        else:
+            (_fill_total_charge, cos_k_dot_r, sin_k_dot_r, real_sf, imag_sf) = (
+                _jax_batch_ewald_reciprocal_fill_structure_factors[dtype](
+                    positions_cast,
+                    charges_cast,
+                    k_vectors_cast,
+                    cell_cast,
+                    alpha_arr,
+                    atom_start,
+                    atom_end,
+                    fill_total_charge,
+                    cos_k_dot_r,
+                    sin_k_dot_r,
+                    real_sf,
+                    imag_sf,
+                    launch_dims=(num_k, num_systems, max_blocks_per_system),
+                )
+            )
     else:
-        (_fill_total_charge, cos_k_dot_r, sin_k_dot_r, real_sf, imag_sf) = (
-            _jax_ewald_reciprocal_fill_structure_factors[dtype](
-                positions_cast,
-                charges_cast,
-                k_vectors_cast,
-                cell_cast,
-                alpha_arr,
-                fill_total_charge,
-                cos_k_dot_r,
-                sin_k_dot_r,
-                real_sf,
-                imag_sf,
-                launch_dims=(num_k,),
+        if _jax_can_tile_ewald_recip() and should_tile_ewald_recip_fill(int(num_atoms)):
+            (_fill_total_charge, cos_k_dot_r, sin_k_dot_r, real_sf, imag_sf) = (
+                _JAX_EWALD_RECIP_FILL_TILED[jnp.dtype(dtype)](
+                    positions_cast,
+                    charges_cast,
+                    k_vectors_cast,
+                    cell_cast,
+                    alpha_arr,
+                    fill_total_charge,
+                    cos_k_dot_r,
+                    sin_k_dot_r,
+                    real_sf,
+                    imag_sf,
+                )
             )
-        )
+        else:
+            (_fill_total_charge, cos_k_dot_r, sin_k_dot_r, real_sf, imag_sf) = (
+                _jax_ewald_reciprocal_fill_structure_factors[dtype](
+                    positions_cast,
+                    charges_cast,
+                    k_vectors_cast,
+                    cell_cast,
+                    alpha_arr,
+                    fill_total_charge,
+                    cos_k_dot_r,
+                    sin_k_dot_r,
+                    real_sf,
+                    imag_sf,
+                    launch_dims=(num_k,),
+                )
+            )
 
     # Step 2: Compute energy (and forces/charge_grads if requested)
     if is_batched:

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
@@ -64,12 +64,18 @@ from nvalchemiops.interactions.electrostatics._factory_common import (
 from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     BATCH_BLOCK_SIZE,
     EIGHTPI,
+    RECIP_TILED_BLOCK_DIM,
     _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
+    _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled,
     _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
+    _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled,
+    can_tile_ewald_recip_on_device,
+    should_tile_ewald_recip_fill,
 )
 from nvalchemiops.interactions.electrostatics.ewald_recip_factory import (
     _make_backward_kspace_from_cache_kernel,
     alloc_ewald_recip_sentinels,
+    get_ewald_recip_component_kernel,
     get_ewald_recip_kernel,
 )
 from nvalchemiops.torch._warp_op_helpers import (
@@ -253,6 +259,9 @@ def _run_fill(
             max_atoms = int((atom_end - atom_start).max().item()) if num_atoms else 0
             max_blocks = (max_atoms + BATCH_BLOCK_SIZE - 1) // BATCH_BLOCK_SIZE
             max_blocks = max(max_blocks, 1)
+            use_tiled_fill = can_tile_ewald_recip_on_device(
+                device
+            ) and should_tile_ewald_recip_fill(max_atoms)
             if want_cellgrad:
                 cache_t = torch.zeros(
                     (num_systems * num_k, 8),
@@ -260,52 +269,80 @@ def _run_fill(
                     device=positions.device,
                 )
                 cache_wp = _wp(cache_t, wp.float64)
-                wp.launch(
-                    _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
-                    dim=(num_k, num_systems, max_blocks),
-                    inputs=[
-                        wp_pos,
-                        wp_chg,
-                        _wp(k_vectors_2d, wp_vec),
-                        wp_cell,
-                        wp_alpha,
-                        wp_as,
-                        wp_ae,
-                        total_charges,
-                        cos_kr,
-                        sin_kr,
-                        real_sf,
-                        imag_sf,
-                        cache_wp,
-                    ],
-                    device=device,
-                )
+                inputs = [
+                    wp_pos,
+                    wp_chg,
+                    _wp(k_vectors_2d, wp_vec),
+                    wp_cell,
+                    wp_alpha,
+                    wp_as,
+                    wp_ae,
+                    total_charges,
+                    cos_kr,
+                    sin_kr,
+                    real_sf,
+                    imag_sf,
+                    cache_wp,
+                ]
+                if use_tiled_fill:
+                    wp.launch_tiled(
+                        _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled,
+                        dim=(num_k, num_systems),
+                        inputs=inputs,
+                        device=device,
+                        block_dim=RECIP_TILED_BLOCK_DIM,
+                    )
+                else:
+                    wp.launch(
+                        _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
+                        dim=(num_k, num_systems, max_blocks),
+                        inputs=inputs,
+                        device=device,
+                    )
                 cellgrad_cache = cache_t
             else:
-                wp.launch(
-                    bundle.fill,
-                    dim=(num_k, num_systems, max_blocks),
-                    inputs=[
-                        wp_pos,
-                        wp_chg,
-                        _wp(k_vectors_2d, wp_vec),
-                        wp_cell,
-                        wp_alpha,
-                        wp_as,
-                        wp_ae,
-                        total_charges,
-                        cos_kr,
-                        sin_kr,
-                        real_sf,
-                        imag_sf,
-                    ],
-                    device=device,
-                )
+                inputs = [
+                    wp_pos,
+                    wp_chg,
+                    _wp(k_vectors_2d, wp_vec),
+                    wp_cell,
+                    wp_alpha,
+                    wp_as,
+                    wp_ae,
+                    total_charges,
+                    cos_kr,
+                    sin_kr,
+                    real_sf,
+                    imag_sf,
+                ]
+                if use_tiled_fill:
+                    wp.launch_tiled(
+                        get_ewald_recip_component_kernel(
+                            wp_scalar,
+                            component="fill",
+                            batched=True,
+                            tiled=True,
+                        ),
+                        dim=(num_k, num_systems),
+                        inputs=inputs,
+                        device=device,
+                        block_dim=RECIP_TILED_BLOCK_DIM,
+                    )
+                else:
+                    wp.launch(
+                        bundle.fill,
+                        dim=(num_k, num_systems, max_blocks),
+                        inputs=inputs,
+                        device=device,
+                    )
         else:
             kv_1d = _wp(k_vectors_2d.reshape(num_k, 3), wp_vec)
             real_1d = _wp_empty_f64(num_k, positions.device)
             imag_1d = _wp_empty_f64(num_k, positions.device)
             total_charge = _wp_zeros_f64(1, positions.device)
+            use_tiled_fill = can_tile_ewald_recip_on_device(
+                device
+            ) and should_tile_ewald_recip_fill(num_atoms)
             if want_cellgrad:
                 # Fused variant: same outputs + the un-weighted (K, 8) cell-grad
                 # reduction, accumulated in the SAME atom loop (marginal cost), so the
@@ -315,43 +352,67 @@ def _run_fill(
                     (num_k, 8), dtype=torch.float64, device=positions.device
                 )
                 cache_wp = _wp(cache_t, wp.float64)
-                wp.launch(
-                    _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
-                    dim=num_k,
-                    inputs=[
-                        wp_pos,
-                        wp_chg,
-                        kv_1d,
-                        wp_cell,
-                        wp_alpha,
-                        total_charge,
-                        cos_kr,
-                        sin_kr,
-                        real_1d,
-                        imag_1d,
-                        cache_wp,
-                    ],
-                    device=device,
-                )
+                inputs = [
+                    wp_pos,
+                    wp_chg,
+                    kv_1d,
+                    wp_cell,
+                    wp_alpha,
+                    total_charge,
+                    cos_kr,
+                    sin_kr,
+                    real_1d,
+                    imag_1d,
+                    cache_wp,
+                ]
+                if use_tiled_fill:
+                    wp.launch_tiled(
+                        _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled,
+                        dim=num_k,
+                        inputs=inputs,
+                        device=device,
+                        block_dim=RECIP_TILED_BLOCK_DIM,
+                    )
+                else:
+                    wp.launch(
+                        _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
+                        dim=num_k,
+                        inputs=inputs,
+                        device=device,
+                    )
                 cellgrad_cache = cache_t
             else:
-                wp.launch(
-                    bundle.fill,
-                    dim=num_k,
-                    inputs=[
-                        wp_pos,
-                        wp_chg,
-                        kv_1d,
-                        wp_cell,
-                        wp_alpha,
-                        total_charge,
-                        cos_kr,
-                        sin_kr,
-                        real_1d,
-                        imag_1d,
-                    ],
-                    device=device,
-                )
+                inputs = [
+                    wp_pos,
+                    wp_chg,
+                    kv_1d,
+                    wp_cell,
+                    wp_alpha,
+                    total_charge,
+                    cos_kr,
+                    sin_kr,
+                    real_1d,
+                    imag_1d,
+                ]
+                if use_tiled_fill:
+                    wp.launch_tiled(
+                        get_ewald_recip_component_kernel(
+                            wp_scalar,
+                            component="fill",
+                            tiled=True,
+                        ),
+                        dim=num_k,
+                        inputs=inputs,
+                        device=device,
+                        block_dim=RECIP_TILED_BLOCK_DIM,
+                    )
+                else:
+                    wp.launch(
+                        bundle.fill,
+                        dim=num_k,
+                        inputs=inputs,
+                        device=device,
+                    )
             real_sf = real_1d.reshape((1, num_k))
             imag_sf = imag_1d.reshape((1, num_k))
     return cos_kr, sin_kr, real_sf, imag_sf, cellgrad_cache
@@ -738,12 +799,22 @@ def _double_backward_impl(
 
     use_charge_db = bool(need_charge)
     use_cell_db = bool(need_cell)
+    if batched and num_atoms:
+        max_atoms = int((atom_end - atom_start).max().item())
+    else:
+        max_atoms = num_atoms
+    use_tiled_reduce = (
+        (not use_cell_db)
+        and can_tile_ewald_recip_on_device(device)
+        and should_tile_ewald_recip_fill(max_atoms)
+    )
     bundle = get_ewald_recip_kernel(
         wp_scalar,
         batched=batched,
         deriv_state=_DerivState.E_F_dQ,
         cell_grad=use_cell_db,
         order="double_backward",
+        tiled=use_tiled_reduce,
     )
     # Per-(system,k) reduction scratch buffers (g_k-scaled sums).
     gA = wp.zeros((num_systems, num_k), dtype=wp.float64, device=device)
@@ -779,40 +850,50 @@ def _double_backward_impl(
     deriv_dq = wp.int32(1 if use_charge_db else 0)
     cell_grad_flag = wp.int32(1 if use_cell_db else 0)
     with _scoped_stream(positions.device):
-        wp.launch(
-            bundle.fill,  # = reduce kernel for double_backward bundle
-            dim=(num_k, num_systems) if batched else num_k,
-            inputs=[
-                wp_pos,
-                wp_chg,
-                wp_kv,
-                cell_mat,
-                wp_alpha,
-                batch_id,
-                wp_as,
-                wp_ae,
-                wp_vpos,
-                wp_vq,
-                wp_ge,
-                deriv_dq,
-                gA,
-                gB,
-                gC,
-                gD,
-                gP,
-                gQ,
-                wp_ggE,
-                cell_grad_flag,
-                wp_vol,
-                wp_vkv,
-                wp_vvol,
-                gPu,
-                gQu,
-                wp_gkv,
-                wp_gvol,
-            ],
-            device=device,
-        )
+        reduce_inputs = [
+            wp_pos,
+            wp_chg,
+            wp_kv,
+            cell_mat,
+            wp_alpha,
+            batch_id,
+            wp_as,
+            wp_ae,
+            wp_vpos,
+            wp_vq,
+            wp_ge,
+            deriv_dq,
+            gA,
+            gB,
+            gC,
+            gD,
+            gP,
+            gQ,
+            wp_ggE,
+            cell_grad_flag,
+            wp_vol,
+            wp_vkv,
+            wp_vvol,
+            gPu,
+            gQu,
+            wp_gkv,
+            wp_gvol,
+        ]
+        if use_tiled_reduce:
+            wp.launch_tiled(
+                bundle.fill,  # = tiled reduce kernel for double_backward bundle
+                dim=(num_k, num_systems) if batched else num_k,
+                inputs=reduce_inputs,
+                device=device,
+                block_dim=RECIP_TILED_BLOCK_DIM,
+            )
+        else:
+            wp.launch(
+                bundle.fill,  # = reduce kernel for double_backward bundle
+                dim=(num_k, num_systems) if batched else num_k,
+                inputs=reduce_inputs,
+                device=device,
+            )
         wp.launch(
             bundle.compute,
             dim=num_atoms,

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -8025,21 +8025,27 @@ class TestEwaldDoubleBackward:
 
     @pytest.mark.parametrize("device", ["cuda"])
     @pytest.mark.parametrize(
-        ("part", "wrt"),
+        ("part", "wrt", "recip_tiling_mode"),
         [
-            ("real", ("positions",)),
-            ("real", ("cell",)),
-            ("real", ("positions", "cell")),
-            ("recip", ("positions",)),
-            ("recip", ("charges",)),
-            ("recip", ("cell",)),
-            ("summation", ("positions", "cell")),
+            ("real", ("positions",), None),
+            ("real", ("cell",), None),
+            ("real", ("positions", "cell"), None),
+            ("recip", ("positions",), "0"),
+            ("recip", ("positions",), "1"),
+            ("recip", ("charges",), "0"),
+            ("recip", ("charges",), "1"),
+            ("recip", ("cell",), None),
+            ("summation", ("positions", "cell"), None),
         ],
     )
-    def test_gradgradcheck_focused_canary(self, device, part, wrt):
+    def test_gradgradcheck_focused_canary(
+        self, device, part, wrt, recip_tiling_mode, monkeypatch
+    ):
         """Non-slow second-order canary for key Ewald derivative paths."""
         if device == "cuda" and not torch.cuda.is_available():
             pytest.skip("CUDA not available")
+        if recip_tiling_mode is not None:
+            monkeypatch.setenv("NVALCHEMIOPS_EWALD_RECIP_TILED", recip_tiling_mode)
         device = torch.device(device)
         energy_fn, positions, charges, cell = self._energy_fn(part, device)
         assert gradgradcheck_energy(energy_fn, positions, charges, cell, wrt=wrt)

--- a/test/interactions/electrostatics/test_ewald_kernels.py
+++ b/test/interactions/electrostatics/test_ewald_kernels.py
@@ -72,6 +72,13 @@ from nvalchemiops.interactions.electrostatics.ewald_kernels import (
 # ==============================================================================
 
 
+@pytest.fixture(params=["0", "1"])
+def recip_tiling_mode(request, monkeypatch):
+    """Force reciprocal tiling dispatch off/on for focused reciprocal tests."""
+    monkeypatch.setenv("NVALCHEMIOPS_EWALD_RECIP_TILED", request.param)
+    return request.param
+
+
 @pytest.fixture(scope="session")
 def two_atom_system():
     """Simple two-atom system for basic Ewald tests.
@@ -968,7 +975,9 @@ class TestWpBatchEwaldRealSpaceMatrix:
 class TestWpEwaldReciprocalSpaceStructureFactors:
     """Tests for wp_ewald_reciprocal_space_fill_structure_factors."""
 
-    def test_structure_factors_computation(self, device, simple_kvector_system):
+    def test_structure_factors_computation(
+        self, device, simple_kvector_system, recip_tiling_mode
+    ):
         """Test structure factor computation."""
         sys = simple_kvector_system
         dtype = wp.float64
@@ -1167,7 +1176,9 @@ class TestWpEwaldReciprocalSpaceStructureFactors:
 class TestWpEwaldReciprocalSpaceEnergy:
     """Tests for wp_ewald_reciprocal_space_compute_energy."""
 
-    def test_reciprocal_energy_computation(self, device, simple_kvector_system):
+    def test_reciprocal_energy_computation(
+        self, device, simple_kvector_system, recip_tiling_mode
+    ):
         """Test reciprocal-space energy computation."""
         sys = simple_kvector_system
         dtype = wp.float64
@@ -2249,7 +2260,9 @@ class TestWpBatchEwaldReciprocalSpaceStructureFactors:
 class TestWpBatchEwaldReciprocalSpaceComputeEnergy:
     """Tests for wp_batch_ewald_reciprocal_space_compute_energy."""
 
-    def test_batch_reciprocal_energy_shape(self, device, batch_kvector_system):
+    def test_batch_reciprocal_energy_shape(
+        self, device, batch_kvector_system, recip_tiling_mode
+    ):
         """Test batched reciprocal energy has correct shape."""
         sys = batch_kvector_system
         dtype = wp.float64


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Accelerate reciprocal-space Ewald structure-factor fill on CUDA with tiled kernels, and add a tiled non-cell reciprocal double-backward reduce path for Torch HVPs.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- Add CUDA tiled reciprocal Ewald structure-factor fill kernels for single-system and batched launches, including cell-gradient cache fill variants.
- Route low-level and Torch reciprocal fill dispatch through CUDA-only tiling controls with CPU fallback.
- Add a tiled non-cell reciprocal double-backward reduce path for Torch HVPs and expand reciprocal tests to cover tiling forced on and off.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Targeted reciprocal Ewald kernel tests passed. Focused Torch reciprocal double-backward canary passed. Staged diff whitespace check passed.

Performance evidence from liquid ammonia systems on an NVIDIA RTX 6000 Ada Generation GPU, driver 580.159.03, Torch 2.10.0+cu128, Warp 1.13.0. Timings are medians over 10 repeats after 3 warmups, with `alpha=0.25`, `k_cutoff=0.75`, `NVALCHEMIOPS_EWALD_RECIP_TILE_DIM=128`, and `NVALCHEMIOPS_EWALD_RECIP_MIN_ATOMS=1024`.

Public `ewald_reciprocal_space(..., compute_forces=False, compute_virial=False)` forward timings:

| dtype | atoms | k-vectors | legacy ms | tiled ms | speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| float32 | 128 | 62 | 0.5387 | 0.5401 | 1.00x |
| float32 | 512 | 171 | 1.4505 | 0.5365 | 2.70x |
| float32 | 2048 | 364 | 6.0971 | 0.5375 | 11.34x |
| float32 | 8192 | 1098 | 21.7485 | 1.3523 | 16.08x |
| float32 | 32768 | 3429 | 86.7487 | 11.1236 | 7.80x |
| float32 | 131072 | 12194 | 366.3993 | 140.8731 | 2.60x |
| float64 | 128 | 62 | 0.5162 | 0.5143 | 1.00x |
| float64 | 512 | 171 | 1.3498 | 0.5111 | 2.64x |
| float64 | 2048 | 364 | 5.5827 | 0.5117 | 10.91x |
| float64 | 8192 | 1098 | 20.1836 | 1.2471 | 16.18x |
| float64 | 32768 | 3429 | 80.5296 | 9.8886 | 8.14x |
| float64 | 131072 | 12194 | 349.9361 | 125.1075 | 2.80x |

Public reciprocal autograd timings:

| dtype | workload | atoms | legacy ms | tiled ms | speedup |
| --- | --- | ---: | ---: | ---: | ---: |
| float32 | forward | 128 | 0.5369 | 0.5442 | 0.99x |
| float32 | backward | 128 | 1.8917 | 1.9132 | 0.99x |
| float32 | double_backward | 128 | 4.1193 | 4.4198 | 0.93x |
| float32 | forward | 512 | 1.4758 | 0.5488 | 2.69x |
| float32 | backward | 512 | 2.3334 | 2.3194 | 1.01x |
| float32 | double_backward | 512 | 5.4022 | 4.5708 | 1.18x |
| float32 | forward | 2048 | 5.9642 | 0.8117 | 7.35x |
| float32 | backward | 2048 | 6.7066 | 2.4650 | 2.72x |
| float32 | double_backward | 2048 | 14.4841 | 5.2241 | 2.77x |
| float32 | forward | 8192 | 23.1113 | 2.6975 | 8.57x |
| float32 | backward | 8192 | 29.1151 | 8.6605 | 3.36x |
| float32 | double_backward | 8192 | 60.3825 | 17.1298 | 3.52x |
| float32 | forward | 32768 | 91.0559 | 14.8401 | 6.14x |
| float32 | backward | 32768 | 158.0298 | 84.0347 | 1.88x |
| float32 | double_backward | 32768 | 330.9359 | 172.3147 | 1.92x |
| float64 | forward | 128 | 0.5114 | 0.5163 | 0.99x |
| float64 | backward | 128 | 1.7980 | 1.8600 | 0.97x |
| float64 | double_backward | 128 | 3.9846 | 3.9399 | 1.01x |
| float64 | forward | 512 | 1.3546 | 0.5097 | 2.66x |
| float64 | backward | 512 | 2.2102 | 2.1600 | 1.02x |
| float64 | double_backward | 512 | 4.9933 | 4.2984 | 1.16x |
| float64 | forward | 2048 | 5.4911 | 0.7815 | 7.03x |
| float64 | backward | 2048 | 6.1183 | 2.6031 | 2.35x |
| float64 | double_backward | 2048 | 13.1890 | 5.0606 | 2.61x |
| float64 | forward | 8192 | 21.4658 | 2.4797 | 8.66x |
| float64 | backward | 8192 | 26.8075 | 7.4179 | 3.61x |
| float64 | double_backward | 8192 | 56.5929 | 17.2559 | 3.28x |
| float64 | forward | 32768 | 84.2478 | 13.3532 | 6.31x |
| float64 | backward | 32768 | 151.4032 | 82.8323 | 1.83x |
| float64 | double_backward | 32768 | 312.4233 | 169.2267 | 1.85x |

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

JAX reciprocal calls remain on the existing dispatch path; tiled JAX callback dispatch is disabled in this change.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
