### PR TITLE
fix(neighbors): handle skewed cluster_tile pruning

### DIFF
--- a/nvalchemiops/neighbors/cluster_tile/kernels.py
+++ b/nvalchemiops/neighbors/cluster_tile/kernels.py
@@ -438,7 +438,22 @@ def _bbox_distance_sq(
     rg_ext: wp.vec3f,
     cg_ext: wp.vec3f,
 ) -> wp.float32:
-    """Return squared distance between two Cartesian axis-aligned boxes."""
+    """Return squared distance between two Cartesian axis-aligned boxes.
+
+    Parameters
+    ----------
+    d : wp.vec3f
+        Cartesian displacement between the two box centers.
+    rg_ext : wp.vec3f
+        Half-extents of the row-group bounding box.
+    cg_ext : wp.vec3f
+        Half-extents of the column-group bounding box.
+
+    Returns
+    -------
+    wp.float32
+        Squared gap distance between the two boxes, or zero when they overlap.
+    """
     dx = wp.max(wp.abs(d[0]) - rg_ext[0] - cg_ext[0], wp.float32(0.0))
     dy = wp.max(wp.abs(d[1]) - rg_ext[1] - cg_ext[1], wp.float32(0.0))
     dz = wp.max(wp.abs(d[2]) - rg_ext[2] - cg_ext[2], wp.float32(0.0))

--- a/nvalchemiops/neighbors/cluster_tile/kernels.py
+++ b/nvalchemiops/neighbors/cluster_tile/kernels.py
@@ -433,6 +433,19 @@ def _rank_to_group_kernel(
 
 
 @wp.func
+def _bbox_distance_sq(
+    d: wp.vec3f,
+    rg_ext: wp.vec3f,
+    cg_ext: wp.vec3f,
+) -> wp.float32:
+    """Return squared distance between two Cartesian axis-aligned boxes."""
+    dx = wp.max(wp.abs(d[0]) - rg_ext[0] - cg_ext[0], wp.float32(0.0))
+    dy = wp.max(wp.abs(d[1]) - rg_ext[1] - cg_ext[1], wp.float32(0.0))
+    dz = wp.max(wp.abs(d[2]) - rg_ext[2] - cg_ext[2], wp.float32(0.0))
+    return dx * dx + dy * dy + dz * dz
+
+
+@wp.func
 def _bbox_valid(
     col_idx: wp.int32,
     row_group: wp.int32,
@@ -485,12 +498,24 @@ def _bbox_valid(
         rg_ctr[2] - cg_ctr[2],
     )
     d_wrapped, _s = _wrap_triclinic(d_ctr, cell, inv_cell)
-    dx = wp.max(wp.abs(d_wrapped[0]) - rg_ext[0] - cg_ext[0], wp.float32(0.0))
-    dy = wp.max(wp.abs(d_wrapped[1]) - rg_ext[1] - cg_ext[1], wp.float32(0.0))
-    dz = wp.max(wp.abs(d_wrapped[2]) - rg_ext[2] - cg_ext[2], wp.float32(0.0))
-    bbox_dist_sq = dx * dx + dy * dy + dz * dz
-    if bbox_dist_sq < cutoff_sq:
+    if _bbox_distance_sq(d_wrapped, rg_ext, cg_ext) < cutoff_sq:
         return 1
+
+    cell_T = wp.transpose(cell)
+    for ia in range(3):
+        shift_a = wp.float32(ia - 1)
+        for ib in range(3):
+            shift_b = wp.float32(ib - 1)
+            for ic in range(3):
+                if ia != 1 or ib != 1 or ic != 1:
+                    shift_c = wp.float32(ic - 1)
+                    d_image = d_wrapped + cell_T * wp.vec3f(
+                        shift_a,
+                        shift_b,
+                        shift_c,
+                    )
+                    if _bbox_distance_sq(d_image, rg_ext, cg_ext) < cutoff_sq:
+                        return 1
     return 0
 
 

--- a/test/neighbors/bindings/torch/test_cluster_tile.py
+++ b/test/neighbors/bindings/torch/test_cluster_tile.py
@@ -28,6 +28,7 @@ from nvalchemiops.torch.neighbors.cluster_tile import (
     estimate_cluster_tile_list_sizes,
     query_cluster_tile,
 )
+from nvalchemiops.torch.neighbors.naive import naive_neighbor_list
 
 from ...test_utils import (
     assert_neighbor_lists_equal,
@@ -185,6 +186,43 @@ class TestTileNeighborListCorrectness:
         i_got, j_got, u_got = _matrix_to_coo_full(nm, nn, nms, N)
         i_ref, j_ref, u_ref, _ = brute_force_neighbors(positions, cell, pbc, cutoff)
         assert_neighbor_lists_equal((i_got, j_got, u_got), (i_ref, j_ref, u_ref))
+
+    def test_nonorthogonal_dense_random_matches_naive(self, device, dtype):
+        """FCC-style skewed cell must not prune valid cluster tiles."""
+        torch.manual_seed(0)
+        N = 512
+        scale = 51.2
+        cell_mat = scale * torch.tensor(
+            [[0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 0.0]],
+            dtype=dtype,
+            device=device,
+        )
+        cell = cell_mat.reshape(1, 3, 3)
+        pbc = torch.ones(1, 3, dtype=torch.bool, device=device)
+        frac = torch.rand(N, 3, dtype=torch.float64, device=device)
+        positions = (frac @ cell_mat.double()).to(dtype).contiguous()
+        cutoff = 12.0
+        max_neighbors = 128
+
+        nm, nn, nms = cluster_tile_neighbor_list(
+            positions,
+            cutoff,
+            cell,
+            max_neighbors=max_neighbors,
+        )
+        nm_ref, nn_ref, nms_ref = naive_neighbor_list(
+            positions,
+            cutoff,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=max_neighbors,
+        )
+
+        assert int(nn.sum().item()) == int(nn_ref.sum().item())
+        torch.testing.assert_close(nn, nn_ref)
+        ct_sets = _per_atom_neighbor_sets(nm, nn, nms, N)
+        ref_sets = _per_atom_neighbor_sets(nm_ref, nn_ref, nms_ref, N)
+        assert ct_sets == ref_sets
 
     @requires_vesin
     def test_larger_random_system(self, device, dtype):

--- a/test/neighbors/test_cluster_tile_kernels.py
+++ b/test/neighbors/test_cluster_tile_kernels.py
@@ -32,6 +32,7 @@ from nvalchemiops.neighbors.cluster_tile import (
     build_cluster_tile_list,
     query_cluster_tile,
 )
+from nvalchemiops.neighbors.cluster_tile.kernels import _bbox_distance_sq
 from nvalchemiops.neighbors.cluster_tile.launchers import (
     _compute_morton,
     _permute_gather_soa,
@@ -39,6 +40,18 @@ from nvalchemiops.neighbors.cluster_tile.launchers import (
 )
 
 pytestmark = pytest.mark.gpu
+
+
+@wp.kernel(enable_backward=False)
+def _bbox_distance_sq_test_kernel(
+    d: wp.array(dtype=wp.vec3f),
+    rg_ext: wp.array(dtype=wp.vec3f),
+    cg_ext: wp.array(dtype=wp.vec3f),
+    out: wp.array(dtype=wp.float32),
+) -> None:
+    """Evaluate ``_bbox_distance_sq`` for test vectors."""
+    i = wp.tid()
+    out[i] = _bbox_distance_sq(d[i], rg_ext[i], cg_ext[i])
 
 
 def _mat33f_from_torch(mat: torch.Tensor):
@@ -61,6 +74,54 @@ def device():
     if not torch.cuda.is_available():
         pytest.skip("cluster_tile kernel tests require torch CUDA tensors")
     return "cuda:0"
+
+
+class TestBBoxDistanceSqHelper:
+    """Tests for the cluster bounding-box distance helper."""
+
+    def test_overlap_and_gap_cases(self, device):
+        """Helper returns zero for overlap and squared gap otherwise."""
+        d = torch.tensor(
+            [
+                [1.0, 0.0, 0.0],
+                [3.0, 0.0, 0.0],
+                [4.0, 5.0, 0.0],
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        rg_ext = torch.tensor(
+            [
+                [1.0, 1.0, 1.0],
+                [1.0, 1.0, 1.0],
+                [1.0, 1.0, 1.0],
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        cg_ext = torch.tensor(
+            [
+                [1.0, 1.0, 1.0],
+                [1.0, 1.0, 1.0],
+                [1.5, 2.0, 1.0],
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        out = torch.empty(3, dtype=torch.float32, device=device)
+        wp.launch(
+            kernel=_bbox_distance_sq_test_kernel,
+            dim=3,
+            inputs=[
+                wp.from_torch(d, dtype=wp.vec3f, return_ctype=True),
+                wp.from_torch(rg_ext, dtype=wp.vec3f, return_ctype=True),
+                wp.from_torch(cg_ext, dtype=wp.vec3f, return_ctype=True),
+                wp.from_torch(out, dtype=wp.float32, return_ctype=True),
+            ],
+            device=device,
+        )
+        expected = torch.tensor([0.0, 1.0, 6.25], dtype=torch.float32, device=device)
+        torch.testing.assert_close(out, expected)
 
 
 class TestComputeMortonLauncher:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Fix cluster-tile neighbor-list pruning for skewed periodic cells by making the group bounding-box filter check neighboring periodic images before rejecting a tile.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- Add a reusable cluster bounding-box distance helper.
- Keep the existing wrapped-center bbox check as the fast path.
- Check surrounding periodic images before rejecting a cluster-tile pair.
- Add a CUDA regression comparing cluster-tile and naive neighbor lists in an FCC-style non-orthogonal cell.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?


## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
