### PR TITLE
fix(neighbors): honor per-axis pbc when wrapping naive neighbor positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 
 ### Fixed
 
+- `batch_naive_neighbor_list` and `naive_neighbor_list` no longer fold a
+  non-periodic axis when a non-zero cell is supplied, so fully non-periodic
+  systems and slabs return correct neighbors when atoms cross the
+  non-periodic boundary (#104).
 - Fixed Torch Ewald gradients for non-uniform per-atom energy cotangents
   (`torch.autograd.grad(..., grad_outputs=w)`).
 - **MTK NPT/NPH cell propagation**: kernels wrote `V·(P − P_ext)/W`

--- a/nvalchemiops/neighbors/naive/launchers.py
+++ b/nvalchemiops/neighbors/naive/launchers.py
@@ -108,6 +108,7 @@ def _wrap_pbc_positions(
     *,
     batched: bool,
     batch_idx: wp.array | None,
+    pbc: wp.array | None = None,
 ) -> None:
     """Launch the shared position-wrapping helper for one batching mode."""
     if batched:
@@ -122,6 +123,7 @@ def _wrap_pbc_positions(
             per_atom_cell_offsets,
             wp_dtype,
             device,
+            pbc=pbc,
         )
         return
     wrap_positions_single(
@@ -132,12 +134,14 @@ def _wrap_pbc_positions(
         per_atom_cell_offsets,
         wp_dtype,
         device,
+        pbc=pbc,
     )
 
 
 def _prepare_pbc_positions(
     positions: wp.array,
     cell: wp.array,
+    pbc: wp.array,
     batch_idx: wp.array | None,
     wp_dtype: type,
     device: str,
@@ -179,6 +183,7 @@ def _prepare_pbc_positions(
         device,
         batched=batched,
         batch_idx=batch_idx,
+        pbc=pbc,
     )
     return positions_wrapped_buffer, per_atom_cell_offsets_buffer
 
@@ -417,6 +422,7 @@ def _launch_naive_neighbor_matrix_pbc(
     positions: wp.array,
     cutoff: float,
     cell: wp.array,
+    pbc: wp.array,
     shift_range: wp.array,
     neighbor_matrix: wp.array,
     neighbor_matrix_shifts: wp.array,
@@ -501,6 +507,7 @@ def _launch_naive_neighbor_matrix_pbc(
     positions_work, per_atom_cell_offsets = _prepare_pbc_positions(
         positions,
         cell,
+        pbc,
         batch_idx,
         wp_dtype,
         device,
@@ -746,6 +753,7 @@ def _launch_naive_neighbor_matrix_pbc_dual_cutoff(
     cutoff1: float,
     cutoff2: float,
     cell: wp.array,
+    pbc: wp.array,
     shift_range: wp.array,
     neighbor_matrix1: wp.array,
     neighbor_matrix2: wp.array,
@@ -775,6 +783,7 @@ def _launch_naive_neighbor_matrix_pbc_dual_cutoff(
     positions_work, per_atom_cell_offsets = _prepare_pbc_positions(
         positions,
         cell,
+        pbc,
         batch_idx,
         wp_dtype,
         device,
@@ -1202,6 +1211,7 @@ def naive_neighbor_matrix_pbc(
     per_atom_cell_offsets_buffer: wp.array | None = None,
     inv_cell_buffer: wp.array | None = None,
     native_strategy: str = "auto",
+    pbc: wp.array | None = None,
     # Deprecated kwarg aliases:
     positions_wrapped: wp.array | None = None,
     per_atom_cell_offsets: wp.array | None = None,
@@ -1343,6 +1353,7 @@ def naive_neighbor_matrix_pbc(
             positions,
             cutoff,
             cell,
+            pbc,
             shift_range,
             neighbor_matrix,
             neighbor_matrix_shifts,
@@ -1363,6 +1374,7 @@ def naive_neighbor_matrix_pbc(
         positions,
         cutoff,
         cell,
+        pbc,
         shift_range,
         neighbor_matrix,
         neighbor_matrix_shifts,
@@ -1421,6 +1433,7 @@ def batch_naive_neighbor_matrix_pbc(
     per_atom_cell_offsets_buffer: wp.array | None = None,
     inv_cell_buffer: wp.array | None = None,
     native_strategy: str = "auto",
+    pbc: wp.array | None = None,
     # Deprecated kwarg aliases:
     positions_wrapped: wp.array | None = None,
     per_atom_cell_offsets: wp.array | None = None,
@@ -1574,6 +1587,7 @@ def batch_naive_neighbor_matrix_pbc(
             positions,
             cutoff,
             cell,
+            pbc,
             shift_range,
             neighbor_matrix,
             neighbor_matrix_shifts,
@@ -1600,6 +1614,7 @@ def batch_naive_neighbor_matrix_pbc(
         positions,
         cutoff,
         cell,
+        pbc,
         shift_range,
         neighbor_matrix,
         neighbor_matrix_shifts,
@@ -1736,6 +1751,7 @@ def naive_neighbor_matrix_pbc_dual_cutoff(
     positions_wrapped_buffer: wp.array | None = None,
     per_atom_cell_offsets_buffer: wp.array | None = None,
     inv_cell_buffer: wp.array | None = None,
+    pbc: wp.array | None = None,
     # Deprecated kwarg aliases:
     positions_wrapped: wp.array | None = None,
     per_atom_cell_offsets: wp.array | None = None,
@@ -1846,6 +1862,7 @@ def naive_neighbor_matrix_pbc_dual_cutoff(
         cutoff1,
         cutoff2,
         cell,
+        pbc,
         shift_range,
         neighbor_matrix1,
         neighbor_matrix2,
@@ -1989,6 +2006,7 @@ def batch_naive_neighbor_matrix_pbc_dual_cutoff(
     positions_wrapped_buffer: wp.array | None = None,
     per_atom_cell_offsets_buffer: wp.array | None = None,
     inv_cell_buffer: wp.array | None = None,
+    pbc: wp.array | None = None,
     # Deprecated kwarg aliases:
     positions_wrapped: wp.array | None = None,
     per_atom_cell_offsets: wp.array | None = None,
@@ -2099,6 +2117,7 @@ def batch_naive_neighbor_matrix_pbc_dual_cutoff(
         cutoff1,
         cutoff2,
         cell,
+        pbc,
         shift_range,
         neighbor_matrix1,
         neighbor_matrix2,

--- a/nvalchemiops/neighbors/neighbor_utils.py
+++ b/nvalchemiops/neighbors/neighbor_utils.py
@@ -1009,73 +1009,153 @@ def estimate_max_neighbors(
 ###########################################################################################
 
 
-def _make_wrap_positions_kernel(wp_dtype: type, *, batched: bool):
-    """Build a position-wrapping kernel for one dtype and batching mode."""
+def _make_wrap_positions_kernel(wp_dtype: type, *, batched: bool, pbc_aware: bool):
+    """Build a position-wrapping kernel for one dtype and batching mode.
+
+    When ``pbc_aware`` is True the kernel takes a per-system ``pbc`` array and
+    never folds a non-periodic axis, so atoms outside the primary cell along
+    that axis keep their coordinate and a zero offset; this mirrors
+    ``_compute_naive_num_shifts``, which already disables image search on
+    non-periodic axes. When False the kernel folds every axis, the historical
+    behavior used by callers that always operate on fully periodic systems.
+    """
     require_supported_dtype(wp_dtype)
     vec_dtype, mat_dtype = dtype_info(wp_dtype)
     BATCHED = wp.constant(bool(batched))
 
-    @wp.kernel(enable_backward=False, module="unique")
-    def _kernel(
-        positions: wp.array(dtype=vec_dtype),
-        cell: wp.array(dtype=mat_dtype),
-        inv_cell: wp.array(dtype=mat_dtype),
-        batch_idx: wp.array(dtype=wp.int32),
-        positions_wrapped: wp.array(dtype=vec_dtype),
-        per_atom_cell_offsets: wp.array(dtype=wp.vec3i),
-    ) -> None:
-        """Wrap positions into the primary cell and store integer offsets
+    if pbc_aware:
 
-        Parameters
-        ----------
-        positions : wp.array, shape (total_atoms,), dtype=wp.vec3*
-            Cartesian coordinates to wrap.
-        cell : wp.array, shape (num_systems,), dtype=wp.mat33*
-            Cell matrices defining lattice vectors.
-        inv_cell : wp.array, shape (num_systems,), dtype=wp.mat33*
-            Precomputed inverse cell matrices.
-        batch_idx : wp.array, shape (total_atoms,), dtype=wp.int32
-            System index for each atom. Zero-size sentinel in single-system
-            specializations.
-        positions_wrapped : wp.array, shape (total_atoms,), dtype=wp.vec3*
-            OUTPUT: Wrapped Cartesian coordinates.
-        per_atom_cell_offsets : wp.array, shape (total_atoms,), dtype=wp.vec3i
-            OUTPUT: Integer cell offsets removed from each atom.
+        @wp.kernel(enable_backward=False, module="unique")
+        def _kernel(
+            positions: wp.array(dtype=vec_dtype),
+            cell: wp.array(dtype=mat_dtype),
+            inv_cell: wp.array(dtype=mat_dtype),
+            pbc: wp.array2d(dtype=wp.bool),
+            batch_idx: wp.array(dtype=wp.int32),
+            positions_wrapped: wp.array(dtype=vec_dtype),
+            per_atom_cell_offsets: wp.array(dtype=wp.vec3i),
+        ) -> None:
+            """Wrap positions into the primary cell, honoring per-axis pbc
 
-        Returns
-        -------
-        None
-            This function modifies the input arrays in-place.
+            Parameters
+            ----------
+            positions : wp.array, shape (total_atoms,), dtype=wp.vec3*
+                Cartesian coordinates to wrap.
+            cell : wp.array, shape (num_systems,), dtype=wp.mat33*
+                Cell matrices defining lattice vectors.
+            inv_cell : wp.array, shape (num_systems,), dtype=wp.mat33*
+                Precomputed inverse cell matrices.
+            pbc : wp.array, shape (num_systems, 3), dtype=wp.bool
+                Per-system periodicity flags. A non-periodic axis is never
+                folded, so atoms outside the primary cell along that axis keep
+                their coordinate and a zero offset.
+            batch_idx : wp.array, shape (total_atoms,), dtype=wp.int32
+                System index for each atom. Zero-size sentinel in single-system
+                specializations.
+            positions_wrapped : wp.array, shape (total_atoms,), dtype=wp.vec3*
+                OUTPUT: Wrapped Cartesian coordinates.
+            per_atom_cell_offsets : wp.array, shape (total_atoms,), dtype=wp.vec3i
+                OUTPUT: Integer cell offsets removed from each atom.
 
-        Notes
-        -----
-        - Thread launch: One thread per atom.
-        - Modifies: ``positions_wrapped`` and ``per_atom_cell_offsets``.
-        ``BATCHED`` is a static specialization. Single-system launchers pass a
-        zero-size ``batch_idx`` sentinel that is not read.
+            Returns
+            -------
+            None
+                This function modifies the input arrays in-place.
 
-        See Also
-        --------
-        get_wrap_positions_kernel : Return the specialized position-wrapping kernel.
-        """
-        i = wp.tid()
-        isys = wp.int32(0)
-        if BATCHED:
-            isys = batch_idx[i]
-        _cell = cell[isys]
-        _inv_cell = inv_cell[isys]
-        _pos = positions[i]
-        _frac = _pos * _inv_cell
-        _int = wp.vec3i(
-            wp.int32(wp.floor(_frac[0])),
-            wp.int32(wp.floor(_frac[1])),
-            wp.int32(wp.floor(_frac[2])),
-        )
-        positions_wrapped[i] = _pos - type(_pos)(_int) * _cell
-        per_atom_cell_offsets[i] = _int
+            Notes
+            -----
+            - Thread launch: One thread per atom.
+            - Modifies: ``positions_wrapped`` and ``per_atom_cell_offsets``.
+            ``BATCHED`` is a static specialization. Single-system launchers pass
+            a zero-size ``batch_idx`` sentinel that is not read.
 
+            See Also
+            --------
+            get_wrap_positions_kernel : Return the specialized wrapping kernel.
+            """
+            i = wp.tid()
+            isys = wp.int32(0)
+            if BATCHED:
+                isys = batch_idx[i]
+            _cell = cell[isys]
+            _inv_cell = inv_cell[isys]
+            _pbc = pbc[isys]
+            _pos = positions[i]
+            _frac = _pos * _inv_cell
+            _int = wp.vec3i(
+                wp.int32(wp.floor(_frac[0])) if _pbc[0] else wp.int32(0),
+                wp.int32(wp.floor(_frac[1])) if _pbc[1] else wp.int32(0),
+                wp.int32(wp.floor(_frac[2])) if _pbc[2] else wp.int32(0),
+            )
+            positions_wrapped[i] = _pos - type(_pos)(_int) * _cell
+            per_atom_cell_offsets[i] = _int
+
+    else:
+
+        @wp.kernel(enable_backward=False, module="unique")
+        def _kernel(
+            positions: wp.array(dtype=vec_dtype),
+            cell: wp.array(dtype=mat_dtype),
+            inv_cell: wp.array(dtype=mat_dtype),
+            batch_idx: wp.array(dtype=wp.int32),
+            positions_wrapped: wp.array(dtype=vec_dtype),
+            per_atom_cell_offsets: wp.array(dtype=wp.vec3i),
+        ) -> None:
+            """Wrap positions into the primary cell and store integer offsets
+
+            Parameters
+            ----------
+            positions : wp.array, shape (total_atoms,), dtype=wp.vec3*
+                Cartesian coordinates to wrap.
+            cell : wp.array, shape (num_systems,), dtype=wp.mat33*
+                Cell matrices defining lattice vectors.
+            inv_cell : wp.array, shape (num_systems,), dtype=wp.mat33*
+                Precomputed inverse cell matrices.
+            batch_idx : wp.array, shape (total_atoms,), dtype=wp.int32
+                System index for each atom. Zero-size sentinel in single-system
+                specializations.
+            positions_wrapped : wp.array, shape (total_atoms,), dtype=wp.vec3*
+                OUTPUT: Wrapped Cartesian coordinates.
+            per_atom_cell_offsets : wp.array, shape (total_atoms,), dtype=wp.vec3i
+                OUTPUT: Integer cell offsets removed from each atom.
+
+            Returns
+            -------
+            None
+                This function modifies the input arrays in-place.
+
+            Notes
+            -----
+            - Thread launch: One thread per atom.
+            - Modifies: ``positions_wrapped`` and ``per_atom_cell_offsets``.
+            ``BATCHED`` is a static specialization. Single-system launchers pass
+            a zero-size ``batch_idx`` sentinel that is not read.
+
+            See Also
+            --------
+            get_wrap_positions_kernel : Return the specialized wrapping kernel.
+            """
+            i = wp.tid()
+            isys = wp.int32(0)
+            if BATCHED:
+                isys = batch_idx[i]
+            _cell = cell[isys]
+            _inv_cell = inv_cell[isys]
+            _pos = positions[i]
+            _frac = _pos * _inv_cell
+            _int = wp.vec3i(
+                wp.int32(wp.floor(_frac[0])),
+                wp.int32(wp.floor(_frac[1])),
+                wp.int32(wp.floor(_frac[2])),
+            )
+            positions_wrapped[i] = _pos - type(_pos)(_int) * _cell
+            per_atom_cell_offsets[i] = _int
+
+    suffix = "_pbc" if pbc_aware else ""
     base = (
-        "_wrap_positions_batch_kernel" if batched else "_wrap_positions_single_kernel"
+        f"_wrap_positions_batch{suffix}_kernel"
+        if batched
+        else f"_wrap_positions_single{suffix}_kernel"
     )
     name = kernel_specialization_name(base, wp_dtype=wp_dtype)
     return set_fn_doc(
@@ -1083,15 +1163,24 @@ def _make_wrap_positions_kernel(wp_dtype: type, *, batched: bool):
         _append_specialization_doc(
             _kernel.__doc__,
             dtype=wp_dtype,
-            entries=(("batched", bool(batched)),),
+            entries=(("batched", bool(batched)), ("pbc_aware", bool(pbc_aware))),
         ),
     )
 
 
 @lru_cache(maxsize=None)
-def get_wrap_positions_kernel(wp_dtype: type, *, batched: bool = False) -> wp.Kernel:
-    """Return the specialized position-wrapping kernel."""
-    return _make_wrap_positions_kernel(wp_dtype, batched=bool(batched))
+def get_wrap_positions_kernel(
+    wp_dtype: type, *, batched: bool = False, pbc_aware: bool = False
+) -> wp.Kernel:
+    """Return the specialized position-wrapping kernel.
+
+    ``pbc_aware`` selects the variant that honors a per-system ``pbc`` array;
+    the default folds every axis, preserving the historical signature and
+    behavior for fully periodic callers.
+    """
+    return _make_wrap_positions_kernel(
+        wp_dtype, batched=bool(batched), pbc_aware=bool(pbc_aware)
+    )
 
 
 def _launch_wrap_positions(
@@ -1105,16 +1194,39 @@ def _launch_wrap_positions(
     device: str,
     *,
     batched: bool,
+    pbc: wp.array | None = None,
 ) -> None:
-    """Launch the shared position-wrapping kernel."""
+    """Launch the shared position-wrapping kernel.
+
+    When ``pbc`` is provided the per-axis-aware kernel variant is launched so
+    non-periodic axes are not folded; otherwise the historical fold-every-axis
+    variant runs.
+    """
+    sentinel_batch_idx = batch_idx if batched else _empty_sentinel(1, wp.int32, device)
+    if pbc is None:
+        wp.launch(
+            kernel=get_wrap_positions_kernel(wp_dtype, batched=batched),
+            dim=positions.shape[0],
+            inputs=[
+                positions,
+                cell,
+                inv_cell,
+                sentinel_batch_idx,
+                positions_wrapped,
+                per_atom_cell_offsets,
+            ],
+            device=device,
+        )
+        return
     wp.launch(
-        kernel=get_wrap_positions_kernel(wp_dtype, batched=batched),
+        kernel=get_wrap_positions_kernel(wp_dtype, batched=batched, pbc_aware=True),
         dim=positions.shape[0],
         inputs=[
             positions,
             cell,
             inv_cell,
-            batch_idx if batched else _empty_sentinel(1, wp.int32, device),
+            pbc,
+            sentinel_batch_idx,
             positions_wrapped,
             per_atom_cell_offsets,
         ],
@@ -1130,6 +1242,8 @@ def wrap_positions_single(
     per_atom_cell_offsets: wp.array,
     wp_dtype: type,
     device: str,
+    *,
+    pbc: wp.array | None = None,
 ) -> None:
     """Core warp launcher for wrapping positions into the primary cell (single system).
 
@@ -1155,6 +1269,9 @@ def wrap_positions_single(
         Warp scalar dtype (wp.float32, wp.float64, or wp.float16).
     device : str
         Warp device string (e.g., ``'cuda:0'``, ``'cpu'``).
+    pbc : wp.array, shape (1, 3), dtype=wp.bool, optional
+        Per-axis periodicity flags. When given, non-periodic axes are not
+        folded; when omitted every axis is folded (fully periodic).
 
     See Also
     --------
@@ -1171,6 +1288,7 @@ def wrap_positions_single(
         wp_dtype,
         device,
         batched=False,
+        pbc=pbc,
     )
 
 
@@ -1183,6 +1301,8 @@ def wrap_positions_batch(
     per_atom_cell_offsets: wp.array,
     wp_dtype: type,
     device: str,
+    *,
+    pbc: wp.array | None = None,
 ) -> None:
     """Core warp launcher for wrapping positions into the primary cell (batch of systems).
 
@@ -1211,6 +1331,9 @@ def wrap_positions_batch(
         Warp scalar dtype (wp.float32, wp.float64, or wp.float16).
     device : str
         Warp device string (e.g., ``'cuda:0'``, ``'cpu'``).
+    pbc : wp.array, shape (num_systems, 3), dtype=wp.bool, optional
+        Per-system, per-axis periodicity flags. When given, non-periodic axes
+        are not folded; when omitted every axis is folded (fully periodic).
 
     See Also
     --------
@@ -1227,6 +1350,7 @@ def wrap_positions_batch(
         wp_dtype,
         device,
         batched=True,
+        pbc=pbc,
     )
 
 

--- a/nvalchemiops/torch/neighbors/batch_naive.py
+++ b/nvalchemiops/torch/neighbors/batch_naive.py
@@ -148,6 +148,7 @@ def _batch_naive_neighbor_matrix_no_pbc(
 def _batch_naive_neighbor_matrix_pbc(
     positions: torch.Tensor,
     cell: torch.Tensor,
+    pbc: torch.Tensor,
     cutoff: float,
     batch_idx: torch.Tensor,
     batch_ptr: torch.Tensor,
@@ -247,6 +248,8 @@ def _batch_naive_neighbor_matrix_pbc(
     if max_atoms_per_system is None:
         max_atoms_per_system = (batch_ptr[1:] - batch_ptr[:-1]).max().item()
 
+    wp_pbc = wp.from_torch(pbc, dtype=wp.bool, requires_grad=False, return_ctype=True)
+
     wp_rebuild_flags = None
     if rebuild_flags is not None:
         wp_rebuild_flags = wp.from_torch(
@@ -282,6 +285,7 @@ def _batch_naive_neighbor_matrix_pbc(
     batch_naive_neighbor_matrix_pbc(
         positions=wp_positions,
         cell=wp_cell,
+        pbc=wp_pbc,
         cutoff=cutoff,
         batch_ptr=wp_batch_ptr,
         batch_idx=wp_batch_idx,
@@ -1043,6 +1047,7 @@ def batch_naive_neighbor_list(
         _batch_naive_neighbor_matrix_pbc(
             positions=positions,
             cell=cell,
+            pbc=pbc,
             cutoff=cutoff,
             batch_idx=batch_idx,
             batch_ptr=batch_ptr,

--- a/nvalchemiops/torch/neighbors/naive.py
+++ b/nvalchemiops/torch/neighbors/naive.py
@@ -138,6 +138,7 @@ def _naive_neighbor_matrix_pbc(
     positions: torch.Tensor,
     cutoff: float,
     cell: torch.Tensor,
+    pbc: torch.Tensor,
     neighbor_matrix: torch.Tensor,
     neighbor_matrix_shifts: torch.Tensor,
     num_neighbors: torch.Tensor,
@@ -265,10 +266,14 @@ def _naive_neighbor_matrix_pbc(
             else None
         )
 
+        wp_pbc = wp.from_torch(
+            pbc, dtype=wp.bool, requires_grad=False, return_ctype=True
+        )
         naive_neighbor_matrix_pbc(
             positions=wp_positions,
             cutoff=cutoff,
             cell=wp_cell,
+            pbc=wp_pbc,
             shift_range=wp_shift_range,
             num_shifts=max_shifts_per_system,
             neighbor_matrix=wp_neighbor_matrix,
@@ -1056,6 +1061,7 @@ def naive_neighbor_list(
             positions=positions,
             cutoff=cutoff,
             cell=cell,
+            pbc=pbc,
             neighbor_matrix=neighbor_matrix,
             neighbor_matrix_shifts=neighbor_matrix_shifts,
             num_neighbors=num_neighbors,

--- a/test/neighbors/bindings/torch/test_batch_naive.py
+++ b/test/neighbors/bindings/torch/test_batch_naive.py
@@ -20,6 +20,7 @@ from unittest import mock
 import pytest
 import torch
 
+from nvalchemiops.torch.neighbors import batch_cell_list
 from nvalchemiops.torch.neighbors.batch_naive import (
     batch_naive_neighbor_list,
 )
@@ -158,6 +159,66 @@ class TestBatchNaiveCorrectness:
 
         # Check neighbor counts
         assert torch.all(num_neighbors >= 0)
+
+    def test_non_periodic_axis_is_not_folded(self, device, dtype):
+        """A non-periodic axis must not be folded when wrapping positions.
+
+        With a non-zero cell and atoms sitting outside the primary cell along a
+        non-periodic axis, the naive launcher used to wrap every axis (it
+        branched only on ``pbc is None``), which corrupts the neighbors of the
+        non-periodic axis. The cell-list method honors per-axis pbc, so the two
+        must reconstruct the same neighbor distances; the comparison fails if
+        the non-periodic axis is folded again.
+        """
+        cutoff = 5.0
+        atol = 1e-4 if dtype == torch.float32 else 1e-9
+
+        def sorted_pair_distances(fn, positions, cell, pbc):
+            batch_idx = torch.zeros(
+                positions.shape[0], dtype=torch.int32, device=device
+            )
+            nbr, _, shifts = fn(
+                positions=positions,
+                cutoff=cutoff,
+                batch_idx=batch_idx,
+                cell=cell.unsqueeze(0),
+                pbc=pbc.unsqueeze(0),
+                return_neighbor_list=True,
+            )
+            i, j = nbr[0].long(), nbr[1].long()
+            disp = positions[j] + shifts.to(dtype) @ cell - positions[i]
+            return torch.sort(torch.linalg.norm(disp, dim=1)).values
+
+        def assert_matches_cell_list(positions, cell, pbc):
+            naive = sorted_pair_distances(
+                batch_naive_neighbor_list, positions, cell, pbc
+            )
+            oracle = sorted_pair_distances(batch_cell_list, positions, cell, pbc)
+            assert naive.shape == oracle.shape
+            assert torch.allclose(naive, oracle, atol=atol)
+
+        # Fully non-periodic molecule carrying a 1 A dummy cell; atoms straddle
+        # the origin so a fold along any axis changes the geometry
+        positions = torch.tensor(
+            [[0.0, 0.0, 0.0], [0.0, 0.76, -0.59], [0.0, -0.76, -0.59]],
+            dtype=dtype,
+            device=device,
+        )
+        cell = torch.eye(3, dtype=dtype, device=device)
+        pbc = torch.tensor([False, False, False], device=device)
+        assert_matches_cell_list(positions, cell, pbc)
+
+        # Slab: periodic in x and y, non-periodic z with atoms straddling z = 0
+        a, lz = 3.0, 20.0
+        coords = [
+            [x, y, z]
+            for (x, y) in [(0.0, 0.0), (1.5, 0.0), (0.0, 1.5), (1.5, 1.5)]
+            for z in (0.5, -0.5)
+        ]
+        positions = torch.tensor(coords, dtype=dtype, device=device)
+        cell = torch.diag(torch.tensor([a, a, lz], dtype=dtype, device=device))
+        pbc = torch.tensor([True, True, False], device=device)
+        assert_matches_cell_list(positions, cell, pbc)
 
     def test_pbc_uses_forwarded_batch_idx_without_rebuilding(self, device, dtype):
         """Test PBC path does not rebuild batch_idx when both batch tensors are provided."""


### PR DESCRIPTION
## Description

`batch_naive_neighbor_list` and `naive_neighbor_list` returned wrong neighbors whenever a non-periodic axis was combined with a non-zero cell and atoms crossed that axis' boundary. This affects fully non-periodic systems (`pbc=[False, False, False]`, for example a molecule carrying a dummy cell) and slabs (`pbc=[True, True, False]`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #104

## Changes Made

- `get_wrap_positions_kernel` now builds a `pbc_aware` variant of the position-wrapping kernel that leaves non-periodic axes unfolded, mirroring how `_compute_naive_num_shifts` already disables image search on those axes.
- The batch and single-system Torch neighbor lists thread their `pbc` through `_prepare_pbc_positions` to that variant. Selection is opt-in: the default kernel and any caller that does not pass `pbc` keep the previous fold-every-axis behavior, so the change stays confined to the periodic wrapping path. The dual-cutoff and JAX wrapping paths are untouched and can adopt the same `pbc` argument in a follow-up.
- Added a regression test and a CHANGELOG entry.

## Testing

- [ ] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

The new `test_non_periodic_axis_is_not_folded` reconstructs neighbor distances from the returned shifts and asserts the naive neighbor list matches `batch_cell_list` for a non-periodic molecule and a slab whose atoms straddle the non-periodic boundary; reverting the fix makes it fail. Both cases were also checked against ase `neighbor_list`. The full suite needs a GPU, so locally I ran the CPU-runnable neighbor tests (the new test plus the existing factory and batch-naive launcher tests) along with `ruff check`, `ruff format`, and `interrogate`; please rely on CI for the GPU paths.

## Checklist

- [x] I have read and understand the Contributing Guidelines
- [x] I have updated the CHANGELOG.md
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

Root cause: the naive launchers branch only on whether `pbc` is `None`, so a non-`None` but non-periodic `pbc` still takes the periodic path, where the wrapping kernel folded every axis with `floor(pos . inv_cell)`. A non-periodic axis has no images, so folding it changes the geometry and corrupts its neighbors. `batch_cell_list` was unaffected, which is why it is the reference in the new test.
