### PR TITLE
add per-system reduction seam in optimizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Added
 
+- FIRE and FIRE2 optimizer steps accept caller-supplied per-system reductions
+  via a `compute_reductions=True` flag (`fire_step`, `fire_update`,
+  `fire2_step`, `fire2_update`, and the Torch `fire2_step_coord` /
+  `fire2_step_coord_cell`). When `False`, the values already in `vf`/`vv`/`ff`
+  (and FIRE2 `v_sumsq`/`f_sumsq`) are used for the mixing and dt/alpha update
+  instead of being recomputed; the per-atom state roll-back still runs. Adds a
+  standalone `fire_compute_vf_vv_ff` reduction helper. Default `True` is
+  byte-identical to previous behavior.
+- FIRE2 exposes its phases so a caller can post-process the displacement clamp
+  threshold between the velocity mix and the clamp: `fire2_apply_step` (Warp)
+  and the Torch `fire2_step_coord_cell_mix` / `_couple` / `_apply` split
+  `fire2_step_coord_cell` into reduce+mix, measure-`max_norm`, and clamp+apply
+  phases. `fire2_reduce` (Warp) and `fire2_compute_extended_reductions` (Torch,
+  returning separate owned-atom and replicated-cell contributions) expose the
+  reductions standalone. All default paths remain byte-identical.
 - Full Torch Ewald/PME APIs support energy-derived forces, charge
   gradients, and strain-first virials, including second-order force/stress
   losses.
@@ -31,6 +46,11 @@
 
 ### Fixed
 
+- Batched pressure kinetic tensor (`compute_kinetic_tensor` /
+  `compute_pressure_tensor` with `batch_idx`) is now computed with a per-atom
+  atomic reduction. The previous tiled reduction summed each thread block as a
+  whole and attributed it to a single system, corrupting per-system kinetic
+  tensors whenever a block spanned more than one system.
 - Cell-list size estimation no longer overflows when a cell is large relative
   to the cutoff: the per-dimension cell-count product is now computed
   overflow-safe (int64) and clamped per system, so `estimate_cell_list_sizes` /

--- a/nvalchemiops/dynamics/optimizers/__init__.py
+++ b/nvalchemiops/dynamics/optimizers/__init__.py
@@ -61,17 +61,26 @@ from nvalchemiops.dynamics.optimizers.fire import (
     _fire_update_params_downhill_ptr_kernel,
     _fire_update_params_no_downhill_ptr_kernel,
     # Unified API
+    fire_compute_vf_vv_ff,
     fire_step,
     fire_update,
 )
-from nvalchemiops.dynamics.optimizers.fire2 import fire2_step, fire2_update
+from nvalchemiops.dynamics.optimizers.fire2 import (
+    fire2_apply_step,
+    fire2_reduce,
+    fire2_step,
+    fire2_update,
+)
 
 __all__ = [
     # Unified API
     "fire_step",
     "fire_update",
+    "fire_compute_vf_vv_ff",
     "fire2_step",
     "fire2_update",
+    "fire2_apply_step",
+    "fire2_reduce",
     # Low-level kernels
     "_fire_step_no_downhill_ptr_kernel",
     "_fire_step_downhill_ptr_kernel",

--- a/nvalchemiops/dynamics/optimizers/fire.py
+++ b/nvalchemiops/dynamics/optimizers/fire.py
@@ -244,6 +244,46 @@ def _fire_revert_and_reduce_kernel(
 
 
 @wp.kernel(enable_backward=False)
+def _fire_revert_kernel(
+    positions: wp.array(dtype=Any),
+    velocities: wp.array(dtype=Any),
+    positions_last: wp.array(dtype=Any),
+    velocities_last: wp.array(dtype=Any),
+    batch_idx: wp.array(dtype=wp.int32),
+    uphill_flag: wp.array(dtype=wp.int32),
+):
+    """Revert uphill systems / accept downhill systems (per-atom, no reduction).
+
+    Companion to the standalone reducer: does only the state roll-back that the
+    fused revert-and-reduce kernel performs, so the reduction can be a separate
+    (skippable) launch that reads the reverted state.
+
+    Launch Grid
+    -----------
+    dim = [num_atoms]
+
+    Parameters
+    ----------
+    positions, velocities : wp.array, shape (N,), dtype vec3*
+        Modified in-place for uphill systems (restored from *_last).
+    positions_last, velocities_last : wp.array, shape (N,), dtype vec3*
+        Modified in-place for downhill systems (set to current state).
+    batch_idx : wp.array, shape (N,), dtype int32
+        System index per atom.
+    uphill_flag : wp.array, shape (M,), dtype int32
+        Per-system uphill flags from the uphill check kernel.
+    """
+    i = wp.tid()
+    s = batch_idx[i]
+    if uphill_flag[s] != 0:
+        positions[i] = positions_last[i]
+        velocities[i] = velocities_last[i]
+    else:
+        positions_last[i] = positions[i]
+        velocities_last[i] = velocities[i]
+
+
+@wp.kernel(enable_backward=False)
 def _fire_update_downhill_batch_idx_kernel(
     positions: wp.array(dtype=Any),
     velocities: wp.array(dtype=Any),
@@ -1221,6 +1261,7 @@ _fire_reduce_batch_idx_rle_kernel_overload = {}
 _fire_update_batch_idx_kernel_overload = {}
 _fire_uphill_check_kernel_overload = {}
 _fire_revert_and_reduce_kernel_overload = {}
+_fire_revert_kernel_overload = {}
 _fire_update_downhill_batch_idx_kernel_overload = {}
 
 # RLE-based update-only kernels (no MD step)
@@ -1321,6 +1362,18 @@ for t, v in zip(_T, _V):
             wp.array(dtype=t),  # ff
             wp.int32,  # N
             wp.int32,  # elems_per_thread
+        ],
+    )
+
+    _fire_revert_kernel_overload[v] = wp.overload(
+        _fire_revert_kernel,
+        [
+            wp.array(dtype=v),  # positions
+            wp.array(dtype=v),  # velocities
+            wp.array(dtype=v),  # positions_last
+            wp.array(dtype=v),  # velocities_last
+            wp.array(dtype=wp.int32),  # batch_idx
+            wp.array(dtype=wp.int32),  # uphill_flag
         ],
     )
 
@@ -1499,6 +1552,64 @@ _FIRE_UPDATE_BATCH_UPDATE_OVERLOADS = {
 # =============================================================================
 
 
+def fire_compute_vf_vv_ff(
+    velocities: wp.array,
+    forces: wp.array,
+    vf: wp.array,
+    vv: wp.array,
+    ff: wp.array,
+    batch_idx: wp.array = None,
+    device: str = None,
+) -> None:
+    """
+    Fill vf[s]=Sum F.v, vv[s]=Sum v.v, ff[s]=Sum F.F over each system's atoms —
+    the same reduction ``fire_step`` / ``fire_update`` perform internally,
+    exposed standalone.
+
+    Lets a caller compute these reductions separately, optionally post-process
+    them, and feed them back via ``fire_step(..., compute_reductions=False)``
+    (or ``fire_update``). Using this helper for the reduction gives
+    machine-precision parity with the values the step would otherwise compute
+    itself.
+
+    Parameters
+    ----------
+    velocities, forces : wp.array, shape (N,), dtype=wp.vec3f or wp.vec3d
+        Atomic velocities and forces.
+    vf, vv, ff : wp.array, shape (1,) or (num_systems,), dtype=wp.float*
+        Output reductions. Zeroed internally before accumulation. MODIFIED
+        in-place.
+    batch_idx : wp.array, shape (N,), dtype=wp.int32, optional
+        Sorted system index per atom. If None, all atoms are one system.
+    device : str, optional
+        Warp device. If None, inferred from velocities.
+    """
+    if device is None:
+        device = velocities.device
+
+    vf.zero_()
+    vv.zero_()
+    ff.zero_()
+
+    num_atoms = velocities.shape[0]
+    if num_atoms == 0:
+        return
+
+    vec_dtype = velocities.dtype
+    if batch_idx is None:
+        batch_idx = wp.zeros(num_atoms, dtype=wp.int32, device=device)
+
+    sm = max(device.sm_count, 1) if hasattr(device, "sm_count") else 1
+    ept = compute_ept(num_atoms, sm, is_vec3=True)
+    dim_reduce = (num_atoms + ept - 1) // ept
+    wp.launch(
+        _fire_reduce_batch_idx_rle_kernel_overload[vec_dtype],
+        dim=dim_reduce,
+        inputs=[velocities, forces, batch_idx, vf, vv, ff, num_atoms, ept],
+        device=device,
+    )
+
+
 def fire_step(
     # Core DOFs (required)
     positions: wp.array,
@@ -1531,6 +1642,7 @@ def fire_step(
     energy_last: wp.array = None,
     positions_last: wp.array = None,
     velocities_last: wp.array = None,
+    compute_reductions: bool = True,
 ) -> None:
     """
     Unified FIRE optimization step with MD integration.
@@ -1589,6 +1701,14 @@ def fire_step(
         Last accepted positions (for downhill rollback).
     velocities_last : wp.array, shape (N,) or (N_total,), dtype=wp.vec3*, optional
         Last accepted velocities (for downhill rollback).
+    compute_reductions : bool, optional
+        If True (default), recompute the per-system reductions vf/vv/ff
+        (Sum F.v / Sum v.v / Sum F.F) internally from velocities/forces. If
+        False, use the caller-supplied values already in vf/vv/ff instead of
+        recomputing them (they are not zeroed); the state roll-back still runs,
+        so the supplied values must reflect the post-roll-back velocities. Only
+        supported for single/batch_idx mode. See ``fire_compute_vf_vv_ff`` for
+        the matching reduction helper.
 
     Examples
     --------
@@ -1624,16 +1744,17 @@ def fire_step(
     """
     device = positions.device
 
-    if vf is not None:
-        vf.zero_()
-        vv.zero_()
-        ff.zero_()
-
     num_atoms = positions.shape[0]
     vec_dtype = positions.dtype
 
     # Determine batching mode
     exec_mode = resolve_execution_mode(batch_idx, atom_ptr)
+
+    if not compute_reductions and exec_mode is ExecutionMode.ATOM_PTR:
+        raise ValueError(
+            "compute_reductions=False is only supported for single/batch_idx "
+            "mode; the atom_ptr kernels compute reductions inline."
+        )
 
     # Determine if downhill check is enabled
     downhill_arrays = [energy, energy_last, positions_last, velocities_last]
@@ -1719,26 +1840,41 @@ def fire_step(
                 device=device,
             )
 
-            # Kernel 2: Revert if uphill + RLE reduction
+            # Kernel 2: Revert if uphill (per-atom roll-back, always runs)
             wp.launch(
-                _fire_revert_and_reduce_kernel_overload[vec_dtype],
-                dim=dim_reduce,
+                _fire_revert_kernel_overload[vec_dtype],
+                dim=num_atoms,
                 inputs=[
                     positions,
                     velocities,
-                    forces,
                     positions_last,
                     velocities_last,
                     batch_idx,
                     uphill_flag,
-                    vf,
-                    vv,
-                    ff,
-                    num_atoms,
-                    ept,
                 ],
                 device=device,
             )
+
+            # Kernel 2b: RLE reduction over the post-revert state (skippable)
+            if compute_reductions:
+                vf.zero_()
+                vv.zero_()
+                ff.zero_()
+                wp.launch(
+                    _fire_reduce_batch_idx_rle_kernel_overload[vec_dtype],
+                    dim=dim_reduce,
+                    inputs=[
+                        velocities,
+                        forces,
+                        batch_idx,
+                        vf,
+                        vv,
+                        ff,
+                        num_atoms,
+                        ept,
+                    ],
+                    device=device,
+                )
 
             # Kernel 3: Parameter update + velocity mixing
             wp.launch(
@@ -1769,22 +1905,26 @@ def fire_step(
                 device=device,
             )
         else:
-            # Kernel 1: RLE-based reduction
-            wp.launch(
-                _fire_reduce_batch_idx_rle_kernel_overload[vec_dtype],
-                dim=dim_reduce,
-                inputs=[
-                    velocities,
-                    forces,
-                    batch_idx,
-                    vf,
-                    vv,
-                    ff,
-                    num_atoms,
-                    ept,
-                ],
-                device=device,
-            )
+            # Kernel 1: RLE-based reduction (skippable)
+            if compute_reductions:
+                vf.zero_()
+                vv.zero_()
+                ff.zero_()
+                wp.launch(
+                    _fire_reduce_batch_idx_rle_kernel_overload[vec_dtype],
+                    dim=dim_reduce,
+                    inputs=[
+                        velocities,
+                        forces,
+                        batch_idx,
+                        vf,
+                        vv,
+                        ff,
+                        num_atoms,
+                        ept,
+                    ],
+                    device=device,
+                )
 
             # Kernel 2: Parameter update + velocity mixing + position update
             wp.launch(
@@ -1843,6 +1983,7 @@ def fire_update(
     positions: wp.array = None,
     positions_last: wp.array = None,
     velocities_last: wp.array = None,
+    compute_reductions: bool = True,
 ) -> None:
     """
     FIRE parameter update and velocity mixing WITHOUT MD integration.
@@ -1899,6 +2040,11 @@ def fire_update(
         Last accepted positions (for downhill rollback).
     velocities_last : wp.array, shape (N,) or (N_total,), dtype=wp.vec3*, optional
         Last accepted velocities (for downhill rollback).
+    compute_reductions : bool, optional
+        If True (default), recompute vf/vv/ff internally. If False, use the
+        caller-supplied values already in vf/vv/ff instead of recomputing them
+        (they are not zeroed); any state roll-back still runs. Only supported
+        for single/batch_idx mode. See ``fire_step`` and ``fire_compute_vf_vv_ff``.
 
     Examples
     --------
@@ -1924,15 +2070,16 @@ def fire_update(
     """
     device = velocities.device
 
-    if vf is not None:
-        vf.zero_()
-        vv.zero_()
-        ff.zero_()
-
     num_atoms = velocities.shape[0]
 
     # Determine batching mode
     exec_mode = resolve_execution_mode(batch_idx, atom_ptr)
+
+    if not compute_reductions and exec_mode is ExecutionMode.ATOM_PTR:
+        raise ValueError(
+            "compute_reductions=False is only supported for single/batch_idx "
+            "mode; the atom_ptr kernels compute reductions inline."
+        )
 
     # Determine if downhill check is enabled
     downhill_arrays = [energy, energy_last, positions, positions_last, velocities_last]
@@ -2018,26 +2165,41 @@ def fire_update(
                 device=device,
             )
 
-            # Kernel 2: Revert if uphill + RLE reduction
+            # Kernel 2: Revert if uphill (per-atom roll-back, always runs)
             wp.launch(
-                _fire_revert_and_reduce_kernel_overload[vec_dtype],
-                dim=dim_reduce,
+                _fire_revert_kernel_overload[vec_dtype],
+                dim=num_atoms,
                 inputs=[
                     positions,
                     velocities,
-                    forces,
                     positions_last,
                     velocities_last,
                     batch_idx,
                     uphill_flag,
-                    vf,
-                    vv,
-                    ff,
-                    num_atoms,
-                    ept,
                 ],
                 device=device,
             )
+
+            # Kernel 2b: RLE reduction over the post-revert state (skippable)
+            if compute_reductions:
+                vf.zero_()
+                vv.zero_()
+                ff.zero_()
+                wp.launch(
+                    _fire_reduce_batch_idx_rle_kernel_overload[vec_dtype],
+                    dim=dim_reduce,
+                    inputs=[
+                        velocities,
+                        forces,
+                        batch_idx,
+                        vf,
+                        vv,
+                        ff,
+                        num_atoms,
+                        ept,
+                    ],
+                    device=device,
+                )
 
             # Kernel 3: Parameter update + velocity mixing (no MD)
             wp.launch(
@@ -2065,22 +2227,26 @@ def fire_update(
                 device=device,
             )
         else:
-            # Kernel 1: RLE-based reduction
-            wp.launch(
-                _fire_reduce_batch_idx_rle_kernel_overload[vec_dtype],
-                dim=dim_reduce,
-                inputs=[
-                    velocities,
-                    forces,
-                    batch_idx,
-                    vf,
-                    vv,
-                    ff,
-                    num_atoms,
-                    ept,
-                ],
-                device=device,
-            )
+            # Kernel 1: RLE-based reduction (skippable)
+            if compute_reductions:
+                vf.zero_()
+                vv.zero_()
+                ff.zero_()
+                wp.launch(
+                    _fire_reduce_batch_idx_rle_kernel_overload[vec_dtype],
+                    dim=dim_reduce,
+                    inputs=[
+                        velocities,
+                        forces,
+                        batch_idx,
+                        vf,
+                        vv,
+                        ff,
+                        num_atoms,
+                        ept,
+                    ],
+                    device=device,
+                )
 
             # Kernel 2: Parameter update + velocity mixing (no MD)
             wp.launch(

--- a/nvalchemiops/dynamics/optimizers/fire2.py
+++ b/nvalchemiops/dynamics/optimizers/fire2.py
@@ -655,6 +655,7 @@ def fire2_step(
     tmax: float = 0.08,
     tmin: float = 0.005,
     maxstep: float = 0.1,
+    compute_reductions: bool = True,
 ) -> None:
     """Complete FIRE2 optimization step.
 
@@ -690,6 +691,13 @@ def fire2_step(
         Timestep bounds.
     maxstep : float
         Maximum step magnitude per system.
+    compute_reductions : bool, default True
+        If True, recompute ``vf``/``v_sumsq``/``f_sumsq`` internally. If False,
+        use the caller-supplied values for the mixing and parameter update. Note
+        that the final ``maxstep`` clamp still uses the ``max_norm`` produced by
+        this call's mixing kernel; for a clamp reduced across a caller-side
+        partition, drive the mixing via ``fire2_update`` and apply the clamp
+        after reducing ``max_norm``.
 
     Notes
     -----
@@ -742,6 +750,7 @@ def fire2_step(
         alpha0=alpha0,
         tmax=tmax,
         tmin=tmin,
+        compute_reductions=compute_reductions,
     )
 
     # Kernel 3: recompute step + clamp + position update + velocity zeroing
@@ -757,6 +766,120 @@ def fire2_step(
             vf,  # vf holds v.f; uphill if <= 0
             maxstep,
         ],
+        device=device,
+    )
+
+
+def fire2_reduce(
+    velocities: wp.array,
+    forces: wp.array,
+    dt: wp.array,
+    batch_idx: wp.array,
+    vf: wp.array,
+    v_sumsq: wp.array,
+    f_sumsq: wp.array,
+) -> None:
+    """Fill the FIRE2 per-system reductions over the half-stepped velocities.
+
+    Computes, per system s:
+    ``vf[s]      = sum_i (v_i + f_i*dt[s]) . f_i``,
+    ``v_sumsq[s] = sum_i (v_i + f_i*dt[s]) . (v_i + f_i*dt[s])``,
+    ``f_sumsq[s] = sum_i f_i . f_i`` — the same reduction ``fire2_update``
+    performs internally (the ``v + f*dt`` half-step is applied in registers,
+    velocities are not modified). Exposed so a caller can build the reductions
+    over a subset of the degrees of freedom and combine them.
+
+    Parameters
+    ----------
+    velocities, forces : wp.array, shape (N,), dtype vec3f/vec3d
+        Velocities and forces (read-only).
+    dt : wp.array, shape (M,), dtype float*
+        Per-system timestep used for the half-step.
+    batch_idx : wp.array, shape (N,), dtype int32
+        Sorted system index per element.
+    vf, v_sumsq, f_sumsq : wp.array, shape (M,), dtype float*
+        Outputs. Zeroed internally before accumulation.
+    """
+    vf.zero_()
+    v_sumsq.zero_()
+    f_sumsq.zero_()
+    N = velocities.shape[0]
+    if N == 0:
+        return
+    if batch_idx is None:
+        raise ValueError("batch_idx is required for fire2_reduce")
+    vec_dtype = velocities.dtype
+    device = velocities.device
+    sm = max(device.sm_count, 1)
+    ept = compute_ept(N, sm, True)
+    dim = (N + ept - 1) // ept
+    wp.launch(
+        _fire2_reduce_only_overloads[vec_dtype],
+        dim=dim,
+        inputs=[velocities, forces, dt, batch_idx, vf, v_sumsq, f_sumsq, N, ept],
+        device=device,
+    )
+
+
+def fire2_apply_step(
+    positions: wp.array,
+    velocities: wp.array,
+    dt: wp.array,
+    batch_idx: wp.array,
+    max_norm: wp.array,
+    vf: wp.array,
+    maxstep: float = 0.1,
+) -> None:
+    """Apply the final FIRE2 clamp + position update from mixed velocities.
+
+    This is the third phase of :func:`fire2_step`, exposed on its own so a
+    caller can interpose between the velocity mix and the displacement clamp.
+    It recomputes each atom's step from the (already mixed) velocities, clamps
+    it by ``min(1, maxstep / max_norm[s])``, updates ``positions``, scales
+    ``dt`` by the same factor, and zeroes velocities for uphill systems
+    (``vf[s] <= 0``).
+
+    Pairing with :func:`fire2_update` reproduces :func:`fire2_step` exactly::
+
+        fire2_update(velocities, forces, batch_idx, alpha, dt, nsteps_inc,
+                     vf, v_sumsq, f_sumsq, max_norm, ...)  # mix, fill max_norm
+        fire2_apply_step(positions, velocities, dt, batch_idx, max_norm, vf,
+                         maxstep=maxstep)
+
+    Splitting the two lets a caller post-process ``max_norm`` (e.g. combine the
+    per-partition maxima with a MAX reduction) before the clamp so every
+    partition scales the step identically.
+
+    Parameters
+    ----------
+    positions : wp.array, shape (N,), dtype vec3f/vec3d
+        Atomic positions, modified in-place.
+    velocities : wp.array, shape (N,), dtype vec3f/vec3d
+        Mixed velocities (from ``fire2_update``), modified in-place (zeroed for
+        uphill systems).
+    dt : wp.array, shape (M,), dtype float*
+        Per-system timestep, scaled in-place by the clamp factor.
+    batch_idx : wp.array, shape (N,), dtype int32
+        Sorted system index per atom.
+    max_norm : wp.array, shape (M,), dtype float*
+        Maximum step norm per system used for the clamp. Supply the
+        post-processed value here to override the one ``fire2_update`` produced.
+    vf : wp.array, shape (M,), dtype float*
+        Per-system ``v . f``; a system is uphill when ``vf[s] <= 0``.
+    maxstep : float
+        Maximum allowed step size.
+    """
+    N = positions.shape[0]
+    if N == 0:
+        return
+    if batch_idx is None:
+        raise ValueError("batch_idx is required for fire2_apply_step")
+    vec_dtype = positions.dtype
+    device = positions.device
+    wp.launch(
+        _fire2_clamp_apply_recompute_overloads[vec_dtype],
+        dim=N,
+        inputs=[positions, velocities, dt, batch_idx, max_norm, vf, maxstep],
         device=device,
     )
 
@@ -781,6 +904,7 @@ def fire2_update(
     tmax: float = 0.08,
     tmin: float = 0.005,
     compute_max_norm: bool = True,
+    compute_reductions: bool = True,
 ) -> None:
     """Run FIRE2 reduction, parameter update, and velocity mixing only.
 
@@ -830,6 +954,14 @@ def fire2_update(
         Whether to compute the extended-DOF maximum raw final-step norm into
         ``max_norm``. Set to false when a custom final apply phase will
         overwrite ``max_norm`` with a different physical displacement norm.
+    compute_reductions : bool, default True
+        If True, recompute ``vf``/``v_sumsq``/``f_sumsq`` internally from the
+        post-half-step velocities and forces. If False, use the caller-supplied
+        values already in those buffers for the mixing and parameter update
+        (they are not zeroed). ``max_norm`` is produced by the mixing kernel and
+        is unaffected by this flag; a caller that needs the displacement clamp
+        reduced across a caller-side partition should leave the final clamp to
+        itself (see ``compute_max_norm`` and the Notes).
 
     Notes
     -----
@@ -858,9 +990,10 @@ def fire2_update(
     vec_dtype = velocities.dtype
     device = velocities.device
 
-    vf.zero_()
-    v_sumsq.zero_()
-    f_sumsq.zero_()
+    if compute_reductions:
+        vf.zero_()
+        v_sumsq.zero_()
+        f_sumsq.zero_()
     if compute_max_norm or N == 0:
         max_norm.zero_()
     if N == 0:
@@ -870,14 +1003,15 @@ def fire2_update(
 
     sm = max(device.sm_count, 1)
 
-    ept1 = compute_ept(N, sm, True)
-    dim1 = (N + ept1 - 1) // ept1
-    wp.launch(
-        _fire2_reduce_only_overloads[vec_dtype],
-        dim=dim1,
-        inputs=[velocities, forces, dt, batch_idx, vf, v_sumsq, f_sumsq, N, ept1],
-        device=device,
-    )
+    if compute_reductions:
+        ept1 = compute_ept(N, sm, True)
+        dim1 = (N + ept1 - 1) // ept1
+        wp.launch(
+            _fire2_reduce_only_overloads[vec_dtype],
+            dim=dim1,
+            inputs=[velocities, forces, dt, batch_idx, vf, v_sumsq, f_sumsq, N, ept1],
+            device=device,
+        )
 
     ept2 = compute_ept(N, sm, True)
     dim2 = (N + ept2 - 1) // ept2

--- a/nvalchemiops/dynamics/utils/cell_filter.py
+++ b/nvalchemiops/dynamics/utils/cell_filter.py
@@ -1810,12 +1810,56 @@ def _apply_fire2_coord_cell_step(
     atomic + cell DOFs and then applies the physically coupled position/cell
     update on the unpacked tensors.
     """
+    _fire2_coord_cell_compute_max_norm(
+        positions,
+        velocities,
+        cell,
+        cell_velocities,
+        dt,
+        vf,
+        ext_batch_idx,
+        ext_atom_ptr,
+        max_norm,
+        device=device,
+    )
+    _fire2_coord_cell_clamp_apply(
+        positions,
+        velocities,
+        cell,
+        cell_velocities,
+        dt,
+        vf,
+        ext_batch_idx,
+        ext_atom_ptr,
+        max_norm,
+        maxstep,
+        device=device,
+    )
+
+
+def _fire2_coord_cell_compute_max_norm(
+    positions: wp.array,
+    velocities: wp.array,
+    cell: wp.array,
+    cell_velocities: wp.array,
+    dt: wp.array,
+    vf: wp.array,
+    ext_batch_idx: wp.array,
+    ext_atom_ptr: wp.array,
+    max_norm: wp.array,
+    device: str = None,
+) -> None:
+    """Fill ``max_norm`` with the per-system max physical displacement norm.
+
+    This is the couple/measure phase of the coupled variable-cell FIRE2 update:
+    it recomputes each atom's cell-coupled step and reduces the largest norm per
+    system into ``max_norm`` (zeroed first). It does **not** move positions or
+    cell, so a caller can post-process ``max_norm`` before the clamp/apply phase.
+    """
     if device is None:
         device = positions.device
-
     num_ext = ext_batch_idx.shape[0]
     vec_dtype = positions.dtype
-    mat_dtype = cell.dtype
 
     max_norm.zero_()
     wp.launch(
@@ -1834,6 +1878,35 @@ def _apply_fire2_coord_cell_step(
         ],
         device=device,
     )
+
+
+def _fire2_coord_cell_clamp_apply(
+    positions: wp.array,
+    velocities: wp.array,
+    cell: wp.array,
+    cell_velocities: wp.array,
+    dt: wp.array,
+    vf: wp.array,
+    ext_batch_idx: wp.array,
+    ext_atom_ptr: wp.array,
+    max_norm: wp.array,
+    maxstep: float,
+    device: str = None,
+) -> None:
+    """Clamp the coupled step by ``max_norm`` and apply it to positions + cell.
+
+    This is the apply phase of the coupled variable-cell FIRE2 update: it
+    recomputes the same cell-coupled step as
+    :func:`_fire2_coord_cell_compute_max_norm`, scales it by
+    ``min(1, maxstep / max_norm[s])``, and writes positions, cell, and the
+    clamped ``dt``. The ``max_norm`` handed in is used as-is.
+    """
+    if device is None:
+        device = positions.device
+    num_ext = ext_batch_idx.shape[0]
+    vec_dtype = positions.dtype
+    mat_dtype = cell.dtype
+
     wp.launch(
         _fire2_coord_cell_apply_positions_kernel_overload[vec_dtype],
         dim=num_ext,

--- a/nvalchemiops/torch/__init__.py
+++ b/nvalchemiops/torch/__init__.py
@@ -40,8 +40,12 @@ if importlib.util.find_spec("torch") is None:
     )
 
 from nvalchemiops.torch.fire2 import (
+    fire2_compute_extended_reductions,
     fire2_step_coord,
     fire2_step_coord_cell,
+    fire2_step_coord_cell_apply,
+    fire2_step_coord_cell_couple,
+    fire2_step_coord_cell_mix,
     fire2_step_extended,
 )
 from nvalchemiops.torch.segment_ops import (
@@ -64,6 +68,10 @@ __all__ = [
     "get_wp_vec_dtype",
     "fire2_step_coord",
     "fire2_step_coord_cell",
+    "fire2_step_coord_cell_mix",
+    "fire2_step_coord_cell_couple",
+    "fire2_step_coord_cell_apply",
+    "fire2_compute_extended_reductions",
     "fire2_step_extended",
     "segmented_dot",
     "segmented_matvec",

--- a/nvalchemiops/torch/fire2.py
+++ b/nvalchemiops/torch/fire2.py
@@ -46,9 +46,15 @@ import torch
 import warp as wp
 
 from nvalchemiops.batch_utils import atom_ptr_to_batch_idx, batch_idx_to_atom_ptr
-from nvalchemiops.dynamics.optimizers.fire2 import fire2_step, fire2_update
+from nvalchemiops.dynamics.optimizers.fire2 import (
+    fire2_reduce,
+    fire2_step,
+    fire2_update,
+)
 from nvalchemiops.dynamics.utils.cell_filter import (
     _apply_fire2_coord_cell_step,
+    _fire2_coord_cell_clamp_apply,
+    _fire2_coord_cell_compute_max_norm,
     extend_atom_ptr,
     pack_forces_with_cell,
     pack_velocities_with_cell,
@@ -68,6 +74,231 @@ def _alloc_or_zero(
         return torch.zeros(size, dtype=dtype, device=device)
     buf.zero_()
     return buf
+
+
+def _coord_cell_ext_metadata(
+    batch_idx: torch.Tensor,
+    M: int,
+    device: torch.device,
+    wp_device,
+    *,
+    atom_ptr: torch.Tensor | None,
+    ext_atom_ptr: torch.Tensor | None,
+    ext_batch_idx: torch.Tensor | None,
+):
+    """Return the packed-layout metadata for variable-cell FIRE2.
+
+    Computes ``atom_ptr`` / ``ext_atom_ptr`` / ``ext_batch_idx`` (as Warp arrays)
+    for the interleaved [atoms, 2 cell rows] layout, filling any not supplied.
+    """
+    N = batch_idx.shape[0]
+    N_ext = N + 2 * M
+    wp_bidx = wp.from_torch(batch_idx.detach(), dtype=wp.int32)
+    if atom_ptr is None:
+        atom_ptr = torch.zeros(M + 1, dtype=torch.int32, device=device)
+        atom_counts = torch.zeros(M, dtype=torch.int32, device=device)
+        batch_idx_to_atom_ptr(
+            wp_bidx,
+            wp.from_torch(atom_counts, dtype=wp.int32),
+            wp.from_torch(atom_ptr, dtype=wp.int32),
+        )
+    wp_atom_ptr = wp.from_torch(atom_ptr, dtype=wp.int32)
+    if ext_atom_ptr is None:
+        ext_atom_ptr = torch.zeros(M + 1, dtype=torch.int32, device=device)
+        extend_atom_ptr(
+            wp_atom_ptr,
+            wp.from_torch(ext_atom_ptr, dtype=wp.int32),
+            device=wp_device,
+        )
+    wp_ext_atom_ptr = wp.from_torch(ext_atom_ptr, dtype=wp.int32)
+    if ext_batch_idx is None:
+        ext_batch_idx = torch.empty(N_ext, dtype=torch.int32, device=device)
+        atom_ptr_to_batch_idx(
+            wp_ext_atom_ptr,
+            wp.from_torch(ext_batch_idx, dtype=wp.int32),
+        )
+    wp_ext_batch_idx = wp.from_torch(ext_batch_idx, dtype=wp.int32)
+    return atom_ptr, wp_atom_ptr, wp_ext_atom_ptr, wp_ext_batch_idx
+
+
+def _coord_cell_mix_impl(
+    positions,
+    velocities,
+    forces,
+    cell,
+    cell_velocities,
+    cell_force,
+    batch_idx,
+    alpha,
+    dt,
+    nsteps_inc,
+    *,
+    atom_ptr,
+    ext_atom_ptr,
+    ext_velocities,
+    ext_forces,
+    ext_batch_idx,
+    vf,
+    v_sumsq,
+    f_sumsq,
+    max_norm,
+    delaystep,
+    dtgrow,
+    dtshrink,
+    alphashrink,
+    alpha0,
+    tmax,
+    tmin,
+    cell_force_scale,
+    compute_reductions,
+    ext_positions,
+):
+    """Shared front half of the variable-cell FIRE2 step.
+
+    Packs atomic + cell DOFs, runs the FIRE2 reduction (gated by
+    ``compute_reductions``) and velocity mix on the packed DOFs, and unpacks the
+    mixed velocities. Does **not** apply positions/cell. Returns the Warp
+    handles the apply phase needs, or ``None`` for an empty system.
+    """
+    dtype = positions.dtype
+    device = positions.device
+    N = positions.shape[0]
+    M = alpha.shape[0]
+    N_ext = N + 2 * M
+    vec_type = _TORCH_TO_WP_VEC[dtype]
+    mat_type = _TORCH_TO_WP_MAT[dtype]
+    wp_device = wp.device_from_torch(device)
+
+    if cell_force_scale <= 0.0:
+        raise ValueError("cell_force_scale must be positive")
+    if ext_positions is not None:
+        warnings.warn(
+            "fire2_step_coord_cell(..., ext_positions=...) is deprecated and ignored.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+    if N == 0:
+        for buf in (vf, v_sumsq, f_sumsq, max_norm):
+            if buf is not None:
+                buf.zero_()
+        return None
+
+    if ext_velocities is None:
+        ext_velocities = torch.empty(N_ext, 3, dtype=dtype, device=device)
+    if ext_forces is None:
+        ext_forces = torch.empty(N_ext, 3, dtype=dtype, device=device)
+
+    if compute_reductions:
+        vf = _alloc_or_zero(vf, M, dtype, device)
+        v_sumsq = _alloc_or_zero(v_sumsq, M, dtype, device)
+        f_sumsq = _alloc_or_zero(f_sumsq, M, dtype, device)
+    elif vf is None or v_sumsq is None or f_sumsq is None:
+        raise ValueError(
+            "vf, v_sumsq, f_sumsq must be provided when compute_reductions=False"
+        )
+    max_norm = _alloc_or_zero(max_norm, M, dtype, device)
+
+    wp_pos = wp.from_torch(positions.detach(), dtype=vec_type)
+    wp_vel = wp.from_torch(velocities.detach(), dtype=vec_type)
+    wp_forces = wp.from_torch(forces.detach(), dtype=vec_type)
+    wp_cell = wp.from_torch(cell.detach(), dtype=mat_type)
+    wp_cell_vel = wp.from_torch(cell_velocities.detach(), dtype=mat_type)
+    wp_bidx = wp.from_torch(batch_idx.detach(), dtype=wp.int32)
+    wp_ext_vel = wp.from_torch(ext_velocities, dtype=vec_type)
+    wp_ext_forces = wp.from_torch(ext_forces, dtype=vec_type)
+
+    atom_ptr, wp_atom_ptr, wp_ext_atom_ptr, wp_ext_batch_idx = _coord_cell_ext_metadata(
+        batch_idx,
+        M,
+        device,
+        wp_device,
+        atom_ptr=atom_ptr,
+        ext_atom_ptr=ext_atom_ptr,
+        ext_batch_idx=ext_batch_idx,
+    )
+
+    atom_counts = atom_ptr[1:] - atom_ptr[:-1]
+    if torch.any(atom_counts <= 0).item():
+        raise ValueError("fire2_step_coord_cell requires at least one atom per system")
+    cell_force_divisor = atom_counts.to(dtype=dtype).reshape(M, 1, 1) * cell_force_scale
+    cell_force_work = (cell_force.detach() / cell_force_divisor).contiguous()
+    wp_cell_force = wp.from_torch(cell_force_work, dtype=mat_type)
+
+    if M == 1:
+        pack_velocities_with_cell(wp_vel, wp_cell_vel, wp_ext_vel, device=wp_device)
+        pack_forces_with_cell(wp_forces, wp_cell_force, wp_ext_forces, device=wp_device)
+    else:
+        pack_velocities_with_cell(
+            wp_vel,
+            wp_cell_vel,
+            wp_ext_vel,
+            wp_atom_ptr,
+            wp_ext_atom_ptr,
+            device=wp_device,
+            batch_idx=wp_bidx,
+        )
+        pack_forces_with_cell(
+            wp_forces,
+            wp_cell_force,
+            wp_ext_forces,
+            wp_atom_ptr,
+            wp_ext_atom_ptr,
+            device=wp_device,
+            batch_idx=wp_bidx,
+        )
+
+    wp_dt = wp.from_torch(dt.detach())
+    wp_vf = wp.from_torch(vf)
+    wp_max_norm = wp.from_torch(max_norm)
+    fire2_update(
+        wp_ext_vel,
+        wp_ext_forces,
+        wp_ext_batch_idx,
+        wp.from_torch(alpha.detach()),
+        wp_dt,
+        wp.from_torch(nsteps_inc.detach(), dtype=wp.int32),
+        wp_vf,
+        wp.from_torch(v_sumsq),
+        wp.from_torch(f_sumsq),
+        wp_max_norm,
+        delaystep=delaystep,
+        dtgrow=dtgrow,
+        dtshrink=dtshrink,
+        alphashrink=alphashrink,
+        alpha0=alpha0,
+        tmax=tmax,
+        tmin=tmin,
+        compute_max_norm=False,
+        compute_reductions=compute_reductions,
+    )
+
+    if M == 1:
+        unpack_velocities_with_cell(
+            wp_ext_vel, wp_vel, wp_cell_vel, num_atoms=N, device=wp_device
+        )
+    else:
+        unpack_velocities_with_cell(
+            wp_ext_vel,
+            wp_vel,
+            wp_cell_vel,
+            atom_ptr=wp_atom_ptr,
+            ext_atom_ptr=wp_ext_atom_ptr,
+            device=wp_device,
+            batch_idx=wp_bidx,
+        )
+
+    return (
+        wp_pos,
+        wp_vel,
+        wp_cell,
+        wp_cell_vel,
+        wp_dt,
+        wp_vf,
+        wp_ext_batch_idx,
+        wp_ext_atom_ptr,
+        wp_max_norm,
+        wp_device,
+    )
 
 
 def fire2_step_coord(
@@ -91,6 +322,7 @@ def fire2_step_coord(
     tmax: float = 0.08,
     tmin: float = 0.005,
     maxstep: float = 0.1,
+    compute_reductions: bool = True,
 ) -> None:
     """FIRE2 coordinate-only optimization step.
 
@@ -133,6 +365,11 @@ def fire2_step_coord(
         FIRE2 hyperparameters.  See
         :func:`~nvalchemiops.dynamics.optimizers.fire2.fire2_step` for
         defaults and descriptions.
+    compute_reductions : bool, default True
+        If True, recompute ``vf``/``v_sumsq``/``f_sumsq`` internally. If False,
+        use the caller-supplied values in those buffers instead of recomputing
+        them (they must be provided and are not zeroed); the ``maxstep`` clamp
+        still uses this call's internally-computed ``max_norm``.
 
     Notes
     -----
@@ -175,10 +412,16 @@ def fire2_step_coord(
     M = alpha.shape[0]
     vec_type = _TORCH_TO_WP_VEC[dtype]
 
-    # Scratch buffers: allocate if not provided, zero if provided
-    vf = _alloc_or_zero(vf, M, dtype, device)
-    v_sumsq = _alloc_or_zero(v_sumsq, M, dtype, device)
-    f_sumsq = _alloc_or_zero(f_sumsq, M, dtype, device)
+    # Scratch buffers: allocate/zero when recomputing; require and preserve
+    # them when the caller supplies precomputed reductions.
+    if compute_reductions:
+        vf = _alloc_or_zero(vf, M, dtype, device)
+        v_sumsq = _alloc_or_zero(v_sumsq, M, dtype, device)
+        f_sumsq = _alloc_or_zero(f_sumsq, M, dtype, device)
+    elif vf is None or v_sumsq is None or f_sumsq is None:
+        raise ValueError(
+            "vf, v_sumsq, f_sumsq must be provided when compute_reductions=False"
+        )
     max_norm = _alloc_or_zero(max_norm, M, dtype, device)
 
     if positions.shape[0] == 0:
@@ -205,6 +448,7 @@ def fire2_step_coord(
         tmax=tmax,
         tmin=tmin,
         maxstep=maxstep,
+        compute_reductions=compute_reductions,
     )
 
 
@@ -239,6 +483,7 @@ def fire2_step_coord_cell(
     tmin: float = 0.005,
     maxstep: float = 0.1,
     cell_force_scale: float = 1.0,
+    compute_reductions: bool = True,
 ) -> None:
     """FIRE2 variable-cell optimization step.
 
@@ -319,6 +564,14 @@ def fire2_step_coord_cell(
     cell_force_scale : float, default=1.0
         Extra positive multiplier for stress-derived cell-force normalization.
         Cell forces are divided by ``atoms_per_system * cell_force_scale``.
+    compute_reductions : bool, default True
+        If True, recompute ``vf``/``v_sumsq``/``f_sumsq`` internally. If False,
+        use the caller-supplied values instead (they must be provided and are
+        not zeroed). These reductions are over the **generalized (atom + cell)
+        DOFs** of each system, so a caller assembling them across a partition
+        must include the (replicated) cell contribution exactly once. The
+        ``maxstep`` clamp still uses this call's internally-recomputed
+        ``max_norm`` (the physical Cartesian displacement after cell coupling).
 
     Notes
     -----
@@ -435,10 +688,290 @@ def fire2_step_coord_cell(
     ...         f_sumsq=f_sumsq, max_norm=max_norm,
     ...     )
     """
+    res = _coord_cell_mix_impl(
+        positions,
+        velocities,
+        forces,
+        cell,
+        cell_velocities,
+        cell_force,
+        batch_idx,
+        alpha,
+        dt,
+        nsteps_inc,
+        atom_ptr=atom_ptr,
+        ext_atom_ptr=ext_atom_ptr,
+        ext_velocities=ext_velocities,
+        ext_forces=ext_forces,
+        ext_batch_idx=ext_batch_idx,
+        vf=vf,
+        v_sumsq=v_sumsq,
+        f_sumsq=f_sumsq,
+        max_norm=max_norm,
+        delaystep=delaystep,
+        dtgrow=dtgrow,
+        dtshrink=dtshrink,
+        alphashrink=alphashrink,
+        alpha0=alpha0,
+        tmax=tmax,
+        tmin=tmin,
+        cell_force_scale=cell_force_scale,
+        compute_reductions=compute_reductions,
+        ext_positions=ext_positions,
+    )
+    if res is None:
+        return
+    (
+        wp_pos,
+        wp_vel,
+        wp_cell,
+        wp_cell_vel,
+        wp_dt,
+        wp_vf,
+        wp_ext_batch_idx,
+        wp_ext_atom_ptr,
+        wp_max_norm,
+        wp_device,
+    ) = res
+    # Couple + clamp + apply the affine cell update directly on positions/cells.
+    _apply_fire2_coord_cell_step(
+        wp_pos,
+        wp_vel,
+        wp_cell,
+        wp_cell_vel,
+        wp_dt,
+        wp_vf,
+        wp_ext_batch_idx,
+        wp_ext_atom_ptr,
+        wp_max_norm,
+        maxstep=maxstep,
+        device=wp_device,
+    )
+
+
+def fire2_step_coord_cell_mix(
+    positions: torch.Tensor,
+    velocities: torch.Tensor,
+    forces: torch.Tensor,
+    cell: torch.Tensor,
+    cell_velocities: torch.Tensor,
+    cell_force: torch.Tensor,
+    batch_idx: torch.Tensor,
+    alpha: torch.Tensor,
+    dt: torch.Tensor,
+    nsteps_inc: torch.Tensor,
+    *,
+    atom_ptr: torch.Tensor | None = None,
+    ext_atom_ptr: torch.Tensor | None = None,
+    ext_velocities: torch.Tensor | None = None,
+    ext_forces: torch.Tensor | None = None,
+    ext_batch_idx: torch.Tensor | None = None,
+    vf: torch.Tensor | None = None,
+    v_sumsq: torch.Tensor | None = None,
+    f_sumsq: torch.Tensor | None = None,
+    max_norm: torch.Tensor | None = None,
+    delaystep: int = 60,
+    dtgrow: float = 1.05,
+    dtshrink: float = 0.75,
+    alphashrink: float = 0.985,
+    alpha0: float = 0.09,
+    tmax: float = 0.08,
+    tmin: float = 0.005,
+    cell_force_scale: float = 1.0,
+    compute_reductions: bool = True,
+) -> None:
+    """Phase 1 of the coupled variable-cell FIRE2 step: reduce + mix only.
+
+    Packs atomic + cell DOFs, runs the FIRE2 reduction (gated by
+    ``compute_reductions``) and velocity mixing on the generalized DOFs, and
+    unpacks the mixed velocities back into ``velocities`` / ``cell_velocities``.
+    Updates ``alpha``, ``dt``, ``nsteps_inc`` in-place. It does **not** apply the
+    position/cell step — pair it with :func:`fire2_step_coord_cell_couple` and
+    :func:`fire2_step_coord_cell_apply` so the displacement clamp can use a
+    ``max_norm`` post-processed between the couple and apply phases.
+
+    See :func:`fire2_step_coord_cell` for parameter descriptions.
+    """
+    _coord_cell_mix_impl(
+        positions,
+        velocities,
+        forces,
+        cell,
+        cell_velocities,
+        cell_force,
+        batch_idx,
+        alpha,
+        dt,
+        nsteps_inc,
+        atom_ptr=atom_ptr,
+        ext_atom_ptr=ext_atom_ptr,
+        ext_velocities=ext_velocities,
+        ext_forces=ext_forces,
+        ext_batch_idx=ext_batch_idx,
+        vf=vf,
+        v_sumsq=v_sumsq,
+        f_sumsq=f_sumsq,
+        max_norm=max_norm,
+        delaystep=delaystep,
+        dtgrow=dtgrow,
+        dtshrink=dtshrink,
+        alphashrink=alphashrink,
+        alpha0=alpha0,
+        tmax=tmax,
+        tmin=tmin,
+        cell_force_scale=cell_force_scale,
+        compute_reductions=compute_reductions,
+        ext_positions=None,
+    )
+
+
+def fire2_step_coord_cell_couple(
+    positions: torch.Tensor,
+    velocities: torch.Tensor,
+    cell: torch.Tensor,
+    cell_velocities: torch.Tensor,
+    dt: torch.Tensor,
+    vf: torch.Tensor,
+    batch_idx: torch.Tensor,
+    max_norm: torch.Tensor,
+    *,
+    atom_ptr: torch.Tensor | None = None,
+    ext_atom_ptr: torch.Tensor | None = None,
+    ext_batch_idx: torch.Tensor | None = None,
+) -> None:
+    """Phase 2 of the coupled variable-cell FIRE2 step: measure ``max_norm``.
+
+    Recomputes each atom's cell-coupled step from the mixed velocities (output
+    of :func:`fire2_step_coord_cell_mix`) and writes the per-system maximum
+    physical Cartesian displacement norm into ``max_norm`` (zeroed first).
+    Positions and cell are **not** moved, so a caller can post-process
+    ``max_norm`` before :func:`fire2_step_coord_cell_apply`.
+    """
+    device = positions.device
+    M = dt.shape[0]
+    if positions.shape[0] == 0:
+        max_norm.zero_()
+        return
+    vec_type = _TORCH_TO_WP_VEC[positions.dtype]
+    mat_type = _TORCH_TO_WP_MAT[cell.dtype]
+    wp_device = wp.device_from_torch(device)
+    _, _, wp_ext_atom_ptr, wp_ext_batch_idx = _coord_cell_ext_metadata(
+        batch_idx,
+        M,
+        device,
+        wp_device,
+        atom_ptr=atom_ptr,
+        ext_atom_ptr=ext_atom_ptr,
+        ext_batch_idx=ext_batch_idx,
+    )
+    _fire2_coord_cell_compute_max_norm(
+        wp.from_torch(positions.detach(), dtype=vec_type),
+        wp.from_torch(velocities.detach(), dtype=vec_type),
+        wp.from_torch(cell.detach(), dtype=mat_type),
+        wp.from_torch(cell_velocities.detach(), dtype=mat_type),
+        wp.from_torch(dt.detach()),
+        wp.from_torch(vf),
+        wp_ext_batch_idx,
+        wp_ext_atom_ptr,
+        wp.from_torch(max_norm),
+        device=wp_device,
+    )
+
+
+def fire2_step_coord_cell_apply(
+    positions: torch.Tensor,
+    velocities: torch.Tensor,
+    cell: torch.Tensor,
+    cell_velocities: torch.Tensor,
+    dt: torch.Tensor,
+    vf: torch.Tensor,
+    batch_idx: torch.Tensor,
+    max_norm: torch.Tensor,
+    *,
+    maxstep: float = 0.1,
+    atom_ptr: torch.Tensor | None = None,
+    ext_atom_ptr: torch.Tensor | None = None,
+    ext_batch_idx: torch.Tensor | None = None,
+) -> None:
+    """Phase 3 of the coupled variable-cell FIRE2 step: clamp + apply.
+
+    Recomputes the same cell-coupled step as
+    :func:`fire2_step_coord_cell_couple`, clamps it by
+    ``min(1, maxstep / max_norm[s])`` using the supplied ``max_norm``, and writes
+    ``positions``, ``cell``, ``cell_velocities`` (uphill zeroing), and the clamped
+    ``dt`` in-place.
+    """
+    device = positions.device
+    M = dt.shape[0]
+    if positions.shape[0] == 0:
+        return
+    vec_type = _TORCH_TO_WP_VEC[positions.dtype]
+    mat_type = _TORCH_TO_WP_MAT[cell.dtype]
+    wp_device = wp.device_from_torch(device)
+    _, _, wp_ext_atom_ptr, wp_ext_batch_idx = _coord_cell_ext_metadata(
+        batch_idx,
+        M,
+        device,
+        wp_device,
+        atom_ptr=atom_ptr,
+        ext_atom_ptr=ext_atom_ptr,
+        ext_batch_idx=ext_batch_idx,
+    )
+    _fire2_coord_cell_clamp_apply(
+        wp.from_torch(positions.detach(), dtype=vec_type),
+        wp.from_torch(velocities.detach(), dtype=vec_type),
+        wp.from_torch(cell.detach(), dtype=mat_type),
+        wp.from_torch(cell_velocities.detach(), dtype=mat_type),
+        wp.from_torch(dt.detach()),
+        wp.from_torch(vf),
+        wp_ext_batch_idx,
+        wp_ext_atom_ptr,
+        wp.from_torch(max_norm),
+        maxstep,
+        device=wp_device,
+    )
+
+
+def fire2_compute_extended_reductions(
+    positions: torch.Tensor,
+    velocities: torch.Tensor,
+    forces: torch.Tensor,
+    cell: torch.Tensor,
+    cell_velocities: torch.Tensor,
+    cell_force: torch.Tensor,
+    batch_idx: torch.Tensor,
+    dt: torch.Tensor,
+    *,
+    atom_ptr: torch.Tensor | None = None,
+    ext_atom_ptr: torch.Tensor | None = None,
+    ext_velocities: torch.Tensor | None = None,
+    ext_forces: torch.Tensor | None = None,
+    ext_batch_idx: torch.Tensor | None = None,
+    cell_force_scale: float = 1.0,
+) -> tuple[
+    tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+]:
+    """Split the variable-cell FIRE2 reductions into atom and cell parts.
+
+    Returns ``(atom_partial, cell_term)``, each a ``(vf, v_sumsq, f_sumsq)``
+    triple of ``(M,)`` tensors, such that ``atom_partial + cell_term`` equals the
+    reduction :func:`fire2_step_coord_cell_mix` computes over the packed
+    generalized DOFs. The atom part is a plain per-atom partition (combine it
+    across a caller-side partition), while the cell part is replicated (add it
+    exactly once)::
+
+        atom, cell_t = fire2_compute_extended_reductions(..., dt)
+        vf = allreduce(SUM, atom[0]) + cell_t[0]   # and v_sumsq, f_sumsq
+        fire2_step_coord_cell_mix(..., vf=vf, ..., compute_reductions=False)
+
+    Uses the same ``v + f*dt`` half-step as the internal reduction, so the
+    combined result is bit-parity with recomputing it in one pass.
+    """
     dtype = positions.dtype
     device = positions.device
     N = positions.shape[0]
-    M = alpha.shape[0]
+    M = cell.shape[0]
     N_ext = N + 2 * M
     vec_type = _TORCH_TO_WP_VEC[dtype]
     mat_type = _TORCH_TO_WP_MAT[dtype]
@@ -447,83 +980,64 @@ def fire2_step_coord_cell(
     if cell_force_scale <= 0.0:
         raise ValueError("cell_force_scale must be positive")
 
-    if ext_positions is not None:
-        warnings.warn(
-            "fire2_step_coord_cell(..., ext_positions=...) is deprecated and ignored.",
-            DeprecationWarning,
-            stacklevel=2,
+    def _triple():
+        return (
+            torch.zeros(M, dtype=dtype, device=device),
+            torch.zeros(M, dtype=dtype, device=device),
+            torch.zeros(M, dtype=dtype, device=device),
         )
 
+    atom_partial = _triple()
+    cell_term = _triple()
     if N == 0:
-        for buf in (vf, v_sumsq, f_sumsq, max_norm):
-            if buf is not None:
-                buf.zero_()
-        return
+        return atom_partial, cell_term
 
-    # --- Allocate extended working arrays if not provided ---
+    wp_dt = wp.from_torch(dt.detach())
+    wp_bidx = wp.from_torch(batch_idx.detach(), dtype=wp.int32)
+
+    # atom partial: the FIRE2 half-step reduction over the atom arrays directly.
+    fire2_reduce(
+        wp.from_torch(velocities.detach(), dtype=vec_type),
+        wp.from_torch(forces.detach(), dtype=vec_type),
+        wp_dt,
+        wp_bidx,
+        wp.from_torch(atom_partial[0]),
+        wp.from_torch(atom_partial[1]),
+        wp.from_torch(atom_partial[2]),
+    )
+
+    # total: pack the extended (atom + cell) DOFs and reduce over them.
     if ext_velocities is None:
         ext_velocities = torch.empty(N_ext, 3, dtype=dtype, device=device)
     if ext_forces is None:
         ext_forces = torch.empty(N_ext, 3, dtype=dtype, device=device)
-
-    # --- Reduction scratch buffers: allocate or zero ---
-    vf = _alloc_or_zero(vf, M, dtype, device)
-    v_sumsq = _alloc_or_zero(v_sumsq, M, dtype, device)
-    f_sumsq = _alloc_or_zero(f_sumsq, M, dtype, device)
-    max_norm = _alloc_or_zero(max_norm, M, dtype, device)
-
-    # --- Convert inputs to Warp arrays for pack/unpack kernels ---
-    wp_pos = wp.from_torch(positions.detach(), dtype=vec_type)
     wp_vel = wp.from_torch(velocities.detach(), dtype=vec_type)
     wp_forces = wp.from_torch(forces.detach(), dtype=vec_type)
-    wp_cell = wp.from_torch(cell.detach(), dtype=mat_type)
     wp_cell_vel = wp.from_torch(cell_velocities.detach(), dtype=mat_type)
-    wp_bidx = wp.from_torch(batch_idx.detach(), dtype=wp.int32)
-
     wp_ext_vel = wp.from_torch(ext_velocities, dtype=vec_type)
     wp_ext_forces = wp.from_torch(ext_forces, dtype=vec_type)
 
-    # --- Compute atom_ptr / ext_atom_ptr if not provided ---
-    if atom_ptr is None:
-        atom_ptr = torch.zeros(M + 1, dtype=torch.int32, device=device)
-        atom_counts = torch.zeros(M, dtype=torch.int32, device=device)
-        batch_idx_to_atom_ptr(
-            wp_bidx,
-            wp.from_torch(atom_counts, dtype=wp.int32),
-            wp.from_torch(atom_ptr, dtype=wp.int32),
-        )
-    wp_atom_ptr = wp.from_torch(atom_ptr, dtype=wp.int32)
-
+    atom_ptr, wp_atom_ptr, wp_ext_atom_ptr, wp_ext_batch_idx = _coord_cell_ext_metadata(
+        batch_idx,
+        M,
+        device,
+        wp_device,
+        atom_ptr=atom_ptr,
+        ext_atom_ptr=ext_atom_ptr,
+        ext_batch_idx=ext_batch_idx,
+    )
     atom_counts = atom_ptr[1:] - atom_ptr[:-1]
     if torch.any(atom_counts <= 0).item():
-        raise ValueError("fire2_step_coord_cell requires at least one atom per system")
+        raise ValueError(
+            "fire2_compute_extended_reductions requires at least one atom per system"
+        )
     cell_force_divisor = atom_counts.to(dtype=dtype).reshape(M, 1, 1) * cell_force_scale
     cell_force_work = (cell_force.detach() / cell_force_divisor).contiguous()
     wp_cell_force = wp.from_torch(cell_force_work, dtype=mat_type)
 
-    if ext_atom_ptr is None:
-        ext_atom_ptr = torch.zeros(M + 1, dtype=torch.int32, device=device)
-        extend_atom_ptr(
-            wp_atom_ptr,
-            wp.from_torch(ext_atom_ptr, dtype=wp.int32),
-            device=wp_device,
-        )
-    wp_ext_atom_ptr = wp.from_torch(ext_atom_ptr, dtype=wp.int32)
-
-    # --- Pack velocities and forces into extended arrays ---
     if M == 1:
-        pack_velocities_with_cell(
-            wp_vel,
-            wp_cell_vel,
-            wp_ext_vel,
-            device=wp_device,
-        )
-        pack_forces_with_cell(
-            wp_forces,
-            wp_cell_force,
-            wp_ext_forces,
-            device=wp_device,
-        )
+        pack_velocities_with_cell(wp_vel, wp_cell_vel, wp_ext_vel, device=wp_device)
+        pack_forces_with_cell(wp_forces, wp_cell_force, wp_ext_forces, device=wp_device)
     else:
         pack_velocities_with_cell(
             wp_vel,
@@ -544,71 +1058,22 @@ def fire2_step_coord_cell(
             batch_idx=wp_bidx,
         )
 
-    # --- Extended batch_idx: compute sorted index from ext_atom_ptr if not provided ---
-    if ext_batch_idx is None:
-        ext_batch_idx = torch.empty(N_ext, dtype=torch.int32, device=device)
-        atom_ptr_to_batch_idx(
-            wp_ext_atom_ptr,
-            wp.from_torch(ext_batch_idx, dtype=wp.int32),
-        )
-    wp_ext_batch_idx = wp.from_torch(ext_batch_idx, dtype=wp.int32)
-
-    # --- FIRE2 mix/update on generalized DOFs (no position application) ---
-    fire2_update(
+    total = _triple()
+    fire2_reduce(
         wp_ext_vel,
         wp_ext_forces,
+        wp_dt,
         wp_ext_batch_idx,
-        wp.from_torch(alpha.detach()),
-        wp.from_torch(dt.detach()),
-        wp.from_torch(nsteps_inc.detach(), dtype=wp.int32),
-        wp.from_torch(vf),
-        wp.from_torch(v_sumsq),
-        wp.from_torch(f_sumsq),
-        wp.from_torch(max_norm),
-        delaystep=delaystep,
-        dtgrow=dtgrow,
-        dtshrink=dtshrink,
-        alphashrink=alphashrink,
-        alpha0=alpha0,
-        tmax=tmax,
-        tmin=tmin,
-        compute_max_norm=False,
+        wp.from_torch(total[0]),
+        wp.from_torch(total[1]),
+        wp.from_torch(total[2]),
     )
 
-    # --- Unpack mixed velocities back to atomic and cell tensors ---
-    if M == 1:
-        unpack_velocities_with_cell(
-            wp_ext_vel,
-            wp_vel,
-            wp_cell_vel,
-            num_atoms=N,
-            device=wp_device,
-        )
-    else:
-        unpack_velocities_with_cell(
-            wp_ext_vel,
-            wp_vel,
-            wp_cell_vel,
-            atom_ptr=wp_atom_ptr,
-            ext_atom_ptr=wp_ext_atom_ptr,
-            device=wp_device,
-            batch_idx=wp_bidx,
-        )
+    # cell term = total (atom + cell) - atom partial.
+    for i in range(3):
+        cell_term[i].copy_(total[i] - atom_partial[i])
 
-    # Apply the coupled affine cell update directly on positions/cells.
-    _apply_fire2_coord_cell_step(
-        wp_pos,
-        wp_vel,
-        wp_cell,
-        wp_cell_vel,
-        wp.from_torch(dt.detach()),
-        wp.from_torch(vf),
-        wp_ext_batch_idx,
-        wp_ext_atom_ptr,
-        wp.from_torch(max_norm),
-        maxstep=maxstep,
-        device=wp_device,
-    )
+    return atom_partial, cell_term
 
 
 def fire2_step_extended(

--- a/test/dynamics/test_fire.py
+++ b/test/dynamics/test_fire.py
@@ -36,7 +36,11 @@ import numpy as np
 import pytest
 import warp as wp
 
-from nvalchemiops.dynamics.optimizers import fire_step, fire_update
+from nvalchemiops.dynamics.optimizers import (
+    fire_compute_vf_vv_ff,
+    fire_step,
+    fire_update,
+)
 from nvalchemiops.dynamics.utils import (
     align_cell,
     compute_cell_volume,
@@ -4163,6 +4167,214 @@ class TestFireDeterminism:
                 assert np.array_equal(ref_vel.numpy(), vel.numpy()), (
                     f"Velocities differ on repeat {i}"
                 )
+
+
+# ==============================================================================
+# compute_reductions flag + fire_compute_vf_vv_ff helper
+# ==============================================================================
+
+
+class TestFireComputeReductions:
+    """Tests for the compute_reductions flag and fire_compute_vf_vv_ff helper."""
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("dtype_vec,dtype_scalar,dtype_mat,np_dtype", DTYPE_CONFIGS)
+    @pytest.mark.parametrize("sizes", [[7], [5, 3]], ids=["single", "batched"])
+    def test_compute_vf_vv_ff_matches_manual(
+        self, device, dtype_vec, dtype_scalar, dtype_mat, np_dtype, sizes
+    ):
+        """fire_compute_vf_vv_ff fills the per-system inner products."""
+        num_atoms = sum(sizes)
+        num_systems = len(sizes)
+        batch_np = np.concatenate(
+            [np.full(n, s, dtype=np.int32) for s, n in enumerate(sizes)]
+        )
+        np.random.seed(0)
+        vel_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        frc_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+
+        velocities = wp.array(vel_np, dtype=dtype_vec, device=device)
+        forces = wp.array(frc_np, dtype=dtype_vec, device=device)
+        batch_idx = wp.array(batch_np, dtype=wp.int32, device=device)
+        vf = wp.empty(num_systems, dtype=dtype_scalar, device=device)
+        vv = wp.empty(num_systems, dtype=dtype_scalar, device=device)
+        ff = wp.empty(num_systems, dtype=dtype_scalar, device=device)
+
+        bidx = batch_idx if num_systems > 1 else None
+        fire_compute_vf_vv_ff(velocities, forces, vf, vv, ff, batch_idx=bidx)
+        wp.synchronize_device(device)
+
+        rtol = 1e-6 if np_dtype == np.float32 else 1e-12
+        for s in range(num_systems):
+            m = batch_np == s
+            np.testing.assert_allclose(
+                vf.numpy()[s], (frc_np[m] * vel_np[m]).sum(), rtol=rtol
+            )
+            np.testing.assert_allclose(
+                vv.numpy()[s], (vel_np[m] * vel_np[m]).sum(), rtol=rtol
+            )
+            np.testing.assert_allclose(
+                ff.numpy()[s], (frc_np[m] * frc_np[m]).sum(), rtol=rtol
+            )
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("dtype_vec,dtype_scalar,dtype_mat,np_dtype", DTYPE_CONFIGS)
+    @pytest.mark.parametrize("downhill", [False, True], ids=["no_downhill", "downhill"])
+    def test_compute_reductions_parity(
+        self, device, dtype_vec, dtype_scalar, dtype_mat, np_dtype, downhill
+    ):
+        """compute_reductions=True must match compute_reductions=False fed the
+        same (post-roll-back) vf/vv/ff — bit-identical."""
+        sizes = [6, 4]
+        num_atoms = sum(sizes)
+        num_systems = len(sizes)
+        batch_np = np.concatenate(
+            [np.full(n, s, dtype=np.int32) for s, n in enumerate(sizes)]
+        )
+        np.random.seed(3)
+        pos_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        vel_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        frc_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+
+        def run(compute_reductions, vf_seed=None):
+            positions = wp.array(pos_np.copy(), dtype=dtype_vec, device=device)
+            velocities = wp.array(vel_np.copy(), dtype=dtype_vec, device=device)
+            forces = wp.array(frc_np, dtype=dtype_vec, device=device)
+            masses = wp.ones(num_atoms, dtype=dtype_scalar, device=device)
+            batch_idx = wp.array(batch_np, dtype=wp.int32, device=device)
+            params = make_fire_params(num_systems, dtype_scalar, device, np_dtype)
+            acc = make_accumulators(num_systems, dtype_scalar, device, np_dtype)
+            if vf_seed is not None:
+                acc["vf"] = wp.array(vf_seed[0], dtype=dtype_scalar, device=device)
+                acc["vv"] = wp.array(vf_seed[1], dtype=dtype_scalar, device=device)
+                acc["ff"] = wp.array(vf_seed[2], dtype=dtype_scalar, device=device)
+            kwargs = dict(batch_idx=batch_idx, compute_reductions=compute_reductions)
+            if downhill:
+                dn = make_downhill_arrays(
+                    num_atoms, num_systems, dtype_vec, dtype_scalar, device, np_dtype
+                )
+                # Force system 1 uphill (energy rose) so it reverts.
+                dn["energy"] = wp.array(
+                    np.array([100.0, 101.0], dtype=np_dtype),
+                    dtype=dtype_scalar,
+                    device=device,
+                )
+                # Distinct last-accepted state so the uphill revert actually
+                # moves system 1's atoms.
+                dn["positions_last"] = wp.array(
+                    (pos_np + 0.3).astype(np_dtype), dtype=dtype_vec, device=device
+                )
+                dn["velocities_last"] = wp.array(
+                    (vel_np * 0.5).astype(np_dtype), dtype=dtype_vec, device=device
+                )
+                kwargs.update(
+                    energy=dn["energy"],
+                    energy_last=dn["energy_last"],
+                    positions_last=dn["positions_last"],
+                    velocities_last=dn["velocities_last"],
+                )
+            fire_step(positions, velocities, forces, masses, **params, **acc, **kwargs)
+            wp.synchronize_device(device)
+            return positions, velocities, params, acc
+
+        ref_p, ref_v, ref_params, ref_acc = run(True)
+        # Feed the reductions the reference used back with compute_reductions=False.
+        seed = (ref_acc["vf"].numpy(), ref_acc["vv"].numpy(), ref_acc["ff"].numpy())
+        dd_p, dd_v, dd_params, _ = run(False, vf_seed=seed)
+
+        np.testing.assert_array_equal(dd_p.numpy(), ref_p.numpy())
+        np.testing.assert_array_equal(dd_v.numpy(), ref_v.numpy())
+        np.testing.assert_array_equal(dd_params["dt"].numpy(), ref_params["dt"].numpy())
+        np.testing.assert_array_equal(
+            dd_params["alpha"].numpy(), ref_params["alpha"].numpy()
+        )
+        np.testing.assert_array_equal(
+            dd_params["n_steps_positive"].numpy(),
+            ref_params["n_steps_positive"].numpy(),
+        )
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("dtype_vec,dtype_scalar,dtype_mat,np_dtype", DTYPE_CONFIGS)
+    def test_global_vs_split(
+        self, device, dtype_vec, dtype_scalar, dtype_mat, np_dtype
+    ):
+        """One system's step must match feeding a reduction summed from two
+        disjoint halves of its atoms (compute_reductions=False)."""
+        num_atoms = 12
+        half = num_atoms // 2
+        np.random.seed(5)
+        pos_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        vel_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+        frc_np = np.random.randn(num_atoms, 3).astype(np_dtype)
+
+        def make():
+            return (
+                wp.array(pos_np.copy(), dtype=dtype_vec, device=device),
+                wp.array(vel_np.copy(), dtype=dtype_vec, device=device),
+                wp.array(frc_np, dtype=dtype_vec, device=device),
+                wp.ones(num_atoms, dtype=dtype_scalar, device=device),
+            )
+
+        # Whole-system reference (single system).
+        p1, v1, f1, m1 = make()
+        prm1 = make_fire_params(1, dtype_scalar, device, np_dtype)
+        acc1 = make_accumulators(1, dtype_scalar, device, np_dtype)
+        fire_step(p1, v1, f1, m1, **prm1, **acc1)
+
+        # Split: reduce each half separately, sum, feed with compute_reductions=False.
+        vf_a = wp.empty(1, dtype=dtype_scalar, device=device)
+        vv_a = wp.empty(1, dtype=dtype_scalar, device=device)
+        ff_a = wp.empty(1, dtype=dtype_scalar, device=device)
+        vf_b = wp.empty(1, dtype=dtype_scalar, device=device)
+        vv_b = wp.empty(1, dtype=dtype_scalar, device=device)
+        ff_b = wp.empty(1, dtype=dtype_scalar, device=device)
+        _, v2, f2, _ = make()
+        fire_compute_vf_vv_ff(v2[:half], f2[:half], vf_a, vv_a, ff_a)
+        fire_compute_vf_vv_ff(v2[half:], f2[half:], vf_b, vv_b, ff_b)
+        vf = wp.array(vf_a.numpy() + vf_b.numpy(), dtype=dtype_scalar, device=device)
+        vv = wp.array(vv_a.numpy() + vv_b.numpy(), dtype=dtype_scalar, device=device)
+        ff = wp.array(ff_a.numpy() + ff_b.numpy(), dtype=dtype_scalar, device=device)
+
+        p2, v2b, f2b, m2 = make()
+        prm2 = make_fire_params(1, dtype_scalar, device, np_dtype)
+        fire_step(
+            p2,
+            v2b,
+            f2b,
+            m2,
+            **prm2,
+            vf=vf,
+            vv=vv,
+            ff=ff,
+            uphill_flag=wp.zeros(1, dtype=wp.int32, device=device),
+            compute_reductions=False,
+        )
+        wp.synchronize_device(device)
+        rtol = 1e-5 if np_dtype == np.float32 else 1e-11
+        np.testing.assert_allclose(p2.numpy(), p1.numpy(), rtol=rtol, atol=rtol)
+        np.testing.assert_allclose(v2b.numpy(), v1.numpy(), rtol=rtol, atol=rtol)
+
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_atom_ptr_rejects_compute_reductions_false(self, device):
+        """atom_ptr mode cannot consume external reductions."""
+        num_atoms = 6
+        positions = wp.zeros(num_atoms, dtype=wp.vec3d, device=device)
+        velocities = wp.zeros(num_atoms, dtype=wp.vec3d, device=device)
+        forces = wp.zeros(num_atoms, dtype=wp.vec3d, device=device)
+        masses = wp.ones(num_atoms, dtype=wp.float64, device=device)
+        params = make_fire_params(1, wp.float64, device, np.float64)
+        del params["uphill_flag"]
+        atom_ptr = wp.array([0, num_atoms], dtype=wp.int32, device=device)
+        with pytest.raises(ValueError, match="compute_reductions=False"):
+            fire_step(
+                positions,
+                velocities,
+                forces,
+                masses,
+                **params,
+                atom_ptr=atom_ptr,
+                compute_reductions=False,
+            )
 
 
 if __name__ == "__main__":

--- a/test/dynamics/test_fire2.py
+++ b/test/dynamics/test_fire2.py
@@ -37,10 +37,18 @@ import pytest
 import torch
 import warp as wp
 
-from nvalchemiops.dynamics.optimizers import fire2_step, fire2_update
+from nvalchemiops.dynamics.optimizers import (
+    fire2_apply_step,
+    fire2_step,
+    fire2_update,
+)
 from nvalchemiops.torch.fire2 import (
+    fire2_compute_extended_reductions,
     fire2_step_coord,
     fire2_step_coord_cell,
+    fire2_step_coord_cell_apply,
+    fire2_step_coord_cell_couple,
+    fire2_step_coord_cell_mix,
     fire2_step_extended,
 )
 
@@ -3965,3 +3973,355 @@ class TestFire2TorchCoordCell:
         )
         assert not np.allclose(pos_a.cpu().numpy(), pos_b.cpu().numpy())
         assert not np.allclose(frac_after_extended, frac_before)
+
+
+# ==============================================================================
+# compute_reductions flag (caller-supplied precomputed reductions)
+# ==============================================================================
+
+
+class TestFire2ComputeReductions:
+    """compute_reductions=True must match =False fed the same reductions."""
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("torch_dtype", [torch.float32, torch.float64])
+    def test_coord_compute_reductions_parity(self, device, torch_dtype):
+        N, M = 40, 2
+
+        def run(compute_reductions, seed_bufs=None):
+            (pos, vel, forces, batch_idx, alpha, dt, nsteps_inc, *_) = (
+                make_fire2_torch_state(
+                    N, M, torch_dtype, device, rng=np.random.default_rng(7)
+                )
+            )
+            vf = torch.zeros(M, dtype=torch_dtype, device=device)
+            vsq = torch.zeros(M, dtype=torch_dtype, device=device)
+            fsq = torch.zeros(M, dtype=torch_dtype, device=device)
+            mn = torch.zeros(M, dtype=torch_dtype, device=device)
+            if seed_bufs is not None:
+                vf.copy_(seed_bufs[0])
+                vsq.copy_(seed_bufs[1])
+                fsq.copy_(seed_bufs[2])
+            fire2_step_coord(
+                pos,
+                vel,
+                forces,
+                batch_idx,
+                alpha,
+                dt,
+                nsteps_inc,
+                vf=vf,
+                v_sumsq=vsq,
+                f_sumsq=fsq,
+                max_norm=mn,
+                compute_reductions=compute_reductions,
+                **FIRE2_DEFAULTS,
+            )
+            return pos, vel, alpha, dt, nsteps_inc, (vf, vsq, fsq)
+
+        rp, rv, ra, rd, rn, bufs = run(True)
+        dp, dv, da, dd, dn, _ = run(False, seed_bufs=[b.clone() for b in bufs])
+        torch.cuda.synchronize()
+
+        assert torch.equal(dp, rp)
+        assert torch.equal(dv, rv)
+        assert torch.equal(da, ra)
+        assert torch.equal(dd, rd)
+        assert torch.equal(dn, rn)
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("torch_dtype", [torch.float32, torch.float64])
+    def test_coord_cell_compute_reductions_parity(self, device, torch_dtype):
+        N, M = 40, 2
+        np_dtype = np.float32 if torch_dtype == torch.float32 else np.float64
+
+        def run(compute_reductions, seed_bufs=None):
+            rng = np.random.default_rng(11)
+            (pos, vel, forces, batch_idx, alpha, dt, nsteps_inc, *_) = (
+                make_fire2_torch_state(N, M, torch_dtype, device, rng=rng)
+            )
+            cell = torch.tensor(
+                _make_upper_triangular_cell(M, np_dtype, rng=rng),
+                dtype=torch_dtype,
+                device=device,
+            )
+            cell_vel = torch.zeros(M, 3, 3, dtype=torch_dtype, device=device)
+            cell_force = torch.tensor(
+                rng.standard_normal((M, 3, 3)).astype(np_dtype) * 0.01,
+                dtype=torch_dtype,
+                device=device,
+            )
+            vf = torch.zeros(M, dtype=torch_dtype, device=device)
+            vsq = torch.zeros(M, dtype=torch_dtype, device=device)
+            fsq = torch.zeros(M, dtype=torch_dtype, device=device)
+            mn = torch.zeros(M, dtype=torch_dtype, device=device)
+            if seed_bufs is not None:
+                vf.copy_(seed_bufs[0])
+                vsq.copy_(seed_bufs[1])
+                fsq.copy_(seed_bufs[2])
+            fire2_step_coord_cell(
+                pos,
+                vel,
+                forces,
+                cell,
+                cell_vel,
+                cell_force,
+                batch_idx,
+                alpha,
+                dt,
+                nsteps_inc,
+                vf=vf,
+                v_sumsq=vsq,
+                f_sumsq=fsq,
+                max_norm=mn,
+                compute_reductions=compute_reductions,
+                **FIRE2_CELL_DEFAULTS,
+            )
+            return pos, vel, cell, cell_vel, alpha, dt, nsteps_inc, (vf, vsq, fsq)
+
+        rp, rv, rc, rcv, ra, rd, rn, bufs = run(True)
+        dp, dv, dc, dcv, da, dd, dn, _ = run(False, seed_bufs=[b.clone() for b in bufs])
+        torch.cuda.synchronize()
+
+        assert torch.equal(dp, rp)
+        assert torch.equal(dv, rv)
+        assert torch.equal(dc, rc)
+        assert torch.equal(dcv, rcv)
+        assert torch.equal(da, ra)
+        assert torch.equal(dd, rd)
+        assert torch.equal(dn, rn)
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("dtype_vec,dtype_scalar,np_dtype", DTYPE_CONFIGS)
+    def test_apply_step_two_phase_matches_fire2_step(
+        self, device, dtype_vec, dtype_scalar, np_dtype
+    ):
+        """fire2_update + fire2_apply_step must reproduce fire2_step exactly.
+
+        This is the seam that lets a caller post-process max_norm (e.g. combine
+        per-partition maxima) between the velocity mix and the clamp.
+        """
+        N, M = 12, 2
+        batch_np = np.repeat(np.arange(M, dtype=np.int32), N // M)
+        rng = np.random.default_rng(9)
+        pos_np = rng.standard_normal((N, 3)).astype(np_dtype)
+        vel_np = (rng.standard_normal((N, 3)) * 0.01).astype(np_dtype)
+        frc_np = rng.standard_normal((N, 3)).astype(np_dtype)
+
+        def make():
+            return (
+                wp.array(pos_np.copy(), dtype=dtype_vec, device=device),
+                wp.array(vel_np.copy(), dtype=dtype_vec, device=device),
+                wp.array(frc_np, dtype=dtype_vec, device=device),
+                wp.array(batch_np, dtype=wp.int32, device=device),
+                wp.array(np.full(M, 0.09, np_dtype), dtype=dtype_scalar, device=device),
+                wp.array(np.full(M, 0.05, np_dtype), dtype=dtype_scalar, device=device),
+                wp.zeros(M, dtype=wp.int32, device=device),
+            )
+
+        def bufs():
+            return [wp.zeros(M, dtype=dtype_scalar, device=device) for _ in range(4)]
+
+        p1, v1, f1, b1, a1, d1, n1 = make()
+        vf1, vs1, fs1, mn1 = bufs()
+        fire2_step(p1, v1, f1, b1, a1, d1, n1, vf1, vs1, fs1, mn1, maxstep=0.1)
+
+        p2, v2, f2, b2, a2, d2, n2 = make()
+        vf2, vs2, fs2, mn2 = bufs()
+        fire2_update(v2, f2, b2, a2, d2, n2, vf2, vs2, fs2, mn2)
+        fire2_apply_step(p2, v2, d2, b2, mn2, vf2, maxstep=0.1)
+        wp.synchronize_device(device)
+
+        np.testing.assert_array_equal(p2.numpy(), p1.numpy())
+        np.testing.assert_array_equal(v2.numpy(), v1.numpy())
+        np.testing.assert_array_equal(d2.numpy(), d1.numpy())
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("torch_dtype", [torch.float32, torch.float64])
+    def test_coord_cell_three_call_matches_monolith(self, device, torch_dtype):
+        """mix + couple + apply must reproduce fire2_step_coord_cell exactly."""
+        N, M = 40, 2
+        np_dtype = np.float32 if torch_dtype == torch.float32 else np.float64
+
+        def state():
+            rng = np.random.default_rng(3)
+            pos = torch.tensor(
+                rng.standard_normal((N, 3)).astype(np_dtype), device=device
+            )
+            vel = torch.tensor(
+                (rng.standard_normal((N, 3)) * 0.01).astype(np_dtype), device=device
+            )
+            frc = torch.tensor(
+                rng.standard_normal((N, 3)).astype(np_dtype), device=device
+            )
+            cell = torch.tensor(
+                _make_upper_triangular_cell(M, np_dtype, rng=rng),
+                dtype=torch_dtype,
+                device=device,
+            )
+            cell_vel = torch.zeros(M, 3, 3, dtype=torch_dtype, device=device)
+            cell_force = torch.tensor(
+                rng.standard_normal((M, 3, 3)).astype(np_dtype) * 0.01,
+                dtype=torch_dtype,
+                device=device,
+            )
+            batch_idx = torch.tensor(
+                np.repeat(np.arange(M, dtype=np.int32), N // M),
+                dtype=torch.int32,
+                device=device,
+            )
+            alpha = torch.full((M,), 0.09, dtype=torch_dtype, device=device)
+            dt = torch.full((M,), 0.05, dtype=torch_dtype, device=device)
+            nsteps = torch.zeros(M, dtype=torch.int32, device=device)
+            return (
+                pos,
+                vel,
+                frc,
+                cell,
+                cell_vel,
+                cell_force,
+                batch_idx,
+                alpha,
+                dt,
+                nsteps,
+            )
+
+        p1, v1, f1, c1, cv1, cf1, b1, a1, d1, n1 = state()
+        fire2_step_coord_cell(
+            p1, v1, f1, c1, cv1, cf1, b1, a1, d1, n1, **FIRE2_CELL_DEFAULTS
+        )
+
+        p2, v2, f2, c2, cv2, cf2, b2, a2, d2, n2 = state()
+        vf = torch.zeros(M, dtype=torch_dtype, device=device)
+        vs = torch.zeros(M, dtype=torch_dtype, device=device)
+        fs = torch.zeros(M, dtype=torch_dtype, device=device)
+        mn = torch.zeros(M, dtype=torch_dtype, device=device)
+        fire2_step_coord_cell_mix(
+            p2,
+            v2,
+            f2,
+            c2,
+            cv2,
+            cf2,
+            b2,
+            a2,
+            d2,
+            n2,
+            vf=vf,
+            v_sumsq=vs,
+            f_sumsq=fs,
+            max_norm=mn,
+            **{k: v for k, v in FIRE2_CELL_DEFAULTS.items() if k != "maxstep"},
+        )
+        fire2_step_coord_cell_couple(p2, v2, c2, cv2, d2, vf, b2, mn)
+        fire2_step_coord_cell_apply(
+            p2, v2, c2, cv2, d2, vf, b2, mn, maxstep=FIRE2_CELL_DEFAULTS["maxstep"]
+        )
+        torch.cuda.synchronize()
+
+        assert torch.equal(p2, p1)
+        assert torch.equal(c2, c1)
+        assert torch.equal(v2, v1)
+        assert torch.equal(cv2, cv1)
+        assert torch.equal(d2, d1)
+
+    @pytest.mark.parametrize("device", DEVICES)
+    @pytest.mark.parametrize("torch_dtype", [torch.float32, torch.float64])
+    def test_extended_reductions_split_matches_internal(self, device, torch_dtype):
+        """atom_partial + cell_term fed with compute_reductions=False must match
+        the internally-computed reduction (bit-identical mixed state)."""
+        N, M = 40, 2
+        np_dtype = np.float32 if torch_dtype == torch.float32 else np.float64
+
+        def state():
+            rng = np.random.default_rng(3)
+            return (
+                torch.tensor(
+                    rng.standard_normal((N, 3)).astype(np_dtype), device=device
+                ),
+                torch.tensor(
+                    (rng.standard_normal((N, 3)) * 0.01).astype(np_dtype), device=device
+                ),
+                torch.tensor(
+                    rng.standard_normal((N, 3)).astype(np_dtype), device=device
+                ),
+                torch.tensor(
+                    _make_upper_triangular_cell(M, np_dtype, rng=rng),
+                    dtype=torch_dtype,
+                    device=device,
+                ),
+                torch.zeros(M, 3, 3, dtype=torch_dtype, device=device),
+                torch.tensor(
+                    rng.standard_normal((M, 3, 3)).astype(np_dtype) * 0.01,
+                    dtype=torch_dtype,
+                    device=device,
+                ),
+                torch.tensor(
+                    np.repeat(np.arange(M, dtype=np.int32), N // M),
+                    dtype=torch.int32,
+                    device=device,
+                ),
+                torch.full((M,), 0.09, dtype=torch_dtype, device=device),
+                torch.full((M,), 0.05, dtype=torch_dtype, device=device),
+                torch.zeros(M, dtype=torch.int32, device=device),
+            )
+
+        hp = {k: v for k, v in FIRE2_CELL_DEFAULTS.items() if k != "maxstep"}
+
+        # Reference: internal reduction.
+        pr, vr, fr, cr, cvr, cfr, br, ar, dr, nr = state()
+        vfr = torch.zeros(M, dtype=torch_dtype, device=device)
+        vsr = torch.zeros(M, dtype=torch_dtype, device=device)
+        fsr = torch.zeros(M, dtype=torch_dtype, device=device)
+        mnr = torch.zeros(M, dtype=torch_dtype, device=device)
+        fire2_step_coord_cell_mix(
+            pr,
+            vr,
+            fr,
+            cr,
+            cvr,
+            cfr,
+            br,
+            ar,
+            dr,
+            nr,
+            vf=vfr,
+            v_sumsq=vsr,
+            f_sumsq=fsr,
+            max_norm=mnr,
+            **hp,
+        )
+
+        # Combined split reductions fed with compute_reductions=False.
+        pd, vd, fd, cd, cvd, cfd, bd, ad, dd, nd_ = state()
+        atom, cell_t = fire2_compute_extended_reductions(
+            pd, vd, fd, cd, cvd, cfd, bd, dd, cell_force_scale=1.0
+        )
+        vfd = (atom[0] + cell_t[0]).clone()
+        vsd = (atom[1] + cell_t[1]).clone()
+        fsd = (atom[2] + cell_t[2]).clone()
+        mnd = torch.zeros(M, dtype=torch_dtype, device=device)
+        fire2_step_coord_cell_mix(
+            pd,
+            vd,
+            fd,
+            cd,
+            cvd,
+            cfd,
+            bd,
+            ad,
+            dd,
+            nd_,
+            vf=vfd,
+            v_sumsq=vsd,
+            f_sumsq=fsd,
+            max_norm=mnd,
+            compute_reductions=False,
+            **hp,
+        )
+        torch.cuda.synchronize()
+
+        rtol = 1e-6 if np_dtype == np.float32 else 1e-12
+        torch.testing.assert_close(vd, vr, rtol=rtol, atol=rtol)
+        torch.testing.assert_close(dd, dr, rtol=rtol, atol=rtol)
+        torch.testing.assert_close(ad, ar, rtol=rtol, atol=rtol)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Adds a backward-compatible seam so the FIRE and FIRE2 optimizers can consume
caller-supplied per-system reductions instead of always recomputing them from the
atoms passed in. This lets a downstream driver reduce the FIRE power/norm scalars
(and FIRE2's displacement-clamp threshold) across its own partition and feed the
combined values back in. Every new flag defaults to today's behavior, so existing
callers are byte-for-byte unchanged.

The FIRE2 displacement clamp (`max_norm`) is a *post-mix* quantity, so it cannot be
supplied to the monolithic step up front; the step is therefore exposed as
composable phases (`mix → couple → apply`) with the clamp threshold injectable
between the mix and the clamp.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Changes Made

<!-- List the key changes made in this PR -->

- **FIRE v1** (`dynamics/optimizers/fire.py`): added `compute_reductions=True` to
  `fire_step` / `fire_update`. Split the fused revert-and-reduce kernel into a
  per-atom `_fire_revert_kernel` (always runs) + the existing RLE reducer (gated),
  so the reduction is skippable while the roll-back still runs. Added the standalone
  `fire_compute_vf_vv_ff` helper. `atom_ptr` mode raises if `compute_reductions=False`.
- **FIRE2** (`dynamics/optimizers/fire2.py`): added `compute_reductions` to
  `fire2_step` / `fire2_update`; exposed `fire2_apply_step` (clamp+apply phase) and
  `fire2_reduce` (standalone half-step reduction).
- **FIRE2 variable-cell** (`torch/fire2.py`, `dynamics/utils/cell_filter.py`):
  refactored `fire2_step_coord_cell` onto a shared `_coord_cell_mix_impl` (behavior
  unchanged) and split the coupled cell apply into compute-`max_norm` / clamp-apply
  launchers. Added Torch phases `fire2_step_coord_cell_mix` / `_couple` / `_apply`
  and `fire2_compute_extended_reductions` (returns separate owned-atom and
  replicated-cell reduction contributions). Added `compute_reductions` to
  `fire2_step_coord`.
- Exports updated in `dynamics/optimizers/__init__.py` and `torch/__init__.py`.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Added `test/dynamics/test_fire.py::TestFireComputeReductions` and
`test/dynamics/test_fire2.py::TestFire2ComputeReductions`: helper-vs-manual,
`compute_reductions` parity (downhill + no-downhill, bit-identical), global-vs-split,
the `atom_ptr` guard, `fire2_update + fire2_apply_step == fire2_step`, the
variable-cell `mix + couple + apply == fire2_step_coord_cell`, and
`atom_partial + cell_term` reproducing the internal reduction. fp32 + fp64.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

- **Defaults preserve behavior:** all `compute_reductions=True` paths (and the
  `fire2_step_coord_cell` refactor) were verified byte-for-byte identical to the
  previous implementation.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
