### PR TITLE
fix(neighbors): support method auto alias

### DIFF
--- a/nvalchemiops/jax/neighbors/__init__.py
+++ b/nvalchemiops/jax/neighbors/__init__.py
@@ -171,11 +171,11 @@ def neighbor_list(
 
     method : str | None, optional
         Method to use for neighbor list computation.
-        Choices: "naive", "cell_list", "cluster_tile", "batch_naive",
+        Choices: "auto", "naive", "cell_list", "cluster_tile", "batch_naive",
         "batch_cell_list", "batch_cluster_tile", "naive_dual_cutoff",
-        "batch_naive_dual_cutoff". If None, a default method is chosen by
-        comparing estimated work from per-system atom counts and cell (or
-        bounding-box) volumes and can select cluster-tile when the CUDA,
+        "batch_naive_dual_cutoff". If None or "auto", a default method is
+        chosen by comparing estimated work from per-system atom counts and cell
+        (or bounding-box) volumes and can select cluster-tile when the CUDA,
         float32, fully-periodic, contiguous-batch, and output-option guards
         allow it. Method names that do not start with ``batch_`` refer to
         single-system algorithms. When ``batch_idx`` or ``batch_ptr`` (batch
@@ -344,6 +344,9 @@ def neighbor_list(
     batch_cell_list : Batched cell list algorithm
     batch_cluster_tile_neighbor_list : Batched cluster-pair tile algorithm
     """
+    if method == "auto":
+        method = None
+
     if batch_ptr is not None and batch_ptr.shape[0] < 2:
         raise ValueError("batch_ptr must have length at least 2")
 

--- a/nvalchemiops/torch/neighbors/__init__.py
+++ b/nvalchemiops/torch/neighbors/__init__.py
@@ -144,11 +144,11 @@ def neighbor_list(
         and only convert to a neighbor list format if absolutely necessary.
     method : str | None, optional
         Method to use for neighbor list computation.
-        Choices: "naive", "cell_list", "cluster_tile", "batch_naive",
+        Choices: "auto", "naive", "cell_list", "cluster_tile", "batch_naive",
         "batch_cell_list", "batch_cluster_tile", "naive_dual_cutoff",
-        "batch_naive_dual_cutoff". If None, a default method is chosen by
-        comparing estimated work from per-system atom counts and cell (or
-        bounding-box) volumes and can select cluster-tile when the CUDA,
+        "batch_naive_dual_cutoff". If None or "auto", a default method is
+        chosen by comparing estimated work from per-system atom counts and cell
+        (or bounding-box) volumes and can select cluster-tile when the CUDA,
         float32, fully-periodic, contiguous-batch, and output-option guards
         allow it. Method names that do not start with ``batch_`` refer to
         single-system algorithms. When ``batch_idx`` or ``batch_ptr`` (batch
@@ -322,6 +322,8 @@ def neighbor_list(
             "Pass a boolean tensor of shape (3,) or (num_systems, 3), "
             "e.g. pbc=torch.tensor([True, True, True])."
         )
+    if method == "auto":
+        method = None
 
     if batch_ptr is not None and batch_ptr.shape[0] < 2:
         raise ValueError("batch_ptr must have length at least 2")

--- a/test/neighbors/bindings/jax/test_neighborlist.py
+++ b/test/neighbors/bindings/jax/test_neighborlist.py
@@ -104,6 +104,98 @@ def assert_neighbor_matrix_equal_jax(result1, result2):
 class TestNeighborListAutoSelection:
     """Test automatic method selection based on system size."""
 
+    def test_method_auto_aliases_none_for_unbatched_dispatch(self, monkeypatch):
+        """method='auto' follows the same unbatched auto-selection path as None."""
+        routes = []
+
+        def fake_auto_method_from_geometry(*args, **kwargs):
+            del args, kwargs
+            return "naive_scalar"
+
+        def fake_naive(positions, cutoff, **kwargs):
+            del positions, cutoff
+            routes.append(kwargs["native_strategy"])
+            return ("naive", kwargs["native_strategy"])
+
+        monkeypatch.setattr(
+            neighbor_module,
+            "_auto_method_from_geometry",
+            fake_auto_method_from_geometry,
+        )
+        monkeypatch.setattr(neighbor_module, "naive_neighbor_list", fake_naive)
+
+        positions = jnp.zeros((8, 3), dtype=jnp.float32)
+        cell = jnp.eye(3, dtype=jnp.float32) * 10.0
+        pbc = jnp.zeros((3,), dtype=bool)
+
+        expected = neighbor_module.neighbor_list(
+            positions,
+            2.0,
+            cell=cell,
+            pbc=pbc,
+            method=None,
+        )
+        actual = neighbor_module.neighbor_list(
+            positions,
+            2.0,
+            cell=cell,
+            pbc=pbc,
+            method="auto",
+        )
+
+        assert actual == expected == ("naive", "scalar")
+        assert routes == ["scalar", "scalar"]
+
+    def test_method_auto_aliases_none_for_batched_dispatch(self, monkeypatch):
+        """method='auto' never reaches the invalid batch_auto method."""
+        routes = []
+
+        def fake_auto_method_from_geometry(*args, **kwargs):
+            del args, kwargs
+            return "cell_list_pair_centric"
+
+        def fake_batch_cell_list(
+            positions, cutoff, cell, pbc, batch_idx, *args, **kwargs
+        ):
+            del positions, cutoff, cell, pbc, batch_idx, args
+            routes.append((kwargs["strategy"], kwargs["atom_centric_path"]))
+            return ("batch_cell_list", kwargs["strategy"], kwargs["atom_centric_path"])
+
+        monkeypatch.setattr(
+            neighbor_module,
+            "_auto_method_from_geometry",
+            fake_auto_method_from_geometry,
+        )
+        monkeypatch.setattr(neighbor_module, "batch_cell_list", fake_batch_cell_list)
+
+        positions = jnp.zeros((8, 3), dtype=jnp.float32)
+        cell = jnp.repeat(jnp.eye(3, dtype=jnp.float32)[None, :, :] * 10.0, 2, axis=0)
+        pbc = jnp.zeros((2, 3), dtype=bool)
+        batch_idx = jnp.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 4, 8], dtype=jnp.int32)
+
+        expected = neighbor_module.neighbor_list(
+            positions,
+            2.0,
+            cell=cell,
+            pbc=pbc,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            method=None,
+        )
+        actual = neighbor_module.neighbor_list(
+            positions,
+            2.0,
+            cell=cell,
+            pbc=pbc,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            method="auto",
+        )
+
+        assert actual == expected == ("batch_cell_list", "pair_centric", "sorted")
+        assert routes == [("pair_centric", "sorted"), ("pair_centric", "sorted")]
+
     @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
     def test_auto_select_cell_list_sparse_no_cell(self, dtype, device):
         """Cell-less auto dispatch is correct at method-dependent COO arity.

--- a/test/neighbors/bindings/torch/test_neighborlist.py
+++ b/test/neighbors/bindings/torch/test_neighborlist.py
@@ -49,6 +49,98 @@ from ...test_utils import (
 class TestNeighborListAutoSelection:
     """Test automatic method selection based on estimated neighbor density."""
 
+    def test_method_auto_aliases_none_for_unbatched_dispatch(self, monkeypatch):
+        """method='auto' follows the same unbatched auto-selection path as None."""
+        routes = []
+
+        def fake_auto_method_from_geometry(*args, **kwargs):
+            del args, kwargs
+            return "naive_scalar"
+
+        def fake_naive(positions, cutoff, **kwargs):
+            del positions, cutoff
+            routes.append(kwargs["native_strategy"])
+            return ("naive", kwargs["native_strategy"])
+
+        monkeypatch.setattr(
+            neighbor_module,
+            "_auto_method_from_geometry",
+            fake_auto_method_from_geometry,
+        )
+        monkeypatch.setattr(neighbor_module, "naive_neighbor_list", fake_naive)
+
+        positions = torch.zeros(8, 3, dtype=torch.float32)
+        cell = torch.eye(3, dtype=torch.float32) * 10.0
+        pbc = torch.zeros(3, dtype=torch.bool)
+
+        expected = neighbor_module.neighbor_list(
+            positions,
+            2.0,
+            cell=cell,
+            pbc=pbc,
+            method=None,
+        )
+        actual = neighbor_module.neighbor_list(
+            positions,
+            2.0,
+            cell=cell,
+            pbc=pbc,
+            method="auto",
+        )
+
+        assert actual == expected == ("naive", "scalar")
+        assert routes == ["scalar", "scalar"]
+
+    def test_method_auto_aliases_none_for_batched_dispatch(self, monkeypatch):
+        """method='auto' never reaches the invalid batch_auto method."""
+        routes = []
+
+        def fake_auto_method_from_geometry(*args, **kwargs):
+            del args, kwargs
+            return "cell_list_pair_centric"
+
+        def fake_batch_cell_list(
+            positions, cutoff, cell, pbc, batch_idx, *args, **kwargs
+        ):
+            del positions, cutoff, cell, pbc, batch_idx, args
+            routes.append((kwargs["strategy"], kwargs["atom_centric_path"]))
+            return ("batch_cell_list", kwargs["strategy"], kwargs["atom_centric_path"])
+
+        monkeypatch.setattr(
+            neighbor_module,
+            "_auto_method_from_geometry",
+            fake_auto_method_from_geometry,
+        )
+        monkeypatch.setattr(neighbor_module, "batch_cell_list", fake_batch_cell_list)
+
+        positions = torch.zeros(8, 3, dtype=torch.float32)
+        cell = torch.eye(3, dtype=torch.float32).repeat(2, 1, 1) * 10.0
+        pbc = torch.zeros(2, 3, dtype=torch.bool)
+        batch_idx = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1], dtype=torch.int32)
+        batch_ptr = torch.tensor([0, 4, 8], dtype=torch.int32)
+
+        expected = neighbor_module.neighbor_list(
+            positions,
+            2.0,
+            cell=cell,
+            pbc=pbc,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            method=None,
+        )
+        actual = neighbor_module.neighbor_list(
+            positions,
+            2.0,
+            cell=cell,
+            pbc=pbc,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            method="auto",
+        )
+
+        assert actual == expected == ("batch_cell_list", "pair_centric", "sorted")
+        assert routes == [("pair_centric", "sorted"), ("pair_centric", "sorted")]
+
     @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
     @pytest.mark.parametrize("device", ["cpu", "cuda"])
     def test_auto_select_cell_list_sparse_no_cell(self, dtype, device):


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Fix neighbor-list frontend dispatch so `method="auto"` follows the same auto-selection path as an omitted method. Auto-selection was already supported when `method` was omitted, but passing the explicit `"auto"` spelling could be treated as an invalid method and, for batched inputs, raise `ValueError: Invalid method: batch_auto`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- Normalize `method="auto"` to `None` in the Torch and JAX neighbor-list frontends before explicit-method batch aliasing.
- Update neighbor-list frontend docstrings to list `"auto"` as a public method alias.
- Add Torch and JAX regression tests covering unbatched and batched `method="auto"` dispatch.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?
- Targeted Torch/JAX neighbor-list regression tests passed.
- Python compile checks and staged diff whitespace checks passed.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
