### PR TITLE
fix bugs regarding cell and num_neighbors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,13 +38,12 @@
   instead of a negative one that crashed `allocate_cell_list`. The estimate
   wrappers and `allocate_cell_list` (Torch and JAX) also validate the count and
   raise a clear error on a bad value.
-- `estimate_max_neighbors` raises its minimum floor to 64 (overridable via the
-  `ALCHEMI_MIN_MAX_NEIGHBORS` environment variable), preventing
-  `NeighborOverflowError` at short cutoffs in clustered or non-equilibrium
-  configurations. Its `safety_factor` argument is deprecated (it scaled the
-  estimate identically to `atomic_density`); it now emits a `DeprecationWarning`
-  and is folded into `atomic_density`. Callers needing more headroom should
-  raise `atomic_density` or the floor env var (#114).
+- `estimate_max_neighbors` exposes a `max_neighbors_lower_bound` keyword
+  (default 16) so callers can raise the floor for dense or clustered systems
+  where short cutoffs underestimate the neighbor count (#114). Its
+  `safety_factor` argument is deprecated (it scaled the estimate identically to
+  `atomic_density`); it now emits a `DeprecationWarning` and is folded into
+  `atomic_density`.
 - Naive PBC neighbor wrapping now leaves non-periodic axes unwrapped when
   per-axis `pbc` flags are supplied, fixing partial-PBC and non-periodic
   systems (#104).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,20 @@
 
 ### Fixed
 
+- Cell-list size estimation no longer overflows when a cell is large relative
+  to the cutoff: the per-dimension cell-count product is now computed
+  overflow-safe (int64) and clamped per system, so `estimate_cell_list_sizes` /
+  `estimate_batch_cell_list_sizes` always return a positive, capped count
+  instead of a negative one that crashed `allocate_cell_list`. The estimate
+  wrappers and `allocate_cell_list` (Torch and JAX) also validate the count and
+  raise a clear error on a bad value.
+- `estimate_max_neighbors` raises its minimum floor to 64 (overridable via the
+  `ALCHEMI_MIN_MAX_NEIGHBORS` environment variable), preventing
+  `NeighborOverflowError` at short cutoffs in clustered or non-equilibrium
+  configurations. Its `safety_factor` argument is deprecated (it scaled the
+  estimate identically to `atomic_density`); it now emits a `DeprecationWarning`
+  and is folded into `atomic_density`. Callers needing more headroom should
+  raise `atomic_density` or the floor env var (#114).
 - Naive PBC neighbor wrapping now leaves non-periodic axes unwrapped when
   per-axis `pbc` flags are supplied, fixing partial-PBC and non-periodic
   systems (#104).

--- a/nvalchemiops/jax/neighbors/neighbor_utils.py
+++ b/nvalchemiops/jax/neighbors/neighbor_utils.py
@@ -527,6 +527,11 @@ def allocate_cell_list(
     nvalchemiops.jax.neighbors.cell_list.build_cell_list : High-level JAX wrapper
     nvalchemiops.jax.neighbors.batch_cell_list.batch_build_cell_list : Batched version
     """
+    if max_total_cells < 0:
+        raise ValueError(
+            f"allocate_cell_list: max_total_cells={max_total_cells} < 0 "
+            "(cell-count overflow or bad estimate)."
+        )
     # Detect number of systems from neighbor_search_radius shape
     is_batched = neighbor_search_radius.ndim == 2
     num_systems = neighbor_search_radius.shape[0] if is_batched else 1

--- a/nvalchemiops/neighbors/cell_list/kernels.py
+++ b/nvalchemiops/neighbors/cell_list/kernels.py
@@ -213,13 +213,13 @@ def _make_estimate_cell_list_sizes_kernel(
 
         # Use int64 so the cell-count product cannot overflow int32 and wrap
         # negative (which would skip the clamp below).
-        max_nbins_64 = wp.int64(max_nbins)
+        max_nbins_dp = wp.int64(max_nbins)
         total_cells = (
             wp.int64(cells_per_dimension[0])
             * wp.int64(cells_per_dimension[1])
             * wp.int64(cells_per_dimension[2])
         )
-        while total_cells > max_nbins_64:
+        while total_cells > max_nbins_dp:
             for dim in range(3):
                 cells_per_dimension[dim] = max(cells_per_dimension[dim] // 2, 1)
             total_cells = (
@@ -381,14 +381,14 @@ def _make_construct_bin_size_kernel(
 
         # Use int64 so neither the product nor the num_systems multiply can
         # overflow int32 and wrap negative (which would skip the clamp below).
-        max_total_cells_64 = wp.int64(max_total_cells)
-        num_systems_64 = wp.int64(num_systems)
+        max_total_cells_dp = wp.int64(max_total_cells)
+        num_systems_dp = wp.int64(num_systems)
         total_cells = (
             wp.int64(cells_per_dimension[0])
             * wp.int64(cells_per_dimension[1])
             * wp.int64(cells_per_dimension[2])
         )
-        while total_cells * num_systems_64 > max_total_cells_64:
+        while total_cells * num_systems_dp > max_total_cells_dp:
             for dim in range(3):
                 cells_per_dimension[dim] = max(cells_per_dimension[dim] // 2, 1)
             total_cells = (

--- a/nvalchemiops/neighbors/cell_list/kernels.py
+++ b/nvalchemiops/neighbors/cell_list/kernels.py
@@ -194,7 +194,10 @@ def _make_estimate_cell_list_sizes_kernel(
             face_distance = type(cell_size)(1.0) / wp.length(
                 inverse_cell_transpose[dim]
             )
-            cells_per_dimension[dim] = max(wp.int32(face_distance / cell_size), 1)
+            # Clamp before the int32 cast: a single dimension never needs more
+            # than max_nbins cells, and an unclamped ratio would overflow.
+            ratio = wp.min(face_distance / cell_size, type(cell_size)(max_nbins))
+            cells_per_dimension[dim] = max(wp.int32(ratio), 1)
 
         for dim in range(3):
             pbc_dim = pbc_z
@@ -208,14 +211,21 @@ def _make_estimate_cell_list_sizes_kernel(
                 while cells_per_dimension[dim] < MIN_CELLS_PER_DIMENSION:
                     cells_per_dimension[dim] = cells_per_dimension[dim] * 2
 
-        total_cells = int(
-            cells_per_dimension[0] * cells_per_dimension[1] * cells_per_dimension[2]
+        # Use int64 so the cell-count product cannot overflow int32 and wrap
+        # negative (which would skip the clamp below).
+        max_nbins_64 = wp.int64(max_nbins)
+        total_cells = (
+            wp.int64(cells_per_dimension[0])
+            * wp.int64(cells_per_dimension[1])
+            * wp.int64(cells_per_dimension[2])
         )
-        while total_cells > max_nbins:
+        while total_cells > max_nbins_64:
             for dim in range(3):
                 cells_per_dimension[dim] = max(cells_per_dimension[dim] // 2, 1)
-            total_cells = int(
-                cells_per_dimension[0] * cells_per_dimension[1] * cells_per_dimension[2]
+            total_cells = (
+                wp.int64(cells_per_dimension[0])
+                * wp.int64(cells_per_dimension[1])
+                * wp.int64(cells_per_dimension[2])
             )
 
         search_radius = wp.vec3i(0, 0, 0)
@@ -239,7 +249,8 @@ def _make_estimate_cell_list_sizes_kernel(
                     )
                 )
 
-        number_of_cells[system_idx] = total_cells
+        # total_cells is now in [1, max_nbins], so the int32 cast is safe.
+        number_of_cells[system_idx] = wp.int32(total_cells)
         if BATCHED:
             neighbor_search_radius_batch[system_idx] = search_radius
         else:
@@ -348,9 +359,13 @@ def _make_construct_bin_size_kernel(
             face_distance = type(target_cell_size)(1.0) / wp.length(
                 inverse_cell_transpose[dim]
             )
-            cells_per_dimension[dim] = max(
-                wp.int32(face_distance / target_cell_size), 1
+            # Clamp before the int32 cast: a single dimension never needs more
+            # than max_total_cells cells, and an unclamped ratio would overflow.
+            ratio = wp.min(
+                face_distance / target_cell_size,
+                type(target_cell_size)(max_total_cells),
             )
+            cells_per_dimension[dim] = max(wp.int32(ratio), 1)
 
         for dim in range(3):
             pbc_dim = pbc_z
@@ -364,14 +379,22 @@ def _make_construct_bin_size_kernel(
                 while cells_per_dimension[dim] < MIN_CELLS_PER_DIMENSION:
                     cells_per_dimension[dim] = cells_per_dimension[dim] * 2
 
-        total_cells = int(
-            cells_per_dimension[0] * cells_per_dimension[1] * cells_per_dimension[2]
+        # Use int64 so neither the product nor the num_systems multiply can
+        # overflow int32 and wrap negative (which would skip the clamp below).
+        max_total_cells_64 = wp.int64(max_total_cells)
+        num_systems_64 = wp.int64(num_systems)
+        total_cells = (
+            wp.int64(cells_per_dimension[0])
+            * wp.int64(cells_per_dimension[1])
+            * wp.int64(cells_per_dimension[2])
         )
-        while total_cells * num_systems > max_total_cells:
+        while total_cells * num_systems_64 > max_total_cells_64:
             for dim in range(3):
                 cells_per_dimension[dim] = max(cells_per_dimension[dim] // 2, 1)
-            total_cells = int(
-                cells_per_dimension[0] * cells_per_dimension[1] * cells_per_dimension[2]
+            total_cells = (
+                wp.int64(cells_per_dimension[0])
+                * wp.int64(cells_per_dimension[1])
+                * wp.int64(cells_per_dimension[2])
             )
 
         if BATCHED:

--- a/nvalchemiops/neighbors/neighbor_utils.py
+++ b/nvalchemiops/neighbors/neighbor_utils.py
@@ -21,7 +21,6 @@ See `nvalchemiops.torch.neighbors` for PyTorch bindings.
 
 import contextlib
 import math
-import os
 import warnings
 from functools import lru_cache
 from typing import Any
@@ -951,53 +950,11 @@ def compute_naive_num_shifts(
     )
 
 
-# Default lower bound on the estimated neighbor count; short cutoffs otherwise
-# collapse toward the 16-neighbor alignment floor, underestimating dense systems.
-_DEFAULT_MIN_MAX_NEIGHBORS = 64
-
-
-def _resolve_min_max_neighbors() -> int:
-    """Resolve the neighbor-count floor, honoring ``ALCHEMI_MIN_MAX_NEIGHBORS``.
-
-    Systems whose local density routinely exceeds the bulk average can raise the
-    floor via the ``ALCHEMI_MIN_MAX_NEIGHBORS`` environment variable. A missing,
-    non-integer, or non-positive value falls back to the default. A zero floor
-    is rejected because it lets short cutoffs collapse back to the 16-neighbor
-    alignment minimum that the floor exists to prevent.
-    """
-    raw = os.environ.get("ALCHEMI_MIN_MAX_NEIGHBORS")
-    if raw is None:
-        return _DEFAULT_MIN_MAX_NEIGHBORS
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
-        warnings.warn(
-            f"Ignoring non-integer ALCHEMI_MIN_MAX_NEIGHBORS={raw!r}; "
-            f"using {_DEFAULT_MIN_MAX_NEIGHBORS}.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-        return _DEFAULT_MIN_MAX_NEIGHBORS
-    if value <= 0:
-        warnings.warn(
-            f"Ignoring non-positive ALCHEMI_MIN_MAX_NEIGHBORS={raw!r}; "
-            f"using {_DEFAULT_MIN_MAX_NEIGHBORS}.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-        return _DEFAULT_MIN_MAX_NEIGHBORS
-    return value
-
-
-# Resolved once at import (not per call), so ``ALCHEMI_MIN_MAX_NEIGHBORS`` must
-# be set before importing this module to take effect.
-_MIN_MAX_NEIGHBORS = _resolve_min_max_neighbors()
-
-
 def estimate_max_neighbors(
     cutoff: float,
     atomic_density: float = 0.2,
     safety_factor: float | None = None,
+    max_neighbors_lower_bound: int = 16,
 ) -> int:
     r"""Estimate maximum neighbors per atom based on volume calculations.
 
@@ -1016,17 +973,19 @@ def estimate_max_neighbors(
     safety_factor : float, optional
         .. deprecated::
             ``safety_factor`` scales the estimate identically to
-            ``atomic_density``; set ``atomic_density`` instead, or raise the
-            neighbor-count floor with the ``ALCHEMI_MIN_MAX_NEIGHBORS``
-            environment variable. When given, it is folded into
-            ``atomic_density`` (``atomic_density *= safety_factor``).
+            ``atomic_density``; set ``atomic_density`` instead. When given, it is
+            folded into ``atomic_density`` (``atomic_density *= safety_factor``).
+    max_neighbors_lower_bound : int, optional
+        Lower bound on the returned estimate. Default is 16. Raise it for dense
+        or clustered systems where short cutoffs would otherwise underestimate
+        the neighbor count.
 
     Returns
     -------
     max_neighbors_estimate : int
         Conservative estimate of maximum neighbors per atom. Returns 0 for
-        empty systems, and never less than the neighbor-count floor (64 by
-        default, or ``ALCHEMI_MIN_MAX_NEIGHBORS``) for a positive cutoff.
+        empty systems, and never less than ``max_neighbors_lower_bound`` for a
+        positive cutoff.
 
     Notes
     -----
@@ -1042,17 +1001,14 @@ def estimate_max_neighbors(
 
         V_{\text{sphere}} = \frac{4}{3}\pi r^3
 
-    The result is floored at ``ALCHEMI_MIN_MAX_NEIGHBORS`` (64 by default) and
-    rounded up to the next multiple of 16 for memory alignment. The floor is
-    read from the environment once at import, so ``ALCHEMI_MIN_MAX_NEIGHBORS``
-    must be set before importing this module to take effect.
+    The result is floored at ``max_neighbors_lower_bound`` and rounded up to the
+    next multiple of 16 for memory alignment.
     """
     if safety_factor is not None:
         warnings.warn(
             "The 'safety_factor' argument to estimate_max_neighbors is "
             "deprecated; it scales the estimate identically to 'atomic_density'. "
-            "Set 'atomic_density' instead, or raise the neighbor-count floor via "
-            "the ALCHEMI_MIN_MAX_NEIGHBORS environment variable.",
+            "Set 'atomic_density' instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -1061,9 +1017,8 @@ def estimate_max_neighbors(
         return 0
     cutoff_sphere_volume = atomic_density * (4.0 / 3.0) * math.pi * (cutoff**3)
 
-    # Estimate neighbors from density and cutoff volume, floored to keep a
-    # safety margin for clustered / non-equilibrium configurations.
-    expected_neighbors = max(_MIN_MAX_NEIGHBORS, cutoff_sphere_volume)
+    # Floor the estimate so short cutoffs keep a safety margin for dense systems.
+    expected_neighbors = max(max_neighbors_lower_bound, cutoff_sphere_volume)
 
     # Round up to multiple of 16 for memory alignment and safety
     max_neighbors_estimate = int(math.ceil(expected_neighbors / 16)) * 16

--- a/nvalchemiops/neighbors/neighbor_utils.py
+++ b/nvalchemiops/neighbors/neighbor_utils.py
@@ -21,6 +21,7 @@ See `nvalchemiops.torch.neighbors` for PyTorch bindings.
 
 import contextlib
 import math
+import os
 import warnings
 from functools import lru_cache
 from typing import Any
@@ -950,10 +951,50 @@ def compute_naive_num_shifts(
     )
 
 
+# Default lower bound on the estimated neighbor count; short cutoffs otherwise
+# collapse toward the 16-neighbor alignment floor, underestimating dense systems.
+_DEFAULT_MIN_MAX_NEIGHBORS = 64
+
+
+def _resolve_min_max_neighbors() -> int:
+    """Resolve the neighbor-count floor, honoring ``ALCHEMI_MIN_MAX_NEIGHBORS``.
+
+    Systems whose local density routinely exceeds the bulk average can raise the
+    floor via the ``ALCHEMI_MIN_MAX_NEIGHBORS`` environment variable. A missing,
+    non-integer, or negative value falls back to the default.
+    """
+    raw = os.environ.get("ALCHEMI_MIN_MAX_NEIGHBORS")
+    if raw is None:
+        return _DEFAULT_MIN_MAX_NEIGHBORS
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        warnings.warn(
+            f"Ignoring non-integer ALCHEMI_MIN_MAX_NEIGHBORS={raw!r}; "
+            f"using {_DEFAULT_MIN_MAX_NEIGHBORS}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return _DEFAULT_MIN_MAX_NEIGHBORS
+    if value < 0:
+        warnings.warn(
+            f"Ignoring negative ALCHEMI_MIN_MAX_NEIGHBORS={raw!r}; "
+            f"using {_DEFAULT_MIN_MAX_NEIGHBORS}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return _DEFAULT_MIN_MAX_NEIGHBORS
+    return value
+
+
+# Resolved once at import; override via the ALCHEMI_MIN_MAX_NEIGHBORS env var.
+_MIN_MAX_NEIGHBORS = _resolve_min_max_neighbors()
+
+
 def estimate_max_neighbors(
     cutoff: float,
     atomic_density: float = 0.2,
-    safety_factor: float = 1.0,
+    safety_factor: float | None = None,
 ) -> int:
     r"""Estimate maximum neighbors per atom based on volume calculations.
 
@@ -966,15 +1007,23 @@ def estimate_max_neighbors(
     cutoff : float
         Maximum distance for considering atoms as neighbors.
     atomic_density : float, optional
-        Atomic density in atoms per unit volume. Default is 0.2.
-    safety_factor : float
-        Safety factor to multiply the estimated number of neighbors. Default is 1.0.
+        Atomic density in atoms per unit volume. Default is 0.2. Increase this
+        for denser or clustered systems whose local density exceeds the bulk
+        average (it scales the estimate linearly).
+    safety_factor : float, optional
+        .. deprecated::
+            ``safety_factor`` scales the estimate identically to
+            ``atomic_density``; set ``atomic_density`` instead, or raise the
+            neighbor-count floor with the ``ALCHEMI_MIN_MAX_NEIGHBORS``
+            environment variable. When given, it is folded into
+            ``atomic_density`` (``atomic_density *= safety_factor``).
 
     Returns
     -------
     max_neighbors_estimate : int
         Conservative estimate of maximum neighbors per atom. Returns 0 for
-        empty systems.
+        empty systems, and never less than the neighbor-count floor (64 by
+        default, or ``ALCHEMI_MIN_MAX_NEIGHBORS``) for a positive cutoff.
 
     Notes
     -----
@@ -982,7 +1031,7 @@ def estimate_max_neighbors(
 
     .. math::
 
-        \text{neighbors} = \text{safety\_factor} \times \text{density} \times V_{\text{sphere}}
+        \text{neighbors} = \text{density} \times V_{\text{sphere}}
 
     where the cutoff sphere volume is:
 
@@ -990,14 +1039,26 @@ def estimate_max_neighbors(
 
         V_{\text{sphere}} = \frac{4}{3}\pi r^3
 
-    The result is rounded up to the multiple of 16 for memory alignment.
+    The result is floored at ``ALCHEMI_MIN_MAX_NEIGHBORS`` (64 by default) and
+    rounded up to the next multiple of 16 for memory alignment.
     """
+    if safety_factor is not None:
+        warnings.warn(
+            "The 'safety_factor' argument to estimate_max_neighbors is "
+            "deprecated; it scales the estimate identically to 'atomic_density'. "
+            "Set 'atomic_density' instead, or raise the neighbor-count floor via "
+            "the ALCHEMI_MIN_MAX_NEIGHBORS environment variable.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        atomic_density = safety_factor * atomic_density
     if cutoff <= 0:
         return 0
     cutoff_sphere_volume = atomic_density * (4.0 / 3.0) * math.pi * (cutoff**3)
 
-    # Estimate neighbors based on density and cutoff volume
-    expected_neighbors = max(1, safety_factor * cutoff_sphere_volume)
+    # Estimate neighbors from density and cutoff volume, floored to keep a
+    # safety margin for clustered / non-equilibrium configurations.
+    expected_neighbors = max(_MIN_MAX_NEIGHBORS, cutoff_sphere_volume)
 
     # Round up to multiple of 16 for memory alignment and safety
     max_neighbors_estimate = int(math.ceil(expected_neighbors / 16)) * 16

--- a/nvalchemiops/neighbors/neighbor_utils.py
+++ b/nvalchemiops/neighbors/neighbor_utils.py
@@ -961,7 +961,9 @@ def _resolve_min_max_neighbors() -> int:
 
     Systems whose local density routinely exceeds the bulk average can raise the
     floor via the ``ALCHEMI_MIN_MAX_NEIGHBORS`` environment variable. A missing,
-    non-integer, or negative value falls back to the default.
+    non-integer, or non-positive value falls back to the default. A zero floor
+    is rejected because it lets short cutoffs collapse back to the 16-neighbor
+    alignment minimum that the floor exists to prevent.
     """
     raw = os.environ.get("ALCHEMI_MIN_MAX_NEIGHBORS")
     if raw is None:
@@ -976,9 +978,9 @@ def _resolve_min_max_neighbors() -> int:
             stacklevel=2,
         )
         return _DEFAULT_MIN_MAX_NEIGHBORS
-    if value < 0:
+    if value <= 0:
         warnings.warn(
-            f"Ignoring negative ALCHEMI_MIN_MAX_NEIGHBORS={raw!r}; "
+            f"Ignoring non-positive ALCHEMI_MIN_MAX_NEIGHBORS={raw!r}; "
             f"using {_DEFAULT_MIN_MAX_NEIGHBORS}.",
             RuntimeWarning,
             stacklevel=2,
@@ -987,7 +989,8 @@ def _resolve_min_max_neighbors() -> int:
     return value
 
 
-# Resolved once at import; override via the ALCHEMI_MIN_MAX_NEIGHBORS env var.
+# Resolved once at import (not per call), so ``ALCHEMI_MIN_MAX_NEIGHBORS`` must
+# be set before importing this module to take effect.
 _MIN_MAX_NEIGHBORS = _resolve_min_max_neighbors()
 
 
@@ -1040,7 +1043,9 @@ def estimate_max_neighbors(
         V_{\text{sphere}} = \frac{4}{3}\pi r^3
 
     The result is floored at ``ALCHEMI_MIN_MAX_NEIGHBORS`` (64 by default) and
-    rounded up to the next multiple of 16 for memory alignment.
+    rounded up to the next multiple of 16 for memory alignment. The floor is
+    read from the environment once at import, so ``ALCHEMI_MIN_MAX_NEIGHBORS``
+    must be set before importing this module to take effect.
     """
     if safety_factor is not None:
         warnings.warn(

--- a/nvalchemiops/torch/neighbors/batch_cell_list.py
+++ b/nvalchemiops/torch/neighbors/batch_cell_list.py
@@ -241,8 +241,8 @@ def estimate_batch_cell_list_sizes(
     if total_cells < num_systems:
         raise RuntimeError(
             "estimate_batch_cell_list_sizes computed a non-positive cell count "
-            f"(max_total_cells={total_cells}) for {num_systems} system(s) at "
-            f"cutoff={cutoff}. Each system must contribute at least one cell; "
+            f"(total cells summed over {num_systems} system(s) = {total_cells}) "
+            f"at cutoff={cutoff}. Each system must contribute at least one cell; "
             "check for degenerate or excessively large cells."
         )
     return (

--- a/nvalchemiops/torch/neighbors/batch_cell_list.py
+++ b/nvalchemiops/torch/neighbors/batch_cell_list.py
@@ -235,8 +235,18 @@ def estimate_batch_cell_list_sizes(
         device=wp_device,
     )
 
+    total_cells = int(max_total_cells.sum().item())
+    # Each system contributes >= 1 cell, so a sum below num_systems means a bad
+    # (overflowed) count that must not reach the allocator.
+    if total_cells < num_systems:
+        raise RuntimeError(
+            "estimate_batch_cell_list_sizes computed a non-positive cell count "
+            f"(max_total_cells={total_cells}) for {num_systems} system(s) at "
+            f"cutoff={cutoff}. Each system must contribute at least one cell; "
+            "check for degenerate or excessively large cells."
+        )
     return (
-        max_total_cells.sum().item(),
+        total_cells,
         neighbor_search_radius,
     )
 

--- a/nvalchemiops/torch/neighbors/cell_list.py
+++ b/nvalchemiops/torch/neighbors/cell_list.py
@@ -288,8 +288,18 @@ def estimate_cell_list_sizes(
         device=wp_device,
     )
 
+    total_cells = int(max_total_cells.item())
+    # A non-positive count means a bad (overflowed) estimate that must not reach
+    # the allocator.
+    if total_cells < 1:
+        raise RuntimeError(
+            "estimate_cell_list_sizes computed a non-positive cell count "
+            f"(max_total_cells={total_cells}) at cutoff={cutoff}. The cell must "
+            "yield at least one cell; check for a degenerate or excessively "
+            "large cell."
+        )
     return (
-        max_total_cells.item(),
+        total_cells,
         neighbor_search_radius,
     )
 

--- a/nvalchemiops/torch/neighbors/neighbor_utils.py
+++ b/nvalchemiops/torch/neighbors/neighbor_utils.py
@@ -540,6 +540,11 @@ def allocate_cell_list(
     nvalchemiops.torch.neighbors.cell_list.build_cell_list : High-level PyTorch wrapper
     nvalchemiops.torch.neighbors.batch_cell_list.batch_build_cell_list : Batched version
     """
+    if max_total_cells < 0:
+        raise ValueError(
+            f"allocate_cell_list: max_total_cells={max_total_cells} < 0 "
+            "(cell-count overflow or bad estimate)."
+        )
     # Detect number of systems from neighbor_search_radius shape
     is_batched = neighbor_search_radius.ndim == 2
     num_systems = neighbor_search_radius.shape[0] if is_batched else 1

--- a/test/neighbors/bindings/jax/test_neighbor_utils.py
+++ b/test/neighbors/bindings/jax/test_neighbor_utils.py
@@ -24,6 +24,7 @@ import jax.numpy as jnp
 import pytest
 
 from nvalchemiops.jax.neighbors.neighbor_utils import (
+    allocate_cell_list,
     compute_naive_num_shifts,
     get_neighbor_list_from_neighbor_matrix,
     prepare_batch_idx_ptr,
@@ -33,6 +34,22 @@ from nvalchemiops.neighbors.neighbor_utils import NeighborOverflowError
 from .conftest import requires_gpu
 
 pytestmark = requires_gpu
+
+# ==============================================================================
+# Tests: allocate_cell_list
+# ==============================================================================
+
+
+class TestAllocateCellList:
+    """Test allocate_cell_list guards."""
+
+    def test_rejects_negative_max_total_cells(self):
+        """A negative cell count must raise a clear error rather than crashing
+        inside the array allocation."""
+        neighbor_search_radius = jnp.ones((3,), dtype=jnp.int32)
+        with pytest.raises(ValueError, match="max_total_cells=-1 < 0"):
+            allocate_cell_list(4, -1, neighbor_search_radius)
+
 
 # ==============================================================================
 # Tests: compute_naive_num_shifts

--- a/test/neighbors/bindings/torch/test_batch_cell_list.py
+++ b/test/neighbors/bindings/torch/test_batch_cell_list.py
@@ -224,9 +224,7 @@ class TestBatchCellListAPI:
         pbc = torch.cat(pbcs_list, dim=0)
         batch_idx = torch.cat(batch_idx_list, dim=0)
 
-        max_neighbors = estimate_max_neighbors(
-            cutoff, atomic_density=0.35 * 5.0
-        )
+        max_neighbors = estimate_max_neighbors(cutoff, atomic_density=0.35 * 5.0)
         neighbor_list, _, u = batch_cell_list(
             positions,
             cutoff,
@@ -326,9 +324,7 @@ class TestBatchCellListAPI:
         cutoff = 3.0
 
         if preallocate:
-            max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=0.35 * 5.0
-            )
+            max_neighbors = estimate_max_neighbors(cutoff, atomic_density=0.35 * 5.0)
             max_cells, neighbor_search_radius = estimate_batch_cell_list_sizes(
                 cell, pbc, cutoff
             )
@@ -377,9 +373,7 @@ class TestBatchCellListAPI:
                 num_neighbors=num_neighbors,
             )
         else:
-            max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=0.35 * 5.0
-            )
+            max_neighbors = estimate_max_neighbors(cutoff, atomic_density=0.35 * 5.0)
             results = batch_cell_list(
                 positions,
                 cutoff,
@@ -745,9 +739,7 @@ class TestBatchEdgeCases:
         )
         assert 1 <= max_cells <= max_nbins, max_cells
         # The estimate must feed the allocator without a negative-dim crash.
-        allocate_cell_list(
-            10, max_cells, neighbor_search_radius, torch.device(device)
-        )
+        allocate_cell_list(10, max_cells, neighbor_search_radius, torch.device(device))
 
     def test_large_cell_batched_mixed(self, device, dtype):
         """A batch mixing a normal and a huge cell: every system contributes at
@@ -763,9 +755,7 @@ class TestBatchEdgeCases:
         )
         num_systems = 2
         assert num_systems <= max_cells <= max_nbins * num_systems, max_cells
-        allocate_cell_list(
-            10, max_cells, neighbor_search_radius, torch.device(device)
-        )
+        allocate_cell_list(10, max_cells, neighbor_search_radius, torch.device(device))
 
     def test_large_cell_build_finds_neighbors(self, device, dtype):
         """Building on a large periodic cell must not overflow the cell-count

--- a/test/neighbors/bindings/torch/test_batch_cell_list.py
+++ b/test/neighbors/bindings/torch/test_batch_cell_list.py
@@ -225,7 +225,7 @@ class TestBatchCellListAPI:
         batch_idx = torch.cat(batch_idx_list, dim=0)
 
         max_neighbors = estimate_max_neighbors(
-            cutoff, atomic_density=0.35, safety_factor=5.0
+            cutoff, atomic_density=0.35 * 5.0
         )
         neighbor_list, _, u = batch_cell_list(
             positions,
@@ -327,7 +327,7 @@ class TestBatchCellListAPI:
 
         if preallocate:
             max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=0.35, safety_factor=5.0
+                cutoff, atomic_density=0.35 * 5.0
             )
             max_cells, neighbor_search_radius = estimate_batch_cell_list_sizes(
                 cell, pbc, cutoff
@@ -378,7 +378,7 @@ class TestBatchCellListAPI:
             )
         else:
             max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=0.35, safety_factor=5.0
+                cutoff, atomic_density=0.35 * 5.0
             )
             results = batch_cell_list(
                 positions,
@@ -490,7 +490,7 @@ class TestBatchCellListAPI:
 
         estimated_density = num_atoms / cell[0].det().abs().item()
         max_neighbors = estimate_max_neighbors(
-            cutoff, atomic_density=estimated_density, safety_factor=5.0
+            cutoff, atomic_density=estimated_density * 5.0
         )
         neighbor_list, _, u = batch_cell_list(
             positions,
@@ -730,6 +730,69 @@ class TestBatchEdgeCases:
 
         with pytest.raises(ValueError, match="max_nbins must be positive"):
             estimate_batch_cell_list_sizes(cell, pbc, 1.0, max_nbins=0)
+
+    @pytest.mark.parametrize("box", [6.0e4, 1.0e5, 1.0e6])
+    def test_large_cell_does_not_overflow(self, device, dtype, box):
+        """A large cell whose per-dimension cell-count product exceeds int32
+        must still yield a positive, clamped estimate (never a negative count
+        from an overflowed multiply), and allocation must succeed."""
+        max_nbins = 8192
+        cell = (torch.eye(3, dtype=dtype, device=device) * box).reshape(1, 3, 3)
+        pbc = torch.ones((1, 3), dtype=torch.bool, device=device)
+
+        max_cells, neighbor_search_radius = estimate_batch_cell_list_sizes(
+            cell, pbc, cutoff=8.5, max_nbins=max_nbins
+        )
+        assert 1 <= max_cells <= max_nbins, max_cells
+        # The estimate must feed the allocator without a negative-dim crash.
+        allocate_cell_list(
+            10, max_cells, neighbor_search_radius, torch.device(device)
+        )
+
+    def test_large_cell_batched_mixed(self, device, dtype):
+        """A batch mixing a normal and a huge cell: every system contributes at
+        least one cell and the total stays within the per-system cap."""
+        max_nbins = 8192
+        normal = torch.eye(3, dtype=dtype, device=device) * 12.0
+        huge = torch.eye(3, dtype=dtype, device=device) * 1.0e5
+        cell = torch.stack([normal, huge], dim=0)
+        pbc = torch.ones((2, 3), dtype=torch.bool, device=device)
+
+        max_cells, neighbor_search_radius = estimate_batch_cell_list_sizes(
+            cell, pbc, cutoff=8.5, max_nbins=max_nbins
+        )
+        num_systems = 2
+        assert num_systems <= max_cells <= max_nbins * num_systems, max_cells
+        allocate_cell_list(
+            10, max_cells, neighbor_search_radius, torch.device(device)
+        )
+
+    def test_large_cell_build_finds_neighbors(self, device, dtype):
+        """Building on a large periodic cell must not overflow the cell-count
+        math (estimate and construct stay consistent) and must still find the
+        correct short-range pair. Two atoms 3.0 apart in an 8e4 box have only
+        each other within a 8.5 cutoff (periodic images are ~8e4 away)."""
+        positions = torch.tensor(
+            [[0.0, 0.0, 0.0], [3.0, 0.0, 0.0]], dtype=dtype, device=device
+        )
+        cell = (torch.eye(3, dtype=dtype, device=device) * 8.0e4).reshape(1, 3, 3)
+        pbc = torch.ones((1, 3), dtype=torch.bool, device=device)
+        batch_idx = torch.zeros(2, dtype=torch.int32, device=device)
+        cutoff = 8.5
+
+        neighbor_list, _, _ = batch_cell_list(
+            positions, cutoff, cell, pbc, batch_idx, return_neighbor_list=True
+        )
+        i, j = neighbor_list
+        pairs = {(int(a), int(b)) for a, b in zip(i.tolist(), j.tolist())}
+        assert pairs == {(0, 1), (1, 0)}, pairs
+
+    def test_allocate_cell_list_rejects_negative(self, device, dtype):
+        """allocate_cell_list must reject a negative cell count with a clear
+        error rather than crashing inside torch.zeros."""
+        neighbor_search_radius = torch.ones((3,), dtype=torch.int32, device=device)
+        with pytest.raises(ValueError, match="max_total_cells=-1 < 0"):
+            allocate_cell_list(4, -1, neighbor_search_radius, torch.device(device))
 
     def test_empty_batch_build_cell_list(self, device, dtype):
         """Test with empty batch."""

--- a/test/neighbors/bindings/torch/test_cell_list.py
+++ b/test/neighbors/bindings/torch/test_cell_list.py
@@ -1902,10 +1902,23 @@ class TestEstimateMaxNeighborsDefaults:
         assert estimate_max_neighbors(-1.0) == 0
 
     @pytest.mark.parametrize("cutoff", [0.5, 1.5, 2.67])
-    def test_short_cutoff_respects_floor(self, cutoff):
-        """Short cutoffs must not collapse to the old 16-neighbor floor, which
-        underestimated clustered / non-equilibrium configurations."""
-        assert estimate_max_neighbors(cutoff) >= 64
+    def test_short_cutoff_respects_default_lower_bound(self, cutoff):
+        """Short cutoffs are floored at the default lower bound (16)."""
+        assert estimate_max_neighbors(cutoff) >= 16
+
+    @pytest.mark.parametrize("cutoff", [0.5, 1.5, 2.67])
+    def test_lower_bound_kwarg_raises_floor(self, cutoff):
+        """max_neighbors_lower_bound raises the floor for short cutoffs where the
+        density estimate would otherwise fall below it."""
+        assert estimate_max_neighbors(cutoff, max_neighbors_lower_bound=64) == 64
+
+    def test_lower_bound_does_not_cap_estimate(self):
+        """A lower bound below the density estimate leaves the estimate
+        unchanged (it is a floor, not a cap)."""
+        cutoff = 8.5
+        assert estimate_max_neighbors(
+            cutoff, max_neighbors_lower_bound=16
+        ) == estimate_max_neighbors(cutoff, max_neighbors_lower_bound=1)
 
     def test_density_scales_estimate(self):
         """A higher atomic_density must raise the estimate (the sole knob for
@@ -1939,32 +1952,3 @@ class TestEstimateMaxNeighborsDefaults:
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
             estimate_max_neighbors(5.0, atomic_density=0.3)
-
-    def test_env_var_overrides_floor(self, monkeypatch):
-        """ALCHEMI_MIN_MAX_NEIGHBORS overrides the neighbor-count floor; bad
-        values fall back to the default."""
-        from nvalchemiops.neighbors import neighbor_utils
-
-        monkeypatch.setenv("ALCHEMI_MIN_MAX_NEIGHBORS", "256")
-        assert neighbor_utils._resolve_min_max_neighbors() == 256
-
-        monkeypatch.setenv("ALCHEMI_MIN_MAX_NEIGHBORS", "not-an-int")
-        with pytest.warns(RuntimeWarning, match="ALCHEMI_MIN_MAX_NEIGHBORS"):
-            assert neighbor_utils._resolve_min_max_neighbors() == 64
-
-        # Zero and negative are rejected: a zero floor would let short cutoffs
-        # collapse back to the 16-neighbor minimum the floor exists to prevent.
-        for bad in ("0", "-8"):
-            monkeypatch.setenv("ALCHEMI_MIN_MAX_NEIGHBORS", bad)
-            with pytest.warns(RuntimeWarning, match="non-positive"):
-                assert neighbor_utils._resolve_min_max_neighbors() == 64
-
-        monkeypatch.delenv("ALCHEMI_MIN_MAX_NEIGHBORS", raising=False)
-        assert neighbor_utils._resolve_min_max_neighbors() == 64
-
-    def test_floor_respects_env_override(self, monkeypatch):
-        """estimate_max_neighbors honors an overridden floor for short cutoffs."""
-        from nvalchemiops.neighbors import neighbor_utils
-
-        monkeypatch.setattr(neighbor_utils, "_MIN_MAX_NEIGHBORS", 128)
-        assert neighbor_utils.estimate_max_neighbors(0.5) == 128

--- a/test/neighbors/bindings/torch/test_cell_list.py
+++ b/test/neighbors/bindings/torch/test_cell_list.py
@@ -682,9 +682,7 @@ class TestCellListOutputFormats:
             pbc = pbc.reshape(1, 3)
 
         if preallocate:
-            max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=0.35 * 5.0
-            )
+            max_neighbors = estimate_max_neighbors(cutoff, atomic_density=0.35 * 5.0)
             max_cells, neighbor_search_radius = estimate_cell_list_sizes(
                 cell, pbc, cutoff
             )
@@ -724,9 +722,7 @@ class TestCellListOutputFormats:
                 num_neighbors=num_neighbors,
             )
         else:
-            max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=0.35 * 5.0
-            )
+            max_neighbors = estimate_max_neighbors(cutoff, atomic_density=0.35 * 5.0)
             results = cell_list(
                 positions,
                 cutoff,
@@ -757,9 +753,7 @@ class TestCellListOutputFormats:
         cutoff = 3.0
 
         if preallocate:
-            max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=0.35 * 5.0
-            )
+            max_neighbors = estimate_max_neighbors(cutoff, atomic_density=0.35 * 5.0)
             max_cells, neighbor_search_radius = estimate_cell_list_sizes(
                 cell, pbc, cutoff
             )
@@ -799,9 +793,7 @@ class TestCellListOutputFormats:
                 num_neighbors=num_neighbors,
             )
         else:
-            max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=0.35 * 5.0
-            )
+            max_neighbors = estimate_max_neighbors(cutoff, atomic_density=0.35 * 5.0)
             results = cell_list(
                 positions,
                 cutoff,
@@ -1006,9 +998,7 @@ class TestCellListCompile:
             cutoff,
         )
         density = positions.shape[0] / cell.det()
-        max_neighbors = estimate_max_neighbors(
-            cutoff, atomic_density=density * 2.0
-        )
+        max_neighbors = estimate_max_neighbors(cutoff, atomic_density=density * 2.0)
         cell_list_cache_uncompiled = allocate_cell_list(
             positions.shape[0],
             max_cells,
@@ -1336,9 +1326,7 @@ class TestCellListComponentsAPI:
         positions, cell, _ = create_simple_cubic_system(dtype=dtype, device=device)
         cutoff = 1.1
         density = positions.shape[0] / cell.det().abs().item()
-        max_neighbors = estimate_max_neighbors(
-            cutoff, atomic_density=density * 5.0
-        )
+        max_neighbors = estimate_max_neighbors(cutoff, atomic_density=density * 5.0)
         assert max_neighbors > 0
         assert isinstance(max_neighbors, int)
 
@@ -1963,6 +1951,13 @@ class TestEstimateMaxNeighborsDefaults:
         monkeypatch.setenv("ALCHEMI_MIN_MAX_NEIGHBORS", "not-an-int")
         with pytest.warns(RuntimeWarning, match="ALCHEMI_MIN_MAX_NEIGHBORS"):
             assert neighbor_utils._resolve_min_max_neighbors() == 64
+
+        # Zero and negative are rejected: a zero floor would let short cutoffs
+        # collapse back to the 16-neighbor minimum the floor exists to prevent.
+        for bad in ("0", "-8"):
+            monkeypatch.setenv("ALCHEMI_MIN_MAX_NEIGHBORS", bad)
+            with pytest.warns(RuntimeWarning, match="non-positive"):
+                assert neighbor_utils._resolve_min_max_neighbors() == 64
 
         monkeypatch.delenv("ALCHEMI_MIN_MAX_NEIGHBORS", raising=False)
         assert neighbor_utils._resolve_min_max_neighbors() == 64

--- a/test/neighbors/bindings/torch/test_cell_list.py
+++ b/test/neighbors/bindings/torch/test_cell_list.py
@@ -173,7 +173,7 @@ class TestCellListCorrectness:
 
             estimated_density = num_atoms / cell.det().abs().item()
             max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=estimated_density, safety_factor=5.0
+                cutoff, atomic_density=estimated_density * 5.0
             )
             neighbor_list, _, u = cell_list(
                 positions,
@@ -216,7 +216,7 @@ class TestCellListCorrectness:
 
         estimated_density = num_atoms / cell.det().abs().item()
         max_neighbors = estimate_max_neighbors(
-            cutoff, atomic_density=estimated_density, safety_factor=5.0
+            cutoff, atomic_density=estimated_density * 5.0
         )
         neighbor_list, _, u = cell_list(
             positions,
@@ -489,7 +489,7 @@ class TestLeftHandedCells:
 
         estimated_density = positions.shape[0] / cell.det().abs().item()
         max_neighbors = estimate_max_neighbors(
-            cutoff, atomic_density=estimated_density, safety_factor=5.0
+            cutoff, atomic_density=estimated_density * 5.0
         )
         neighbor_list, _, u = cell_list(
             positions,
@@ -683,7 +683,7 @@ class TestCellListOutputFormats:
 
         if preallocate:
             max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=0.35, safety_factor=5.0
+                cutoff, atomic_density=0.35 * 5.0
             )
             max_cells, neighbor_search_radius = estimate_cell_list_sizes(
                 cell, pbc, cutoff
@@ -725,7 +725,7 @@ class TestCellListOutputFormats:
             )
         else:
             max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=0.35, safety_factor=5.0
+                cutoff, atomic_density=0.35 * 5.0
             )
             results = cell_list(
                 positions,
@@ -758,7 +758,7 @@ class TestCellListOutputFormats:
 
         if preallocate:
             max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=0.35, safety_factor=5.0
+                cutoff, atomic_density=0.35 * 5.0
             )
             max_cells, neighbor_search_radius = estimate_cell_list_sizes(
                 cell, pbc, cutoff
@@ -800,7 +800,7 @@ class TestCellListOutputFormats:
             )
         else:
             max_neighbors = estimate_max_neighbors(
-                cutoff, atomic_density=0.35, safety_factor=5.0
+                cutoff, atomic_density=0.35 * 5.0
             )
             results = cell_list(
                 positions,
@@ -1007,7 +1007,7 @@ class TestCellListCompile:
         )
         density = positions.shape[0] / cell.det()
         max_neighbors = estimate_max_neighbors(
-            cutoff, atomic_density=density, safety_factor=2.0
+            cutoff, atomic_density=density * 2.0
         )
         cell_list_cache_uncompiled = allocate_cell_list(
             positions.shape[0],
@@ -1337,7 +1337,7 @@ class TestCellListComponentsAPI:
         cutoff = 1.1
         density = positions.shape[0] / cell.det().abs().item()
         max_neighbors = estimate_max_neighbors(
-            cutoff, atomic_density=density, safety_factor=5.0
+            cutoff, atomic_density=density * 5.0
         )
         assert max_neighbors > 0
         assert isinstance(max_neighbors, int)
@@ -1904,3 +1904,72 @@ class TestCellListAutograd:
                 for col in range(int(count))
             ]
             assert sorted(active_a) == sorted(active_b)
+
+
+class TestEstimateMaxNeighborsDefaults:
+    """Defaults for estimate_max_neighbors (pure Python, framework-agnostic)."""
+
+    def test_nonpositive_cutoff_returns_zero(self):
+        assert estimate_max_neighbors(0.0) == 0
+        assert estimate_max_neighbors(-1.0) == 0
+
+    @pytest.mark.parametrize("cutoff", [0.5, 1.5, 2.67])
+    def test_short_cutoff_respects_floor(self, cutoff):
+        """Short cutoffs must not collapse to the old 16-neighbor floor, which
+        underestimated clustered / non-equilibrium configurations."""
+        assert estimate_max_neighbors(cutoff) >= 64
+
+    def test_density_scales_estimate(self):
+        """A higher atomic_density must raise the estimate (the sole knob for
+        denser / clustered systems)."""
+        cutoff = 5.0
+        assert estimate_max_neighbors(
+            cutoff, atomic_density=0.8
+        ) > estimate_max_neighbors(cutoff, atomic_density=0.2)
+
+    @pytest.mark.parametrize("cutoff", [1.0, 3.0, 5.0, 8.5])
+    def test_result_is_positive_multiple_of_16(self, cutoff):
+        result = estimate_max_neighbors(cutoff)
+        assert result > 0
+        assert result % 16 == 0
+        assert isinstance(result, int)
+
+    def test_safety_factor_deprecated_and_folded(self):
+        """safety_factor is deprecated: it must warn and fold into atomic_density
+        (identical result to scaling the density directly)."""
+        cutoff = 5.0
+        with pytest.warns(DeprecationWarning, match="safety_factor"):
+            result = estimate_max_neighbors(
+                cutoff, atomic_density=0.2, safety_factor=3.0
+            )
+        assert result == estimate_max_neighbors(cutoff, atomic_density=0.2 * 3.0)
+
+    def test_no_warning_without_safety_factor(self):
+        """The default path must not emit a deprecation warning."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            estimate_max_neighbors(5.0, atomic_density=0.3)
+
+    def test_env_var_overrides_floor(self, monkeypatch):
+        """ALCHEMI_MIN_MAX_NEIGHBORS overrides the neighbor-count floor; bad
+        values fall back to the default."""
+        from nvalchemiops.neighbors import neighbor_utils
+
+        monkeypatch.setenv("ALCHEMI_MIN_MAX_NEIGHBORS", "256")
+        assert neighbor_utils._resolve_min_max_neighbors() == 256
+
+        monkeypatch.setenv("ALCHEMI_MIN_MAX_NEIGHBORS", "not-an-int")
+        with pytest.warns(RuntimeWarning, match="ALCHEMI_MIN_MAX_NEIGHBORS"):
+            assert neighbor_utils._resolve_min_max_neighbors() == 64
+
+        monkeypatch.delenv("ALCHEMI_MIN_MAX_NEIGHBORS", raising=False)
+        assert neighbor_utils._resolve_min_max_neighbors() == 64
+
+    def test_floor_respects_env_override(self, monkeypatch):
+        """estimate_max_neighbors honors an overridden floor for short cutoffs."""
+        from nvalchemiops.neighbors import neighbor_utils
+
+        monkeypatch.setattr(neighbor_utils, "_MIN_MAX_NEIGHBORS", 128)
+        assert neighbor_utils.estimate_max_neighbors(0.5) == 128

--- a/test/neighbors/test_batch_cell_list_kernels.py
+++ b/test/neighbors/test_batch_cell_list_kernels.py
@@ -877,7 +877,7 @@ class TestBatchCellListScalingPureWarp:
         # Query using the cell list
         estimated_density = num_atoms / cell_torch[0].det().abs().item()
         max_neighbors = estimate_max_neighbors(
-            cutoff, atomic_density=estimated_density, safety_factor=5.0
+            cutoff, atomic_density=estimated_density * 5.0
         )
 
         neighbor_matrix_torch = torch.full(


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Two neighbor-list robustness fixes:

1. Cell-list size estimation returned a **negative** `max_total_cells` for a
   large-extent cell, which then crashed `allocate_cell_list` in
   `torch.zeros((max_total_cells,))` with `RuntimeError: Dimension size must be
   non-negative`. The per-dimension cell-count product (`cells_x * cells_y *
   cells_z`) was computed in int32 and wrapped negative, and the `max_nbins`
   clamp never fired on a negative value.
2. `estimate_max_neighbors` produced overly conservative estimates at short
   cutoffs (collapsing to the 16-neighbor alignment floor), causing
   `NeighborOverflowError` in dense / clustered configurations (#114).

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #114. Also addresses a separately reported `allocate_cell_list` crash on
large cells (negative `max_total_cells`).

## Changes Made

- **Overflow-safe cell counts** (`nvalchemiops/neighbors/cell_list/kernels.py`):
  the `estimate_sizes` **and** `construct_bin_size` kernels now clamp each
  per-dimension ratio before the int32 cast and accumulate the cell-count
  product (and the `× num_systems` term) in int64, so the count is always
  positive and capped. Both kernels are fixed so the allocation estimate and
  the actual grid stay consistent.
- **Validated estimates** (`estimate_batch_cell_list_sizes`,
  `estimate_cell_list_sizes`, torch): raise a clear error if the reduced count
  is non-positive instead of passing it to the allocator.
- **Validated allocation** (`allocate_cell_list`, torch **and** JAX): reject a
  negative `max_total_cells` with a clear `ValueError` rather than crashing
  inside the array allocation.
- **`estimate_max_neighbors`** (`nvalchemiops/neighbors/neighbor_utils.py`):
  raised the neighbor-count floor to 64, overridable via the new
  `ALCHEMI_MIN_MAX_NEIGHBORS` environment variable. Deprecated the
  `safety_factor` argument (it scaled the estimate identically to
  `atomic_density`) — it now emits a `DeprecationWarning` and is folded into
  `atomic_density`. Callers needing more headroom should raise `atomic_density`
  or the floor env var.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

New tests (run on the Warp CPU backend):
- `TestBatchEdgeCases` — large cells (`6e4`–`1e6` Å) yield positive, clamped
  estimates; batched mixed sizes; a large-cell build still finds the correct
  short-range pair; `allocate_cell_list` rejects a negative count.
- `TestEstimateMaxNeighborsDefaults` — floor of 64 at short cutoffs, density
  scaling, `safety_factor` deprecation + folding, no warning on the default
  path, and `ALCHEMI_MIN_MAX_NEIGHBORS` parsing (valid / bad / unset).
- `TestAllocateCellList` (JAX) — negative-count guard.

Ran `pytest test/neighbors/bindings/torch/test_cell_list.py
test/neighbors/bindings/torch/test_batch_cell_list.py` → 180 passed, 73 skipped,
0 failed (skips are the vesin/ASE- and CUDA-gated cases, unavailable in my
environment).

## Checklist

- [ ] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

- **`safety_factor` is deprecated, not removed** — existing callers keep working
  (with a warning); the value is folded into `atomic_density`. The only callers
  were tests, which were updated to pass `atomic_density` directly.
- The JAX `estimate_batch_cell_list_sizes` is a separate pure-Python-int
  implementation (floored at 8, cannot int32-overflow), so it needed only the
  `allocate_cell_list` guard, not the kernel fix.
- `make lint` unchecked: `ruff` wasn't available in my environment. The 3+-line
  comment blocks touched here are pre-existing (license/section headers); the
  comments I added are 1–2 lines.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
