### PR TITLE
fix(electrostatics): handle q(R) charge gradients

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -43,7 +43,7 @@
 
 ### Fixed
 
-- Fixed an issue with JAX `naive` PBC pair-output paths that dropped non-zero 
+- Fixed an issue with JAX `naive` PBC pair-output paths that dropped non-zero
   periodic images. The  JAX `naive_neighbor_list` pair-output path (`return_distances` /
   `return_vectors`, and now `pair_fn`) launched its periodic kernel with the
   shift axis pinned to 1, so when `cutoff` exceeded half the cell width (R>1)

--- a/docs/userguide/components/electrostatics.md
+++ b/docs/userguide/components/electrostatics.md
@@ -828,12 +828,9 @@ direct-output escape hatch for no-autograd MD/inference loops. Snippets in this
 section that still request full-API direct outputs show compatibility behavior
 and emit `DeprecationWarning`.
 
-For JAX PME under `jax.jit` or other JAX transformations, pass explicit
-`mesh_dimensions` when `cell`, `alpha`, or batch metadata are traced. For JAX
-Ewald under `jax.jit`, pass `miller_bounds` as a concrete static tuple or build
-`k_vectors` outside jit; dynamic `miller_bounds` changes the reciprocal array
-shape and is not traceable.
-`mesh_spacing` and `accuracy`-based mesh sizing need concrete mesh setup values.
+For hot-path and JIT setup guidance, including when to pass explicit mesh and
+reciprocal metadata, see {ref}`sync-free-electrostatics`. The examples below use
+explicit `mesh_dimensions` unless they are demonstrating setup inference.
 
 #### Basic Usage
 
@@ -1967,6 +1964,11 @@ neighbor_list_coo, neighbor_ptr, neighbor_shifts = neighbor_list(
 # Per-system alpha values (optional)
 alphas = torch.tensor([0.3, 0.35, 0.3], dtype=torch.float64, device=positions.device)
 
+# Upper bound on per-system atom counts (for sync-free batched reciprocal)
+max_atoms_per_system = max(
+    len(pos_system0), len(pos_system1), len(pos_system2)
+)
+
 # Batched calculation
 energies, forces = ewald_summation(
     positions=positions,
@@ -1979,6 +1981,7 @@ energies, forces = ewald_summation(
     neighbor_ptr=neighbor_ptr,
     neighbor_shifts=neighbor_shifts,
     compute_forces=True,
+    max_atoms_per_system=max_atoms_per_system,
 )
 
 # energies: (total_atoms,) - per-atom energies
@@ -1990,7 +1993,8 @@ energy_per_system.scatter_add_(0, batch_idx.long(), energies)
 Batch mode uses one shared set of Miller indices for the reciprocal-space
 calculation. If `k_cutoff` is supplied per system, either directly or via
 `estimate_ewald_parameters`, `nvalchemiops` uses the maximum cutoff across the
-batch to build that shared set.
+batch to build that shared set. For cross-framework sync-free setup guidance,
+see {ref}`sync-free-electrostatics`.
 
 :::
 
@@ -2613,6 +2617,42 @@ intended loss.
 Second-order support means differentiating scalar losses through these energy
 paths with Torch/JAX autograd. Electrostatics does not expose public Hessian or
 Jacobian tensors/functions.
+
+(sync-free-electrostatics)=
+
+### Sync-Free Electrostatics Calls
+
+Here, sync-free means avoiding known Toolkit-Ops host/device reads for
+shape, launch-size, or setup inference on Torch CUDA or JAX tracing hot paths. It is
+not a blanket guarantee that PyTorch, JAX, Warp, CUDA kernels, FFT libraries, or
+user-side logging never synchronize internally. The guidance below applies to
+energy-returning autograd paths unless stated otherwise; deprecated full-API
+direct-output flags and component direct outputs are compatibility or
+MD/inference paths, not the primary differentiable sync-free contract.
+
+For Torch batched Ewald reciprocal calls, pass a host-known
+`max_atoms_per_system` upper bound to `ewald_reciprocal_space` or
+`ewald_summation`. When this argument is omitted, the reciprocal kernel infers
+the launch bound from `atom_start` / `atom_end` and may synchronize on CUDA.
+For Torch PME, pass explicit `mesh_dimensions` in hot training loops; deriving
+mesh dimensions from `mesh_spacing` is setup inference and can require a host
+read. For fixed-cell Ewald/PME loops, precompute `k_vectors`, PME reciprocal
+metadata, and B-spline moduli outside the training step when the cell is fixed.
+
+For JAX under `jax.jit` or other transformations, pass concrete/static setup
+values: `max_atoms_per_system` for batched Ewald, explicit `mesh_dimensions` for
+PME, and static `miller_bounds` or prebuilt `k_vectors` for Ewald reciprocal
+shapes. Avoid parameter estimation and mesh-spacing-to-dimensions inference
+inside traced or hot derivative functions; run setup once outside the transformed
+function and pass constants into the energy call.
+
+These setup rules do not change derivative support. Torch Ewald/PME first and
+second derivatives for training losses come from scalar energy autograd; use
+`torch.autograd.grad(..., create_graph=True)` when differentiating through
+forces or stress. JAX Ewald/PME first-order energy autograd supports positions,
+charges, and strain-first virials. Higher-order JAX support is limited to tested
+position and charge scalar losses; JAX PME cell/stress/strain HVPs remain
+unsupported.
 
 ### Fixed-Cell Metadata Recipes
 

--- a/examples/electrostatics/02_ewald_summation_example.py
+++ b/examples/electrostatics/02_ewald_summation_example.py
@@ -473,6 +473,7 @@ all_charges = []
 all_cells = []
 all_pbc = []
 batch_idx_list = []
+atom_counts = []
 
 print(f"\nBatch Evaluation: Creating {n_systems} systems...")
 
@@ -480,6 +481,7 @@ for i in range(n_systems):
     n_cells = i + 2  # 2×2×2, 3×3×3, 4×4×4
     pos, chrg, cell_i, pbc_i = create_nacl_system(n_cells=n_cells)
     batch_idx_list.extend([i] * len(pos))
+    atom_counts.append(len(pos))
     all_positions.append(pos)
     all_charges.append(chrg)
     all_cells.append(cell_i)
@@ -494,6 +496,7 @@ charges_batch = torch.cat(all_charges, dim=0)
 cells_batch = torch.cat(all_cells, dim=0)
 pbc_batch = torch.cat(all_pbc, dim=0)
 batch_idx = torch.tensor(batch_idx_list, dtype=torch.int32, device=device)
+max_atoms_per_system = max(atom_counts)
 
 # Estimate parameters for the batch with desired accuracy
 params_batch = estimate_ewald_parameters(
@@ -542,6 +545,7 @@ for i in range(n_systems):
 
 # %%
 # Preferred training recipe: derive batched forces from the scalar energy.
+# Pass max_atoms_per_system to avoid CUDA launch-bound inference sync.
 
 positions_batch_ag = positions_batch.detach().clone().requires_grad_(True)
 energies_batch_ag = ewald_summation(
@@ -552,6 +556,7 @@ energies_batch_ag = ewald_summation(
     neighbor_matrix=neighbor_matrix_batch,
     neighbor_matrix_shifts=neighbor_matrix_shifts_batch,
     accuracy=1e-5,
+    max_atoms_per_system=max_atoms_per_system,
 )
 forces_batch_ag = -torch.autograd.grad(energies_batch_ag.sum(), positions_batch_ag)[0]
 

--- a/examples/electrostatics/02_ewald_summation_example.py
+++ b/examples/electrostatics/02_ewald_summation_example.py
@@ -496,6 +496,7 @@ charges_batch = torch.cat(all_charges, dim=0)
 cells_batch = torch.cat(all_cells, dim=0)
 pbc_batch = torch.cat(all_pbc, dim=0)
 batch_idx = torch.tensor(batch_idx_list, dtype=torch.int32, device=device)
+# Host-known launch bound from the systems constructed above.
 max_atoms_per_system = max(atom_counts)
 
 # Estimate parameters for the batch with desired accuracy
@@ -545,7 +546,7 @@ for i in range(n_systems):
 
 # %%
 # Preferred training recipe: derive batched forces from the scalar energy.
-# Pass max_atoms_per_system to avoid CUDA launch-bound inference sync.
+# Passing max_atoms_per_system avoids reciprocal-kernel launch-bound inference.
 
 positions_batch_ag = positions_batch.detach().clone().requires_grad_(True)
 energies_batch_ag = ewald_summation(

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
@@ -213,6 +213,30 @@ def _recip_ksum_energy_torch(
     return energy
 
 
+def _resolve_max_atoms_per_system(
+    max_atoms_per_system_hint: int,
+    atom_start: torch.Tensor,
+    atom_end: torch.Tensor,
+    num_atoms: int,
+) -> int:
+    """Resolve batched launch bound; hint ``0`` infers from atom ranges (may sync)."""
+    if num_atoms == 0:
+        return 0
+    value = int(max_atoms_per_system_hint)
+    if value > 0:
+        return value
+    return int((atom_end - atom_start).max().item())
+
+
+def _fake_need_flags(args: tuple) -> tuple[bool, bool, bool]:
+    """Parse trailing ``need_pos``, ``need_charge``, ``need_cell`` from forward fakes."""
+    if len(args) == 8:
+        return bool(args[-3]), bool(args[-2]), bool(args[-1])
+    if len(args) == 12:
+        return bool(args[-4]), bool(args[-3]), bool(args[-2])
+    raise RuntimeError(f"Unexpected Ewald reciprocal fake signature length {len(args)}")
+
+
 def _run_fill(
     bundle,
     positions,
@@ -230,6 +254,7 @@ def _run_fill(
     wp_vec,
     device,
     want_cellgrad=False,
+    max_atoms_per_system_hint: int = 0,
 ):
     """Launch the (reused hand-written) fill kernel; return cos/sin/S_real/S_imag.
 
@@ -256,7 +281,9 @@ def _run_fill(
             total_charges = _wp_zeros_f64(num_systems, positions.device)
             wp_as = _wp(atom_start, wp.int32)
             wp_ae = _wp(atom_end, wp.int32)
-            max_atoms = int((atom_end - atom_start).max().item()) if num_atoms else 0
+            max_atoms = _resolve_max_atoms_per_system(
+                max_atoms_per_system_hint, atom_start, atom_end, num_atoms
+            )
             max_blocks = (max_atoms + BATCH_BLOCK_SIZE - 1) // BATCH_BLOCK_SIZE
             max_blocks = max(max_blocks, 1)
             use_tiled_fill = can_tile_ewald_recip_on_device(
@@ -448,6 +475,7 @@ def _forward_impl(
     need_pos,
     need_charge,
     need_cell,
+    max_atoms_per_system_hint: int = 0,
 ):
     """Fused recip forward: energy (always) + detached ``dE/dR`` / ``dE/dq`` caches.
 
@@ -509,6 +537,7 @@ def _forward_impl(
         wp_vec,
         device,
         want_cellgrad=want_cellgrad,
+        max_atoms_per_system_hint=max_atoms_per_system_hint,
     )
     if cellgrad_fill is not None:
         cellgrad_cache = cellgrad_fill.detach()
@@ -564,6 +593,7 @@ def _backward_impl(
     need_pos,
     need_charge,
     need_cell,
+    max_atoms_per_system_hint: int = 0,
 ):
     """First backward: scale the cached atom-major dE/dR / dE/dq; recompute k/V on demand.
 
@@ -763,6 +793,7 @@ def _double_backward_impl(
     need_pos,
     need_charge,
     need_cell,
+    max_atoms_per_system_hint: int = 0,
 ):
     # ``dEdR_cache`` / ``dEdq_cache`` (the backward op's leading first-order caches) and
     # the trailing ``need_*`` flags are accepted for positional alignment but unused: the
@@ -800,7 +831,9 @@ def _double_backward_impl(
     use_charge_db = bool(need_charge)
     use_cell_db = bool(need_cell)
     if batched and num_atoms:
-        max_atoms = int((atom_end - atom_start).max().item())
+        max_atoms = _resolve_max_atoms_per_system(
+            max_atoms_per_system_hint, atom_start, atom_end, num_atoms
+        )
     else:
         max_atoms = num_atoms
     use_tiled_reduce = (
@@ -1061,6 +1094,7 @@ def _recip_forward_batch(
     need_pos: bool,
     need_charge: bool,
     need_cell: bool,
+    max_atoms_per_system_hint: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return _forward_impl(
         positions,
@@ -1075,6 +1109,7 @@ def _recip_forward_batch(
         need_pos,
         need_charge,
         need_cell,
+        max_atoms_per_system_hint,
     )
 
 
@@ -1095,6 +1130,7 @@ def _recip_backward_batch(
     need_pos: bool,
     need_charge: bool,
     need_cell: bool,
+    max_atoms_per_system_hint: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return _backward_impl(
         dEdR_cache,
@@ -1113,6 +1149,7 @@ def _recip_backward_batch(
         need_pos,
         need_charge,
         need_cell,
+        max_atoms_per_system_hint,
     )
 
 
@@ -1137,6 +1174,7 @@ def _recip_double_backward_batch(
     need_pos: bool,
     need_charge: bool,
     need_cell: bool,
+    max_atoms_per_system_hint: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return _double_backward_impl(
         v_pos,
@@ -1159,6 +1197,7 @@ def _recip_double_backward_batch(
         need_pos,
         need_charge,
         need_cell,
+        max_atoms_per_system_hint,
     )
 
 
@@ -1176,10 +1215,9 @@ def _recip_double_backward_batch(
 def _recip_forward_fake(positions, *args):
     """Forward fake: ``(energy, dE/dR cache, dE/dq cache, cellgrad cache)``.
 
-    Cache shapes gated by the ``need_pos`` / ``need_charge`` booleans (the last three
-    trailing args are ``need_pos, need_charge, need_cell``).
+    Cache shapes gated by the ``need_pos`` / ``need_charge`` booleans.
     """
-    need_pos, need_charge = bool(args[-3]), bool(args[-2])
+    need_pos, need_charge, _need_cell = _fake_need_flags(args)
     n = positions.shape[0]
     energy = positions.new_empty(n, dtype=torch.float64)
     dEdR = positions.new_empty(n if need_pos else 0, 3, dtype=positions.dtype)
@@ -1266,9 +1304,9 @@ def register_ewald_recip_ops() -> None:
         double_backward_return_arity=5,
     )
 
-    # Batched forward inputs (12): 0 positions, 1 charges, 2 cell, 3 k_vectors,
+    # Batched forward inputs (13): 0 positions, 1 charges, 2 cell, 3 k_vectors,
     #   4 volume, 5 alpha, 6 batch_idx, 7 atom_start, 8 atom_end, 9 need_pos,
-    #   10 need_charge, 11 need_cell.
+    #   10 need_charge, 11 need_cell, 12 max_atoms_per_system_hint.
     _RECIP_BATCH = register_warp_op_chain(
         name="nvalchemiops::ewald_recip_energy_batch",
         forward=_recip_forward_batch,
@@ -1281,10 +1319,10 @@ def register_ewald_recip_ops() -> None:
         propagate_outputs=(0,),
         save_forward_outputs=(1, 2, 3),
         diff_input_positions=(0, 1, 3, 4),
-        n_forward_inputs=12,
+        n_forward_inputs=13,
         backward_return_arity=4,
         second_order_diff_positions=(3, 4, 5, 7, 8),
-        n_backward_inputs=16,
+        n_backward_inputs=17,
         double_backward_return_arity=5,
         batch_match=True,
     )

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
@@ -214,15 +214,15 @@ def _recip_ksum_energy_torch(
 
 
 def _resolve_max_atoms_per_system(
-    max_atoms_per_system_hint: int,
+    max_atoms_per_system_bound: int,
     atom_start: torch.Tensor,
     atom_end: torch.Tensor,
     num_atoms: int,
 ) -> int:
-    """Resolve batched launch bound; hint ``0`` infers from atom ranges (may sync)."""
+    """Resolve batched launch bound; bound ``0`` infers from atom ranges (may sync)."""
     if num_atoms == 0:
         return 0
-    value = int(max_atoms_per_system_hint)
+    value = int(max_atoms_per_system_bound)
     if value > 0:
         return value
     return int((atom_end - atom_start).max().item())
@@ -254,7 +254,7 @@ def _run_fill(
     wp_vec,
     device,
     want_cellgrad=False,
-    max_atoms_per_system_hint: int = 0,
+    max_atoms_per_system_bound: int = 0,
 ):
     """Launch the (reused hand-written) fill kernel; return cos/sin/S_real/S_imag.
 
@@ -282,7 +282,7 @@ def _run_fill(
             wp_as = _wp(atom_start, wp.int32)
             wp_ae = _wp(atom_end, wp.int32)
             max_atoms = _resolve_max_atoms_per_system(
-                max_atoms_per_system_hint, atom_start, atom_end, num_atoms
+                max_atoms_per_system_bound, atom_start, atom_end, num_atoms
             )
             max_blocks = (max_atoms + BATCH_BLOCK_SIZE - 1) // BATCH_BLOCK_SIZE
             max_blocks = max(max_blocks, 1)
@@ -475,7 +475,7 @@ def _forward_impl(
     need_pos,
     need_charge,
     need_cell,
-    max_atoms_per_system_hint: int = 0,
+    max_atoms_per_system_bound: int = 0,
 ):
     """Fused recip forward: energy (always) + detached ``dE/dR`` / ``dE/dq`` caches.
 
@@ -537,7 +537,7 @@ def _forward_impl(
         wp_vec,
         device,
         want_cellgrad=want_cellgrad,
-        max_atoms_per_system_hint=max_atoms_per_system_hint,
+        max_atoms_per_system_bound=max_atoms_per_system_bound,
     )
     if cellgrad_fill is not None:
         cellgrad_cache = cellgrad_fill.detach()
@@ -593,7 +593,7 @@ def _backward_impl(
     need_pos,
     need_charge,
     need_cell,
-    max_atoms_per_system_hint: int = 0,
+    max_atoms_per_system_bound: int = 0,
 ):
     """First backward: scale the cached atom-major dE/dR / dE/dq; recompute k/V on demand.
 
@@ -793,7 +793,7 @@ def _double_backward_impl(
     need_pos,
     need_charge,
     need_cell,
-    max_atoms_per_system_hint: int = 0,
+    max_atoms_per_system_bound: int = 0,
 ):
     # ``dEdR_cache`` / ``dEdq_cache`` (the backward op's leading first-order caches) and
     # the trailing ``need_*`` flags are accepted for positional alignment but unused: the
@@ -832,7 +832,7 @@ def _double_backward_impl(
     use_cell_db = bool(need_cell)
     if batched and num_atoms:
         max_atoms = _resolve_max_atoms_per_system(
-            max_atoms_per_system_hint, atom_start, atom_end, num_atoms
+            max_atoms_per_system_bound, atom_start, atom_end, num_atoms
         )
     else:
         max_atoms = num_atoms
@@ -1094,7 +1094,7 @@ def _recip_forward_batch(
     need_pos: bool,
     need_charge: bool,
     need_cell: bool,
-    max_atoms_per_system_hint: int = 0,
+    max_atoms_per_system_bound: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return _forward_impl(
         positions,
@@ -1109,7 +1109,7 @@ def _recip_forward_batch(
         need_pos,
         need_charge,
         need_cell,
-        max_atoms_per_system_hint,
+        max_atoms_per_system_bound,
     )
 
 
@@ -1130,7 +1130,7 @@ def _recip_backward_batch(
     need_pos: bool,
     need_charge: bool,
     need_cell: bool,
-    max_atoms_per_system_hint: int = 0,
+    max_atoms_per_system_bound: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return _backward_impl(
         dEdR_cache,
@@ -1149,7 +1149,7 @@ def _recip_backward_batch(
         need_pos,
         need_charge,
         need_cell,
-        max_atoms_per_system_hint,
+        max_atoms_per_system_bound,
     )
 
 
@@ -1174,7 +1174,7 @@ def _recip_double_backward_batch(
     need_pos: bool,
     need_charge: bool,
     need_cell: bool,
-    max_atoms_per_system_hint: int = 0,
+    max_atoms_per_system_bound: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return _double_backward_impl(
         v_pos,
@@ -1197,7 +1197,7 @@ def _recip_double_backward_batch(
         need_pos,
         need_charge,
         need_cell,
-        max_atoms_per_system_hint,
+        max_atoms_per_system_bound,
     )
 
 
@@ -1306,7 +1306,7 @@ def register_ewald_recip_ops() -> None:
 
     # Batched forward inputs (13): 0 positions, 1 charges, 2 cell, 3 k_vectors,
     #   4 volume, 5 alpha, 6 batch_idx, 7 atom_start, 8 atom_end, 9 need_pos,
-    #   10 need_charge, 11 need_cell, 12 max_atoms_per_system_hint.
+    #   10 need_charge, 11 need_cell, 12 max_atoms_per_system_bound.
     _RECIP_BATCH = register_warp_op_chain(
         name="nvalchemiops::ewald_recip_energy_batch",
         forward=_recip_forward_batch,

--- a/nvalchemiops/torch/interactions/electrostatics/_util.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_util.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import torch
 
 __all__ = [
+    "_has_potentially_geometry_dependent_charges",
     "_InjectCachedEvalGrad",
     "_InjectCachedEvalGradWithFallback",
     "_InjectChargeGrad",
@@ -44,6 +45,37 @@ def _sum_charge_gradients(
 ) -> torch.Tensor:
     """Sum electrostatic charge gradients with traceable Torch arithmetic."""
     return real_space_charge_grads + reciprocal_charge_grads
+
+
+def _has_potentially_geometry_dependent_charges(
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+) -> bool:
+    """Return whether ``charges`` may carry a q(R) autograd path.
+
+    A non-leaf charge tensor may depend on positions, e.g. charges = q(positions).
+    Custom backwards must avoid differentiating a connected recompute with respect
+    to both positions and charges and then returning both gradients, because
+    PyTorch would apply dE/dq * dq/dR twice.
+
+    Returns
+    -------
+    bool
+        True when ``positions`` and ``charges`` both require gradients and
+        ``charges`` is a non-leaf tensor that may depend on ``positions``.
+
+    Notes
+    -----
+    Issue #115 is prevented by routing these workloads through
+    :class:`_InjectChargeGrad`, eager electrostatics chains, or safe cached
+    fallback paths that recompute independent partial derivatives before PyTorch
+    applies the dE/dq * dq/dR chain term exactly once.
+    """
+    return bool(
+        positions.requires_grad
+        and charges.requires_grad
+        and charges.grad_fn is not None
+    )
 
 
 def _detach_setup_tensor(tensor: torch.Tensor | None) -> torch.Tensor | None:
@@ -504,6 +536,7 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_energy):
         """Use caches for uniform eval, else lazily recompute the energy graph."""
+        create_graph = torch.is_grad_enabled()
         (
             positions,
             charges,
@@ -513,7 +546,97 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
             cell_grad_state,
         ) = ctx.saved_tensors
 
-        if torch.is_grad_enabled() or not _is_uniform_cotangent(grad_energy):
+        if create_graph or not _is_uniform_cotangent(grad_energy):
+            # q(R) routing:
+            # - create_graph: return connected position/cell/alpha gradients only; do not
+            #   also return grad_charges from the same connected recompute.
+            # - first-order weighted loss: recompute position/cell/alpha partials with
+            #   charges detached, then return dE/dq separately so PyTorch chains q(R) once.
+            if _has_potentially_geometry_dependent_charges(positions, charges):
+                if create_graph:
+                    diff_inputs = []
+                    diff_names = []
+                    for name, tensor in (
+                        ("positions", positions),
+                        ("cell", cell),
+                    ):
+                        if tensor.requires_grad:
+                            diff_inputs.append(tensor)
+                            diff_names.append(name)
+                    with torch.enable_grad():
+                        recomputed = ctx.fallback_fn(positions, charges, cell)
+                        if diff_inputs:
+                            diff_grads = torch.autograd.grad(
+                                recomputed,
+                                tuple(diff_inputs),
+                                grad_outputs=grad_energy,
+                                allow_unused=True,
+                                create_graph=True,
+                            )
+                            grad_map = dict(zip(diff_names, diff_grads, strict=True))
+                        else:
+                            grad_map = {}
+                    return (
+                        None,
+                        grad_map.get("positions"),
+                        None,
+                        grad_map.get("cell"),
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
+
+                partial_inputs = []
+                partial_names = []
+                if positions.requires_grad:
+                    partial_inputs.append(positions)
+                    partial_names.append("positions")
+                if cell.requires_grad:
+                    partial_inputs.append(cell)
+                    partial_names.append("cell")
+
+                with torch.enable_grad():
+                    partial_map = {}
+                    if partial_inputs:
+                        recomputed_partial = ctx.fallback_fn(
+                            positions,
+                            charges.detach(),
+                            cell,
+                        )
+                        partial_grads = torch.autograd.grad(
+                            recomputed_partial,
+                            tuple(partial_inputs),
+                            grad_outputs=grad_energy,
+                            allow_unused=True,
+                            create_graph=create_graph,
+                        )
+                        partial_map = dict(
+                            zip(partial_names, partial_grads, strict=True)
+                        )
+
+                    grad_charges = None
+                    if charges.requires_grad:
+                        recomputed_charge = ctx.fallback_fn(positions, charges, cell)
+                        (grad_charges,) = torch.autograd.grad(
+                            recomputed_charge,
+                            charges,
+                            grad_outputs=grad_energy,
+                            allow_unused=True,
+                            create_graph=create_graph,
+                        )
+                return (
+                    None,
+                    partial_map.get("positions"),
+                    grad_charges,
+                    partial_map.get("cell"),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
             with torch.enable_grad():
                 recomputed = ctx.fallback_fn(positions, charges, cell)
                 diff_inputs = []
@@ -534,7 +657,7 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
                         tuple(diff_inputs),
                         grad_outputs=grad_energy,
                         allow_unused=True,
-                        create_graph=torch.is_grad_enabled(),
+                        create_graph=create_graph,
                     )
                     grad_map = dict(zip(diff_names, diff_grads, strict=True))
             return (

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -244,6 +244,26 @@ def _atom_ranges(
     return starts.to(torch.int32), ends.to(torch.int32)
 
 
+def _normalize_max_atoms_per_system(
+    max_atoms_per_system: int | None,
+    positions: torch.Tensor,
+    batch_idx: torch.Tensor | None,
+) -> int:
+    """Convert public ``max_atoms_per_system`` to a custom-op hint (0 = infer)."""
+    if batch_idx is None or max_atoms_per_system is None:
+        return 0
+    value = int(max_atoms_per_system)
+    if positions.shape[0] == 0:
+        if value < 0:
+            raise ValueError("max_atoms_per_system must be non-negative")
+        return value
+    if value <= 0:
+        raise ValueError("max_atoms_per_system must be positive for non-empty batches")
+    if value > positions.shape[0]:
+        raise ValueError("max_atoms_per_system cannot exceed the total number of atoms")
+    return value
+
+
 def _attach_virial_charge_grad(
     virial_value: torch.Tensor,
     charges: torch.Tensor,
@@ -549,6 +569,7 @@ def _reciprocal_space_energy(
     alpha: torch.Tensor,
     *,
     batch_idx: torch.Tensor | None,
+    max_atoms_per_system: int | None = None,
 ) -> torch.Tensor:
     """Per-atom reciprocal-space Ewald energy, connected to autograd via the chain.
 
@@ -604,6 +625,9 @@ def _reciprocal_space_energy(
         )
         volume = torch.abs(torch.linalg.det(cell)).to(torch.float64)
         atom_start, atom_end = _atom_ranges(batch_idx, num_systems)
+        max_atoms_hint = _normalize_max_atoms_per_system(
+            max_atoms_per_system, positions, batch_idx
+        )
         e_ksum, _, _, _ = torch.ops.nvalchemiops.ewald_recip_energy_batch(
             positions,
             charges,
@@ -617,6 +641,7 @@ def _reciprocal_space_energy(
             need_pos,
             need_charge,
             need_cell,
+            max_atoms_hint,
         )
 
     return _apply_reciprocal_corrections(e_ksum, charges, volume, alpha, batch_idx)
@@ -965,6 +990,8 @@ def ewald_reciprocal_space(
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
     hybrid_forces: bool = False,
+    *,
+    max_atoms_per_system: int | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     r"""Compute reciprocal-space Ewald energy and optionally forces, charge gradients, virial.
 
@@ -1002,6 +1029,13 @@ def ewald_reciprocal_space(
         charge gradients are attached to the energy via a straight-through
         trick.  Forces and virial are forward-only (not differentiable).
         See :func:`ewald_real_space` for details.
+    max_atoms_per_system : int, optional, keyword-only
+        Maximum number of atoms in any single system when ``batch_idx`` is
+        provided. Passing this host-known upper bound avoids CUDA host
+        synchronization from launch-size inference in the reciprocal kernel.
+        Overestimates are safe but may launch extra blocks. When omitted, the
+        bound is inferred from ``atom_start`` / ``atom_end`` and may
+        synchronize on CUDA.
 
     Returns
     -------
@@ -1039,6 +1073,7 @@ def ewald_reciprocal_space(
         compute_virial=compute_virial,
         hybrid_forces=hybrid_forces,
         allow_cell_grad_with_k_vectors=False,
+        max_atoms_per_system=max_atoms_per_system,
     )
 
 
@@ -1054,6 +1089,7 @@ def _ewald_reciprocal_space(
     compute_virial: bool = False,
     hybrid_forces: bool = False,
     allow_cell_grad_with_k_vectors: bool = False,
+    max_atoms_per_system: int | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     """Private reciprocal-space implementation with an internal cell-gradient path."""
     component_deprecated_flags = tuple(
@@ -1177,6 +1213,7 @@ def _ewald_reciprocal_space(
                     k_vectors_hybrid,
                     alpha,
                     batch_idx=batch_idx,
+                    max_atoms_per_system=max_atoms_per_system,
                 )
 
             energies = _InjectCachedEvalGradWithFallback.apply(
@@ -1224,7 +1261,13 @@ def _ewald_reciprocal_space(
         return _build_result(energies, forces, charge_grads_out, virial)
 
     energies = _reciprocal_space_energy(
-        positions, charges, cell, k_vectors_2d, alpha, batch_idx=batch_idx
+        positions,
+        charges,
+        cell,
+        k_vectors_2d,
+        alpha,
+        batch_idx=batch_idx,
+        max_atoms_per_system=max_atoms_per_system,
     )
 
     if not want_direct:
@@ -1250,7 +1293,15 @@ def _ewald_reciprocal_space(
     if compute_virial and charges.requires_grad:
 
         def _rec_energy_fn(p, q, c, k):
-            return _reciprocal_space_energy(p, q, c, k, alpha, batch_idx=batch_idx)
+            return _reciprocal_space_energy(
+                p,
+                q,
+                c,
+                k,
+                alpha,
+                batch_idx=batch_idx,
+                max_atoms_per_system=max_atoms_per_system,
+            )
 
         virial = _attach_virial_charge_grad(
             virial,
@@ -1311,6 +1362,7 @@ def ewald_summation(
     slab_correction: bool = False,
     *,
     miller_bounds: tuple[int, int, int] | torch.Tensor | None = None,
+    max_atoms_per_system: int | None = None,
 ) -> tuple[torch.Tensor, ...] | torch.Tensor:
     """Complete Ewald summation for long-range electrostatics.
 
@@ -1335,6 +1387,10 @@ def ewald_summation(
         Precomputed Miller-index half-bounds used when ``k_vectors`` is not
         supplied. Passing Python integer bounds avoids deriving range sizes from
         device tensors inside regenerated-k-vector loops.
+    max_atoms_per_system : int, optional, keyword-only
+        Maximum number of atoms in any single system when ``batch_idx`` is
+        provided. See :func:`ewald_reciprocal_space` for the sync-free launch
+        contract.
     batch_idx : torch.Tensor, shape (N,), optional
         System index for each atom. When provided, atoms must be grouped by
         system: ``batch_idx`` must be contiguous, nondecreasing, and use system
@@ -1508,6 +1564,7 @@ def ewald_summation(
             compute_virial=compute_virial,
             hybrid_forces=hybrid_forces,
             allow_cell_grad_with_k_vectors=generated_k_vectors,
+            max_atoms_per_system=max_atoms_per_system,
         )
         return real, reciprocal
 

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -44,7 +44,7 @@ The full ``ewald_summation`` API treats energy autograd as the differentiable
 contract; its direct-output flags warn and are deprecated. The component APIs
 (``ewald_real_space`` and ``ewald_reciprocal_space``) intentionally retain direct
 forces as no-autograd MD/inference escape hatches. Component charge-gradient,
-virial, and hybrid direct outputs are legacy training-style outputs and warn.
+virial, and hybrid direct outputs are deprecated training-style outputs and warn.
 
 Examples
 --------
@@ -109,6 +109,7 @@ from nvalchemiops.torch.interactions.electrostatics._util import (
     _component_direct_output_deprecation_msg,
     _detach_setup_tensor,
     _direct_output_deprecation_msg,
+    _has_potentially_geometry_dependent_charges,
     _InjectCachedEvalGrad,
     _InjectCachedEvalGradWithFallback,
     _InjectChargeGrad,
@@ -213,7 +214,7 @@ def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, int]:
 #     the reciprocal ``cell`` gradient through Torch.
 #
 # When nothing requires grad, the forward-only ``_DerivState.E`` kernel runs with no
-# derivative state (inference performance preserved). The legacy direct flags
+# derivative state (inference performance preserved). The deprecated direct flags
 # (``compute_forces`` / ``compute_charge_gradients`` / ``compute_virial`` /
 # ``hybrid_forces``) are served by :mod:`_ewald_direct` (tape-free forward kernels).
 
@@ -254,9 +255,9 @@ def _attach_virial_charge_grad(
 ) -> torch.Tensor:
     """Give the direct (kernel) ``virial`` a charge gradient via strain autograd.
 
-    The legacy ``compute_virial`` output is differentiable w.r.t. ``charges``
-    (the historical tape connected it). The direct factory kernel output is
-    forward-only, so this re-attaches the charge gradient with a straight-through:
+    The deprecated ``compute_virial`` output remains differentiable w.r.t.
+    ``charges``. The direct factory kernel output is forward-only, so this
+    re-attaches the charge gradient with a straight-through:
     the value stays the kernel ``virial_value`` while the gradient comes from the
     row-vector displacement virial ``W = -dE/dstrain`` of the autograd-connected
     energy, recomputed with ``positions`` / ``cell`` detached so only the
@@ -321,12 +322,12 @@ def _real_space_energy_outputs(
     want_charge_grad: bool = False,
     want_virial: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
-    """Per-atom real-space Ewald energy plus optional legacy direct outputs.
+    """Per-atom real-space Ewald energy plus optional deprecated direct outputs.
 
     Differentiable in ``positions`` / ``charges`` through the explicit chain and in ``cell``
     through :func:`real_space_cell_connect` (literal ``dE/dcell``). When no input
     requires grad, the plain forward-only chain op runs (no derivative state).
-    Legacy direct outputs reuse the same forward launch and remain forward-only.
+    Deprecated direct outputs reuse the same forward launch and remain forward-only.
     """
     num_atoms = positions.shape[0]
     device = positions.device
@@ -710,6 +711,14 @@ def ewald_real_space(
     Energies are always float64 for numerical stability during accumulation.
     Forces, virial, and charge gradients match the input dtype (float32 or float64).
 
+    When ``charges`` is a non-leaf tensor that may depend on ``positions``
+    (q = q(R)), ordinary first-order losses may use cached partial derivatives
+    and let PyTorch apply dE/dq * dq/dR once. Weighted losses and higher-order
+    derivatives recompute safe partials or connected gradients as needed to
+    avoid double-counting that chain term (issue #115). Hybrid direct-output
+    mode uses :func:`_InjectChargeGrad` because positions and cell are detached
+    and direct forces/virials are forward-only.
+
     """
     component_deprecated_flags = tuple(
         name
@@ -790,6 +799,12 @@ def ewald_real_space(
             want_virial=compute_virial,
         )
         if charges.requires_grad:
+            charge_graph_depends_on_positions = (
+                _has_potentially_geometry_dependent_charges(
+                    positions,
+                    charges,
+                )
+            )
 
             def _fallback(p, q, c):
                 return _real_space_energy(
@@ -806,17 +821,25 @@ def ewald_real_space(
                     mask_value=mask_value,
                 )
 
-            energies = _InjectCachedEvalGradWithFallback.apply(
-                energies,
-                positions,
-                charges,
-                cell,
-                None,
-                charge_grads.detach(),
-                None,
-                batch_idx,
-                _fallback,
-            )
+            if charge_graph_depends_on_positions:
+                energies = _InjectChargeGrad.apply(
+                    energies,
+                    charges,
+                    charge_grads.detach(),
+                    batch_idx,
+                )
+            else:
+                energies = _InjectCachedEvalGradWithFallback.apply(
+                    energies,
+                    positions,
+                    charges,
+                    cell,
+                    None,
+                    charge_grads.detach(),
+                    None,
+                    batch_idx,
+                    _fallback,
+                )
         return _build_result(energies, forces, charge_grads.to(positions.dtype), virial)
 
     if (
@@ -824,6 +847,7 @@ def ewald_real_space(
         and not cell.requires_grad
         and not alpha.requires_grad
         and (positions.requires_grad or charges.requires_grad)
+        and not _has_potentially_geometry_dependent_charges(positions, charges)
     ):
         # Ordinary scalar first-derivative evaluations can use detached direct
         # caches. Weighted losses and create_graph=True rebuild the true energy
@@ -873,7 +897,7 @@ def ewald_real_space(
         )
         return energies
 
-    # Differentiable energy plus optional legacy direct outputs from one chain
+    # Differentiable energy plus optional deprecated direct outputs from one chain
     # forward launch. Autograd still propagates only from the energy output.
     energies, forces, charge_grads, virial = _real_space_energy_outputs(
         positions,
@@ -895,7 +919,7 @@ def ewald_real_space(
     if not want_direct:
         return energies
 
-    # The legacy direct virial is differentiable w.r.t. charges; re-attach that
+    # The deprecated direct virial is differentiable w.r.t. charges; re-attach that
     # gradient (value stays the kernel output) via the strain virial of the
     # autograd-connected real-space energy.
     if compute_virial and charges.requires_grad:
@@ -1010,6 +1034,12 @@ def ewald_reciprocal_space(
     Forces, virial, and charge gradients match the input dtype (float32 or float64).
     ``k_vectors`` are setup metadata. Caller-supplied vectors are treated as
     static values that correspond to the current ``cell``.
+
+    When ``charges`` is a non-leaf tensor that may depend on ``positions``
+    (q = q(R)), ordinary first-order losses may use cached partial derivatives
+    and let PyTorch apply dE/dq * dq/dR once. Weighted losses and higher-order
+    derivatives recompute safe partials or connected gradients as needed to
+    avoid double-counting that chain term (issue #115).
     """
     return _ewald_reciprocal_space(
         positions=positions,
@@ -1152,6 +1182,12 @@ def _ewald_reciprocal_space(
             batch_idx,
         )
         if charges.requires_grad:
+            charge_graph_depends_on_positions = (
+                _has_potentially_geometry_dependent_charges(
+                    positions,
+                    charges,
+                )
+            )
 
             def _fallback(p, q, c):
                 return _reciprocal_space_energy(
@@ -1163,17 +1199,25 @@ def _ewald_reciprocal_space(
                     batch_idx=batch_idx,
                 )
 
-            energies = _InjectCachedEvalGradWithFallback.apply(
-                energies,
-                positions,
-                charges,
-                cell,
-                None,
-                charge_grads.detach(),
-                None,
-                batch_idx,
-                _fallback,
-            )
+            if charge_graph_depends_on_positions:
+                energies = _InjectChargeGrad.apply(
+                    energies,
+                    charges,
+                    charge_grads.detach(),
+                    batch_idx,
+                )
+            else:
+                energies = _InjectCachedEvalGradWithFallback.apply(
+                    energies,
+                    positions,
+                    charges,
+                    cell,
+                    None,
+                    charge_grads.detach(),
+                    None,
+                    batch_idx,
+                    _fallback,
+                )
         return _build_result(energies, forces, charge_grads.to(positions.dtype), virial)
 
     differentiable_inputs = (
@@ -1381,6 +1425,12 @@ def ewald_summation(
     Energies are accumulated in float64 for numerical stability. Deprecated
     direct forces, charge gradients, and virials match the input dtype where the
     underlying component path returns typed outputs.
+
+    When ``charges`` is a non-leaf tensor that may depend on ``positions``
+    (q = q(R)), ordinary first-order losses may use cached partial derivatives
+    and let PyTorch apply dE/dq * dq/dR once. Weighted losses and higher-order
+    derivatives recompute safe partials or connected gradients as needed to
+    avoid double-counting that chain term (issue #115).
 
     Enabled output flags are appended in order: energies, [forces],
     [charge_gradients], [virial]. A single output is returned unwrapped;

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -244,26 +244,6 @@ def _atom_ranges(
     return starts.to(torch.int32), ends.to(torch.int32)
 
 
-def _normalize_max_atoms_per_system(
-    max_atoms_per_system: int | None,
-    positions: torch.Tensor,
-    batch_idx: torch.Tensor | None,
-) -> int:
-    """Convert public ``max_atoms_per_system`` to a custom-op hint (0 = infer)."""
-    if batch_idx is None or max_atoms_per_system is None:
-        return 0
-    value = int(max_atoms_per_system)
-    if positions.shape[0] == 0:
-        if value < 0:
-            raise ValueError("max_atoms_per_system must be non-negative")
-        return value
-    if value <= 0:
-        raise ValueError("max_atoms_per_system must be positive for non-empty batches")
-    if value > positions.shape[0]:
-        raise ValueError("max_atoms_per_system cannot exceed the total number of atoms")
-    return value
-
-
 def _attach_virial_charge_grad(
     virial_value: torch.Tensor,
     charges: torch.Tensor,
@@ -625,9 +605,20 @@ def _reciprocal_space_energy(
         )
         volume = torch.abs(torch.linalg.det(cell)).to(torch.float64)
         atom_start, atom_end = _atom_ranges(batch_idx, num_systems)
-        max_atoms_hint = _normalize_max_atoms_per_system(
-            max_atoms_per_system, positions, batch_idx
-        )
+        max_atoms_bound = 0
+        if max_atoms_per_system is not None:
+            max_atoms_bound = int(max_atoms_per_system)
+            if positions.shape[0] == 0:
+                if max_atoms_bound < 0:
+                    raise ValueError("max_atoms_per_system must be non-negative")
+            elif max_atoms_bound <= 0:
+                raise ValueError(
+                    "max_atoms_per_system must be positive for non-empty batches"
+                )
+            elif max_atoms_bound > positions.shape[0]:
+                raise ValueError(
+                    "max_atoms_per_system cannot exceed the total number of atoms"
+                )
         e_ksum, _, _, _ = torch.ops.nvalchemiops.ewald_recip_energy_batch(
             positions,
             charges,
@@ -641,7 +632,7 @@ def _reciprocal_space_energy(
             need_pos,
             need_charge,
             need_cell,
-            max_atoms_hint,
+            max_atoms_bound,
         )
 
     return _apply_reciprocal_corrections(e_ksum, charges, volume, alpha, batch_idx)

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -716,8 +716,8 @@ def ewald_real_space(
     and let PyTorch apply dE/dq * dq/dR once. Weighted losses and higher-order
     derivatives recompute safe partials or connected gradients as needed to
     avoid double-counting that chain term (issue #115). Hybrid direct-output
-    mode uses :func:`_InjectChargeGrad` because positions and cell are detached
-    and direct forces/virials are forward-only.
+    mode uses the same cached fallback connector so weighted q(R) losses can
+    recover a valid energy gradient when the forward energy was detached.
 
     """
     component_deprecated_flags = tuple(
@@ -799,12 +799,6 @@ def ewald_real_space(
             want_virial=compute_virial,
         )
         if charges.requires_grad:
-            charge_graph_depends_on_positions = (
-                _has_potentially_geometry_dependent_charges(
-                    positions,
-                    charges,
-                )
-            )
 
             def _fallback(p, q, c):
                 return _real_space_energy(
@@ -821,25 +815,17 @@ def ewald_real_space(
                     mask_value=mask_value,
                 )
 
-            if charge_graph_depends_on_positions:
-                energies = _InjectChargeGrad.apply(
-                    energies,
-                    charges,
-                    charge_grads.detach(),
-                    batch_idx,
-                )
-            else:
-                energies = _InjectCachedEvalGradWithFallback.apply(
-                    energies,
-                    positions,
-                    charges,
-                    cell,
-                    None,
-                    charge_grads.detach(),
-                    None,
-                    batch_idx,
-                    _fallback,
-                )
+            energies = _InjectCachedEvalGradWithFallback.apply(
+                energies,
+                positions,
+                charges,
+                cell,
+                None,
+                charge_grads.detach(),
+                None,
+                batch_idx,
+                _fallback,
+            )
         return _build_result(energies, forces, charge_grads.to(positions.dtype), virial)
 
     if (
@@ -1182,12 +1168,6 @@ def _ewald_reciprocal_space(
             batch_idx,
         )
         if charges.requires_grad:
-            charge_graph_depends_on_positions = (
-                _has_potentially_geometry_dependent_charges(
-                    positions,
-                    charges,
-                )
-            )
 
             def _fallback(p, q, c):
                 return _reciprocal_space_energy(
@@ -1199,25 +1179,17 @@ def _ewald_reciprocal_space(
                     batch_idx=batch_idx,
                 )
 
-            if charge_graph_depends_on_positions:
-                energies = _InjectChargeGrad.apply(
-                    energies,
-                    charges,
-                    charge_grads.detach(),
-                    batch_idx,
-                )
-            else:
-                energies = _InjectCachedEvalGradWithFallback.apply(
-                    energies,
-                    positions,
-                    charges,
-                    cell,
-                    None,
-                    charge_grads.detach(),
-                    None,
-                    batch_idx,
-                    _fallback,
-                )
+            energies = _InjectCachedEvalGradWithFallback.apply(
+                energies,
+                positions,
+                charges,
+                cell,
+                None,
+                charge_grads.detach(),
+                None,
+                batch_idx,
+                _fallback,
+            )
         return _build_result(energies, forces, charge_grads.to(positions.dtype), virial)
 
     differentiable_inputs = (

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -52,7 +52,7 @@ The batch_idx parameter determines kernel dispatch:
 contract; its direct-output flags warn and are deprecated. The
 ``pme_reciprocal_space`` component intentionally retains direct forces as
 no-autograd MD/inference escape hatches. Component charge-gradient, virial,
-and hybrid direct outputs are legacy training-style outputs and warn.
+and hybrid direct outputs are deprecated training-style outputs and warn.
 
 MATHEMATICAL FORMULATION
 ========================
@@ -165,6 +165,7 @@ References
 
 import math
 import warnings
+from contextlib import nullcontext
 
 import torch
 import warp as wp
@@ -195,6 +196,7 @@ from nvalchemiops.torch.interactions.electrostatics._util import (
     _component_direct_output_deprecation_msg,
     _detach_setup_tensor,
     _direct_output_deprecation_msg,
+    _has_potentially_geometry_dependent_charges,
     _InjectCachedEvalGrad,
     _InjectCachedEvalGradWithFallback,
     _InjectChargeGrad,
@@ -320,8 +322,6 @@ def _pme_scoped_warp_stream(device: torch.device):
     up on the stream being captured rather than Warp's default stream.
     """
     if device.type != "cuda":
-        from contextlib import nullcontext
-
         return nullcontext()
     torch_stream = torch.cuda.current_stream(device)
     return wp.ScopedStream(wp.stream_from_torch(torch_stream))
@@ -372,7 +372,7 @@ def pme_green_structure_factor(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     r"""Compute the PME Green's function and B-spline structure-factor correction.
 
-    Compatibility entry point retained for the 0.3.1 public API. Returns the
+    Compatibility entry point for the public PME API. Returns the
     volume-normalized Coulomb Green's function and the squared B-spline structure
     factor used for PME deconvolution:
 
@@ -2168,6 +2168,7 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_energy):
         """Return cached first gradients or recompute for higher-order fallback."""
+        create_graph = torch.is_grad_enabled()
         (
             positions,
             charges,
@@ -2186,7 +2187,169 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
             cached_dEdcell,
         ) = ctx.saved_tensors
 
-        if torch.is_grad_enabled() or not _is_uniform_cotangent(grad_energy):
+        if create_graph or not _is_uniform_cotangent(grad_energy):
+            if _has_potentially_geometry_dependent_charges(positions, charges):
+                if create_graph:
+                    diff_inputs = []
+                    diff_names = []
+                    for name, tensor in (
+                        ("positions", positions),
+                        ("cell", cell),
+                        ("alpha", alpha),
+                    ):
+                        if tensor.requires_grad:
+                            diff_inputs.append(tensor)
+                            diff_names.append(name)
+
+                    with torch.enable_grad():
+                        recomputed, _forces, _charge_grads, _virial = (
+                            _pme_reciprocal_space_impl(
+                                positions,
+                                charges,
+                                cell,
+                                alpha,
+                                ctx.mesh_dimensions,
+                                ctx.spline_order,
+                                batch_idx,
+                                compute_forces=False,
+                                compute_charge_gradients=False,
+                                compute_virial=False,
+                                k_vectors=k_vectors,
+                                k_squared=k_squared,
+                                volume=volume,
+                                cell_inv_t=cell_inv_t,
+                                moduli_x=moduli_x,
+                                moduli_y=moduli_y,
+                                moduli_z=moduli_z,
+                            )
+                        )
+                        if diff_inputs:
+                            diff_grads = torch.autograd.grad(
+                                recomputed,
+                                tuple(diff_inputs),
+                                grad_outputs=grad_energy,
+                                allow_unused=True,
+                                create_graph=True,
+                            )
+                            grad_map = dict(zip(diff_names, diff_grads, strict=True))
+                        else:
+                            grad_map = {}
+                    return (
+                        grad_map.get("positions"),
+                        None,
+                        grad_map.get("cell"),
+                        grad_map.get("alpha"),
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
+
+                partial_inputs = []
+                partial_names = []
+                for name, tensor in (
+                    ("positions", positions),
+                    ("cell", cell),
+                    ("alpha", alpha),
+                ):
+                    if tensor.requires_grad:
+                        partial_inputs.append(tensor)
+                        partial_names.append(name)
+
+                with torch.enable_grad():
+                    partial_map = {}
+                    if partial_inputs:
+                        recomputed_partial, _forces, _charge_grads, _virial = (
+                            _pme_reciprocal_space_impl(
+                                positions,
+                                charges.detach(),
+                                cell,
+                                alpha,
+                                ctx.mesh_dimensions,
+                                ctx.spline_order,
+                                batch_idx,
+                                compute_forces=False,
+                                compute_charge_gradients=False,
+                                compute_virial=False,
+                                k_vectors=k_vectors,
+                                k_squared=k_squared,
+                                volume=volume,
+                                cell_inv_t=cell_inv_t,
+                                moduli_x=moduli_x,
+                                moduli_y=moduli_y,
+                                moduli_z=moduli_z,
+                            )
+                        )
+                        partial_grads = torch.autograd.grad(
+                            recomputed_partial,
+                            tuple(partial_inputs),
+                            grad_outputs=grad_energy,
+                            allow_unused=True,
+                            create_graph=create_graph,
+                        )
+                        partial_map = dict(
+                            zip(partial_names, partial_grads, strict=True)
+                        )
+
+                    grad_charges = None
+                    if charges.requires_grad:
+                        recomputed_charge, _forces, _charge_grads, _virial = (
+                            _pme_reciprocal_space_impl(
+                                positions,
+                                charges,
+                                cell,
+                                alpha,
+                                ctx.mesh_dimensions,
+                                ctx.spline_order,
+                                batch_idx,
+                                compute_forces=False,
+                                compute_charge_gradients=False,
+                                compute_virial=False,
+                                k_vectors=k_vectors,
+                                k_squared=k_squared,
+                                volume=volume,
+                                cell_inv_t=cell_inv_t,
+                                moduli_x=moduli_x,
+                                moduli_y=moduli_y,
+                                moduli_z=moduli_z,
+                            )
+                        )
+                        (grad_charges,) = torch.autograd.grad(
+                            recomputed_charge,
+                            charges,
+                            grad_outputs=grad_energy,
+                            allow_unused=True,
+                            create_graph=create_graph,
+                        )
+                return (
+                    partial_map.get("positions"),
+                    grad_charges,
+                    partial_map.get("cell"),
+                    partial_map.get("alpha"),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+
             with torch.enable_grad():
                 recomputed, _forces, _charge_grads, _virial = (
                     _pme_reciprocal_space_impl(
@@ -2225,7 +2388,7 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
                     tuple(diff_inputs),
                     grad_outputs=grad_energy,
                     allow_unused=True,
-                    create_graph=torch.is_grad_enabled(),
+                    create_graph=create_graph,
                 )
                 grad_map = dict(zip(diff_names, diff_grads, strict=True))
                 grad_positions = grad_map.get("positions")
@@ -2697,17 +2860,25 @@ def _pme_reciprocal_space_impl(
             )
             return fallback_energies
 
-        reciprocal_energies = _InjectCachedEvalGradWithFallback.apply(
-            reciprocal_energies,
-            positions,
-            charges,
-            cell,
-            None,
-            charge_grads.detach(),
-            None,
-            batch_idx,
-            _fallback,
-        )
+        if _has_potentially_geometry_dependent_charges(positions, charges):
+            reciprocal_energies = _InjectChargeGrad.apply(
+                reciprocal_energies,
+                charges,
+                charge_grads.detach(),
+                batch_idx,
+            )
+        else:
+            reciprocal_energies = _InjectCachedEvalGradWithFallback.apply(
+                reciprocal_energies,
+                positions,
+                charges,
+                cell,
+                None,
+                charge_grads.detach(),
+                None,
+                batch_idx,
+                _fallback,
+            )
 
     if return_cell_inv_t:
         return reciprocal_energies, forces, charge_grads, virial, cell_inv_t
@@ -2844,6 +3015,12 @@ def pme_reciprocal_space(
     ``k_vectors``, ``k_squared``, ``volume``, and ``cell_inv_t`` is treated as
     static setup state that corresponds to the current ``cell``.
 
+    When ``charges`` is a non-leaf tensor that may depend on ``positions``
+    (q = q(R)), ordinary first-order losses may use cached partial derivatives
+    and let PyTorch apply dE/dq * dq/dR once. Weighted losses and higher-order
+    derivatives recompute safe partials or connected gradients as needed to
+    avoid double-counting that chain term (issue #115).
+
     ``torch.compile`` is supported by the public wrapper tests, although custom
     Warp operators and FFTs can still limit compiler fusion for PME workloads.
 
@@ -2944,6 +3121,9 @@ def pme_reciprocal_space(
     charge_grad = bool(charges.requires_grad)
     cell_grad = bool(cell.requires_grad)
     output_grad_requested = compute_forces or compute_charge_gradients or compute_virial
+    # q(R) workloads may keep this cached-first path: _PMEReciprocalCachedFirstGrad.backward
+    # routes non-uniform/create_graph cases through safe partial recompute instead of
+    # returning connected position and charge gradients from the same graph.
     use_cached_first_grad = (
         not output_grad_requested
         and not hybrid_forces
@@ -3249,6 +3429,12 @@ def particle_mesh_ewald(
     ``charges``, and ``cell``. Caller-supplied reciprocal metadata such as
     ``k_vectors``, ``k_squared``, ``volume``, and ``cell_inv_t`` is treated as
     static setup state that corresponds to the current ``cell``.
+
+    When ``charges`` is a non-leaf tensor that may depend on ``positions``
+    (q = q(R)), ordinary first-order losses may use cached partial derivatives
+    and let PyTorch apply dE/dq * dq/dR once. Weighted losses and higher-order
+    derivatives recompute safe partials or connected gradients as needed to
+    avoid double-counting that chain term (issue #115).
 
     Enabled output flags are appended in order: energies, [forces],
     [charge_gradients], [virial]. A single output is returned unwrapped;
@@ -3564,6 +3750,8 @@ def particle_mesh_ewald(
             )
             return rs_energy + rec_energy
 
+        # q(R): shared fallback recompute detaches charges for geometry partials and
+        # returns dE/dq separately so PyTorch chains dq/dR exactly once (issue #115).
         return _InjectCachedEvalGradWithFallback.apply(
             energies,
             positions,
@@ -3682,17 +3870,25 @@ def particle_mesh_ewald(
             )
             return rs_energy + rec_energy
 
-        energies = _InjectCachedEvalGradWithFallback.apply(
-            energies,
-            positions,
-            charges,
-            cell,
-            None,
-            charge_grads.detach(),
-            None,
-            batch_idx,
-            _fallback,
-        )
+        if _has_potentially_geometry_dependent_charges(positions, charges):
+            energies = _InjectChargeGrad.apply(
+                energies,
+                charges,
+                charge_grads.detach(),
+                batch_idx,
+            )
+        else:
+            energies = _InjectCachedEvalGradWithFallback.apply(
+                energies,
+                positions,
+                charges,
+                cell,
+                None,
+                charge_grads.detach(),
+                None,
+                batch_idx,
+                _fallback,
+            )
 
         return _build_electrostatic_result(
             energies,

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -2860,25 +2860,17 @@ def _pme_reciprocal_space_impl(
             )
             return fallback_energies
 
-        if _has_potentially_geometry_dependent_charges(positions, charges):
-            reciprocal_energies = _InjectChargeGrad.apply(
-                reciprocal_energies,
-                charges,
-                charge_grads.detach(),
-                batch_idx,
-            )
-        else:
-            reciprocal_energies = _InjectCachedEvalGradWithFallback.apply(
-                reciprocal_energies,
-                positions,
-                charges,
-                cell,
-                None,
-                charge_grads.detach(),
-                None,
-                batch_idx,
-                _fallback,
-            )
+        reciprocal_energies = _InjectCachedEvalGradWithFallback.apply(
+            reciprocal_energies,
+            positions,
+            charges,
+            cell,
+            None,
+            charge_grads.detach(),
+            None,
+            batch_idx,
+            _fallback,
+        )
 
     if return_cell_inv_t:
         return reciprocal_energies, forces, charge_grads, virial, cell_inv_t
@@ -3870,25 +3862,17 @@ def particle_mesh_ewald(
             )
             return rs_energy + rec_energy
 
-        if _has_potentially_geometry_dependent_charges(positions, charges):
-            energies = _InjectChargeGrad.apply(
-                energies,
-                charges,
-                charge_grads.detach(),
-                batch_idx,
-            )
-        else:
-            energies = _InjectCachedEvalGradWithFallback.apply(
-                energies,
-                positions,
-                charges,
-                cell,
-                None,
-                charge_grads.detach(),
-                None,
-                batch_idx,
-                _fallback,
-            )
+        energies = _InjectCachedEvalGradWithFallback.apply(
+            energies,
+            positions,
+            charges,
+            cell,
+            None,
+            charge_grads.detach(),
+            None,
+            batch_idx,
+            _fallback,
+        )
 
         return _build_electrostatic_result(
             energies,

--- a/test/interactions/electrostatics/_deriv_check.py
+++ b/test/interactions/electrostatics/_deriv_check.py
@@ -87,6 +87,8 @@ __all__ = [
     "assert_tape_vs_explicit",
     "fixed_charge_system",
     "toy_charge_model",
+    "qr_manual_chain_gradient",
+    "qr_hvp_positions",
 ]
 
 # Central-difference step. ~ eps_f64**(1/3) balances O(h^2) truncation error
@@ -718,3 +720,165 @@ def toy_charge_model(
     counts = counts.index_add(0, bidx, torch.ones_like(q_raw))
     means = sums / counts
     return q_raw - means.index_select(0, bidx)
+
+
+def qr_manual_chain_gradient(
+    energy_fn: EnergyFn,
+    positions: torch.Tensor,
+    cell: torch.Tensor,
+    *,
+    charge_model: Callable[..., torch.Tensor] = toy_charge_model,
+    batch_idx: torch.Tensor | None = None,
+    per_atom_weights: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compare full ``q(R)`` autograd against the manual chain-rule decomposition.
+
+    Parameters
+    ----------
+    energy_fn : EnergyFn
+        ``(positions, charges, cell) -> (N,)`` per-atom energies.
+    positions : torch.Tensor, shape (N, 3)
+        Reference positions (float64 recommended).
+    cell : torch.Tensor
+        Fixed cell.
+    charge_model : callable
+        Differentiable ``q(R)`` mapping; defaults to :func:`toy_charge_model`.
+    batch_idx : torch.Tensor or None
+        Optional per-atom system index passed to ``charge_model``.
+    per_atom_weights : torch.Tensor or None
+        Optional per-atom loss weights. When set, both paths differentiate
+        ``(E * weights).sum()`` to exercise non-uniform CUDA cotangents.
+
+    Returns
+    -------
+    full_grad : torch.Tensor
+        ``grad(loss, positions)`` with ``charges = charge_model(positions)``.
+    manual_grad : torch.Tensor
+        ``dE/dR|_q + (dE/dq)(dq/dR)`` with independent leaf charges.
+    """
+    cell = cell.detach()
+
+    def _reduce(energies: torch.Tensor) -> torch.Tensor:
+        if per_atom_weights is not None:
+            return (energies * per_atom_weights).sum()
+        return energies.sum()
+
+    pos_leaf = positions.detach().clone().requires_grad_(True)
+    if batch_idx is None:
+        q_leaf = charge_model(pos_leaf).detach().requires_grad_(True)
+    else:
+        q_leaf = (
+            charge_model(pos_leaf, batch_idx=batch_idx).detach().requires_grad_(True)
+        )
+    e_leaf = energy_fn(pos_leaf, q_leaf, cell)
+    scalar_leaf = _reduce(e_leaf)
+    d_edr, d_edq = torch.autograd.grad(
+        scalar_leaf,
+        (pos_leaf, q_leaf),
+        retain_graph=False,
+    )
+
+    pos_q = positions.detach().clone().requires_grad_(True)
+    if batch_idx is None:
+        (chain,) = torch.autograd.grad(
+            charge_model(pos_q),
+            pos_q,
+            grad_outputs=d_edq.detach(),
+        )
+    else:
+        (chain,) = torch.autograd.grad(
+            charge_model(pos_q, batch_idx=batch_idx),
+            pos_q,
+            grad_outputs=d_edq.detach(),
+        )
+    manual_grad = d_edr + chain
+
+    pos_full = positions.detach().clone().requires_grad_(True)
+    if batch_idx is None:
+        q_full = charge_model(pos_full)
+    else:
+        q_full = charge_model(pos_full, batch_idx=batch_idx)
+    e_full = energy_fn(pos_full, q_full, cell)
+    (full_grad,) = torch.autograd.grad(_reduce(e_full), pos_full)
+
+    return full_grad, manual_grad
+
+
+def qr_hvp_positions(
+    energy_fn: EnergyFn,
+    positions: torch.Tensor,
+    cell: torch.Tensor,
+    direction: torch.Tensor,
+    *,
+    charge_model: Callable[..., torch.Tensor] = toy_charge_model,
+    batch_idx: torch.Tensor | None = None,
+    per_atom_weights: torch.Tensor | None = None,
+    eps: float = DEFAULT_FD_EPS,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """HVP of the full ``q(R)`` position gradient along ``direction``.
+
+    Compares autograd ``grad(grad(loss, p), p, grad_outputs=v)`` against a
+    central finite difference of the manual first-gradient chain rule.
+
+    Parameters
+    ----------
+    energy_fn : EnergyFn
+        ``(positions, charges, cell) -> (N,)`` per-atom energies.
+    positions : torch.Tensor, shape (N, 3)
+        Reference positions (float64 recommended).
+    cell : torch.Tensor
+        Fixed cell.
+    direction : torch.Tensor, shape (N, 3)
+        Direction vector for the Hessian-vector product.
+    charge_model : callable
+        Differentiable ``q(R)`` mapping; defaults to :func:`toy_charge_model`.
+    batch_idx : torch.Tensor or None
+        Optional per-atom system index passed to ``charge_model``.
+    per_atom_weights : torch.Tensor or None
+        Optional per-atom loss weights for non-uniform cotangent coverage.
+    eps : float
+        Finite-difference step size for the manual-gradient oracle.
+
+    Returns
+    -------
+    hvp_ad : torch.Tensor
+        Autograd Hessian-vector product of the full ``q(R)`` position gradient.
+    hvp_fd : torch.Tensor
+        Finite-difference oracle for the same quantity.
+    """
+    cell = cell.detach()
+    v = direction.detach()
+
+    def first_grad_manual(p: torch.Tensor) -> torch.Tensor:
+        full, manual = qr_manual_chain_gradient(
+            energy_fn,
+            p,
+            cell,
+            charge_model=charge_model,
+            batch_idx=batch_idx,
+            per_atom_weights=per_atom_weights,
+        )
+        del full
+        return manual
+
+    def loss_scalar(p: torch.Tensor) -> torch.Tensor:
+        if batch_idx is None:
+            q = charge_model(p)
+        else:
+            q = charge_model(p, batch_idx=batch_idx)
+        energies = energy_fn(p, q, cell)
+        if per_atom_weights is not None:
+            return (energies * per_atom_weights).sum()
+        return energies.sum()
+
+    p = positions.detach().clone().requires_grad_(True)
+    (grad_p,) = torch.autograd.grad(loss_scalar(p), p, create_graph=True)
+    (hvp_ad,) = torch.autograd.grad(grad_p, p, grad_outputs=v, retain_graph=False)
+
+    def grad_dot_v(p_in: torch.Tensor) -> torch.Tensor:
+        g = first_grad_manual(p_in)
+        return (g * v).sum()
+
+    hvp_fd = finite_difference_jacobian(grad_dot_v, positions.detach(), eps)
+
+    return hvp_ad, hvp_fd

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -8900,5 +8900,205 @@ class TestDirectOutputDeprecation:
         assert torch.isfinite(recip_energy).all()
 
 
+class TestMaxAtomsPerSystem:
+    """Explicit ``max_atoms_per_system`` avoids launch-bound inference on batched recip."""
+
+    @staticmethod
+    def _batch_recip_inputs(device):
+        """Return batch inputs for reciprocal-space tests."""
+        positions, charges, cell, batch_idx = _contract_batch(device)
+        alpha = torch.tensor([0.3, 0.3], dtype=torch.float64, device=device)
+        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=2.0)
+        return positions, charges, cell, batch_idx, alpha, k_vectors
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_batched_reciprocal_energy_matches_inferred(self, device):
+        """Explicit launch bound matches the legacy inferred path."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell, batch_idx, alpha, k_vectors = (
+            self._batch_recip_inputs(device)
+        )
+        inferred = ewald_reciprocal_space(
+            positions, charges, cell, k_vectors, alpha, batch_idx=batch_idx
+        )
+        explicit = ewald_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            k_vectors,
+            alpha,
+            batch_idx=batch_idx,
+            max_atoms_per_system=2,
+        )
+        torch.testing.assert_close(inferred, explicit, rtol=0, atol=0)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_batched_reciprocal_first_derivative_matches_inferred(self, device):
+        """First derivatives match when an explicit launch bound is supplied."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell, batch_idx, alpha, k_vectors = (
+            self._batch_recip_inputs(device)
+        )
+        pos_inf = positions.clone().requires_grad_(True)
+        pos_exp = positions.clone().requires_grad_(True)
+        e_inf = ewald_reciprocal_space(
+            pos_inf, charges, cell, k_vectors, alpha, batch_idx=batch_idx
+        )
+        e_exp = ewald_reciprocal_space(
+            pos_exp,
+            charges,
+            cell,
+            k_vectors,
+            alpha,
+            batch_idx=batch_idx,
+            max_atoms_per_system=2,
+        )
+        (g_inf,) = torch.autograd.grad(e_inf.sum(), pos_inf)
+        (g_exp,) = torch.autograd.grad(e_exp.sum(), pos_exp)
+        torch.testing.assert_close(g_inf, g_exp, rtol=1e-10, atol=1e-10)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_batched_reciprocal_second_derivative_matches_inferred(self, device):
+        """Second derivatives match when an explicit launch bound is supplied."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell, batch_idx, alpha, k_vectors = (
+            self._batch_recip_inputs(device)
+        )
+        pos_inf = positions.clone().requires_grad_(True)
+        pos_exp = positions.clone().requires_grad_(True)
+        e_inf = ewald_reciprocal_space(
+            pos_inf, charges, cell, k_vectors, alpha, batch_idx=batch_idx
+        )
+        e_exp = ewald_reciprocal_space(
+            pos_exp,
+            charges,
+            cell,
+            k_vectors,
+            alpha,
+            batch_idx=batch_idx,
+            max_atoms_per_system=2,
+        )
+        (f_inf,) = torch.autograd.grad(e_inf.sum(), pos_inf, create_graph=True)
+        (f_exp,) = torch.autograd.grad(e_exp.sum(), pos_exp, create_graph=True)
+        loss_inf = f_inf.pow(2).sum()
+        loss_exp = f_exp.pow(2).sum()
+        (g2_inf,) = torch.autograd.grad(loss_inf, pos_inf)
+        (g2_exp,) = torch.autograd.grad(loss_exp, pos_exp)
+        torch.testing.assert_close(g2_inf, g2_exp, rtol=1e-8, atol=1e-8)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_ewald_summation_threads_max_atoms_per_system(self, device):
+        """Full summation accepts and threads the explicit launch bound."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell, batch_idx = _contract_batch(device)
+        pbc = torch.tensor([[True, True, True], [True, True, True]], device=device)
+        nl, nptr, ns = batch_cell_list(
+            positions,
+            5.0,
+            cell,
+            pbc,
+            batch_idx=batch_idx,
+            return_neighbor_list=True,
+        )
+        alpha = torch.tensor([0.3, 0.3], dtype=torch.float64, device=device)
+        inferred = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=alpha,
+            k_cutoff=2.0,
+            batch_idx=batch_idx,
+            neighbor_list=nl,
+            neighbor_ptr=nptr,
+            neighbor_shifts=ns,
+        )
+        explicit = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=alpha,
+            k_cutoff=2.0,
+            batch_idx=batch_idx,
+            neighbor_list=nl,
+            neighbor_ptr=nptr,
+            neighbor_shifts=ns,
+            max_atoms_per_system=2,
+        )
+        torch.testing.assert_close(inferred, explicit, rtol=0, atol=0)
+
+    @pytest.mark.parametrize(
+        ("bad_value", "match"),
+        [
+            (0, "must be positive"),
+            (-1, "must be positive"),
+            (5, "cannot exceed"),
+        ],
+    )
+    def test_invalid_max_atoms_per_system_raises(self, bad_value, match):
+        """Host-known invalid bounds raise before launching kernels."""
+        device = torch.device("cpu")
+        positions, charges, cell, batch_idx, alpha, k_vectors = (
+            self._batch_recip_inputs(device)
+        )
+        with pytest.raises(ValueError, match=match):
+            ewald_reciprocal_space(
+                positions,
+                charges,
+                cell,
+                k_vectors,
+                alpha,
+                batch_idx=batch_idx,
+                max_atoms_per_system=bad_value,
+            )
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_explicit_bound_skips_inference_fallback(self, device, monkeypatch):
+        """Positive hint bypasses ``_resolve_max_atoms_per_system`` inference."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell, batch_idx, alpha, k_vectors = (
+            self._batch_recip_inputs(device)
+        )
+        inference_calls = 0
+        original = _ewald_recip_chain._resolve_max_atoms_per_system
+
+        def _counting_resolve(hint, atom_start, atom_end, num_atoms):
+            nonlocal inference_calls
+            if int(hint) <= 0 and num_atoms:
+                inference_calls += 1
+            return original(hint, atom_start, atom_end, num_atoms)
+
+        monkeypatch.setattr(
+            _ewald_recip_chain,
+            "_resolve_max_atoms_per_system",
+            _counting_resolve,
+        )
+        ewald_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            k_vectors,
+            alpha,
+            batch_idx=batch_idx,
+            max_atoms_per_system=2,
+        )
+        assert inference_calls == 0
+
+        inference_calls = 0
+        ewald_reciprocal_space(
+            positions, charges, cell, k_vectors, alpha, batch_idx=batch_idx
+        )
+        assert inference_calls >= 1
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -9061,7 +9061,7 @@ class TestMaxAtomsPerSystem:
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_explicit_bound_skips_inference_fallback(self, device, monkeypatch):
-        """Positive hint bypasses ``_resolve_max_atoms_per_system`` inference."""
+        """Positive launch bound bypasses ``_resolve_max_atoms_per_system`` inference."""
         if device == "cuda" and not torch.cuda.is_available():
             pytest.skip("CUDA not available")
         device = torch.device(device)
@@ -9071,11 +9071,11 @@ class TestMaxAtomsPerSystem:
         inference_calls = 0
         original = _ewald_recip_chain._resolve_max_atoms_per_system
 
-        def _counting_resolve(hint, atom_start, atom_end, num_atoms):
+        def _counting_resolve(bound, atom_start, atom_end, num_atoms):
             nonlocal inference_calls
-            if int(hint) <= 0 and num_atoms:
+            if int(bound) <= 0 and num_atoms:
                 inference_calls += 1
-            return original(hint, atom_start, atom_end, num_atoms)
+            return original(bound, atom_start, atom_end, num_atoms)
 
         monkeypatch.setattr(
             _ewald_recip_chain,

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -80,6 +80,8 @@ from test.interactions.electrostatics._deriv_check import (
     finite_difference_jacobian,
     gradgradcheck_energy,
     max_abs_rel,
+    qr_hvp_positions,
+    qr_manual_chain_gradient,
     toy_charge_model,
 )
 from test.interactions.electrostatics.bindings.torch.test_utils import (
@@ -110,7 +112,7 @@ def _torchpme_smearing(alpha: float | torch.Tensor) -> float:
 
 
 def _ewald_summation_without_direct_output_deprecation(*args, **kwargs):
-    """Call legacy direct-output Ewald paths without polluting warning summaries."""
+    """Call deprecated direct-output Ewald paths without polluting warning summaries."""
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
@@ -7763,8 +7765,8 @@ class TestEwaldEnergyDerivativeContract:
         )
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
-    def test_qR_legacy_direct_equals_fixed_partial(self, device):
-        """Legacy direct force == fixed-charge partial; full q(R) force differs by dE/dq.dq/dR."""
+    def test_qR_direct_output_equals_fixed_partial(self, device):
+        """Direct force equals the fixed-charge partial; full q(R) force includes dE/dq.dq/dR."""
         if device == "cuda" and not torch.cuda.is_available():
             pytest.skip("CUDA not available")
         device = torch.device(device)
@@ -7780,8 +7782,8 @@ class TestEwaldEnergyDerivativeContract:
         k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=2.0)
         q_fixed = toy_charge_model(positions).detach()
 
-        # Legacy direct force: kernel -dE/dR at fixed (detached) q(R).
-        _, legacy_force = ewald_summation(
+        # Direct-output force: kernel -dE/dR at fixed (detached) q(R).
+        _, direct_force = ewald_summation(
             positions,
             q_fixed,
             cell,
@@ -7809,11 +7811,11 @@ class TestEwaldEnergyDerivativeContract:
         partial_force = -gp
 
         torch.testing.assert_close(
-            legacy_force,
+            direct_force,
             partial_force,
             rtol=1e-5,
             atol=1e-7,
-            msg="legacy direct force must equal the fixed-charge partial",
+            msg="direct-output force must equal the fixed-charge partial",
         )
 
         # Full q(R) force (charges graph-connected) differs by the chain-rule term.
@@ -7901,6 +7903,128 @@ class TestEwaldEnergyDerivativeContract:
         max_abs, max_rel = max_abs_rel(fd, ad)
         assert torch.allclose(fd, ad, rtol=C_VIRIAL_RTOL, atol=C_VIRIAL_ATOL), (
             f"batch strain-virial FD vs autograd: max_abs={max_abs:.3e} max_rel={max_rel:.3e}"
+        )
+
+
+class TestEwaldQRGeometryFallback:
+    """q(R) manual-chain and HVP guards for CUDA non-uniform cotangent fallback."""
+
+    def _neighbors(self, positions, cell, device):
+        return cell_list(
+            positions,
+            5.0,
+            cell,
+            torch.tensor([[True, True, True]], device=device),
+            return_neighbor_list=True,
+        )
+
+    def _real_energy_fn(self, positions, cell, device, alpha, nl, nptr, ns):
+        def energy_fn(p, q, c):
+            return ewald_real_space(
+                p,
+                q,
+                c,
+                alpha=alpha,
+                neighbor_list=nl,
+                neighbor_ptr=nptr,
+                neighbor_shifts=ns,
+            )
+
+        return energy_fn
+
+    def _recip_energy_fn(self, positions, cell, device, alpha):
+        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=2.0).squeeze(0)
+
+        def energy_fn(p, q, c):
+            return ewald_reciprocal_space(p, q, c, k_vectors, alpha)
+
+        return energy_fn
+
+    def _summation_energy_fn(self, positions, cell, device, alpha, nl, nptr, ns):
+        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=2.0)
+
+        def energy_fn(p, q, c):
+            return ewald_summation(
+                p,
+                q,
+                c,
+                alpha=alpha,
+                k_vectors=k_vectors,
+                neighbor_list=nl,
+                neighbor_ptr=nptr,
+                neighbor_shifts=ns,
+            )
+
+        return energy_fn
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    @pytest.mark.parametrize("which", ["real", "recip", "summation"])
+    def test_qR_manual_chain_weighted_loss(self, device, which):
+        """Weighted q(R) loss: full autograd == manual chain (CUDA fallback path)."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, _, cell = _contract_dipole(device)
+        nl, nptr, ns = self._neighbors(positions, cell, device)
+        alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
+        if which == "real":
+            energy_fn = self._real_energy_fn(
+                positions, cell, device, alpha, nl, nptr, ns
+            )
+        elif which == "recip":
+            energy_fn = self._recip_energy_fn(positions, cell, device, alpha)
+        else:
+            energy_fn = self._summation_energy_fn(
+                positions, cell, device, alpha, nl, nptr, ns
+            )
+        weights = torch.tensor([1.2, 0.8], dtype=torch.float64, device=device)
+        full, manual = qr_manual_chain_gradient(
+            energy_fn,
+            positions,
+            cell,
+            per_atom_weights=weights,
+        )
+        max_abs, max_rel = max_abs_rel(full, manual)
+        rtol = 2e-3 if which == "summation" else 1e-4
+        assert torch.allclose(full, manual, rtol=rtol, atol=1e-6), (
+            f"{which} q(R) manual chain weighted: max_abs={max_abs:.3e} "
+            f"max_rel={max_rel:.3e}"
+        )
+
+    @pytest.mark.parametrize("device", ["cuda"])
+    @pytest.mark.parametrize("which", ["real", "summation"])
+    def test_qR_hvp_weighted_loss(self, device, which):
+        """q(R) HVP along random direction matches FD of manual first gradient."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, _, cell = _contract_dipole(device)
+        nl, nptr, ns = self._neighbors(positions, cell, device)
+        alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
+        if which == "real":
+            energy_fn = self._real_energy_fn(
+                positions, cell, device, alpha, nl, nptr, ns
+            )
+        else:
+            energy_fn = self._summation_energy_fn(
+                positions, cell, device, alpha, nl, nptr, ns
+            )
+        weights = torch.tensor([1.2, 0.8], dtype=torch.float64, device=device)
+        gen = torch.Generator(device=device)
+        gen.manual_seed(115)
+        direction = torch.randn_like(positions, generator=gen)
+        direction = direction / direction.norm()
+        hvp_ad, hvp_fd = qr_hvp_positions(
+            energy_fn,
+            positions,
+            cell,
+            direction,
+            per_atom_weights=weights,
+        )
+        max_abs, max_rel = max_abs_rel(hvp_ad, hvp_fd)
+        rtol = 2e-3 if which == "summation" else 1e-4
+        assert torch.allclose(hvp_ad, hvp_fd, rtol=rtol, atol=1e-5), (
+            f"{which} q(R) HVP weighted: max_abs={max_abs:.3e} max_rel={max_rel:.3e}"
         )
 
 
@@ -8357,11 +8481,9 @@ class TestEwaldDoubleBackward:
 
         Regression guard for the energy-autograd ``q(R)`` higher-order contract in
         the batched / asymmetric regime: the single-system near-symmetric
-        ``_energy_fn`` cases (``_contract_dipole``) do not exercise it, and this is
-        exactly the regime the PR85-compare flagged (the disagreement there is a
-        legacy direct/tape vs energy-autograd *contract* difference, not a bug --
-        finite difference is the oracle here). ``charges = toy_charge_model(p)``
-        stays in the graph so ``loss.backward()`` must compose the
+        ``_energy_fn`` cases (``_contract_dipole``) do not exercise it. Finite
+        difference over the full ``q(R)`` energy is the oracle here: ``charges =
+        toy_charge_model(p)`` stays in the graph so ``loss.backward()`` must compose the
         ``dE/dq * dq/dR`` chain-rule second order; FD over positions is the oracle.
         """
         if device == "cuda" and not torch.cuda.is_available():
@@ -8542,8 +8664,8 @@ class TestDirectOutputDeprecation:
         torch.testing.assert_close(e_flag, e_no_flag, rtol=0, atol=1e-10)
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
-    def test_legacy_tuple_ordering_unchanged(self, device):
-        """Legacy direct outputs keep their documented (E, F, dQ, virial) ordering."""
+    def test_direct_output_tuple_ordering_unchanged(self, device):
+        """Deprecated direct outputs keep their documented (E, F, dQ, virial) ordering."""
         if device == "cuda" and not torch.cuda.is_available():
             pytest.skip("CUDA not available")
         device = torch.device(device)

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -1252,6 +1252,78 @@ class TestAutogradRealSpace:
         assert positions.grad.abs().sum() > 0
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_geometry_dependent_charges_weighted_grad(self, device):
+        """Hybrid real-space q(R) supports per-atom weighted energy gradients."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        (
+            positions_base,
+            charges_base,
+            cell,
+            neighbor_list,
+            neighbor_ptr,
+            neighbor_shifts,
+        ) = create_dipole_system(device)
+        weight = torch.tensor(
+            [[0.1, -0.05, 0.02], [-0.1, 0.05, -0.02]],
+            dtype=torch.float64,
+            device=device,
+        )
+        alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
+
+        positions = positions_base.clone().requires_grad_(True)
+        charges = charges_base + (positions * weight).sum(dim=1)
+        charges = charges - charges.mean()
+        energies, _forces = ewald_real_space(
+            positions,
+            charges,
+            cell,
+            alpha,
+            neighbor_list=neighbor_list,
+            neighbor_ptr=neighbor_ptr,
+            neighbor_shifts=neighbor_shifts,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+        energy_weights = torch.linspace(
+            1.0,
+            2.0,
+            energies.numel(),
+            dtype=energies.dtype,
+            device=device,
+        )
+        (weighted_grad,) = torch.autograd.grad(
+            energies,
+            positions,
+            grad_outputs=energy_weights,
+        )
+
+        positions_ref = positions_base.clone().requires_grad_(True)
+        charges_ref = charges_base + (positions_ref * weight).sum(dim=1)
+        charges_ref = charges_ref - charges_ref.mean()
+        energies_ref = ewald_real_space(
+            positions_ref,
+            charges_ref,
+            cell,
+            alpha,
+            neighbor_list=neighbor_list,
+            neighbor_ptr=neighbor_ptr,
+            neighbor_shifts=neighbor_shifts,
+        )
+        (weighted_grad_ref,) = torch.autograd.grad(
+            energies_ref,
+            positions_ref,
+            grad_outputs=energy_weights,
+        )
+
+        assert torch.isfinite(weighted_grad).all()
+        torch.testing.assert_close(
+            weighted_grad, weighted_grad_ref, rtol=1e-5, atol=1e-7
+        )
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
     @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
     def test_charge_gradients(self, device, dtype):
         """Test gradients w.r.t. charges."""
@@ -2268,6 +2340,68 @@ class TestAutogradReciprocalSpace:
 
         assert positions.grad is not None
         assert torch.isfinite(positions.grad).all()
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_geometry_dependent_charges_weighted_grad(self, device):
+        """Hybrid reciprocal q(R) supports per-atom weighted energy gradients."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions_base, charges_base, cell, _, _, _ = create_dipole_system(device)
+        weight = torch.tensor(
+            [[0.1, -0.05, 0.02], [-0.1, 0.05, -0.02]],
+            dtype=torch.float64,
+            device=device,
+        )
+        alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
+        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=8.0).squeeze(0)
+
+        positions = positions_base.clone().requires_grad_(True)
+        charges = charges_base + (positions * weight).sum(dim=1)
+        charges = charges - charges.mean()
+        energies, _forces = ewald_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            k_vectors,
+            alpha,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+        energy_weights = torch.linspace(
+            1.0,
+            2.0,
+            energies.numel(),
+            dtype=energies.dtype,
+            device=device,
+        )
+        (weighted_grad,) = torch.autograd.grad(
+            energies,
+            positions,
+            grad_outputs=energy_weights,
+        )
+
+        positions_ref = positions_base.clone().requires_grad_(True)
+        charges_ref = charges_base + (positions_ref * weight).sum(dim=1)
+        charges_ref = charges_ref - charges_ref.mean()
+        energies_ref = ewald_reciprocal_space(
+            positions_ref,
+            charges_ref,
+            cell,
+            k_vectors,
+            alpha,
+        )
+        (weighted_grad_ref,) = torch.autograd.grad(
+            energies_ref,
+            positions_ref,
+            grad_outputs=energy_weights,
+        )
+
+        assert torch.isfinite(weighted_grad).all()
+        torch.testing.assert_close(
+            weighted_grad, weighted_grad_ref, rtol=1e-5, atol=1e-7
+        )
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -4370,6 +4370,69 @@ class TestPMEHybridForces:
                 )
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_geometry_dependent_charges_pme_reciprocal_weighted_grad(
+        self, device
+    ):
+        """Hybrid PME reciprocal q(R) supports per-atom weighted energy gradients."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions_base, charges_base, cell = create_dipole_system(device)
+        mesh_dims = (16, 16, 16)
+        weight = torch.tensor(
+            [[0.1, -0.05, 0.02], [-0.1, 0.05, -0.02]],
+            dtype=torch.float64,
+            device=device,
+        )
+
+        positions = positions_base.clone().requires_grad_(True)
+        charges = charges_base + (positions * weight).sum(dim=1)
+        charges = charges - charges.mean()
+        energies, _forces = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+        energy_weights = torch.linspace(
+            1.0,
+            2.0,
+            energies.numel(),
+            dtype=energies.dtype,
+            device=device,
+        )
+        (weighted_grad,) = torch.autograd.grad(
+            energies,
+            positions,
+            grad_outputs=energy_weights,
+        )
+
+        positions_ref = positions_base.clone().requires_grad_(True)
+        charges_ref = charges_base + (positions_ref * weight).sum(dim=1)
+        charges_ref = charges_ref - charges_ref.mean()
+        energies_ref = pme_reciprocal_space(
+            positions_ref,
+            charges_ref,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+        )
+        (weighted_grad_ref,) = torch.autograd.grad(
+            energies_ref,
+            positions_ref,
+            grad_outputs=energy_weights,
+        )
+
+        assert torch.isfinite(weighted_grad).all()
+        torch.testing.assert_close(
+            weighted_grad, weighted_grad_ref, rtol=1e-5, atol=1e-7
+        )
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_hybrid_geometry_dependent_charges_particle_mesh_ewald(self, device):
         """Full PME hybrid q(R) force includes the charge chain-rule term once."""
         if device == "cuda" and not torch.cuda.is_available():
@@ -4402,21 +4465,42 @@ class TestPMEHybridForces:
             compute_forces=True,
             hybrid_forces=True,
         )
-        weighted_grad = torch.autograd.grad(
+        energy_weights = torch.linspace(
+            1.0,
+            2.0,
+            energies.numel(),
+            dtype=energies.dtype,
+            device=device,
+        )
+        (weighted_grad,) = torch.autograd.grad(
             energies,
             positions,
-            grad_outputs=torch.linspace(
-                1.0,
-                2.0,
-                energies.numel(),
-                dtype=energies.dtype,
-                device=device,
-            ),
-            allow_unused=True,
+            grad_outputs=energy_weights,
             retain_graph=True,
-        )[0]
-        if weighted_grad is not None:
-            assert torch.isfinite(weighted_grad).all()
+        )
+
+        positions_energy_ref = positions_ref.clone().requires_grad_(True)
+        q_energy_ref = charges_base + (positions_energy_ref * weight).sum(dim=1)
+        q_energy_ref = q_energy_ref - q_energy_ref.mean()
+        energies_ref = particle_mesh_ewald(
+            positions_energy_ref,
+            q_energy_ref,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+        )
+        (weighted_grad_ref,) = torch.autograd.grad(
+            energies_ref,
+            positions_energy_ref,
+            grad_outputs=energy_weights,
+        )
+
+        assert torch.isfinite(weighted_grad).all()
+        torch.testing.assert_close(
+            weighted_grad, weighted_grad_ref, rtol=1e-5, atol=1e-7
+        )
 
         charge_force = -torch.autograd.grad(
             energies.sum(), positions, retain_graph=True

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -77,6 +77,8 @@ from test.interactions.electrostatics._deriv_check import (
     finite_difference_jacobian,
     gradgradcheck_energy,
     max_abs_rel,
+    qr_hvp_positions,
+    qr_manual_chain_gradient,
     toy_charge_model,
 )
 from test.interactions.electrostatics.bindings.torch.test_utils import (
@@ -106,7 +108,7 @@ def _torchpme_smearing(alpha: float | torch.Tensor) -> float:
 
 
 def _particle_mesh_ewald_without_direct_output_deprecation(*args, **kwargs):
-    """Call legacy direct-output PME paths without polluting warning summaries."""
+    """Call deprecated direct-output PME paths without polluting warning summaries."""
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
@@ -4367,6 +4369,109 @@ class TestPMEHybridForces:
                     f"FD={fd_force:.8e}, rel={rel_err:.2e}"
                 )
 
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_hybrid_geometry_dependent_charges_particle_mesh_ewald(self, device):
+        """Full PME hybrid q(R) force includes the charge chain-rule term once."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+
+        positions_ref, charges_base, cell = create_dipole_system(device)
+        mesh_dims = (16, 16, 16)
+        neighbor_matrix = torch.tensor([[1], [0]], dtype=torch.int32, device=device)
+        neighbor_matrix_shifts = torch.zeros(
+            (2, 1, 3), dtype=torch.int32, device=device
+        )
+        weight = torch.tensor(
+            [[0.1, -0.05, 0.02], [-0.1, 0.05, -0.02]],
+            dtype=torch.float64,
+            device=device,
+        )
+        positions = positions_ref.clone().requires_grad_(True)
+        q = charges_base + (positions * weight).sum(dim=1)
+        q = q - q.mean()
+
+        energies, forces = particle_mesh_ewald(
+            positions,
+            q,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=mesh_dims,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            compute_forces=True,
+            hybrid_forces=True,
+        )
+        weighted_grad = torch.autograd.grad(
+            energies,
+            positions,
+            grad_outputs=torch.linspace(
+                1.0,
+                2.0,
+                energies.numel(),
+                dtype=energies.dtype,
+                device=device,
+            ),
+            allow_unused=True,
+            retain_graph=True,
+        )[0]
+        if weighted_grad is not None:
+            assert torch.isfinite(weighted_grad).all()
+
+        charge_force = -torch.autograd.grad(
+            energies.sum(), positions, retain_graph=True
+        )[0]
+        total_force = forces + charge_force
+
+        h = 1e-5
+        for atom in range(2):
+            for dim in range(3):
+                pos_p = positions.detach().clone()
+                pos_p[atom, dim] += h
+                q_p = charges_base + (pos_p * weight).sum(dim=1)
+                q_p = q_p - q_p.mean()
+                e_p = (
+                    particle_mesh_ewald(
+                        pos_p,
+                        q_p,
+                        cell,
+                        alpha=0.3,
+                        mesh_dimensions=mesh_dims,
+                        neighbor_matrix=neighbor_matrix,
+                        neighbor_matrix_shifts=neighbor_matrix_shifts,
+                    )
+                    .sum()
+                    .item()
+                )
+
+                pos_m = positions.detach().clone()
+                pos_m[atom, dim] -= h
+                q_m = charges_base + (pos_m * weight).sum(dim=1)
+                q_m = q_m - q_m.mean()
+                e_m = (
+                    particle_mesh_ewald(
+                        pos_m,
+                        q_m,
+                        cell,
+                        alpha=0.3,
+                        mesh_dimensions=mesh_dims,
+                        neighbor_matrix=neighbor_matrix,
+                        neighbor_matrix_shifts=neighbor_matrix_shifts,
+                    )
+                    .sum()
+                    .item()
+                )
+
+                fd_force = -(e_p - e_m) / (2 * h)
+                rel_err = abs(total_force[atom, dim].item() - fd_force) / (
+                    abs(fd_force) + 1e-30
+                )
+                assert rel_err < 0.02, (
+                    f"atom {atom}, dim {dim}: "
+                    f"hybrid={total_force[atom, dim].item():.8e}, "
+                    f"FD={fd_force:.8e}, rel={rel_err:.2e}"
+                )
+
 
 ###########################################################################################
 ########################### torch.compile Tests ###########################################
@@ -4995,8 +5100,8 @@ class TestPMEEnergyDerivativeContract:
         )
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
-    def test_qR_legacy_direct_equals_fixed_partial(self, device):
-        """Legacy direct force == fixed-charge partial; full q(R) force differs by dE/dq.dq/dR."""
+    def test_qR_direct_output_equals_fixed_partial(self, device):
+        """Direct force equals the fixed-charge partial; full q(R) force includes dE/dq.dq/dR."""
         if device == "cuda" and not torch.cuda.is_available():
             pytest.skip("CUDA not available")
         device = torch.device(device)
@@ -5005,7 +5110,7 @@ class TestPMEEnergyDerivativeContract:
         nl, nptr, ns = _pme_full_neighbors(positions, cell, device)
         q_fixed = toy_charge_model(positions).detach()
 
-        _, legacy_force = particle_mesh_ewald(
+        _, direct_force = particle_mesh_ewald(
             positions,
             q_fixed,
             cell,
@@ -5033,11 +5138,11 @@ class TestPMEEnergyDerivativeContract:
         partial_force = -gp
 
         torch.testing.assert_close(
-            legacy_force,
+            direct_force,
             partial_force,
             rtol=1e-4,
             atol=1e-6,
-            msg="legacy direct force must equal the fixed-charge partial",
+            msg="direct-output force must equal the fixed-charge partial",
         )
 
         p2 = positions.clone().requires_grad_(True)
@@ -5076,6 +5181,101 @@ class TestPMEEnergyDerivativeContract:
         assert torch.allclose(fd, ad, rtol=PC_FORCE_RTOL, atol=PC_FORCE_ATOL), (
             f"{which} batch forces FD vs autograd: "
             f"max_abs={max_abs:.3e} max_rel={max_rel:.3e}"
+        )
+
+
+class TestPMEQRGeometryFallback:
+    """q(R) manual-chain and HVP guards for CUDA non-uniform cotangent fallback."""
+
+    _QR_MESH = (10, 10, 10)
+
+    def _recip_energy_fn(self, positions, cell, device, alpha):
+        def energy_fn(p, q, c):
+            return pme_reciprocal_space(
+                p,
+                q,
+                c,
+                alpha=alpha,
+                mesh_dimensions=self._QR_MESH,
+                compute_forces=False,
+            )
+
+        return energy_fn
+
+    def _full_energy_fn(self, positions, cell, device, alpha):
+        nl, nptr, ns = _pme_full_neighbors(positions, cell, device)
+
+        def energy_fn(p, q, c):
+            return particle_mesh_ewald(
+                p,
+                q,
+                c,
+                alpha=alpha,
+                mesh_dimensions=self._QR_MESH,
+                neighbor_list=nl,
+                neighbor_ptr=nptr,
+                neighbor_shifts=ns,
+                compute_forces=False,
+            )
+
+        return energy_fn
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    @pytest.mark.parametrize("which", ["recip", "full"])
+    def test_qR_manual_chain_weighted_loss(self, device, which):
+        """Weighted q(R) loss: full autograd == manual chain (CUDA fallback path)."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, _, cell = _pme_contract_dipole(device)
+        alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
+        if which == "recip":
+            energy_fn = self._recip_energy_fn(positions, cell, device, alpha)
+        else:
+            energy_fn = self._full_energy_fn(positions, cell, device, alpha)
+        weights = torch.tensor([1.2, 0.8], dtype=torch.float64, device=device)
+        full, manual = qr_manual_chain_gradient(
+            energy_fn,
+            positions,
+            cell,
+            per_atom_weights=weights,
+        )
+        max_abs, max_rel = max_abs_rel(full, manual)
+        rtol = 3e-3 if which == "full" else 2e-3
+        assert torch.allclose(full, manual, rtol=rtol, atol=1e-6), (
+            f"{which} q(R) manual chain weighted: max_abs={max_abs:.3e} "
+            f"max_rel={max_rel:.3e}"
+        )
+
+    @pytest.mark.parametrize("device", ["cuda"])
+    @pytest.mark.parametrize("which", ["recip", "full"])
+    def test_qR_hvp_weighted_loss(self, device, which):
+        """q(R) HVP along random direction matches FD of manual first gradient."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, _, cell = _pme_contract_dipole(device)
+        alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
+        if which == "recip":
+            energy_fn = self._recip_energy_fn(positions, cell, device, alpha)
+        else:
+            energy_fn = self._full_energy_fn(positions, cell, device, alpha)
+        weights = torch.tensor([1.2, 0.8], dtype=torch.float64, device=device)
+        gen = torch.Generator(device=device)
+        gen.manual_seed(115)
+        direction = torch.randn_like(positions, generator=gen)
+        direction = direction / direction.norm()
+        hvp_ad, hvp_fd = qr_hvp_positions(
+            energy_fn,
+            positions,
+            cell,
+            direction,
+            per_atom_weights=weights,
+        )
+        max_abs, max_rel = max_abs_rel(hvp_ad, hvp_fd)
+        rtol = 3e-3 if which == "full" else 2e-3
+        assert torch.allclose(hvp_ad, hvp_fd, rtol=rtol, atol=1e-5), (
+            f"{which} q(R) HVP weighted: max_abs={max_abs:.3e} max_rel={max_rel:.3e}"
         )
 
 
@@ -5142,6 +5342,57 @@ class TestPMEDoubleBackward:
         max_abs, max_rel = max_abs_rel(ad, fd)
         assert torch.allclose(ad, fd, rtol=1e-3, atol=1e-5), (
             f"{which} force-loss dbwd grad: max_abs={max_abs:.3e} max_rel={max_rel:.3e}"
+        )
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    @pytest.mark.parametrize("which", ["recip", "full"])
+    def test_qR_force_loss_double_backward_batch(self, device, which):
+        """Batched q(R) force-loss double-backward FD-matches positions.grad."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, _charges, cell, batch_idx = _pme_contract_batch(device)
+        alpha = torch.tensor([0.3, 0.3], dtype=torch.float64, device=device)
+        nl, nptr, ns = _pme_full_neighbors(positions, cell, device, batch_idx=batch_idx)
+
+        def energy_fn(p, q, c):
+            if which == "recip":
+                return pme_reciprocal_space(
+                    p,
+                    q,
+                    c,
+                    alpha=alpha,
+                    mesh_dimensions=_MESH,
+                    batch_idx=batch_idx,
+                )
+            return particle_mesh_ewald(
+                p,
+                q,
+                c,
+                alpha=alpha,
+                mesh_dimensions=_MESH,
+                neighbor_list=nl,
+                neighbor_ptr=nptr,
+                neighbor_shifts=ns,
+                batch_idx=batch_idx,
+            )
+
+        def loss_of_positions(p_in):
+            p = p_in.clone().requires_grad_(True)
+            q = toy_charge_model(p, batch_idx=batch_idx)
+            e = energy_fn(p, q, cell)
+            (f,) = torch.autograd.grad(e.sum(), p, create_graph=True)
+            return f.pow(2).sum()
+
+        p_leaf = positions.detach().clone().requires_grad_(True)
+        loss_of_positions(p_leaf).backward()
+        ad = p_leaf.grad.clone()
+        assert torch.isfinite(ad).all() and ad.abs().sum() > 0
+        fd = finite_difference_jacobian(loss_of_positions, positions.detach(), eps=1e-6)
+        max_abs, max_rel = max_abs_rel(ad, fd)
+        assert torch.allclose(ad, fd, rtol=3e-3, atol=1e-5), (
+            f"{which} batched q(R) force-loss dbwd: "
+            f"max_abs={max_abs:.3e} max_rel={max_rel:.3e}"
         )
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
@@ -5439,8 +5690,8 @@ class TestDirectOutputDeprecation:
         torch.testing.assert_close(e_flag, e_no_flag, rtol=1e-6, atol=1e-8)
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
-    def test_legacy_tuple_ordering_unchanged(self, device):
-        """Legacy direct outputs keep their documented (E, F, dQ, virial) ordering."""
+    def test_direct_output_tuple_ordering_unchanged(self, device):
+        """Deprecated direct outputs keep their documented (E, F, dQ, virial) ordering."""
         if device == "cuda" and not torch.cuda.is_available():
             pytest.skip("CUDA not available")
         device = torch.device(device)

--- a/test/interactions/electrostatics/test_util.py
+++ b/test/interactions/electrostatics/test_util.py
@@ -22,13 +22,18 @@ import pytest
 torch = pytest.importorskip("torch")
 _util = pytest.importorskip("nvalchemiops.torch.interactions.electrostatics._util")
 _InjectChargeGrad = _util._InjectChargeGrad
+_InjectCachedEvalGradWithFallback = _util._InjectCachedEvalGradWithFallback
 _is_uniform_cotangent = _util._is_uniform_cotangent
+
+from test.interactions.electrostatics._deriv_check import (  # noqa: E402
+    finite_difference_jacobian,
+)
 
 DT = torch.float64
 
 
-def _legacy_charge_grad(grad_energy, charge_grad, batch_idx):
-    """Reference: the historical charge-gradient injector backward math."""
+def _expected_charge_grad(grad_energy, charge_grad, batch_idx):
+    """Reference charge-gradient injector backward math."""
     if batch_idx is not None:
         atom_grad = grad_energy.index_select(0, batch_idx)
     else:
@@ -37,7 +42,7 @@ def _legacy_charge_grad(grad_energy, charge_grad, batch_idx):
 
 
 def test_charge_grad_single_system_bit_identical():
-    """Single-system per-system cotangent matches the legacy charge path."""
+    """Single-system per-system cotangent matches the injector charge path."""
     energy = torch.tensor([3.0], dtype=DT)
     charges = torch.tensor([1.0, -1.0, 0.5], dtype=DT, requires_grad=True)
     charge_grad = torch.tensor([0.2, -0.3, 0.1], dtype=DT)
@@ -47,7 +52,7 @@ def test_charge_grad_single_system_bit_identical():
     grad_energy = torch.tensor([1.7], dtype=DT)
     out.backward(grad_energy)
 
-    expected = _legacy_charge_grad(grad_energy, charge_grad, None)
+    expected = _expected_charge_grad(grad_energy, charge_grad, None)
     assert torch.equal(charges.grad, expected)
 
 
@@ -62,7 +67,7 @@ def test_charge_grad_batched_bit_identical():
     grad_energy = torch.tensor([2.0, 5.0], dtype=DT)
     out.backward(grad_energy)
 
-    expected = _legacy_charge_grad(grad_energy, charge_grad, batch_idx)
+    expected = _expected_charge_grad(grad_energy, charge_grad, batch_idx)
     assert torch.equal(charges.grad, expected)
 
 
@@ -93,6 +98,97 @@ def test_charge_grad_batched_per_atom_cotangent_uses_system_mean():
 
     assert charges.grad is None
     assert torch.equal(energy.grad, grad_energy)
+
+
+def test_cached_eval_qR_nonuniform_fallback_uses_partial_derivatives():
+    """q(R) weighted fallback returns partial dE/dR plus dE/dq for one chain term."""
+    positions = torch.randn(3, 3, dtype=DT, requires_grad=True)
+    theta = torch.randn(3, dtype=DT, requires_grad=True)
+    charges = positions[:, 0].square() + theta
+    cell = torch.eye(3, dtype=DT).unsqueeze(0).requires_grad_()
+    energy = positions[:, 1].detach().clone().requires_grad_()
+    pos_grad_state = torch.zeros_like(positions)
+    charge_grad_state = torch.zeros_like(charges)
+    cell_grad_state = torch.zeros_like(cell)
+    grad_energy = torch.tensor([1.0, 2.0, 4.0], dtype=DT)
+
+    def fallback_fn(p, q, _cell):
+        return p[:, 1] * q + 0.5 * p[:, 2].square()
+
+    out = _InjectCachedEvalGradWithFallback.apply(
+        energy,
+        positions,
+        charges,
+        cell,
+        pos_grad_state,
+        charge_grad_state,
+        cell_grad_state,
+        None,
+        fallback_fn,
+    )
+
+    out.backward(grad_energy)
+
+    expected_positions_grad = torch.stack(
+        (
+            grad_energy * 2.0 * positions.detach()[:, 0] * positions.detach()[:, 1],
+            grad_energy * charges.detach(),
+            grad_energy * positions.detach()[:, 2],
+        ),
+        dim=1,
+    )
+    torch.testing.assert_close(positions.grad, expected_positions_grad)
+
+    expected_theta_grad = grad_energy * positions.detach()[:, 1]
+    torch.testing.assert_close(theta.grad, expected_theta_grad)
+
+
+def test_cached_eval_qR_create_graph_second_order():
+    """create_graph q(R) fallback differentiates connected position gradients once."""
+    positions = torch.randn(3, 3, dtype=DT, requires_grad=True)
+    theta = torch.randn(3, dtype=DT, requires_grad=True)
+    charges = positions[:, 0].square() + theta
+    cell = torch.eye(3, dtype=DT).unsqueeze(0)
+    energy = positions[:, 1].detach().clone()
+    pos_grad_state = torch.zeros_like(positions)
+    charge_grad_state = torch.zeros_like(charges)
+    cell_grad_state = torch.zeros_like(cell)
+
+    def fallback_fn(p, q, _cell):
+        return p[:, 1] * q + 0.5 * p[:, 2].square()
+
+    out = _InjectCachedEvalGradWithFallback.apply(
+        energy,
+        positions,
+        charges,
+        cell,
+        pos_grad_state,
+        charge_grad_state,
+        cell_grad_state,
+        None,
+        fallback_fn,
+    )
+
+    grad_pos = torch.autograd.grad(out.sum(), positions, create_graph=True)[0]
+    loss = grad_pos.pow(2).sum()
+    (grad_theta_ad,) = torch.autograd.grad(loss, theta)
+
+    def loss_of_theta(theta_in: torch.Tensor) -> torch.Tensor:
+        p = positions.detach().clone().requires_grad_(True)
+        q = p[:, 0].square() + theta_in
+        e = fallback_fn(p, q, cell)
+        g = torch.autograd.grad(e.sum(), p, create_graph=True)[0]
+        return g.pow(2).sum()
+
+    eps = 1e-6
+    grad_theta_fd = finite_difference_jacobian(loss_of_theta, theta.detach(), eps=eps)
+
+    torch.testing.assert_close(
+        grad_theta_ad,
+        grad_theta_fd,
+        rtol=1e-5,
+        atol=1e-7,
+    )
 
 
 def _available_devices():


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Fix electrostatics autograd routing for geometry-dependent charges, where `charges = q(positions)` can otherwise combine connected position gradients and explicit charge gradients from the same recompute path. The updated Ewald and PME Torch wrappers route q(R) workloads through charge-gradient injection or fallback recomputes that separate fixed-charge geometry partials from `dE/dq`, letting PyTorch apply the `dE/dq * dq/dR` chain term once.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes https://github.com/NVIDIA/nvalchemi-toolkit-ops/issues/115

## Changes Made

- Add a shared q(R) detection helper and use it in cached Ewald/PME Torch autograd paths.
- Recompute safe fixed-charge geometry partials for non-uniform cotangents and higher-order fallback paths while returning charge gradients separately.
- Route direct-output q(R) Ewald/PME paths through charge-gradient injection where positions and cells are detached.
- Add q(R) manual-chain, weighted-loss, HVP, hybrid-force, and batched double-backward regression coverage for Ewald and PME.
- Rename legacy direct-output wording to deprecated direct-output wording in touched electrostatics code and tests.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Not run while preparing PR materials.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
