### PR TITLE
fix(neighbors): require pair_params with pair functions

### DIFF
--- a/nvalchemiops/neighbors/cluster_tile/launchers.py
+++ b/nvalchemiops/neighbors/cluster_tile/launchers.py
@@ -21,8 +21,8 @@ GROMACS-style NxM cluster pair list: Morton-sorted atoms grouped into
 compiled kernels and factories live in :mod:`nvalchemiops.neighbors.cluster_tile.kernels`.
 """
 
-from collections.abc import Iterable
 import math
+from collections.abc import Iterable
 
 import warp as wp
 

--- a/nvalchemiops/torch/neighbors/batch_cell_list.py
+++ b/nvalchemiops/torch/neighbors/batch_cell_list.py
@@ -74,6 +74,7 @@ from nvalchemiops.torch.neighbors._compiled_pair_fn import (
     is_compiled_pair_fn,
 )
 from nvalchemiops.torch.neighbors.neighbor_utils import (
+    _validate_pair_params_present,
     allocate_cell_list,
     coo_pack_pair_geometry,
     get_neighbor_list_from_neighbor_matrix,
@@ -937,6 +938,7 @@ def batch_query_cell_list(
         pair_energies=pair_energies,
         pair_forces=pair_forces,
     ):
+        _validate_pair_params_present(pair_fn, pair_params)
         if (
             pair_fn is None
             and pair_params is None
@@ -1776,6 +1778,7 @@ def batch_cell_list(
                 "fixed-shape caller-provided buffers/metadata; missing "
                 f"{', '.join(missing)}.",
             )
+    _validate_pair_params_present(pair_fn, pair_params)
 
     if fill_value is None:
         fill_value = total_atoms

--- a/nvalchemiops/torch/neighbors/batch_naive.py
+++ b/nvalchemiops/torch/neighbors/batch_naive.py
@@ -38,6 +38,7 @@ from nvalchemiops.torch.neighbors._compiled_pair_fn import (
     is_compiled_pair_fn,
 )
 from nvalchemiops.torch.neighbors.neighbor_utils import (
+    _validate_pair_params_present,
     compute_naive_num_shifts,
     coo_pack_pair_geometry,
     get_neighbor_list_from_neighbor_matrix,
@@ -1407,6 +1408,7 @@ def batch_naive_neighbor_list(
                 "fixed-shape caller-provided buffers/metadata; missing "
                 f"{', '.join(missing)}.",
             )
+    _validate_pair_params_present(pair_fn, pair_params)
 
     if max_neighbors is None and (
         neighbor_matrix is None

--- a/nvalchemiops/torch/neighbors/cell_list.py
+++ b/nvalchemiops/torch/neighbors/cell_list.py
@@ -79,6 +79,7 @@ from nvalchemiops.torch.neighbors._compiled_pair_fn import (
     is_compiled_pair_fn,
 )
 from nvalchemiops.torch.neighbors.neighbor_utils import (
+    _validate_pair_params_present,
     allocate_cell_list,
     coo_pack_pair_geometry,
     get_neighbor_list_from_neighbor_matrix,
@@ -881,6 +882,7 @@ def query_cell_list(
         pair_energies=pair_energies,
         pair_forces=pair_forces,
     ):
+        _validate_pair_params_present(pair_fn, pair_params)
         if (
             pair_fn is None
             and pair_params is None
@@ -1849,6 +1851,7 @@ def cell_list(
                 "fixed-shape caller-provided buffers/metadata; missing "
                 f"{', '.join(missing)}.",
             )
+    _validate_pair_params_present(pair_fn, pair_params)
 
     if fill_value is None:
         fill_value = total_atoms

--- a/nvalchemiops/torch/neighbors/naive.py
+++ b/nvalchemiops/torch/neighbors/naive.py
@@ -39,6 +39,7 @@ from nvalchemiops.torch.neighbors._compiled_pair_fn import (
     is_compiled_pair_fn,
 )
 from nvalchemiops.torch.neighbors.neighbor_utils import (
+    _validate_pair_params_present,
     compute_naive_num_shifts,
     coo_pack_pair_geometry,
     get_neighbor_list_from_neighbor_matrix,
@@ -1337,6 +1338,7 @@ def naive_neighbor_list(
                     "fixed-shape caller-provided buffers/metadata; missing "
                     f"{', '.join(missing)}.",
                 )
+        _validate_pair_params_present(pair_fn, pair_params)
         if rebuild_flags is not None:
             raise NotImplementedError(
                 "Pair outputs are not supported with rebuild_flags.",

--- a/nvalchemiops/torch/neighbors/neighbor_utils.py
+++ b/nvalchemiops/torch/neighbors/neighbor_utils.py
@@ -53,6 +53,15 @@ def _raise_if_compiling_host_only(name: str, replacement: str) -> None:
         )
 
 
+def _validate_pair_params_present(
+    pair_fn: object,
+    pair_params: torch.Tensor | None,
+) -> None:
+    """Validate the torch pair-function parameter contract."""
+    if pair_fn is not None and pair_params is None:
+        raise ValueError("pair_params is required when pair_fn is provided")
+
+
 def compute_naive_num_shifts(
     cell: torch.Tensor,
     cutoff: float,

--- a/test/neighbors/bindings/torch/test_pair_fn.py
+++ b/test/neighbors/bindings/torch/test_pair_fn.py
@@ -32,6 +32,7 @@ import warp as wp
 from nvalchemiops.torch.neighbors import compile_pair_fn
 from nvalchemiops.torch.neighbors.batch_cell_list import (
     batch_cell_list,
+    batch_query_cell_list,
     estimate_batch_cell_list_sizes,
 )
 from nvalchemiops.torch.neighbors.batch_naive import batch_naive_neighbor_list
@@ -39,6 +40,7 @@ from nvalchemiops.torch.neighbors.cell_list import (
     allocate_query_sort_scratch,
     cell_list,
     estimate_cell_list_sizes,
+    query_cell_list,
 )
 from nvalchemiops.torch.neighbors.naive import naive_neighbor_list
 from nvalchemiops.torch.neighbors.neighbor_utils import (
@@ -47,6 +49,35 @@ from nvalchemiops.torch.neighbors.neighbor_utils import (
 )
 
 from ...test_utils import create_simple_cubic_system
+
+_PAIR_PARAMS_REQUIRED = "pair_params is required when pair_fn is provided"
+
+
+def _missing_pair_params_cpu_fixtures():
+    """Small CPU tensors for missing-``pair_params`` validation tests."""
+    positions = _two_cluster_positions("cpu")
+    cell = torch.eye(3, dtype=torch.float32).reshape(1, 3, 3) * 3.0
+    pbc = torch.tensor([[True, True, True]], dtype=torch.bool)
+    batch_idx = torch.zeros(positions.shape[0], dtype=torch.int32)
+    batch_ptr = torch.tensor([0, positions.shape[0]], dtype=torch.int32)
+    return positions, cell, pbc, batch_idx, batch_ptr
+
+
+def _alloc_query_neighbor_buffers(n_atoms: int, max_neighbors: int, device: str):
+    """Allocate minimal neighbor-matrix buffers for query-wrapper tests."""
+    neighbor_matrix = torch.full(
+        (n_atoms, max_neighbors),
+        n_atoms,
+        dtype=torch.int32,
+        device=device,
+    )
+    neighbor_matrix_shifts = torch.zeros(
+        (n_atoms, max_neighbors, 3),
+        dtype=torch.int32,
+        device=device,
+    )
+    num_neighbors = torch.zeros((n_atoms,), dtype=torch.int32, device=device)
+    return neighbor_matrix, neighbor_matrix_shifts, num_neighbors
 
 
 @wp.func
@@ -1189,3 +1220,178 @@ def test_batch_naive_pair_fn_target_indices_compact_rows(device):
     assert pe.shape == (2, 4)
     assert pf.shape == (2, 4, 3)
     _check_target_pair_outputs(nm, nn, nv, nd, pe, pf, pp, target_indices)
+
+
+def test_compiled_naive_missing_pair_params_raises():
+    """Compiled naive rejects omitted ``pair_params`` before custom-op dispatch."""
+    positions, _cell, _pbc, _batch_idx, _batch_ptr = _missing_pair_params_cpu_fixtures()
+    cpf = _compiled_pair_fn("missing_pair_params_naive")
+    with pytest.raises(ValueError, match=_PAIR_PARAMS_REQUIRED):
+        naive_neighbor_list(positions, 0.75, max_neighbors=4, pair_fn=cpf)
+
+
+def test_compiled_batch_naive_missing_pair_params_raises():
+    """Compiled batch naive rejects omitted ``pair_params`` before dispatch."""
+    positions, _cell, _pbc, batch_idx, batch_ptr = _missing_pair_params_cpu_fixtures()
+    cpf = _compiled_pair_fn("missing_pair_params_batch_naive")
+    with pytest.raises(ValueError, match=_PAIR_PARAMS_REQUIRED):
+        batch_naive_neighbor_list(
+            positions,
+            0.75,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=4,
+            pair_fn=cpf,
+        )
+
+
+def test_compiled_cell_list_missing_pair_params_raises():
+    """Compiled cell list rejects omitted ``pair_params`` before dispatch."""
+    positions, cell, pbc, _batch_idx, _batch_ptr = _missing_pair_params_cpu_fixtures()
+    cpf = _compiled_pair_fn("missing_pair_params_cell_list")
+    with pytest.raises(ValueError, match=_PAIR_PARAMS_REQUIRED):
+        cell_list(
+            positions,
+            0.75,
+            cell,
+            pbc.reshape(3),
+            max_neighbors=4,
+            pair_fn=cpf,
+        )
+
+
+def test_compiled_batch_cell_list_missing_pair_params_raises():
+    """Compiled batch cell list rejects omitted ``pair_params`` before dispatch."""
+    positions, cell, pbc, batch_idx, _batch_ptr = _missing_pair_params_cpu_fixtures()
+    cpf = _compiled_pair_fn("missing_pair_params_batch_cell_list")
+    with pytest.raises(ValueError, match=_PAIR_PARAMS_REQUIRED):
+        batch_cell_list(
+            positions,
+            0.75,
+            cell,
+            pbc,
+            batch_idx,
+            max_neighbors=4,
+            pair_fn=cpf,
+        )
+
+
+def test_compiled_query_cell_list_missing_pair_params_raises():
+    """Compiled query wrapper rejects omitted ``pair_params`` before dispatch."""
+    positions, cell, pbc, _batch_idx, _batch_ptr = _missing_pair_params_cpu_fixtures()
+    max_neighbors = 4
+    max_total_cells, neighbor_search_radius = estimate_cell_list_sizes(
+        cell,
+        pbc.reshape(3),
+        0.75,
+    )
+    cell_list_cache = allocate_cell_list(
+        positions.shape[0],
+        max_total_cells,
+        neighbor_search_radius,
+        positions.device,
+    )
+    neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
+        _alloc_query_neighbor_buffers(
+            positions.shape[0],
+            max_neighbors,
+            positions.device,
+        )
+    )
+    cpf = _compiled_pair_fn("missing_pair_params_query_cell_list")
+    with pytest.raises(ValueError, match=_PAIR_PARAMS_REQUIRED):
+        query_cell_list(
+            positions,
+            0.75,
+            cell,
+            pbc.reshape(3),
+            *cell_list_cache,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            num_neighbors,
+            pair_fn=cpf,
+        )
+
+
+def test_compiled_batch_query_cell_list_missing_pair_params_raises():
+    """Compiled batch query wrapper rejects omitted ``pair_params`` before dispatch."""
+    positions, cell, pbc, batch_idx, _batch_ptr = _missing_pair_params_cpu_fixtures()
+    max_neighbors = 4
+    max_total_cells, neighbor_search_radius = estimate_batch_cell_list_sizes(
+        cell,
+        pbc,
+        0.75,
+    )
+    cell_list_cache = allocate_cell_list(
+        positions.shape[0],
+        max_total_cells,
+        neighbor_search_radius,
+        positions.device,
+    )
+    neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
+        _alloc_query_neighbor_buffers(
+            positions.shape[0],
+            max_neighbors,
+            positions.device,
+        )
+    )
+    cpf = _compiled_pair_fn("missing_pair_params_batch_query_cell_list")
+    with pytest.raises(ValueError, match=_PAIR_PARAMS_REQUIRED):
+        batch_query_cell_list(
+            positions,
+            cell,
+            pbc,
+            0.75,
+            batch_idx,
+            *cell_list_cache,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            num_neighbors,
+            pair_fn=cpf,
+        )
+
+
+def test_naive_pair_fn_missing_pair_params_raises():
+    """Raw ``pair_fn`` also rejects omitted ``pair_params`` at the torch wrapper."""
+    positions, _cell, _pbc, _batch_idx, _batch_ptr = _missing_pair_params_cpu_fixtures()
+    with pytest.raises(ValueError, match=_PAIR_PARAMS_REQUIRED):
+        naive_neighbor_list(
+            positions,
+            0.75,
+            max_neighbors=4,
+            pair_fn=_sum_pair_fn,
+        )
+
+
+def test_compiled_naive_fullgraph_missing_pair_params_diagnostic(device):
+    """Fullgraph keeps the specific missing-buffer diagnostic for ``pair_params``."""
+    _skip_without_cuda(device)
+    positions = _two_cluster_positions(device)
+    max_neighbors = 4
+    cpf = _compiled_pair_fn("missing_pair_params_naive_fullgraph")
+    nm, _nms, nn, nv, nd, pe, pf, _pp = _alloc_pair_buffers(
+        positions.shape[0], max_neighbors, device
+    )
+
+    @torch.compile(fullgraph=True)
+    def run(positions, nm, nn, nv, nd, pe, pf):
+        return naive_neighbor_list(
+            positions,
+            0.75,
+            max_neighbors=max_neighbors,
+            neighbor_matrix=nm,
+            num_neighbors=nn,
+            return_distances=True,
+            return_vectors=True,
+            neighbor_vectors=nv,
+            neighbor_distances=nd,
+            pair_fn=cpf,
+            pair_energies=pe,
+            pair_forces=pf,
+        )
+
+    with pytest.raises(
+        Exception,
+        match=r"CompiledPairFn under torch\.compile\(fullgraph=True\).*missing .*pair_params",
+    ):
+        run(positions, nm, nn, nv, nd, pe, pf)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Fix Torch neighbor pair-function entry points so they reject `pair_fn` calls that omit `pair_params` before dispatching into custom operators or compiled pair-function paths.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

- Add shared Torch neighbor validation for the pair-function parameter contract.
- Apply the validation to naive, batch naive, cell-list, batch cell-list, and query cell-list pair-output paths.
- Add Torch neighbor tests for missing `pair_params` across compiled pair functions, raw pair functions, query wrappers, and the fullgraph diagnostic path.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
