### PR TITLE
Add integrator flags for pre-computing thermo quanities

### DIFF
--- a/nvalchemiops/dynamics/integrators/__init__.py
+++ b/nvalchemiops/dynamics/integrators/__init__.py
@@ -140,6 +140,7 @@ from nvalchemiops.dynamics.integrators.langevin import (
     langevin_baoab_half_step_out,
 )
 from nvalchemiops.dynamics.integrators.nose_hoover import (
+    nhc_compute_2ke,
     nhc_compute_chain_energy,
     # Utilities
     nhc_compute_masses,
@@ -157,6 +158,7 @@ from nvalchemiops.dynamics.integrators.npt import (
     compute_barostat_mass,
     compute_barostat_potential_energy,
     compute_cell_kinetic_energy,
+    compute_kinetic_tensor,
     # Pressure calculations
     compute_pressure_tensor,
     compute_scalar_pressure,
@@ -235,6 +237,7 @@ __all__ = [
     "nhc_position_update_out",
     # Nosé-Hoover Chain - Utilities
     "nhc_compute_masses",
+    "nhc_compute_2ke",
     # NPT/NPH - Virial conversion
     "flat_virial_to_vec9",
     # NPT/NPH - Tensor types
@@ -245,6 +248,7 @@ __all__ = [
     # NPT/NPH - Pressure calculations
     "compute_pressure_tensor",
     "compute_scalar_pressure",
+    "compute_kinetic_tensor",
     # NPT/NPH - Barostat utilities
     "compute_barostat_mass",
     "compute_cell_kinetic_energy",

--- a/nvalchemiops/dynamics/integrators/nose_hoover.py
+++ b/nvalchemiops/dynamics/integrators/nose_hoover.py
@@ -1057,7 +1057,6 @@ def nhc_compute_2ke(
     masses: wp.array,
     ke2: wp.array,
     batch_idx: wp.array = None,
-    num_systems: int = 1,
     device: str = None,
 ) -> wp.array:
     """
@@ -1076,12 +1075,11 @@ def nhc_compute_2ke(
     masses : wp.array(dtype=wp.float32 or wp.float64)
         Atomic masses. Shape (N,).
     ke2 : wp.array
-        Output 2*KE. Shape (1,) for single system, (num_systems,) for batched.
-        Zeroed internally before accumulation. MODIFIED in-place.
+        Output 2*KE. Shape (1,) for single system, (num_systems,) for batched
+        (its length sets the number of systems). Zeroed internally before
+        accumulation. MODIFIED in-place.
     batch_idx : wp.array(dtype=wp.int32), optional
         System index for each atom. Required for batched mode.
-    num_systems : int, optional
-        Number of systems for batched mode. Default: 1.
     device : str, optional
         Warp device. If None, inferred from velocities.
 
@@ -1409,7 +1407,10 @@ def nhc_thermostat_chain_update_out(
     ndof : wp.array(dtype=wp.float64)
         Degrees of freedom. Shape (1,) or (B,).
     ke2 : wp.array
-        Scratch array for 2*KE computation. Zeroed internally before each use.
+        2*KE = sum(m * v^2) per system. Zeroed and filled internally when
+        compute_ke is True (default); when compute_ke is False it is an INPUT
+        supplying a caller-precomputed 2*KE that is not zeroed. See
+        ``nhc_thermostat_chain_update``.
         Shape (1,) for single system, (num_systems,) for batched.
     total_scale : wp.array
         Scratch array for accumulated velocity scale factor.

--- a/nvalchemiops/dynamics/integrators/nose_hoover.py
+++ b/nvalchemiops/dynamics/integrators/nose_hoover.py
@@ -1052,6 +1052,72 @@ def nhc_compute_masses(
     return masses
 
 
+def nhc_compute_2ke(
+    velocities: wp.array,
+    masses: wp.array,
+    ke2: wp.array,
+    batch_idx: wp.array = None,
+    num_systems: int = 1,
+    device: str = None,
+) -> wp.array:
+    """
+    Fill ke2[s] = sum_{i in s} m_i * ||v_i||^2 — the same 2*KE reduction that
+    ``nhc_thermostat_chain_update`` performs internally, exposed standalone.
+
+    Under domain decomposition the caller computes the per-rank (local) 2*KE
+    with this helper, all-reduces it across the process mesh, then feeds the
+    global result back via ``nhc_thermostat_chain_update(..., compute_ke=False)``.
+    Using this kernel for the local reduction gives machine-precision parity
+    with the single-process reference.
+
+    Parameters
+    ----------
+    velocities : wp.array(dtype=wp.vec3f or wp.vec3d)
+        Atomic velocities. Shape (N,).
+    masses : wp.array(dtype=wp.float32 or wp.float64)
+        Atomic masses. Shape (N,).
+    ke2 : wp.array
+        Output 2*KE. Shape (1,) for single system, (num_systems,) for batched.
+        Zeroed internally before accumulation. MODIFIED in-place.
+    batch_idx : wp.array(dtype=wp.int32), optional
+        System index for each atom. Required for batched mode.
+    num_systems : int, optional
+        Number of systems for batched mode. Default: 1.
+    device : str, optional
+        Warp device. If None, inferred from velocities.
+
+    Returns
+    -------
+    wp.array
+        The ``ke2`` array, filled with 2*KE per system.
+    """
+    if device is None:
+        device = velocities.device
+
+    num_atoms = velocities.shape[0]
+    is_batched = batch_idx is not None
+    vec_dtype = velocities.dtype
+    out_dtype = ke2.dtype
+
+    ke2.zero_()
+    if is_batched:
+        wp.launch(
+            _batch_compute_2ke_kernel_overload[(vec_dtype, out_dtype)],
+            dim=num_atoms,
+            inputs=[velocities, masses, batch_idx, ke2],
+            device=device,
+        )
+    else:
+        wp.launch(
+            _compute_2ke_kernel_overload[(vec_dtype, out_dtype)],
+            dim=num_atoms,
+            inputs=[velocities, masses, ke2],
+            device=device,
+        )
+
+    return ke2
+
+
 def nhc_thermostat_chain_update(
     velocities: wp.array,
     masses: wp.array,
@@ -1069,6 +1135,7 @@ def nhc_thermostat_chain_update(
     batch_idx: wp.array = None,
     num_systems: int = 1,
     device: str = None,
+    compute_ke: bool = True,
 ) -> None:
     """
     Propagate Nosé-Hoover chain and scale velocities (in-place).
@@ -1098,7 +1165,11 @@ def nhc_thermostat_chain_update(
     ndof : wp.array(dtype=wp.float64)
         Degrees of freedom. Shape (1,) or (num_systems,).
     ke2 : wp.array
-        Scratch array for 2*KE computation. Zeroed internally before each use.
+        2*KE = sum(m * v^2) per system. When compute_ke is True (default) this
+        is a scratch array zeroed and filled internally from velocities/masses
+        before use. When compute_ke is False it is an INPUT supplying a
+        caller-computed (e.g. domain-decomposed, mesh-reduced) global 2*KE; it
+        is not zeroed. Either way the chain forward sweep rescales it in place.
         Shape (1,) for single system, (num_systems,) for batched.
     total_scale : wp.array
         Scratch array for accumulated velocity scale factor.
@@ -1119,6 +1190,13 @@ def nhc_thermostat_chain_update(
         Number of systems for batched mode. Default: 1.
     device : str, optional
         Warp device. If None, inferred from velocities.
+    compute_ke : bool, optional
+        If True (default), recompute 2*KE from velocities/masses internally
+        (byte-identical to legacy behavior). If False, trust the global 2*KE
+        supplied in ``ke2`` instead of recomputing it from the local atom set
+        — used under domain decomposition, where the caller all-reduces the
+        per-rank 2*KE across the process mesh and feeds the global value back.
+        See ``nhc_compute_2ke`` for the matching reduction helper.
     """
     if device is None:
         device = velocities.device
@@ -1148,25 +1226,29 @@ def nhc_thermostat_chain_update(
             f"Chain length {chain_length} exceeds maximum {MAX_CHAIN_LENGTH}"
         )
 
-    # Compute 2*KE - ke2 is zeroed internally before each use
+    # Compute 2*KE - ke2 is zeroed internally before each use UNLESS the caller
+    # supplied it (e.g. a domain-decomposed global reduction performed outside
+    # this kernel). When compute_ke is False, ke2 arrives pre-filled with the
+    # global 2*KE and is NOT zeroed — the caller owns it.
     vec_dtype = velocities.dtype
     chain_dtype = eta.dtype
     n_scale = num_systems if is_batched else 1
-    ke2.zero_()
-    if is_batched:
-        wp.launch(
-            _batch_compute_2ke_kernel_overload[(vec_dtype, chain_dtype)],
-            dim=num_atoms,
-            inputs=[velocities, masses, batch_idx, ke2],
-            device=device,
-        )
-    else:
-        wp.launch(
-            _compute_2ke_kernel_overload[(vec_dtype, chain_dtype)],
-            dim=num_atoms,
-            inputs=[velocities, masses, ke2],
-            device=device,
-        )
+    if compute_ke:
+        ke2.zero_()
+        if is_batched:
+            wp.launch(
+                _batch_compute_2ke_kernel_overload[(vec_dtype, chain_dtype)],
+                dim=num_atoms,
+                inputs=[velocities, masses, batch_idx, ke2],
+                device=device,
+            )
+        else:
+            wp.launch(
+                _compute_2ke_kernel_overload[(vec_dtype, chain_dtype)],
+                dim=num_atoms,
+                inputs=[velocities, masses, ke2],
+                device=device,
+            )
 
     # Run Yoshida-Suzuki sub-steps
     for w in weights:
@@ -1307,6 +1389,7 @@ def nhc_thermostat_chain_update_out(
     batch_idx: wp.array = None,
     num_systems: int = 1,
     device: str = None,
+    compute_ke: bool = True,
 ) -> tuple[wp.array, wp.array, wp.array]:
     """
     Propagate Nosé-Hoover chain and scale velocities (non-mutating).
@@ -1356,6 +1439,10 @@ def nhc_thermostat_chain_update_out(
         Number of systems for batched mode. Default: 1.
     device : str, optional
         Warp device. If None, inferred from velocities.
+    compute_ke : bool, optional
+        If True (default), recompute 2*KE internally. If False, trust the
+        caller-supplied global 2*KE in ``ke2``. See
+        ``nhc_thermostat_chain_update`` for details.
 
     Returns
     -------
@@ -1392,6 +1479,7 @@ def nhc_thermostat_chain_update_out(
         batch_idx=batch_idx,
         num_systems=num_systems,
         device=device,
+        compute_ke=compute_ke,
     )
 
     return velocities_out, eta_out, eta_dot_out

--- a/nvalchemiops/dynamics/integrators/nose_hoover.py
+++ b/nvalchemiops/dynamics/integrators/nose_hoover.py
@@ -1064,11 +1064,10 @@ def nhc_compute_2ke(
     Fill ke2[s] = sum_{i in s} m_i * ||v_i||^2 — the same 2*KE reduction that
     ``nhc_thermostat_chain_update`` performs internally, exposed standalone.
 
-    Under domain decomposition the caller computes the per-rank (local) 2*KE
-    with this helper, all-reduces it across the process mesh, then feeds the
-    global result back via ``nhc_thermostat_chain_update(..., compute_ke=False)``.
-    Using this kernel for the local reduction gives machine-precision parity
-    with the single-process reference.
+    Lets a caller compute 2*KE separately, optionally post-process it, and feed
+    it back via ``nhc_thermostat_chain_update(..., compute_ke=False)``. Using
+    this kernel for the reduction gives machine-precision parity with the
+    value the chain update would otherwise compute itself.
 
     Parameters
     ----------
@@ -1168,8 +1167,8 @@ def nhc_thermostat_chain_update(
         2*KE = sum(m * v^2) per system. When compute_ke is True (default) this
         is a scratch array zeroed and filled internally from velocities/masses
         before use. When compute_ke is False it is an INPUT supplying a
-        caller-computed (e.g. domain-decomposed, mesh-reduced) global 2*KE; it
-        is not zeroed. Either way the chain forward sweep rescales it in place.
+        caller-precomputed 2*KE; it is not zeroed. Either way the chain forward
+        sweep rescales it in place.
         Shape (1,) for single system, (num_systems,) for batched.
     total_scale : wp.array
         Scratch array for accumulated velocity scale factor.
@@ -1192,11 +1191,9 @@ def nhc_thermostat_chain_update(
         Warp device. If None, inferred from velocities.
     compute_ke : bool, optional
         If True (default), recompute 2*KE from velocities/masses internally
-        (byte-identical to legacy behavior). If False, trust the global 2*KE
-        supplied in ``ke2`` instead of recomputing it from the local atom set
-        — used under domain decomposition, where the caller all-reduces the
-        per-rank 2*KE across the process mesh and feeds the global value back.
-        See ``nhc_compute_2ke`` for the matching reduction helper.
+        (byte-identical to legacy behavior). If False, use the caller-supplied
+        value already in ``ke2`` instead of recomputing it. See
+        ``nhc_compute_2ke`` for the matching reduction helper.
     """
     if device is None:
         device = velocities.device
@@ -1227,9 +1224,8 @@ def nhc_thermostat_chain_update(
         )
 
     # Compute 2*KE - ke2 is zeroed internally before each use UNLESS the caller
-    # supplied it (e.g. a domain-decomposed global reduction performed outside
-    # this kernel). When compute_ke is False, ke2 arrives pre-filled with the
-    # global 2*KE and is NOT zeroed — the caller owns it.
+    # supplied it. When compute_ke is False, ke2 arrives pre-filled and is NOT
+    # zeroed — the caller owns it.
     vec_dtype = velocities.dtype
     chain_dtype = eta.dtype
     n_scale = num_systems if is_batched else 1
@@ -1440,8 +1436,8 @@ def nhc_thermostat_chain_update_out(
     device : str, optional
         Warp device. If None, inferred from velocities.
     compute_ke : bool, optional
-        If True (default), recompute 2*KE internally. If False, trust the
-        caller-supplied global 2*KE in ``ke2``. See
+        If True (default), recompute 2*KE internally. If False, use the
+        caller-supplied value in ``ke2``. See
         ``nhc_thermostat_chain_update`` for details.
 
     Returns

--- a/nvalchemiops/dynamics/integrators/nose_hoover.py
+++ b/nvalchemiops/dynamics/integrators/nose_hoover.py
@@ -1059,14 +1059,16 @@ def nhc_compute_2ke(
     batch_idx: wp.array = None,
     device: str = None,
 ) -> wp.array:
-    """
-    Fill ke2[s] = sum_{i in s} m_i * ||v_i||^2 — the same 2*KE reduction that
+    r"""
+    Fill ``ke2[s]`` with :math:`\sum_{i \in s} m_i \lVert \mathbf{v}_i \rVert^2`
+    (i.e. :math:`2\,\mathrm{KE}` per system) — the same reduction that
     ``nhc_thermostat_chain_update`` performs internally, exposed standalone.
 
-    Lets a caller compute 2*KE separately, optionally post-process it, and feed
-    it back via ``nhc_thermostat_chain_update(..., compute_ke=False)``. Using
-    this kernel for the reduction gives machine-precision parity with the
-    value the chain update would otherwise compute itself.
+    Lets a caller compute :math:`2\,\mathrm{KE}` separately, optionally
+    post-process it, and feed it back via
+    ``nhc_thermostat_chain_update(..., compute_ke=False)``. Using this kernel for
+    the reduction gives machine-precision parity with the value the chain update
+    would otherwise compute itself.
 
     Parameters
     ----------
@@ -1075,9 +1077,9 @@ def nhc_compute_2ke(
     masses : wp.array(dtype=wp.float32 or wp.float64)
         Atomic masses. Shape (N,).
     ke2 : wp.array
-        Output 2*KE. Shape (1,) for single system, (num_systems,) for batched
-        (its length sets the number of systems). Zeroed internally before
-        accumulation. MODIFIED in-place.
+        Output :math:`2\,\mathrm{KE}`. Shape (1,) for single system,
+        (num_systems,) for batched (its length sets the number of systems).
+        Zeroed internally before accumulation. MODIFIED in-place.
     batch_idx : wp.array(dtype=wp.int32), optional
         System index for each atom. Required for batched mode.
     device : str, optional
@@ -1086,7 +1088,7 @@ def nhc_compute_2ke(
     Returns
     -------
     wp.array
-        The ``ke2`` array, filled with 2*KE per system.
+        The ``ke2`` array, filled with :math:`2\,\mathrm{KE}` per system.
     """
     if device is None:
         device = velocities.device

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -1562,12 +1562,11 @@ def compute_kinetic_tensor(
     same accumulation ``compute_pressure_tensor`` performs internally, exposed
     standalone.
 
-    Under domain decomposition the caller computes the per-rank (local) kinetic
-    tensor with this helper, all-reduces it across the process mesh, then feeds
-    the global result back via
+    Lets a caller compute the kinetic tensor separately, optionally
+    post-process it, and feed it back via
     ``compute_pressure_tensor(..., compute_kinetic=False)``. Using this kernel
-    for the local reduction gives machine-precision parity with the
-    single-process reference.
+    for the reduction gives machine-precision parity with the value
+    ``compute_pressure_tensor`` would otherwise compute itself.
 
     Parameters
     ----------
@@ -1636,9 +1635,8 @@ def compute_pressure_tensor(
         Kinetic tensor K[s] = sum_{i in s} m_i (v_i ⊗ v_i), vec9 layout. Shape
         (B, 9). When compute_kinetic is True (default) this is a scratch array
         zeroed and filled internally from velocities/masses. When
-        compute_kinetic is False it is an INPUT supplying a caller-computed
-        (e.g. domain-decomposed, mesh-reduced) global kinetic tensor; it is not
-        zeroed or recomputed.
+        compute_kinetic is False it is an INPUT supplying a caller-precomputed
+        kinetic tensor; it is not zeroed or recomputed.
     pressure_tensors : wp.array(dtype=vec9f or vec9d)
         Output pressure tensor. Shape (B,).
     volumes : wp.array(dtype=scalar)
@@ -1650,12 +1648,9 @@ def compute_pressure_tensor(
         Warp device.
     compute_kinetic : bool, optional
         If True (default), recompute the kinetic tensor from velocities/masses
-        internally (byte-identical to legacy behavior). If False, trust the
-        global kinetic tensor supplied in ``kinetic_tensors`` instead of
-        recomputing it from the local atom set — used under domain
-        decomposition, where the caller all-reduces the per-rank kinetic tensor
-        across the process mesh and feeds the global value back (the virial is
-        already global). See ``compute_kinetic_tensor`` for the matching
+        internally (byte-identical to legacy behavior). If False, use the
+        caller-supplied value already in ``kinetic_tensors`` instead of
+        recomputing it. See ``compute_kinetic_tensor`` for the matching
         reduction helper.
 
     Returns

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -1557,10 +1557,11 @@ def compute_kinetic_tensor(
     batch_idx: wp.array = None,
     device: str = None,
 ) -> wp.array:
-    """
-    Fill kinetic_tensors[s] = sum_{i in s} m_i (v_i ⊗ v_i) (vec9 layout) — the
-    same accumulation ``compute_pressure_tensor`` performs internally, exposed
-    standalone.
+    r"""
+    Fill ``kinetic_tensors[s]`` with
+    :math:`\sum_{i \in s} m_i (\mathbf{v}_i \otimes \mathbf{v}_i)` (vec9 layout)
+    — the same accumulation ``compute_pressure_tensor`` performs internally,
+    exposed standalone.
 
     Lets a caller compute the kinetic tensor separately, optionally
     post-process it, and feed it back via
@@ -1585,7 +1586,8 @@ def compute_kinetic_tensor(
     Returns
     -------
     wp.array
-        The ``kinetic_tensors`` array, filled with sum m (v ⊗ v) per system.
+        The ``kinetic_tensors`` array, filled with
+        :math:`\sum_i m_i (\mathbf{v}_i \otimes \mathbf{v}_i)` per system.
     """
     if device is None:
         device = velocities.device
@@ -1616,10 +1618,10 @@ def compute_pressure_tensor(
     device: str = None,
     compute_kinetic: bool = True,
 ) -> wp.array:
-    """
-    Compute full pressure tensor.
-
-    P = (kinetic + virial) / V
+    r"""
+    Compute full pressure tensor :math:`\mathbf{P} = (\mathbf{K} + \mathbf{W}) / V`,
+    with kinetic term :math:`\mathbf{K}`, virial term :math:`\mathbf{W}`, and
+    cell volume :math:`V`.
 
     Parameters
     ----------
@@ -1632,9 +1634,10 @@ def compute_pressure_tensor(
     cells : wp.array(dtype=wp.mat33f or wp.mat33d)
         Cell matrices. Shape (B,).
     kinetic_tensors : wp.array(dtype=scalar, ndim=2)
-        Kinetic tensor K[s] = sum_{i in s} m_i (v_i ⊗ v_i), vec9 layout. Shape
-        (B, 9). When compute_kinetic is True (default) this is a scratch array
-        zeroed and filled internally from velocities/masses. When
+        Kinetic tensor
+        :math:`\mathbf{K}_s = \sum_{i \in s} m_i (\mathbf{v}_i \otimes \mathbf{v}_i)`,
+        vec9 layout. Shape (B, 9). When compute_kinetic is True (default) this is
+        a scratch array zeroed and filled internally from velocities/masses. When
         compute_kinetic is False it is an INPUT supplying a caller-precomputed
         kinetic tensor; it is not zeroed or recomputed.
     pressure_tensors : wp.array(dtype=vec9f or vec9d)

--- a/nvalchemiops/dynamics/integrators/npt.py
+++ b/nvalchemiops/dynamics/integrators/npt.py
@@ -1550,6 +1550,61 @@ def _npt_thermostat_chain_update_kernel(
 # ==============================================================================
 
 
+def compute_kinetic_tensor(
+    velocities: wp.array,
+    masses: wp.array,
+    kinetic_tensors: wp.array,
+    batch_idx: wp.array = None,
+    device: str = None,
+) -> wp.array:
+    """
+    Fill kinetic_tensors[s] = sum_{i in s} m_i (v_i ⊗ v_i) (vec9 layout) — the
+    same accumulation ``compute_pressure_tensor`` performs internally, exposed
+    standalone.
+
+    Under domain decomposition the caller computes the per-rank (local) kinetic
+    tensor with this helper, all-reduces it across the process mesh, then feeds
+    the global result back via
+    ``compute_pressure_tensor(..., compute_kinetic=False)``. Using this kernel
+    for the local reduction gives machine-precision parity with the
+    single-process reference.
+
+    Parameters
+    ----------
+    velocities : wp.array(dtype=wp.vec3f or wp.vec3d)
+        Particle velocities. Shape (N,).
+    masses : wp.array
+        Particle masses. Shape (N,).
+    kinetic_tensors : wp.array(dtype=scalar, ndim=2)
+        Output kinetic tensor. Shape (B, 9). Zeroed internally before
+        accumulation. MODIFIED in-place.
+    batch_idx : wp.array(dtype=wp.int32), optional
+        System index for each atom. If None, assumes single system.
+    device : str, optional
+        Warp device.
+
+    Returns
+    -------
+    wp.array
+        The ``kinetic_tensors`` array, filled with sum m (v ⊗ v) per system.
+    """
+    if device is None:
+        device = velocities.device
+
+    num_atoms = velocities.shape[0]
+
+    kinetic_tensors.zero_()
+    if batch_idx is None:
+        kernel = _KINETIC_TENSOR_FAMILY.single
+        inputs = [velocities, masses, kinetic_tensors]
+    else:
+        kernel = _KINETIC_TENSOR_FAMILY.batch_idx
+        inputs = [velocities, masses, batch_idx, kinetic_tensors]
+    wp.launch(kernel, dim=num_atoms, inputs=inputs, device=device, block_dim=TILE_DIM)
+
+    return kinetic_tensors
+
+
 def compute_pressure_tensor(
     velocities: wp.array,
     masses: wp.array,
@@ -1560,6 +1615,7 @@ def compute_pressure_tensor(
     volumes: wp.array,
     batch_idx: wp.array = None,
     device: str = None,
+    compute_kinetic: bool = True,
 ) -> wp.array:
     """
     Compute full pressure tensor.
@@ -1577,8 +1633,12 @@ def compute_pressure_tensor(
     cells : wp.array(dtype=wp.mat33f or wp.mat33d)
         Cell matrices. Shape (B,).
     kinetic_tensors : wp.array(dtype=scalar, ndim=2)
-        Scratch array for kinetic tensor accumulation. Shape (B, 9).
-        Zeroed internally before each use.
+        Kinetic tensor K[s] = sum_{i in s} m_i (v_i ⊗ v_i), vec9 layout. Shape
+        (B, 9). When compute_kinetic is True (default) this is a scratch array
+        zeroed and filled internally from velocities/masses. When
+        compute_kinetic is False it is an INPUT supplying a caller-computed
+        (e.g. domain-decomposed, mesh-reduced) global kinetic tensor; it is not
+        zeroed or recomputed.
     pressure_tensors : wp.array(dtype=vec9f or vec9d)
         Output pressure tensor. Shape (B,).
     volumes : wp.array(dtype=scalar)
@@ -1588,6 +1648,15 @@ def compute_pressure_tensor(
         System index for each atom. If None, assumes single system.
     device : str, optional
         Warp device.
+    compute_kinetic : bool, optional
+        If True (default), recompute the kinetic tensor from velocities/masses
+        internally (byte-identical to legacy behavior). If False, trust the
+        global kinetic tensor supplied in ``kinetic_tensors`` instead of
+        recomputing it from the local atom set — used under domain
+        decomposition, where the caller all-reduces the per-rank kinetic tensor
+        across the process mesh and feeds the global value back (the virial is
+        already global). See ``compute_kinetic_tensor`` for the matching
+        reduction helper.
 
     Returns
     -------
@@ -1597,17 +1666,20 @@ def compute_pressure_tensor(
     if device is None:
         device = velocities.device
 
-    kinetic_tensors.zero_()
     num_atoms = velocities.shape[0]
     num_systems = cells.shape[0]
 
-    if batch_idx is None:
-        kernel = _KINETIC_TENSOR_FAMILY.single
-        inputs = [velocities, masses, kinetic_tensors]
-    else:
-        kernel = _KINETIC_TENSOR_FAMILY.batch_idx
-        inputs = [velocities, masses, batch_idx, kinetic_tensors]
-    wp.launch(kernel, dim=num_atoms, inputs=inputs, device=device, block_dim=TILE_DIM)
+    if compute_kinetic:
+        kinetic_tensors.zero_()
+        if batch_idx is None:
+            kernel = _KINETIC_TENSOR_FAMILY.single
+            inputs = [velocities, masses, kinetic_tensors]
+        else:
+            kernel = _KINETIC_TENSOR_FAMILY.batch_idx
+            inputs = [velocities, masses, batch_idx, kinetic_tensors]
+        wp.launch(
+            kernel, dim=num_atoms, inputs=inputs, device=device, block_dim=TILE_DIM
+        )
 
     wp.launch(
         _finalize_pressure_tensor_kernel,

--- a/test/dynamics/test_nose_hoover.py
+++ b/test/dynamics/test_nose_hoover.py
@@ -1772,7 +1772,6 @@ class TestNHCComputeKE:
             masses,
             ke2,
             batch_idx=batch_idx,
-            num_systems=num_systems,
             device=device,
         )
         wp.synchronize_device(device)
@@ -1953,7 +1952,6 @@ class TestNHCComputeKE:
             supplied["masses"],
             ke2_in,
             batch_idx=batch_idx,
-            num_systems=num_systems,
             device=device,
         )
         run(supplied, ke2_in, False)

--- a/test/dynamics/test_nose_hoover.py
+++ b/test/dynamics/test_nose_hoover.py
@@ -30,6 +30,7 @@ import pytest
 import warp as wp
 
 from nvalchemiops.dynamics.integrators import (
+    nhc_compute_2ke,
     nhc_compute_chain_energy,
     nhc_compute_masses,
     nhc_position_update,
@@ -1704,6 +1705,391 @@ class TestNHCAtomPtr:
                 f"System {sys_id} (size={n}) velocities not updated"
             )
             offset += n
+
+
+# ==============================================================================
+# compute_ke flag + nhc_compute_2ke helper (domain-decomposition support)
+# ==============================================================================
+
+
+def _tol(np_dtype):
+    """Relative tolerance for fp comparisons that differ only by reduction order.
+
+    The internal 2*KE reduction uses atomic adds whose ordering is not
+    deterministic across launches, so byte-identity is not guaranteed even over
+    the same atoms. A tight rtol confirms the values are physically the same.
+    """
+    return 1e-6 if np_dtype == np.float32 else 1e-12
+
+
+class TestNHCComputeKE:
+    """Tests for the compute_ke flag and the nhc_compute_2ke reduction helper."""
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("dtype_vec,dtype_scalar,np_dtype", DTYPE_CONFIGS)
+    def test_nhc_compute_2ke_matches_manual_single(
+        self, device, dtype_vec, dtype_scalar, np_dtype
+    ):
+        """nhc_compute_2ke fills ke2 = sum(m * |v|^2) for a single system."""
+        num_atoms = 64
+        np.random.seed(0)
+        vel_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        mass_np = (np.random.rand(num_atoms) + 0.5).astype(np_dtype)
+
+        velocities = wp.array(vel_np, dtype=dtype_vec, device=device)
+        masses = wp.array(mass_np, dtype=dtype_scalar, device=device)
+        ke2 = wp.empty(1, dtype=dtype_scalar, device=device)
+
+        nhc_compute_2ke(velocities, masses, ke2, device=device)
+        wp.synchronize_device(device)
+
+        expected = float(np.sum(mass_np * (vel_np * vel_np).sum(axis=1)))
+        np.testing.assert_allclose(ke2.numpy()[0], expected, rtol=_tol(np_dtype))
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("dtype_vec,dtype_scalar,np_dtype", DTYPE_CONFIGS)
+    def test_nhc_compute_2ke_matches_manual_batched(
+        self, device, dtype_vec, dtype_scalar, np_dtype
+    ):
+        """nhc_compute_2ke fills ke2[s] = sum_{i in s} m_i |v_i|^2 per system."""
+        sizes = [40, 24]
+        num_systems = len(sizes)
+        num_atoms = sum(sizes)
+        batch_np = np.concatenate(
+            [np.full(n, s, dtype=np.int32) for s, n in enumerate(sizes)]
+        )
+        np.random.seed(1)
+        vel_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        mass_np = (np.random.rand(num_atoms) + 0.5).astype(np_dtype)
+
+        velocities = wp.array(vel_np, dtype=dtype_vec, device=device)
+        masses = wp.array(mass_np, dtype=dtype_scalar, device=device)
+        batch_idx = wp.array(batch_np, dtype=wp.int32, device=device)
+        ke2 = wp.empty(num_systems, dtype=dtype_scalar, device=device)
+
+        nhc_compute_2ke(
+            velocities,
+            masses,
+            ke2,
+            batch_idx=batch_idx,
+            num_systems=num_systems,
+            device=device,
+        )
+        wp.synchronize_device(device)
+
+        per_atom = mass_np * (vel_np * vel_np).sum(axis=1)
+        expected = np.array(
+            [per_atom[batch_np == s].sum() for s in range(num_systems)]
+        )
+        np.testing.assert_allclose(ke2.numpy(), expected, rtol=_tol(np_dtype))
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("dtype_vec,dtype_scalar,np_dtype", DTYPE_CONFIGS)
+    @pytest.mark.parametrize("nloops", [1, 3])
+    def test_compute_ke_parity_single(
+        self, device, dtype_vec, dtype_scalar, np_dtype, nloops
+    ):
+        """compute_ke=True must match compute_ke=False with ke2 pre-filled
+        (by nhc_compute_2ke) over the SAME atoms — single system."""
+        num_atoms = 50
+        chain_length = 3
+        target_temp = 1.5
+        tau = 0.1
+        ndof = 3 * num_atoms - 3
+        np.random.seed(7)
+
+        vel_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        mass_np = (np.random.rand(num_atoms) + 0.5).astype(np_dtype)
+
+        chain_masses = wp.empty(chain_length, dtype=wp.float64, device=device)
+        nhc_compute_masses(
+            wp.array([ndof], dtype=wp.int32, device=device),
+            wp.array([target_temp], dtype=wp.float64, device=device),
+            wp.array([tau], dtype=wp.float64, device=device),
+            chain_length,
+            chain_masses,
+            device=device,
+        )
+
+        def make_state():
+            return {
+                "velocities": wp.array(vel_np.copy(), dtype=dtype_vec, device=device),
+                "masses": wp.array(mass_np, dtype=dtype_scalar, device=device),
+                "eta": wp.zeros(chain_length, dtype=dtype_scalar, device=device),
+                "eta_dot": wp.zeros(chain_length, dtype=dtype_scalar, device=device),
+                "eta_mass": wp.array(chain_masses, dtype=dtype_scalar, device=device),
+                "target_temp": wp.array(
+                    [target_temp], dtype=dtype_scalar, device=device
+                ),
+                "dt": wp.array([0.005], dtype=dtype_scalar, device=device),
+                "ndof": wp.array([float(ndof)], dtype=dtype_scalar, device=device),
+            }
+
+        def run(state, ke2, compute_ke):
+            nhc_thermostat_chain_update(
+                state["velocities"],
+                state["masses"],
+                state["eta"],
+                state["eta_dot"],
+                state["eta_mass"],
+                state["target_temp"],
+                state["dt"],
+                state["ndof"],
+                ke2=ke2,
+                total_scale=wp.ones(1, dtype=dtype_scalar, device=device),
+                step_scale=wp.empty(1, dtype=dtype_scalar, device=device),
+                dt_chain=wp.empty(1, dtype=dtype_scalar, device=device),
+                nloops=nloops,
+                device=device,
+                compute_ke=compute_ke,
+            )
+
+        # Reference: recompute KE internally.
+        ref = make_state()
+        run(ref, wp.empty(1, dtype=dtype_scalar, device=device), compute_ke=True)
+
+        # DD path: pre-fill ke2 from the same atoms, then skip the recompute.
+        dd = make_state()
+        ke2_in = wp.empty(1, dtype=dtype_scalar, device=device)
+        nhc_compute_2ke(dd["velocities"], dd["masses"], ke2_in, device=device)
+        run(dd, ke2_in, compute_ke=False)
+
+        wp.synchronize_device(device)
+        rtol = _tol(np_dtype)
+        np.testing.assert_allclose(
+            dd["velocities"].numpy(), ref["velocities"].numpy(), rtol=rtol
+        )
+        np.testing.assert_allclose(dd["eta"].numpy(), ref["eta"].numpy(), rtol=rtol)
+        np.testing.assert_allclose(
+            dd["eta_dot"].numpy(), ref["eta_dot"].numpy(), rtol=rtol
+        )
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("dtype_vec,dtype_scalar,np_dtype", DTYPE_CONFIGS)
+    @pytest.mark.parametrize("nloops", [1, 3])
+    def test_compute_ke_parity_batched(
+        self, device, dtype_vec, dtype_scalar, np_dtype, nloops
+    ):
+        """compute_ke parity for a batched (multi-system) chain update."""
+        sizes = [30, 18]
+        num_systems = len(sizes)
+        num_atoms = sum(sizes)
+        chain_length = 3
+        tau = 0.1
+        target_temps = [1.0, 2.0]
+        ndofs = [3 * n - 3 for n in sizes]
+        batch_np = np.concatenate(
+            [np.full(n, s, dtype=np.int32) for s, n in enumerate(sizes)]
+        )
+        np.random.seed(11)
+        vel_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        mass_np = (np.random.rand(num_atoms) + 0.5).astype(np_dtype)
+
+        chain_masses = wp.empty(
+            (num_systems, chain_length), dtype=wp.float64, device=device
+        )
+        nhc_compute_masses(
+            wp.array(ndofs, dtype=wp.int32, device=device),
+            wp.array(target_temps, dtype=wp.float64, device=device),
+            wp.array([tau, tau], dtype=wp.float64, device=device),
+            chain_length,
+            chain_masses,
+            num_systems=num_systems,
+            device=device,
+        )
+
+        batch_idx = wp.array(batch_np, dtype=wp.int32, device=device)
+
+        def make_state():
+            return {
+                "velocities": wp.array(vel_np.copy(), dtype=dtype_vec, device=device),
+                "masses": wp.array(mass_np, dtype=dtype_scalar, device=device),
+                "eta": wp.zeros(
+                    (num_systems, chain_length), dtype=dtype_scalar, device=device
+                ),
+                "eta_dot": wp.zeros(
+                    (num_systems, chain_length), dtype=dtype_scalar, device=device
+                ),
+                "eta_mass": wp.array(chain_masses, dtype=dtype_scalar, device=device),
+                "target_temp": wp.array(
+                    target_temps, dtype=dtype_scalar, device=device
+                ),
+                "dt": wp.array([0.005, 0.005], dtype=dtype_scalar, device=device),
+                "ndof": wp.array(
+                    [float(d) for d in ndofs], dtype=dtype_scalar, device=device
+                ),
+            }
+
+        def run(state, ke2, compute_ke):
+            nhc_thermostat_chain_update(
+                state["velocities"],
+                state["masses"],
+                state["eta"],
+                state["eta_dot"],
+                state["eta_mass"],
+                state["target_temp"],
+                state["dt"],
+                state["ndof"],
+                ke2=ke2,
+                total_scale=wp.ones(num_systems, dtype=dtype_scalar, device=device),
+                step_scale=wp.empty(num_systems, dtype=dtype_scalar, device=device),
+                dt_chain=wp.empty(num_systems, dtype=dtype_scalar, device=device),
+                nloops=nloops,
+                batch_idx=batch_idx,
+                num_systems=num_systems,
+                device=device,
+                compute_ke=compute_ke,
+            )
+
+        ref = make_state()
+        run(ref, wp.empty(num_systems, dtype=dtype_scalar, device=device), True)
+
+        dd = make_state()
+        ke2_in = wp.empty(num_systems, dtype=dtype_scalar, device=device)
+        nhc_compute_2ke(
+            dd["velocities"],
+            dd["masses"],
+            ke2_in,
+            batch_idx=batch_idx,
+            num_systems=num_systems,
+            device=device,
+        )
+        run(dd, ke2_in, False)
+
+        wp.synchronize_device(device)
+        rtol = _tol(np_dtype)
+        np.testing.assert_allclose(
+            dd["velocities"].numpy(), ref["velocities"].numpy(), rtol=rtol
+        )
+        np.testing.assert_allclose(dd["eta"].numpy(), ref["eta"].numpy(), rtol=rtol)
+        np.testing.assert_allclose(
+            dd["eta_dot"].numpy(), ref["eta_dot"].numpy(), rtol=rtol
+        )
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("dtype_vec,dtype_scalar,np_dtype", DTYPE_CONFIGS)
+    def test_global_vs_split_trajectory(
+        self, device, dtype_vec, dtype_scalar, np_dtype
+    ):
+        """The domain-decomposition scenario: a whole N-atom system run with
+        compute_ke=True must match two half-shards whose local 2*KE are summed
+        and fed back with compute_ke=False, over many integration steps."""
+        num_atoms = 80
+        half = num_atoms // 2
+        chain_length = 3
+        target_temp = 1.0
+        tau = 0.1
+        spring_k = 1.0
+        dt_val = 0.005
+        ndof = 3 * num_atoms - 3
+        num_steps = 200
+        nloops = 3
+
+        np.random.seed(123)
+        pos_np = (np.random.randn(num_atoms, 3) * 0.5).astype(np_dtype)
+        vel_np = (np.random.randn(num_atoms, 3) * 0.1).astype(np_dtype)
+        mass_np = np.ones(num_atoms, dtype=np_dtype)
+
+        chain_masses = wp.empty(chain_length, dtype=wp.float64, device=device)
+        nhc_compute_masses(
+            wp.array([ndof], dtype=wp.int32, device=device),
+            wp.array([target_temp], dtype=wp.float64, device=device),
+            wp.array([tau], dtype=wp.float64, device=device),
+            chain_length,
+            chain_masses,
+            device=device,
+        )
+
+        def make_run():
+            return {
+                "positions": wp.array(pos_np.copy(), dtype=dtype_vec, device=device),
+                "velocities": wp.array(vel_np.copy(), dtype=dtype_vec, device=device),
+                "forces": wp.zeros(num_atoms, dtype=dtype_vec, device=device),
+                "masses": wp.array(mass_np, dtype=dtype_scalar, device=device),
+                "eta": wp.zeros(chain_length, dtype=dtype_scalar, device=device),
+                "eta_dot": wp.zeros(chain_length, dtype=dtype_scalar, device=device),
+                "eta_mass": wp.array(chain_masses, dtype=dtype_scalar, device=device),
+                "target_temp": wp.array(
+                    [target_temp], dtype=dtype_scalar, device=device
+                ),
+                "dt": wp.array([dt_val], dtype=dtype_scalar, device=device),
+                "ndof": wp.array([float(ndof)], dtype=dtype_scalar, device=device),
+            }
+
+        def chain_update(st, split):
+            if split:
+                # Local reductions on each shard, summed -> global 2*KE (the
+                # all_reduce the toolkit performs across the process mesh).
+                ke2_a = wp.empty(1, dtype=dtype_scalar, device=device)
+                ke2_b = wp.empty(1, dtype=dtype_scalar, device=device)
+                nhc_compute_2ke(
+                    st["velocities"][:half], st["masses"][:half], ke2_a, device=device
+                )
+                nhc_compute_2ke(
+                    st["velocities"][half:], st["masses"][half:], ke2_b, device=device
+                )
+                ke2_in = wp.array(
+                    ke2_a.numpy() + ke2_b.numpy(), dtype=dtype_scalar, device=device
+                )
+                compute_ke = False
+            else:
+                ke2_in = wp.empty(1, dtype=dtype_scalar, device=device)
+                compute_ke = True
+            nhc_thermostat_chain_update(
+                st["velocities"],
+                st["masses"],
+                st["eta"],
+                st["eta_dot"],
+                st["eta_mass"],
+                st["target_temp"],
+                st["dt"],
+                st["ndof"],
+                ke2=ke2_in,
+                total_scale=wp.ones(1, dtype=dtype_scalar, device=device),
+                step_scale=wp.empty(1, dtype=dtype_scalar, device=device),
+                dt_chain=wp.empty(1, dtype=dtype_scalar, device=device),
+                nloops=nloops,
+                device=device,
+                compute_ke=compute_ke,
+            )
+
+        def step(st, split):
+            chain_update(st, split)
+            nhc_velocity_half_step(
+                st["velocities"], st["forces"], st["masses"], st["dt"], device=device
+            )
+            nhc_position_update(
+                st["positions"], st["velocities"], st["dt"], device=device
+            )
+            compute_harmonic_forces(st["positions"], st["forces"], spring_k)
+            nhc_velocity_half_step(
+                st["velocities"], st["forces"], st["masses"], st["dt"], device=device
+            )
+            chain_update(st, split)
+
+        whole = make_run()
+        split = make_run()
+        compute_harmonic_forces(whole["positions"], whole["forces"], spring_k)
+        compute_harmonic_forces(split["positions"], split["forces"], spring_k)
+
+        for _ in range(num_steps):
+            step(whole, split=False)
+            step(split, split=True)
+
+        wp.synchronize_device(device)
+        rtol = 1e-4 if np_dtype == np.float32 else 1e-9
+        np.testing.assert_allclose(
+            split["positions"].numpy(),
+            whole["positions"].numpy(),
+            rtol=rtol,
+            atol=rtol,
+        )
+        np.testing.assert_allclose(
+            split["velocities"].numpy(),
+            whole["velocities"].numpy(),
+            rtol=rtol,
+            atol=rtol,
+        )
 
 
 if __name__ == "__main__":

--- a/test/dynamics/test_nose_hoover.py
+++ b/test/dynamics/test_nose_hoover.py
@@ -1708,7 +1708,7 @@ class TestNHCAtomPtr:
 
 
 # ==============================================================================
-# compute_ke flag + nhc_compute_2ke helper (domain-decomposition support)
+# compute_ke flag + nhc_compute_2ke helper
 # ==============================================================================
 
 
@@ -1848,20 +1848,24 @@ class TestNHCComputeKE:
         ref = make_state()
         run(ref, wp.empty(1, dtype=dtype_scalar, device=device), compute_ke=True)
 
-        # DD path: pre-fill ke2 from the same atoms, then skip the recompute.
-        dd = make_state()
+        # Supplied path: pre-fill ke2 from the same atoms, then skip the recompute.
+        supplied = make_state()
         ke2_in = wp.empty(1, dtype=dtype_scalar, device=device)
-        nhc_compute_2ke(dd["velocities"], dd["masses"], ke2_in, device=device)
-        run(dd, ke2_in, compute_ke=False)
+        nhc_compute_2ke(
+            supplied["velocities"], supplied["masses"], ke2_in, device=device
+        )
+        run(supplied, ke2_in, compute_ke=False)
 
         wp.synchronize_device(device)
         rtol = _tol(np_dtype)
         np.testing.assert_allclose(
-            dd["velocities"].numpy(), ref["velocities"].numpy(), rtol=rtol
+            supplied["velocities"].numpy(), ref["velocities"].numpy(), rtol=rtol
         )
-        np.testing.assert_allclose(dd["eta"].numpy(), ref["eta"].numpy(), rtol=rtol)
         np.testing.assert_allclose(
-            dd["eta_dot"].numpy(), ref["eta_dot"].numpy(), rtol=rtol
+            supplied["eta"].numpy(), ref["eta"].numpy(), rtol=rtol
+        )
+        np.testing.assert_allclose(
+            supplied["eta_dot"].numpy(), ref["eta_dot"].numpy(), rtol=rtol
         )
 
     @pytest.mark.parametrize("device", DEVICES)
@@ -1944,26 +1948,28 @@ class TestNHCComputeKE:
         ref = make_state()
         run(ref, wp.empty(num_systems, dtype=dtype_scalar, device=device), True)
 
-        dd = make_state()
+        supplied = make_state()
         ke2_in = wp.empty(num_systems, dtype=dtype_scalar, device=device)
         nhc_compute_2ke(
-            dd["velocities"],
-            dd["masses"],
+            supplied["velocities"],
+            supplied["masses"],
             ke2_in,
             batch_idx=batch_idx,
             num_systems=num_systems,
             device=device,
         )
-        run(dd, ke2_in, False)
+        run(supplied, ke2_in, False)
 
         wp.synchronize_device(device)
         rtol = _tol(np_dtype)
         np.testing.assert_allclose(
-            dd["velocities"].numpy(), ref["velocities"].numpy(), rtol=rtol
+            supplied["velocities"].numpy(), ref["velocities"].numpy(), rtol=rtol
         )
-        np.testing.assert_allclose(dd["eta"].numpy(), ref["eta"].numpy(), rtol=rtol)
         np.testing.assert_allclose(
-            dd["eta_dot"].numpy(), ref["eta_dot"].numpy(), rtol=rtol
+            supplied["eta"].numpy(), ref["eta"].numpy(), rtol=rtol
+        )
+        np.testing.assert_allclose(
+            supplied["eta_dot"].numpy(), ref["eta_dot"].numpy(), rtol=rtol
         )
 
     @pytest.mark.parametrize("device", DEVICES)
@@ -1971,9 +1977,10 @@ class TestNHCComputeKE:
     def test_global_vs_split_trajectory(
         self, device, dtype_vec, dtype_scalar, np_dtype
     ):
-        """The domain-decomposition scenario: a whole N-atom system run with
-        compute_ke=True must match two half-shards whose local 2*KE are summed
-        and fed back with compute_ke=False, over many integration steps."""
+        """A whole N-atom system run with compute_ke=True must match a run that
+        computes 2*KE over two disjoint halves of the atoms, sums them, and
+        feeds the result back with compute_ke=False, over many integration
+        steps."""
         num_atoms = 80
         half = num_atoms // 2
         chain_length = 3
@@ -2018,8 +2025,7 @@ class TestNHCComputeKE:
 
         def chain_update(st, split):
             if split:
-                # Local reductions on each shard, summed -> global 2*KE (the
-                # all_reduce the toolkit performs across the process mesh).
+                # Reduce each half separately, then sum to the full 2*KE.
                 ke2_a = wp.empty(1, dtype=dtype_scalar, device=device)
                 ke2_b = wp.empty(1, dtype=dtype_scalar, device=device)
                 nhc_compute_2ke(

--- a/test/dynamics/test_nose_hoover.py
+++ b/test/dynamics/test_nose_hoover.py
@@ -1778,9 +1778,7 @@ class TestNHCComputeKE:
         wp.synchronize_device(device)
 
         per_atom = mass_np * (vel_np * vel_np).sum(axis=1)
-        expected = np.array(
-            [per_atom[batch_np == s].sum() for s in range(num_systems)]
-        )
+        expected = np.array([per_atom[batch_np == s].sum() for s in range(num_systems)])
         np.testing.assert_allclose(ke2.numpy(), expected, rtol=_tol(np_dtype))
 
     @pytest.mark.parametrize("device", DEVICES)

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -4054,7 +4054,7 @@ class TestCellKineticEnergyConvention:
 
 
 # ==============================================================================
-# compute_kinetic flag + compute_kinetic_tensor helper (domain decomposition)
+# compute_kinetic flag + compute_kinetic_tensor helper
 # ==============================================================================
 
 
@@ -4175,15 +4175,15 @@ class TestComputeKineticFlag:
             device=device,
         )
 
-        # DD path: pre-fill the (global) kinetic tensor, skip the recompute.
-        kt_dd = wp.empty((1, 9), dtype=scalar_dtype, device=device)
-        compute_kinetic_tensor(velocities, masses, kt_dd, device=device)
-        p_dd = compute_pressure_tensor(
+        # Supplied path: pre-fill the kinetic tensor, skip the recompute.
+        kt_supplied = wp.empty((1, 9), dtype=scalar_dtype, device=device)
+        compute_kinetic_tensor(velocities, masses, kt_supplied, device=device)
+        p_supplied = compute_pressure_tensor(
             velocities,
             masses,
             virial_tensors,
             cells,
-            kt_dd,
+            kt_supplied,
             wp.empty(1, dtype=tensor_dtype, device=device),
             volumes,
             device=device,
@@ -4192,13 +4192,13 @@ class TestComputeKineticFlag:
         wp.synchronize_device(device)
 
         np.testing.assert_allclose(
-            p_dd.numpy(), p_ref.numpy(), rtol=self._rtol(dtype)
+            p_supplied.numpy(), p_ref.numpy(), rtol=self._rtol(dtype)
         )
 
     def test_compute_kinetic_global_vs_split(self, dtype, device):
-        """DD scenario: one N-atom system's pressure (compute_kinetic=True) must
-        match two half-shards whose local kinetic tensors are summed and fed
-        with compute_kinetic=False."""
+        """One N-atom system's pressure (compute_kinetic=True) must match a run
+        that computes the kinetic tensor over two disjoint halves of the atoms,
+        sums them, and feeds the result with compute_kinetic=False."""
         vec_dtype = wp.vec3f if dtype == "float32" else wp.vec3d
         scalar_dtype = wp.float32 if dtype == "float32" else wp.float64
         tensor_dtype = vec9f if dtype == "float32" else vec9d
@@ -4233,7 +4233,7 @@ class TestComputeKineticFlag:
             device=device,
         )
 
-        # Split: per-shard kinetic tensors summed -> global K (the all_reduce).
+        # Split: reduce each half separately, then sum to the full kinetic tensor.
         kt_a = wp.empty((1, 9), dtype=scalar_dtype, device=device)
         kt_b = wp.empty((1, 9), dtype=scalar_dtype, device=device)
         compute_kinetic_tensor(
@@ -4242,7 +4242,7 @@ class TestComputeKineticFlag:
         compute_kinetic_tensor(
             velocities[half:], masses[half:], kt_b, device=device
         )
-        kt_global = wp.array(
+        kt_summed = wp.array(
             kt_a.numpy() + kt_b.numpy(), dtype=scalar_dtype, device=device
         )
         p_split = compute_pressure_tensor(
@@ -4250,7 +4250,7 @@ class TestComputeKineticFlag:
             masses,
             virial_tensors,
             cells,
-            kt_global,
+            kt_summed,
             wp.empty(1, dtype=tensor_dtype, device=device),
             volumes,
             device=device,

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -28,6 +28,7 @@ from nvalchemiops.dynamics.integrators.npt import (
     compute_barostat_mass,
     compute_barostat_potential_energy,
     compute_cell_kinetic_energy,
+    compute_kinetic_tensor,
     compute_pressure_tensor,
     compute_scalar_pressure,
     nph_barostat_half_step,
@@ -4050,3 +4051,213 @@ class TestCellKineticEnergyConvention:
             kinetic_energy.numpy()[0], expected, rtol=1e-12, atol=1e-12
         )
         np.testing.assert_allclose(kinetic_energy.numpy()[0], 0.01515, rtol=1e-12)
+
+
+# ==============================================================================
+# compute_kinetic flag + compute_kinetic_tensor helper (domain decomposition)
+# ==============================================================================
+
+
+# Cell shapes used to confirm the finalize kernel (P = (K + virial)/V) is
+# unaffected by the compute_kinetic gate — the kinetic tensor itself is
+# pressure-coupling-mode independent.
+_PRESSURE_CELLS = {
+    "isotropic": np.diag([10.0, 10.0, 10.0]),
+    "anisotropic": np.diag([8.0, 11.0, 13.0]),
+    "triclinic": np.array(
+        [[10.0, 0.0, 0.0], [1.5, 9.0, 0.0], [0.7, 1.1, 11.0]]
+    ),
+}
+
+
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+class TestComputeKineticFlag:
+    """Tests for the compute_kinetic flag and compute_kinetic_tensor helper."""
+
+    @staticmethod
+    def _rtol(dtype):
+        return 1e-5 if dtype == "float32" else 1e-11
+
+    def test_compute_kinetic_tensor_matches_manual_single(self, dtype, device):
+        """compute_kinetic_tensor fills K = sum m (v ⊗ v) (vec9 row-major)."""
+        vec_dtype = wp.vec3f if dtype == "float32" else wp.vec3d
+        scalar_dtype = wp.float32 if dtype == "float32" else wp.float64
+        np_dtype = np.float32 if dtype == "float32" else np.float64
+
+        num_atoms = 64
+        np.random.seed(3)
+        vel_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        mass_np = (np.random.rand(num_atoms) + 0.5).astype(np_dtype)
+
+        velocities = wp.array(vel_np, dtype=vec_dtype, device=device)
+        masses = wp.array(mass_np, dtype=scalar_dtype, device=device)
+        kinetic_tensors = wp.empty((1, 9), dtype=scalar_dtype, device=device)
+
+        compute_kinetic_tensor(velocities, masses, kinetic_tensors, device=device)
+        wp.synchronize_device(device)
+
+        # K[i,j] = sum_k m_k v_k[i] v_k[j], flattened row-major.
+        expected = np.einsum("k,ki,kj->ij", mass_np, vel_np, vel_np).reshape(9)
+        np.testing.assert_allclose(
+            kinetic_tensors.numpy()[0], expected, rtol=self._rtol(dtype)
+        )
+
+    def test_compute_kinetic_tensor_matches_manual_batched(self, dtype, device):
+        """Batched compute_kinetic_tensor fills K per system."""
+        vec_dtype = wp.vec3f if dtype == "float32" else wp.vec3d
+        scalar_dtype = wp.float32 if dtype == "float32" else wp.float64
+        np_dtype = np.float32 if dtype == "float32" else np.float64
+
+        sizes = [40, 24]
+        num_systems = len(sizes)
+        num_atoms = sum(sizes)
+        batch_np = np.concatenate(
+            [np.full(n, s, dtype=np.int32) for s, n in enumerate(sizes)]
+        )
+        np.random.seed(4)
+        vel_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        mass_np = (np.random.rand(num_atoms) + 0.5).astype(np_dtype)
+
+        velocities = wp.array(vel_np, dtype=vec_dtype, device=device)
+        masses = wp.array(mass_np, dtype=scalar_dtype, device=device)
+        batch_idx = wp.array(batch_np, dtype=wp.int32, device=device)
+        kinetic_tensors = wp.empty((num_systems, 9), dtype=scalar_dtype, device=device)
+
+        compute_kinetic_tensor(
+            velocities, masses, kinetic_tensors, batch_idx=batch_idx, device=device
+        )
+        wp.synchronize_device(device)
+
+        result = kinetic_tensors.numpy()
+        for s in range(num_systems):
+            m = batch_np == s
+            expected = np.einsum(
+                "k,ki,kj->ij", mass_np[m], vel_np[m], vel_np[m]
+            ).reshape(9)
+            np.testing.assert_allclose(result[s], expected, rtol=self._rtol(dtype))
+
+    @pytest.mark.parametrize("mode", list(_PRESSURE_CELLS))
+    def test_compute_kinetic_parity(self, dtype, device, mode):
+        """compute_kinetic=True must match compute_kinetic=False with
+        kinetic_tensors pre-filled over the same atoms, for every cell shape."""
+        vec_dtype = wp.vec3f if dtype == "float32" else wp.vec3d
+        scalar_dtype = wp.float32 if dtype == "float32" else wp.float64
+        tensor_dtype = vec9f if dtype == "float32" else vec9d
+        np_dtype = np.float32 if dtype == "float32" else np.float64
+
+        num_atoms = 50
+        np.random.seed(8)
+        vel_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        mass_np = (np.random.rand(num_atoms) + 0.5).astype(np_dtype)
+        # Non-symmetric, non-trivial virial to exercise the finalize fully.
+        virial_np = np.random.randn(9).astype(np_dtype)
+
+        velocities = wp.array(vel_np, dtype=vec_dtype, device=device)
+        masses = wp.array(mass_np, dtype=scalar_dtype, device=device)
+        virial_tensors = wp.array(
+            [tensor_dtype(*virial_np)], dtype=tensor_dtype, device=device
+        )
+        cells = make_cell(_PRESSURE_CELLS[mode], dtype, device)
+        volumes = wp.empty(1, dtype=scalar_dtype, device=device)
+        compute_cell_volume(cells, volumes, device=device)
+
+        # Reference: recompute the kinetic tensor internally.
+        kt_ref = wp.zeros((1, 9), dtype=scalar_dtype, device=device)
+        p_ref = compute_pressure_tensor(
+            velocities,
+            masses,
+            virial_tensors,
+            cells,
+            kt_ref,
+            wp.empty(1, dtype=tensor_dtype, device=device),
+            volumes,
+            device=device,
+        )
+
+        # DD path: pre-fill the (global) kinetic tensor, skip the recompute.
+        kt_dd = wp.empty((1, 9), dtype=scalar_dtype, device=device)
+        compute_kinetic_tensor(velocities, masses, kt_dd, device=device)
+        p_dd = compute_pressure_tensor(
+            velocities,
+            masses,
+            virial_tensors,
+            cells,
+            kt_dd,
+            wp.empty(1, dtype=tensor_dtype, device=device),
+            volumes,
+            device=device,
+            compute_kinetic=False,
+        )
+        wp.synchronize_device(device)
+
+        np.testing.assert_allclose(
+            p_dd.numpy(), p_ref.numpy(), rtol=self._rtol(dtype)
+        )
+
+    def test_compute_kinetic_global_vs_split(self, dtype, device):
+        """DD scenario: one N-atom system's pressure (compute_kinetic=True) must
+        match two half-shards whose local kinetic tensors are summed and fed
+        with compute_kinetic=False."""
+        vec_dtype = wp.vec3f if dtype == "float32" else wp.vec3d
+        scalar_dtype = wp.float32 if dtype == "float32" else wp.float64
+        tensor_dtype = vec9f if dtype == "float32" else vec9d
+        np_dtype = np.float32 if dtype == "float32" else np.float64
+
+        num_atoms = 80
+        half = num_atoms // 2
+        np.random.seed(9)
+        vel_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        mass_np = (np.random.rand(num_atoms) + 0.5).astype(np_dtype)
+        virial_np = np.random.randn(9).astype(np_dtype)
+
+        velocities = wp.array(vel_np, dtype=vec_dtype, device=device)
+        masses = wp.array(mass_np, dtype=scalar_dtype, device=device)
+        virial_tensors = wp.array(
+            [tensor_dtype(*virial_np)], dtype=tensor_dtype, device=device
+        )
+        cells = make_cell(_PRESSURE_CELLS["triclinic"], dtype, device)
+        volumes = wp.empty(1, dtype=scalar_dtype, device=device)
+        compute_cell_volume(cells, volumes, device=device)
+
+        # Whole system.
+        kt_whole = wp.zeros((1, 9), dtype=scalar_dtype, device=device)
+        p_whole = compute_pressure_tensor(
+            velocities,
+            masses,
+            virial_tensors,
+            cells,
+            kt_whole,
+            wp.empty(1, dtype=tensor_dtype, device=device),
+            volumes,
+            device=device,
+        )
+
+        # Split: per-shard kinetic tensors summed -> global K (the all_reduce).
+        kt_a = wp.empty((1, 9), dtype=scalar_dtype, device=device)
+        kt_b = wp.empty((1, 9), dtype=scalar_dtype, device=device)
+        compute_kinetic_tensor(
+            velocities[:half], masses[:half], kt_a, device=device
+        )
+        compute_kinetic_tensor(
+            velocities[half:], masses[half:], kt_b, device=device
+        )
+        kt_global = wp.array(
+            kt_a.numpy() + kt_b.numpy(), dtype=scalar_dtype, device=device
+        )
+        p_split = compute_pressure_tensor(
+            velocities,
+            masses,
+            virial_tensors,
+            cells,
+            kt_global,
+            wp.empty(1, dtype=tensor_dtype, device=device),
+            volumes,
+            device=device,
+            compute_kinetic=False,
+        )
+        wp.synchronize_device(device)
+
+        np.testing.assert_allclose(
+            p_split.numpy(), p_whole.numpy(), rtol=self._rtol(dtype)
+        )

--- a/test/dynamics/test_npt.py
+++ b/test/dynamics/test_npt.py
@@ -4064,9 +4064,7 @@ class TestCellKineticEnergyConvention:
 _PRESSURE_CELLS = {
     "isotropic": np.diag([10.0, 10.0, 10.0]),
     "anisotropic": np.diag([8.0, 11.0, 13.0]),
-    "triclinic": np.array(
-        [[10.0, 0.0, 0.0], [1.5, 9.0, 0.0], [0.7, 1.1, 11.0]]
-    ),
+    "triclinic": np.array([[10.0, 0.0, 0.0], [1.5, 9.0, 0.0], [0.7, 1.1, 11.0]]),
 }
 
 
@@ -4236,12 +4234,8 @@ class TestComputeKineticFlag:
         # Split: reduce each half separately, then sum to the full kinetic tensor.
         kt_a = wp.empty((1, 9), dtype=scalar_dtype, device=device)
         kt_b = wp.empty((1, 9), dtype=scalar_dtype, device=device)
-        compute_kinetic_tensor(
-            velocities[:half], masses[:half], kt_a, device=device
-        )
-        compute_kinetic_tensor(
-            velocities[half:], masses[half:], kt_b, device=device
-        )
+        compute_kinetic_tensor(velocities[:half], masses[:half], kt_a, device=device)
+        compute_kinetic_tensor(velocities[half:], masses[half:], kt_b, device=device)
         kt_summed = wp.array(
             kt_a.numpy() + kt_b.numpy(), dtype=scalar_dtype, device=device
         )


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Adds two backward-compatible keyword flags that let a caller supply an
already-computed kinetic quantity instead of having the kernel recompute it from
the velocities passed in. Both kernels otherwise derive that quantity internally
from whatever atoms they receive, which is incorrect for callers that need to
inject a value aggregated elsewhere. Both flags default to the existing behavior,
so every current caller is byte-for-byte unchanged.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

Adds caller-supplied-reduction flags to the NHC and NPT/NPH dynamics kernels.

## Changes Made

<!-- List the key changes made in this PR -->

- **NHC (`dynamics/integrators/nose_hoover.py`):** added `compute_ke: bool = True`
  to `nhc_thermostat_chain_update`. When `False`, the internal `ke2.zero_()` +
  `Σ m v²` launch are skipped and the value already in `ke2` is used directly;
  the Yoshida–Suzuki propagate/scaling math is unchanged. Threaded the flag
  through the `nhc_thermostat_chain_update_out` sibling.
- **NPT/NPH (`dynamics/integrators/npt.py`):** added `compute_kinetic: bool = True`
  to `compute_pressure_tensor`. When `False`, the kinetic-tensor recompute is
  skipped and the value already in `kinetic_tensors` is fed straight into the
  unchanged `_finalize_pressure_tensor_kernel`.
- **Helpers:** added public `nhc_compute_2ke(...)` and `compute_kinetic_tensor(...)`
  wrapping the existing reduction kernels, so a caller can produce the same
  reduction the kernels use internally (to optionally post-process and feed back)
  with machine-precision parity. Exported both from
  `dynamics/integrators/__init__.py`.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Added `TestNHCComputeKE` (test_nose_hoover.py) and `TestComputeKineticFlag`
(test_npt.py) covering: helper-vs-manual reduction (single + batched), `compute_ke`
/ `compute_kinetic` parity (fp32/fp64, single + batched, `nloops` 1 & 3, all three
pressure-coupling cell shapes with a non-symmetric virial), and a whole-vs-split
parity test (one N-atom system vs. computing the reduction over two disjoint halves
of the atoms, summed and fed back). All 249 tests in the two files **collect**
cleanly.

## Checklist

- [ ] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

- **Defaults preserve behavior:** `compute_ke=True` / `compute_kinetic=True` are
  byte-identical to the previous code for every existing caller (`run_npt_step`,
  `run_nhc_nvt_step`, etc.).
- **Parity is tolerance-based, not bit-exact:** the `Σ m v²` / `Σ m v⊗v` reductions
  use `atomic_add`, whose ordering is non-deterministic across launches, so the
  tests assert tight `rtol` (1e-6/1e-5 fp32, 1e-12/1e-11 fp64) rather than exact
  equality.
> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.