### PR TITLE
feat(neighbors): coarsen pair-centric cell-list launches

### DIFF
--- a/docs/userguide/components/neighborlist.md
+++ b/docs/userguide/components/neighborlist.md
@@ -511,7 +511,11 @@ dual-cutoff variant — use `naive_dual_cutoff` for two-cutoff queries.
 
 The query has two CUDA kernel strategies, `atom_centric` (default) and `pair_centric`,
 chosen with `strategy="auto"` or pinned explicitly; both produce identical pair sets
-(only per-row ordering differs) and are available on PyTorch and JAX. On JAX,
+(only per-row ordering differs) and are available on PyTorch and JAX. On the fast
+path, `pair_centric` schedules one CUDA block per `(source_cell, neighbor offset)`;
+when that uncoarsened launch would exceed the Warp one-dimensional limit, the
+launcher transparently coarsens multiple logical blocks per CUDA block under the
+same strategy name (no new public method or `strategy` value). On JAX,
 `pair_centric` is bound through `jax_callable`, sizes its launch from the host, and
 requires `graph_mode="none"` (it raises under `jax.jit` with a traced radius; use
 `atom_centric` there).

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -51,11 +51,7 @@ from nvalchemiops.neighbors.cell_list import (
     get_cell_list_cells_per_system_kernel,
     get_cell_list_gather_kernel,
     get_query_cell_list_kernel,
-    is_pair_centric_launch_safe,
     is_pair_centric_parallelism_sufficient,
-)
-from nvalchemiops.neighbors.cell_list.launchers import (
-    _raise_unsafe_pair_centric_launch,
 )
 from nvalchemiops.neighbors.neighbor_utils import estimate_max_neighbors
 from nvalchemiops.neighbors.output_args import (
@@ -1563,11 +1559,7 @@ def batch_query_cell_list(
         else:
             # JAX batch cell_list is full-fill (half_fill+pair_centric raised above).
             n_outer = compute_batch_pair_centric_n_outer(R_max, False)
-            if not is_pair_centric_launch_safe(total_cells, n_outer):
-                if strategy == "pair_centric":
-                    _raise_unsafe_pair_centric_launch(total_cells, n_outer, 64)
-                chosen = "atom_centric"
-            elif strategy == "auto" and not is_pair_centric_parallelism_sufficient(
+            if strategy == "auto" and not is_pair_centric_parallelism_sufficient(
                 total_atoms, total_cells, n_outer
             ):
                 chosen = "atom_centric"
@@ -2302,8 +2294,6 @@ def batch_cell_list(
                 ) from exc
             # JAX batch cell_list is full-fill (half_fill+pair_centric raised).
             pc_n_outer = compute_batch_pair_centric_n_outer(pc_r_max, False)
-            if not is_pair_centric_launch_safe(pc_total_cells, pc_n_outer):
-                _raise_unsafe_pair_centric_launch(pc_total_cells, pc_n_outer, 64)
             pc_strategy = "pair_centric"
 
         forward_kwargs = {

--- a/nvalchemiops/jax/neighbors/cell_list.py
+++ b/nvalchemiops/jax/neighbors/cell_list.py
@@ -42,15 +42,11 @@ from nvalchemiops.neighbors.cell_list import (
     compute_batch_pair_centric_n_outer,
     get_build_cell_list_kernel,
     get_query_cell_list_kernel,
-    is_pair_centric_launch_safe,
     is_pair_centric_parallelism_sufficient,
     select_cell_list_strategy,
 )
 from nvalchemiops.neighbors.cell_list import (
     query_cell_list as _warp_query_cell_list,
-)
-from nvalchemiops.neighbors.cell_list.launchers import (
-    _raise_unsafe_pair_centric_launch,
 )
 from nvalchemiops.neighbors.neighbor_utils import (
     estimate_max_neighbors,
@@ -525,9 +521,10 @@ def _resolve_cell_strategy(
     - ``"atom_centric"`` -> ``"atom_centric"``.
     - ``"pair_centric"`` -> ``"pair_centric"`` on GPU; raises on CPU.
 
-    This is the strategy *decision* only.  The pair-centric launch-safety /
-    parallelism guards and the ``n_outer`` host read live in ``query_cell_list``
-    where the concrete ``neighbor_search_radius`` is available.
+    This is the strategy *decision* only.  Pair-centric parallelism guards,
+    transparent launch coarsening, and the ``n_outer`` host read live in
+    ``query_cell_list`` where the concrete ``neighbor_search_radius`` is
+    available.
     """
     if strategy == "auto":
         if device_is_cpu or half_fill:
@@ -627,9 +624,11 @@ def _run_graph_query_cell_list(
     ``strategy`` / ``n_outer`` thread the cell-list query sub-strategy through
     to ``_warp_query_cell_list``.  For ``strategy="pair_centric"`` the launcher
     runs the internal ``gather_fused`` into ``sorted_positions`` /
-    ``sorted_atom_periodic_shifts`` and the pair-centric linear launch sized by
-    the host-computed ``n_outer``.  ``n_outer`` is a static scalar baked at
-    launch-build time (see :func:`compute_batch_pair_centric_n_outer`).
+    ``sorted_atom_periodic_shifts`` and the pair-centric launch sized by
+    the host-computed ``n_outer``, coarsening logical blocks when the
+    uncoarsened grid would exceed the Warp one-dimensional launch limit.
+    ``n_outer`` is a static scalar baked at launch-build time (see
+    :func:`compute_batch_pair_centric_n_outer`).
 
     The optional ``return_vectors`` / ``return_distances`` / ``pair_fn`` (+
     ``pair_params`` and the ``neighbor_vectors`` / ``neighbor_distances`` /
@@ -2515,8 +2514,6 @@ def query_cell_list(
                 ) from exc
             pc_n_outer = compute_batch_pair_centric_n_outer((rx, ry, rz), False)
             total_cells = int(atoms_per_cell_count.shape[0])
-            if not is_pair_centric_launch_safe(total_cells, pc_n_outer):
-                _raise_unsafe_pair_centric_launch(total_cells, pc_n_outer)
             pc_strategy = "pair_centric"
 
         forward_kwargs = {
@@ -2719,11 +2716,7 @@ def query_cell_list(
             # JAX cell_list is full-fill (half_fill+pair_centric raised above).
             n_outer = compute_batch_pair_centric_n_outer((Rx, Ry, Rz), False)
             total_cells = int(atoms_per_cell_count.shape[0])
-            if not is_pair_centric_launch_safe(total_cells, n_outer):
-                if strategy == "pair_centric":
-                    _raise_unsafe_pair_centric_launch(total_cells, n_outer)
-                chosen = "atom_centric"
-            elif strategy == "auto" and not is_pair_centric_parallelism_sufficient(
+            if strategy == "auto" and not is_pair_centric_parallelism_sufficient(
                 total_atoms, total_cells, n_outer
             ):
                 chosen = "atom_centric"
@@ -3285,9 +3278,6 @@ def cell_list(
                     ) from exc
                 # JAX cell_list is full-fill (half_fill+pair_centric raised above).
                 pc_n_outer = compute_batch_pair_centric_n_outer((Rx, Ry, Rz), False)
-                total_cells = int(atoms_per_cell_count.shape[0])
-                if not is_pair_centric_launch_safe(total_cells, pc_n_outer):
-                    _raise_unsafe_pair_centric_launch(total_cells, pc_n_outer)
                 pc_strategy = "pair_centric"
 
             forward_kwargs = {

--- a/nvalchemiops/neighbors/base_dispatch.py
+++ b/nvalchemiops/neighbors/base_dispatch.py
@@ -759,14 +759,16 @@ def get_select_neighbor_list_method_cost_kernel(wp_dtype: type) -> wp.Kernel:
         )
         atom_blocks = wp.int64(max(n_atoms, wp.int32(1)) + wp.int32(63)) // wp.int64(64)
         pair_blocks = wp.int64(total_cells_i32) * wp.int64(n_outer + wp.int32(1))
-        if (not has_cuda) or pair_launch > max_launch_size or pair_blocks < atom_blocks:
+        if (not has_cuda) or pair_blocks < atom_blocks:
             wp.atomic_max(flags, 7, wp.int32(1))
+        pair_launch_effective = wp.min(pair_launch, max_launch_size)
         # Pair-centric: cheaper per pair (0.55 write, 0.5 scan) but pays a
-        # per-block launch term (0.025 * pair_launch) for its many small blocks.
+        # per-block launch term (0.025 * pair_launch_effective) for its many
+        # small blocks (capped when coarsening is required).
         cell_pair_cost = (
             setup
             + wp.float32(0.55) * expected_pairs
-            + wp.float32(0.025) * wp.float32(pair_launch)
+            + wp.float32(0.025) * wp.float32(pair_launch_effective)
             + wp.float32(0.5) * grid_work
         )
         wp.atomic_add(costs, 2, cell_atom_cost)

--- a/nvalchemiops/neighbors/cell_list/__init__.py
+++ b/nvalchemiops/neighbors/cell_list/__init__.py
@@ -15,25 +15,29 @@
 
 """Public cell-list launchers, strategy helpers, and kernel getters."""
 
-from nvalchemiops.neighbors.cell_list.launchers import (
+from nvalchemiops.neighbors.cell_list.dispatch import (
     PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
-    batch_build_cell_list,
-    batch_query_cell_list,
-    batch_query_cell_list_pair_centric_sorted,
-    build_cell_list,
     compute_batch_pair_centric_n_outer,
+    is_pair_centric_launch_safe,
+    is_pair_centric_parallelism_sufficient,
+    pair_centric_launch_size,
+    select_batch_cell_list_strategy,
+    select_cell_list_strategy,
+)
+from nvalchemiops.neighbors.cell_list.kernels import (
     get_build_cell_list_kernel,
     get_cell_list_cells_per_system_kernel,
     get_cell_list_gather_kernel,
     get_query_cell_list_kernel,
-    is_pair_centric_launch_safe,
-    is_pair_centric_parallelism_sufficient,
-    pair_centric_launch_size,
+)
+from nvalchemiops.neighbors.cell_list.launchers import (
+    batch_build_cell_list,
+    batch_query_cell_list,
+    batch_query_cell_list_pair_centric_sorted,
+    build_cell_list,
     query_cell_list,
     query_cell_list_atom_centric_sorted,
     query_cell_list_pair_centric_sorted,
-    select_batch_cell_list_strategy,
-    select_cell_list_strategy,
 )
 
 __all__ = [

--- a/nvalchemiops/neighbors/cell_list/dispatch.py
+++ b/nvalchemiops/neighbors/cell_list/dispatch.py
@@ -67,12 +67,150 @@ def compute_batch_pair_centric_n_outer(
     return (2 * Rx + 1) * (2 * Ry + 1) * (2 * Rz + 1) - 1
 
 
+def _pair_centric_logical_block_count(total_cells: int, n_outer: int) -> int:
+    """Return the number of logical (source cell, offset) blocks.
+
+    Parameters
+    ----------
+    total_cells : int
+        Number of source cells in the launch.
+    n_outer : int
+        Number of non-self neighbor-cell offsets.
+
+    Returns
+    -------
+    int
+        Total logical block count ``total_cells * (n_outer + 1)``.
+    """
+    return int(total_cells) * (int(n_outer) + 1)
+
+
+def _pair_centric_max_cuda_blocks(
+    block_dim: int = 64,
+    *,
+    max_launch_size: int = PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
+) -> int:
+    """Return the maximum CUDA blocks that fit in one Warp launch.
+
+    Parameters
+    ----------
+    block_dim : int, default=64
+        Threads per CUDA block.
+    max_launch_size : int, default=PAIR_CENTRIC_MAX_LINEAR_LAUNCH
+        Maximum allowed one-dimensional Warp launch size.
+
+    Returns
+    -------
+    int
+        Maximum CUDA blocks ``max_launch_size // block_dim``, at least 1.
+
+    Raises
+    ------
+    ValueError
+        If ``block_dim <= 0`` or ``max_launch_size < block_dim``.
+    """
+    block_dim_int = int(block_dim)
+    max_launch_int = int(max_launch_size)
+    if block_dim_int <= 0:
+        raise ValueError(f"block_dim must be positive, got {block_dim_int}")
+    if max_launch_int < block_dim_int:
+        raise ValueError(
+            f"max_launch_size ({max_launch_int}) must be >= block_dim ({block_dim_int})"
+        )
+    return max(1, max_launch_int // block_dim_int)
+
+
+def _pair_centric_work_per_cuda_block(
+    total_cells: int,
+    n_outer: int,
+    block_dim: int = 64,
+    *,
+    max_launch_size: int = PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
+) -> int:
+    """Return how many logical blocks each CUDA block processes when coarsening.
+
+    Parameters
+    ----------
+    total_cells : int
+        Number of source cells in the launch.
+    n_outer : int
+        Number of non-self neighbor-cell offsets.
+    block_dim : int, default=64
+        Threads per CUDA block.
+    max_launch_size : int, default=PAIR_CENTRIC_MAX_LINEAR_LAUNCH
+        Maximum allowed one-dimensional Warp launch size.
+
+    Returns
+    -------
+    int
+        Logical blocks per CUDA block.  Returns 1 when the uncoarsened
+        fast path fits within ``max_launch_size``.
+
+    Raises
+    ------
+    ValueError
+        If ``block_dim <= 0`` or ``max_launch_size < block_dim``.
+    """
+    logical_blocks = _pair_centric_logical_block_count(total_cells, n_outer)
+    max_cuda_blocks = _pair_centric_max_cuda_blocks(
+        block_dim,
+        max_launch_size=max_launch_size,
+    )
+    return max(1, (logical_blocks + max_cuda_blocks - 1) // max_cuda_blocks)
+
+
+def _pair_centric_coarsened_launch_size(
+    total_cells: int,
+    n_outer: int,
+    block_dim: int = 64,
+    *,
+    max_launch_size: int = PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
+) -> int:
+    """Return the one-dimensional Warp launch size after coarsening.
+
+    Parameters
+    ----------
+    total_cells : int
+        Number of source cells in the launch.
+    n_outer : int
+        Number of non-self neighbor-cell offsets.
+    block_dim : int, default=64
+        Threads per CUDA block.
+    max_launch_size : int, default=PAIR_CENTRIC_MAX_LINEAR_LAUNCH
+        Maximum allowed one-dimensional Warp launch size.
+
+    Returns
+    -------
+    int
+        Total launch dimension ``ceil(logical_blocks / work_per_cuda_block)
+        * block_dim``.
+
+    Raises
+    ------
+    ValueError
+        If ``block_dim <= 0`` or ``max_launch_size < block_dim``.
+    """
+    logical_blocks = _pair_centric_logical_block_count(total_cells, n_outer)
+    work_per_cuda_block = _pair_centric_work_per_cuda_block(
+        total_cells,
+        n_outer,
+        block_dim,
+        max_launch_size=max_launch_size,
+    )
+    cuda_blocks = (logical_blocks + work_per_cuda_block - 1) // work_per_cuda_block
+    return cuda_blocks * int(block_dim)
+
+
 def pair_centric_launch_size(
     total_cells: int,
     n_outer: int,
     block_dim: int = 64,
 ) -> int:
-    """Return the linear launch size for a pair-centric cell-list query.
+    """Return the uncoarsened linear launch size for a pair-centric query.
+
+    This describes the fast-path launch shape (one logical block per CUDA
+    block).  Oversized launches use
+    :func:`_pair_centric_coarsened_launch_size` instead.
 
     Parameters
     ----------
@@ -86,7 +224,7 @@ def pair_centric_launch_size(
     Returns
     -------
     int
-        Total one-dimensional Warp launch size.
+        Total one-dimensional Warp launch size for the uncoarsened fast path.
     """
     return int(total_cells) * (int(n_outer) + 1) * int(block_dim)
 
@@ -98,7 +236,11 @@ def is_pair_centric_launch_safe(
     *,
     max_launch_size: int = PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
 ) -> bool:
-    """Return whether a pair-centric launch fits the safe linear launch limit.
+    """Return whether the uncoarsened pair-centric fast path fits the launch limit.
+
+    A ``False`` result does not mean pair-centric is infeasible; the
+    launcher may transparently coarsen logical blocks into fewer CUDA
+    blocks via :func:`_pair_centric_work_per_cuda_block`.
 
     Parameters
     ----------
@@ -114,7 +256,7 @@ def is_pair_centric_launch_safe(
     Returns
     -------
     bool
-        ``True`` if the pair-centric launch size is safe.
+        ``True`` if the uncoarsened fast-path launch size is safe.
     """
     return pair_centric_launch_size(total_cells, n_outer, block_dim) <= int(
         max_launch_size

--- a/nvalchemiops/neighbors/cell_list/kernels.py
+++ b/nvalchemiops/neighbors/cell_list/kernels.py
@@ -1319,6 +1319,7 @@ def _make_pair_centric_kernel(
     return_vectors: bool,
     return_distances: bool,
     pair_fn: wp.Function | None,
+    coarsened: bool,
 ) -> wp.Kernel:
     """Build the pair-centric neighbor-matrix kernel."""
     _require_supported_dtype(wp_dtype)
@@ -1334,8 +1335,10 @@ def _make_pair_centric_kernel(
         pair_fn=pair_fn,
     )
 
-    @wp.kernel(enable_backward=False, module="unique")
-    def _kernel(
+    @wp.func
+    def _process_logical_block(
+        logical_bid: wp.int64,
+        lane: wp.int32,
         sorted_positions: wp.array(dtype=vec_dtype),
         sorted_atom_periodic_shifts: wp.array(dtype=wp.vec3i),
         cell: wp.array(dtype=mat_dtype),
@@ -1363,13 +1366,18 @@ def _make_pair_centric_kernel(
         block_dim_const: wp.int32,
         total_cells: wp.int32,
         n_offsets: wp.int32,
+        total_logical_blocks: wp.int64,
         max_radius: wp.vec3i,
         rebuild_flags: wp.array(dtype=wp.bool),
     ) -> None:
-        """Build cell-list neighbor-matrix rows with one block per cell/offset pair
+        """Process one logical (source cell, offset) block for pair-centric search.
 
         Parameters
         ----------
+        logical_bid : wp.int64
+            Flat logical block index.
+        lane : wp.int32
+            Lane index within the CUDA block.
         sorted_positions : wp.array, shape (total_atoms,), dtype=wp.vec3*
             Cell-contiguous positions.
         sorted_atom_periodic_shifts : wp.array, shape (total_atoms,), dtype=wp.vec3i
@@ -1424,32 +1432,22 @@ def _make_pair_centric_kernel(
             Number of global cells to traverse.
         n_offsets : wp.int32
             Number of neighbor-cell offsets encoded in the launch grid.
+        total_logical_blocks : wp.int64
+            Total number of logical (source cell, offset) blocks.
         max_radius : wp.vec3i
             Maximum search radius used to decode batched offsets.
         rebuild_flags : wp.array, shape (num_systems,), dtype=wp.bool
             Selective rebuild flags. Sentinel for non-selective specializations.
 
-        Returns
-        -------
-        None
-            This function modifies the input arrays in-place.
-
         Notes
         -----
-        - Thread launch: One CUDA block per source-cell/offset pair, with lanes covering source-cell atoms.
-        - Modifies: ``neighbor_matrix``, ``neighbor_matrix_shifts``, ``num_neighbors`` atomically, and enabled pair-output buffers.
-        Batching, selective rebuild, partial rows, and pair outputs are static
-        specializations. Pair-centric execution is CUDA-only at the launcher boundary.
-
-        See Also
-        --------
-        get_query_cell_list_kernel : Return the specialized pair-centric neighbor-search kernel.
+        Early ``return`` statements skip inactive logical blocks or systems.
         """
-        tid = wp.tid()
-        bid = tid / block_dim_const
-        lane = tid - bid * block_dim_const
-        source_cell = bid / n_offsets
-        offset_idx = bid % n_offsets
+
+        if logical_bid >= total_logical_blocks:
+            return
+        source_cell = wp.int32(logical_bid / wp.int64(n_offsets))
+        offset_idx = wp.int32(logical_bid % wp.int64(n_offsets))
         if source_cell >= total_cells:
             return
 
@@ -1626,6 +1624,323 @@ def _make_pair_centric_kernel(
                         )
             slot += block_dim_const
 
+    if coarsened:
+
+        @wp.kernel(enable_backward=False, module="unique")
+        def _kernel(
+            sorted_positions: wp.array(dtype=vec_dtype),
+            sorted_atom_periodic_shifts: wp.array(dtype=wp.vec3i),
+            cell: wp.array(dtype=mat_dtype),
+            pbc_single: wp.array(dtype=wp.bool),
+            pbc_batch: wp.array2d(dtype=wp.bool),
+            cutoff: wp_dtype,
+            cells_per_dimension_single: wp.array(dtype=wp.int32),
+            cells_per_dimension_batch: wp.array(dtype=wp.vec3i),
+            neighbor_search_radius_single: wp.array(dtype=wp.int32),
+            neighbor_search_radius_batch: wp.array(dtype=wp.vec3i),
+            atoms_per_cell_count: wp.array(dtype=wp.int32),
+            cell_atom_start_indices: wp.array(dtype=wp.int32),
+            cell_atom_list: wp.array(dtype=wp.int32),
+            cell_offsets: wp.array(dtype=wp.int32),
+            cell_to_system: wp.array(dtype=wp.int32),
+            target_row_lookup: wp.array(dtype=wp.int32),
+            neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+            neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+            num_neighbors: wp.array(dtype=wp.int32),
+            neighbor_vectors: wp.array(dtype=vec_dtype, ndim=2),
+            neighbor_distances: wp.array(dtype=wp_dtype, ndim=2),
+            pair_params: wp.array(dtype=wp_dtype, ndim=2),
+            pair_energies: wp.array(dtype=wp_dtype, ndim=2),
+            pair_forces: wp.array(dtype=vec_dtype, ndim=2),
+            block_dim_const: wp.int32,
+            total_cells: wp.int32,
+            n_offsets: wp.int32,
+            total_logical_blocks: wp.int64,
+            work_per_cuda_block: wp.int32,
+            max_radius: wp.vec3i,
+            rebuild_flags: wp.array(dtype=wp.bool),
+        ) -> None:
+            """Build cell-list neighbor-matrix rows with pair-centric search.
+
+            Parameters
+            ----------
+            sorted_positions : wp.array, shape (total_atoms,), dtype=wp.vec3*
+                Cell-contiguous positions.
+            sorted_atom_periodic_shifts : wp.array, shape (total_atoms,), dtype=wp.vec3i
+                Cell-contiguous periodic shifts.
+            cell : wp.array, shape (num_systems,), dtype=wp.mat33*
+                Cell matrices defining lattice vectors.
+            pbc_single : wp.array, shape (3,), dtype=wp.bool
+                Single-system PBC flags. Sentinel in batched mode.
+            pbc_batch : wp.array, shape (num_systems, 3), dtype=wp.bool
+                Batched PBC flags. Sentinel in single-system mode.
+            cutoff : float
+                Neighbor cutoff distance.
+            cells_per_dimension_single : wp.array, shape (3,), dtype=wp.int32
+                Single-system cell counts per dimension.
+            cells_per_dimension_batch : wp.array, shape (num_systems,), dtype=wp.vec3i
+                Batched cell counts per dimension.
+            neighbor_search_radius_single : wp.array, shape (3,), dtype=wp.int32
+                Single-system neighbor-search radius.
+            neighbor_search_radius_batch : wp.array, shape (num_systems,), dtype=wp.vec3i
+                Batched neighbor-search radius.
+            atoms_per_cell_count : wp.array, shape (total_cells,), dtype=wp.int32
+                Atom counts per cell.
+            cell_atom_start_indices : wp.array, shape (total_cells,), dtype=wp.int32
+                Cell start offsets into ``cell_atom_list``.
+            cell_atom_list : wp.array, shape (total_atoms,), dtype=wp.int32
+                Atom indices in cell-contiguous order.
+            cell_offsets : wp.array, shape (num_systems,), dtype=wp.int32
+                Global cell offset per system. Sentinel in single-system mode.
+            cell_to_system : wp.array, shape (total_cells,), dtype=wp.int32
+                System index for each global cell. Sentinel in single-system mode.
+            target_row_lookup : wp.array, shape (total_atoms,), dtype=wp.int32
+                Atom-id to compact target-row lookup for partial mode.
+            neighbor_matrix : wp.array, shape (rows, max_neighbors), dtype=wp.int32
+                OUTPUT: Neighbor atom indices.
+            neighbor_matrix_shifts : wp.array, shape (rows, max_neighbors), dtype=wp.vec3i
+                OUTPUT: Periodic shift vectors.
+            num_neighbors : wp.array, shape (rows,), dtype=wp.int32
+                OUTPUT: Neighbor counts per row, updated atomically.
+            neighbor_vectors : wp.array, shape (rows, max_neighbors), dtype=wp.vec3*
+                OUTPUT: Optional displacement vectors. Sentinel when disabled.
+            neighbor_distances : wp.array, shape (rows, max_neighbors), dtype=wp.float*
+                OUTPUT: Optional pair distances. Sentinel when disabled.
+            pair_params : wp.array, shape (total_atoms, K), dtype=wp.float*
+                Pair-function parameters. Sentinel when no pair function is active.
+            pair_energies : wp.array, shape (rows, max_neighbors), dtype=wp.float*
+                OUTPUT: Optional pair-function energies. Sentinel when disabled.
+            pair_forces : wp.array, shape (rows, max_neighbors), dtype=wp.vec3*
+                OUTPUT: Optional pair-function forces. Sentinel when disabled.
+            block_dim_const : wp.int32
+                Runtime copy of the CUDA block dimension.
+            total_cells : wp.int32
+                Number of global cells to traverse.
+            n_offsets : wp.int32
+                Number of neighbor-cell offsets encoded in the launch grid.
+            total_logical_blocks : wp.int64
+                Total number of logical (source cell, offset) blocks.
+            work_per_cuda_block : wp.int32
+                Number of logical blocks processed per CUDA block.
+            max_radius : wp.vec3i
+                Maximum search radius used to decode batched offsets.
+            rebuild_flags : wp.array, shape (num_systems,), dtype=wp.bool
+                Selective rebuild flags. Sentinel for non-selective specializations.
+
+            Returns
+            -------
+            None
+                This function modifies the input arrays in-place.
+
+            Notes
+            -----
+            - Thread launch: One CUDA block per source-cell/offset pair for the fast path;
+              multiple logical blocks per CUDA block for the coarsened path.
+            - Modifies: ``neighbor_matrix``, ``neighbor_matrix_shifts``, ``num_neighbors`` atomically, and enabled pair-output buffers.
+
+            See Also
+            --------
+            get_query_cell_list_kernel : Return the specialized pair-centric neighbor-search kernel.
+            """
+            tid = wp.tid()
+            cuda_bid = tid / block_dim_const
+            lane = tid - cuda_bid * block_dim_const
+            for local_work_idx in range(work_per_cuda_block):
+                logical_bid = wp.int64(cuda_bid) * wp.int64(
+                    work_per_cuda_block
+                ) + wp.int64(local_work_idx)
+                _process_logical_block(
+                    logical_bid,
+                    lane,
+                    sorted_positions,
+                    sorted_atom_periodic_shifts,
+                    cell,
+                    pbc_single,
+                    pbc_batch,
+                    cutoff,
+                    cells_per_dimension_single,
+                    cells_per_dimension_batch,
+                    neighbor_search_radius_single,
+                    neighbor_search_radius_batch,
+                    atoms_per_cell_count,
+                    cell_atom_start_indices,
+                    cell_atom_list,
+                    cell_offsets,
+                    cell_to_system,
+                    target_row_lookup,
+                    neighbor_matrix,
+                    neighbor_matrix_shifts,
+                    num_neighbors,
+                    neighbor_vectors,
+                    neighbor_distances,
+                    pair_params,
+                    pair_energies,
+                    pair_forces,
+                    block_dim_const,
+                    total_cells,
+                    n_offsets,
+                    total_logical_blocks,
+                    max_radius,
+                    rebuild_flags,
+                )
+
+    else:
+
+        @wp.kernel(enable_backward=False, module="unique")
+        def _kernel(
+            sorted_positions: wp.array(dtype=vec_dtype),
+            sorted_atom_periodic_shifts: wp.array(dtype=wp.vec3i),
+            cell: wp.array(dtype=mat_dtype),
+            pbc_single: wp.array(dtype=wp.bool),
+            pbc_batch: wp.array2d(dtype=wp.bool),
+            cutoff: wp_dtype,
+            cells_per_dimension_single: wp.array(dtype=wp.int32),
+            cells_per_dimension_batch: wp.array(dtype=wp.vec3i),
+            neighbor_search_radius_single: wp.array(dtype=wp.int32),
+            neighbor_search_radius_batch: wp.array(dtype=wp.vec3i),
+            atoms_per_cell_count: wp.array(dtype=wp.int32),
+            cell_atom_start_indices: wp.array(dtype=wp.int32),
+            cell_atom_list: wp.array(dtype=wp.int32),
+            cell_offsets: wp.array(dtype=wp.int32),
+            cell_to_system: wp.array(dtype=wp.int32),
+            target_row_lookup: wp.array(dtype=wp.int32),
+            neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+            neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+            num_neighbors: wp.array(dtype=wp.int32),
+            neighbor_vectors: wp.array(dtype=vec_dtype, ndim=2),
+            neighbor_distances: wp.array(dtype=wp_dtype, ndim=2),
+            pair_params: wp.array(dtype=wp_dtype, ndim=2),
+            pair_energies: wp.array(dtype=wp_dtype, ndim=2),
+            pair_forces: wp.array(dtype=vec_dtype, ndim=2),
+            block_dim_const: wp.int32,
+            total_cells: wp.int32,
+            n_offsets: wp.int32,
+            total_logical_blocks: wp.int64,
+            work_per_cuda_block: wp.int32,
+            max_radius: wp.vec3i,
+            rebuild_flags: wp.array(dtype=wp.bool),
+        ) -> None:
+            """Build cell-list neighbor-matrix rows with pair-centric search.
+
+            Parameters
+            ----------
+            sorted_positions : wp.array, shape (total_atoms,), dtype=wp.vec3*
+                Cell-contiguous positions.
+            sorted_atom_periodic_shifts : wp.array, shape (total_atoms,), dtype=wp.vec3i
+                Cell-contiguous periodic shifts.
+            cell : wp.array, shape (num_systems,), dtype=wp.mat33*
+                Cell matrices defining lattice vectors.
+            pbc_single : wp.array, shape (3,), dtype=wp.bool
+                Single-system PBC flags. Sentinel in batched mode.
+            pbc_batch : wp.array, shape (num_systems, 3), dtype=wp.bool
+                Batched PBC flags. Sentinel in single-system mode.
+            cutoff : float
+                Neighbor cutoff distance.
+            cells_per_dimension_single : wp.array, shape (3,), dtype=wp.int32
+                Single-system cell counts per dimension.
+            cells_per_dimension_batch : wp.array, shape (num_systems,), dtype=wp.vec3i
+                Batched cell counts per dimension.
+            neighbor_search_radius_single : wp.array, shape (3,), dtype=wp.int32
+                Single-system neighbor-search radius.
+            neighbor_search_radius_batch : wp.array, shape (num_systems,), dtype=wp.vec3i
+                Batched neighbor-search radius.
+            atoms_per_cell_count : wp.array, shape (total_cells,), dtype=wp.int32
+                Atom counts per cell.
+            cell_atom_start_indices : wp.array, shape (total_cells,), dtype=wp.int32
+                Cell start offsets into ``cell_atom_list``.
+            cell_atom_list : wp.array, shape (total_atoms,), dtype=wp.int32
+                Atom indices in cell-contiguous order.
+            cell_offsets : wp.array, shape (num_systems,), dtype=wp.int32
+                Global cell offset per system. Sentinel in single-system mode.
+            cell_to_system : wp.array, shape (total_cells,), dtype=wp.int32
+                System index for each global cell. Sentinel in single-system mode.
+            target_row_lookup : wp.array, shape (total_atoms,), dtype=wp.int32
+                Atom-id to compact target-row lookup for partial mode.
+            neighbor_matrix : wp.array, shape (rows, max_neighbors), dtype=wp.int32
+                OUTPUT: Neighbor atom indices.
+            neighbor_matrix_shifts : wp.array, shape (rows, max_neighbors), dtype=wp.vec3i
+                OUTPUT: Periodic shift vectors.
+            num_neighbors : wp.array, shape (rows,), dtype=wp.int32
+                OUTPUT: Neighbor counts per row, updated atomically.
+            neighbor_vectors : wp.array, shape (rows, max_neighbors), dtype=wp.vec3*
+                OUTPUT: Optional displacement vectors. Sentinel when disabled.
+            neighbor_distances : wp.array, shape (rows, max_neighbors), dtype=wp.float*
+                OUTPUT: Optional pair distances. Sentinel when disabled.
+            pair_params : wp.array, shape (total_atoms, K), dtype=wp.float*
+                Pair-function parameters. Sentinel when no pair function is active.
+            pair_energies : wp.array, shape (rows, max_neighbors), dtype=wp.float*
+                OUTPUT: Optional pair-function energies. Sentinel when disabled.
+            pair_forces : wp.array, shape (rows, max_neighbors), dtype=wp.vec3*
+                OUTPUT: Optional pair-function forces. Sentinel when disabled.
+            block_dim_const : wp.int32
+                Runtime copy of the CUDA block dimension.
+            total_cells : wp.int32
+                Number of global cells to traverse.
+            n_offsets : wp.int32
+                Number of neighbor-cell offsets encoded in the launch grid.
+            total_logical_blocks : wp.int64
+                Total number of logical (source cell, offset) blocks.
+            work_per_cuda_block : wp.int32
+                Number of logical blocks processed per CUDA block. Unused by the uncoarsened fast path.
+            max_radius : wp.vec3i
+                Maximum search radius used to decode batched offsets.
+            rebuild_flags : wp.array, shape (num_systems,), dtype=wp.bool
+                Selective rebuild flags. Sentinel for non-selective specializations.
+
+            Returns
+            -------
+            None
+                This function modifies the input arrays in-place.
+
+            Notes
+            -----
+            - Thread launch: One CUDA block per source-cell/offset pair for the fast path;
+              multiple logical blocks per CUDA block for the coarsened path.
+            - Modifies: ``neighbor_matrix``, ``neighbor_matrix_shifts``, ``num_neighbors`` atomically, and enabled pair-output buffers.
+
+            See Also
+            --------
+            get_query_cell_list_kernel : Return the specialized pair-centric neighbor-search kernel.
+            """
+
+            tid = wp.tid()
+            bid = tid / block_dim_const
+            lane = tid - bid * block_dim_const
+            _process_logical_block(
+                wp.int64(bid),
+                lane,
+                sorted_positions,
+                sorted_atom_periodic_shifts,
+                cell,
+                pbc_single,
+                pbc_batch,
+                cutoff,
+                cells_per_dimension_single,
+                cells_per_dimension_batch,
+                neighbor_search_radius_single,
+                neighbor_search_radius_batch,
+                atoms_per_cell_count,
+                cell_atom_start_indices,
+                cell_atom_list,
+                cell_offsets,
+                cell_to_system,
+                target_row_lookup,
+                neighbor_matrix,
+                neighbor_matrix_shifts,
+                num_neighbors,
+                neighbor_vectors,
+                neighbor_distances,
+                pair_params,
+                pair_energies,
+                pair_forces,
+                block_dim_const,
+                total_cells,
+                n_offsets,
+                total_logical_blocks,
+                max_radius,
+                rebuild_flags,
+            )
+
     name = kernel_specialization_name(
         _cell_list_neighbor_base_name(
             batched=bool(batched),
@@ -1634,6 +1949,7 @@ def _make_pair_centric_kernel(
         wp_dtype=wp_dtype,
         features=(
             "pair_centric",
+            "coarsened" if coarsened else "",
             "half" if bool(half_fill) else "",
             "partial" if partial else "",
             *_pair_output_features(
@@ -1654,6 +1970,7 @@ def _make_pair_centric_kernel(
                 ("selective", bool(selective)),
                 ("partial", bool(partial)),
                 ("half_fill", bool(half_fill)),
+                ("coarsened", bool(coarsened)),
                 ("return_vectors", bool(return_vectors)),
                 ("return_distances", bool(return_distances)),
                 ("pair_fn", pair_fn is not None),
@@ -1673,6 +1990,7 @@ def get_query_cell_list_kernel(
     return_vectors: bool = False,
     return_distances: bool = False,
     pair_fn: wp.Function | None = None,
+    coarsened: bool = False,
     atom_centric_path: str = "sorted",
 ) -> wp.Kernel:
     """Return a cached cell-list neighbor-matrix kernel."""
@@ -1704,6 +2022,7 @@ def get_query_cell_list_kernel(
             return_vectors=bool(return_vectors),
             return_distances=bool(return_distances),
             pair_fn=pair_fn,
+            coarsened=bool(coarsened),
         )
     raise ValueError(
         f"strategy must be 'atom_centric' | 'pair_centric', got {strategy!r}"

--- a/nvalchemiops/neighbors/cell_list/launchers.py
+++ b/nvalchemiops/neighbors/cell_list/launchers.py
@@ -22,8 +22,10 @@ import warp as wp
 
 from nvalchemiops.neighbors.cell_list.dispatch import (
     PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
+    _pair_centric_coarsened_launch_size,
+    _pair_centric_logical_block_count,
+    _pair_centric_work_per_cuda_block,
     compute_batch_pair_centric_n_outer,
-    is_pair_centric_launch_safe,
     is_pair_centric_parallelism_sufficient,
     pair_centric_launch_size,
     select_batch_cell_list_strategy,
@@ -56,7 +58,6 @@ __all__ = [
     "batch_query_cell_list_pair_centric_sorted",
     "build_cell_list",
     "compute_batch_pair_centric_n_outer",
-    "is_pair_centric_launch_safe",
     "is_pair_centric_parallelism_sufficient",
     "pair_centric_launch_size",
     "get_cell_list_cells_per_system_kernel",
@@ -76,29 +77,35 @@ __all__ = [
 _ZERO_RADIUS = wp.vec3i(0, 0, 0)
 
 
-def _pair_centric_unsafe_message(
+def _pair_centric_launch_plan(
     total_cells: int,
     n_outer: int,
     block_dim: int,
-) -> str:
-    """Return a user-facing message for an unsafe pair-centric launch."""
-    launch_size = pair_centric_launch_size(total_cells, n_outer, block_dim)
-    return (
-        "strategy='pair_centric' would require "
-        f"{launch_size} logical threads "
-        f"({int(total_cells)} cells * {int(n_outer) + 1} offsets * "
-        f"{int(block_dim)} threads), exceeding the safe linear launch limit "
-        f"of {PAIR_CENTRIC_MAX_LINEAR_LAUNCH}."
+    *,
+    max_launch_size: int = PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
+) -> tuple[int, int, int, bool]:
+    """Return coarsened pair-centric launch metadata.
+
+    Returns
+    -------
+    tuple[int, int, int, bool]
+        ``(logical_blocks, work_per_cuda_block, launch_dim, coarsened)``.
+    """
+    logical_blocks = _pair_centric_logical_block_count(total_cells, n_outer)
+    work_per_cuda_block = _pair_centric_work_per_cuda_block(
+        total_cells,
+        n_outer,
+        block_dim,
+        max_launch_size=max_launch_size,
     )
-
-
-def _raise_unsafe_pair_centric_launch(
-    total_cells: int,
-    n_outer: int,
-    block_dim: int,
-) -> None:
-    """Raise for raw pair-centric launchers that cannot fall back."""
-    raise ValueError(_pair_centric_unsafe_message(total_cells, n_outer, block_dim))
+    launch_dim = _pair_centric_coarsened_launch_size(
+        total_cells,
+        n_outer,
+        block_dim,
+        max_launch_size=max_launch_size,
+    )
+    coarsened = work_per_cuda_block > 1
+    return logical_blocks, work_per_cuda_block, launch_dim, coarsened
 
 
 def _prepare_target_row_lookup(
@@ -513,6 +520,7 @@ def query_cell_list_pair_centric_sorted(
     pair_forces: wp.array | None = None,
     target_row_lookup: wp.array | None = None,
     selective: bool = True,
+    max_launch_size: int = PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
 ) -> None:
     """Pair-centric query: one block per (source cell, offset).
 
@@ -529,6 +537,10 @@ def query_cell_list_pair_centric_sorted(
     Pair-set output is identical to the atom-centric kernel; per-row
     ordering inside ``neighbor_matrix`` is non-deterministic across
     builds.
+
+    Oversized launches transparently coarsen multiple logical
+    ``(source_cell, offset)`` blocks into each CUDA block while keeping
+    the same strategy name.
 
     Parameters
     ----------
@@ -550,6 +562,8 @@ def query_cell_list_pair_centric_sorted(
         Threads per CUDA block.  Should bracket typical
         atoms-per-cell counts; cells with more atoms see lanes
         stride-loop.
+    max_launch_size : int, default PAIR_CENTRIC_MAX_LINEAR_LAUNCH
+        Internal/test hook for the safe one-dimensional Warp launch limit.
     rebuild_flags : wp.array(dtype=wp.bool), shape (1,)
         Caller-allocated GPU-resident flag.  ``False`` makes every block
         return immediately and outputs are preserved.  ``True`` runs the
@@ -561,8 +575,8 @@ def query_cell_list_pair_centric_sorted(
     -----
     The pair-centric kernel factory supports compact ``target_indices`` rows,
     optional vector/distance buffers, and ``pair_fn`` slot outputs directly.
-    It remains CUDA-only because it maps one logical block to each
-    ``(source_cell, offset)`` pair.
+    It remains CUDA-only because it maps logical blocks to
+    ``(source_cell, offset)`` work items.
     """
 
     if "cpu" in str(device).lower():
@@ -574,8 +588,14 @@ def query_cell_list_pair_centric_sorted(
     total_cells = int(atoms_per_cell_count.shape[0])
     block_dim_int = int(block_dim)
     n_offsets_int = int(n_outer) + 1
-    if not is_pair_centric_launch_safe(total_cells, int(n_outer), block_dim_int):
-        _raise_unsafe_pair_centric_launch(total_cells, int(n_outer), block_dim_int)
+    logical_blocks, work_per_cuda_block, launch_dim, coarsened = (
+        _pair_centric_launch_plan(
+            total_cells,
+            int(n_outer),
+            block_dim_int,
+            max_launch_size=max_launch_size,
+        )
+    )
     partial = target_indices is not None
     target_row_lookup_arg = _prepare_target_row_lookup(
         target_indices,
@@ -611,10 +631,11 @@ def query_cell_list_pair_centric_sorted(
         return_vectors=return_vectors,
         return_distances=return_distances,
         pair_fn=pair_fn,
+        coarsened=coarsened,
     )
     wp.launch(
         kernel,
-        dim=total_cells * n_offsets_int * block_dim_int,
+        dim=launch_dim,
         block_dim=block_dim_int,
         inputs=[
             sorted_positions,
@@ -644,6 +665,8 @@ def query_cell_list_pair_centric_sorted(
             block_dim_int,
             total_cells,
             n_offsets_int,
+            logical_blocks,
+            work_per_cuda_block,
             _ZERO_RADIUS,
             rebuild_flags,
         ],
@@ -686,6 +709,7 @@ def query_cell_list(
     pair_energies: wp.array | None = None,
     pair_forces: wp.array | None = None,
     target_row_lookup: wp.array | None = None,
+    max_launch_size: int = PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
 ) -> None:
     """Core warp launcher for querying spatial cell list to build neighbor matrix.
 
@@ -826,10 +850,6 @@ def query_cell_list(
                 "strategy='pair_centric' requires n_outer.  Compute via "
                 "compute_batch_pair_centric_n_outer((Rx, Ry, Rz), half_fill).",
             )
-        block_dim = 64
-        total_cells = int(atoms_per_cell_count.shape[0])
-        if not is_pair_centric_launch_safe(total_cells, int(n_outer), block_dim):
-            _raise_unsafe_pair_centric_launch(total_cells, int(n_outer), block_dim)
         chosen = "pair_centric"
     else:
         raise ValueError(
@@ -908,6 +928,7 @@ def query_cell_list(
             pair_forces=pair_forces,
             target_row_lookup=target_row_lookup,
             selective=selective,
+            max_launch_size=max_launch_size,
         )
     else:
         query_cell_list_atom_centric_sorted(
@@ -1137,12 +1158,15 @@ def batch_query_cell_list_pair_centric_sorted(
     pair_forces: wp.array | None = None,
     rebuild_flags: wp.array | None = None,
     target_row_lookup: wp.array | None = None,
+    max_launch_size: int = PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
 ) -> None:
     """Core warp launcher for the pair-centric batched cell-list query.
 
-    Launches ``_batch_pair_centric_outer`` over ``total_cells x
-    (n_outer + 1)`` blocks of ``block_dim`` threads.  ``offset_idx == 0``
-    is the self-cell entry (within-cell pairs, with the appropriate filter
+    Launches the pair-centric kernel over ``total_cells x (n_outer + 1)``
+    logical blocks of ``block_dim`` threads, coarsening multiple logical
+    blocks per CUDA block when the uncoarsened launch would exceed the
+    safe one-dimensional Warp launch limit.  ``offset_idx == 0`` is the
+    self-cell entry (within-cell pairs, with the appropriate filter
     for ``half_fill``); ``offset_idx > 0`` are the outer-shell offsets
     decoded on-the-fly from ``R_max``.  Per-system out-of-range offsets
     early-return.
@@ -1231,8 +1255,14 @@ def batch_query_cell_list_pair_centric_sorted(
     num_systems = int(cell.shape[0])
     block_dim_int = int(block_dim)
     n_offsets_int = int(n_outer) + 1
-    if not is_pair_centric_launch_safe(int(total_cells), int(n_outer), block_dim_int):
-        _raise_unsafe_pair_centric_launch(int(total_cells), int(n_outer), block_dim_int)
+    logical_blocks, work_per_cuda_block, launch_dim, coarsened = (
+        _pair_centric_launch_plan(
+            int(total_cells),
+            int(n_outer),
+            block_dim_int,
+            max_launch_size=max_launch_size,
+        )
+    )
     R_max_vec = wp.vec3i(int(R_max[0]), int(R_max[1]), int(R_max[2]))
     partial = target_indices is not None
     rebuild_flags_arg = (
@@ -1295,10 +1325,11 @@ def batch_query_cell_list_pair_centric_sorted(
         return_vectors=return_vectors,
         return_distances=return_distances,
         pair_fn=pair_fn,
+        coarsened=coarsened,
     )
     wp.launch(
         kernel,
-        dim=total_cells * n_offsets_int * block_dim_int,
+        dim=launch_dim,
         block_dim=block_dim_int,
         inputs=[
             sorted_positions,
@@ -1328,6 +1359,8 @@ def batch_query_cell_list_pair_centric_sorted(
             block_dim_int,
             total_cells,
             n_offsets_int,
+            logical_blocks,
+            work_per_cuda_block,
             R_max_vec,
             rebuild_flags_arg,
         ],
@@ -1376,6 +1409,7 @@ def batch_query_cell_list(
     pair_energies: wp.array | None = None,
     pair_forces: wp.array | None = None,
     target_row_lookup: wp.array | None = None,
+    max_launch_size: int = PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
 ) -> None:
     """Core warp launcher for querying batch spatial cell lists to build neighbor matrices.
 
@@ -1503,9 +1537,6 @@ def batch_query_cell_list(
                 f"metadata): {missing}.  See compute_batch_pair_centric_n_outer "
                 f"for n_outer.",
             )
-        block_dim = 64
-        if not is_pair_centric_launch_safe(int(total_cells), int(n_outer), block_dim):
-            _raise_unsafe_pair_centric_launch(int(total_cells), int(n_outer), block_dim)
     elif strategy != "atom_centric":
         raise ValueError(
             f"strategy must be 'atom_centric' | 'pair_centric', got {strategy!r}",
@@ -1575,6 +1606,7 @@ def batch_query_cell_list(
             pair_forces=pair_forces,
             rebuild_flags=rebuild_flags,
             target_row_lookup=target_row_lookup,
+            max_launch_size=max_launch_size,
         )
         return
 

--- a/nvalchemiops/torch/neighbors/batch_cell_list.py
+++ b/nvalchemiops/torch/neighbors/batch_cell_list.py
@@ -42,19 +42,16 @@ import torch
 import warp as wp
 
 from nvalchemiops.neighbors.cell_list import (
-    PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
-    compute_batch_pair_centric_n_outer,
-    get_build_cell_list_kernel,
-    is_pair_centric_launch_safe,
-    is_pair_centric_parallelism_sufficient,
-    pair_centric_launch_size,
-    select_batch_cell_list_strategy,
-)
-from nvalchemiops.neighbors.cell_list import (
     batch_build_cell_list as wp_batch_build_cell_list,
 )
 from nvalchemiops.neighbors.cell_list import (
     batch_query_cell_list as wp_batch_query_cell_list,
+)
+from nvalchemiops.neighbors.cell_list import (
+    compute_batch_pair_centric_n_outer,
+    get_build_cell_list_kernel,
+    is_pair_centric_parallelism_sufficient,
+    select_batch_cell_list_strategy,
 )
 from nvalchemiops.neighbors.neighbor_utils import empty_sentinel, estimate_max_neighbors
 from nvalchemiops.neighbors.neighbor_utils import (
@@ -87,31 +84,6 @@ __all__ = [
     "batch_query_cell_list",
     "batch_cell_list",
 ]
-
-
-def _pair_centric_unsafe_message(
-    total_cells: int,
-    n_outer: int,
-    block_dim: int = 64,
-) -> str:
-    """Return the unsafe pair-centric launch message."""
-    launch_size = pair_centric_launch_size(total_cells, n_outer, block_dim)
-    return (
-        "strategy='pair_centric' would require "
-        f"{launch_size} logical threads "
-        f"({int(total_cells)} cells * {int(n_outer) + 1} offsets * "
-        f"{int(block_dim)} threads), exceeding the safe linear launch limit "
-        f"of {PAIR_CENTRIC_MAX_LINEAR_LAUNCH}."
-    )
-
-
-def _raise_unsafe_pair_centric_launch(
-    total_cells: int,
-    n_outer: int,
-    block_dim: int = 64,
-) -> None:
-    """Raise when an explicit pair-centric request is unsafe."""
-    raise ValueError(_pair_centric_unsafe_message(total_cells, n_outer, block_dim))
 
 
 def _resolve_atom_centric_path(atom_centric_path: str) -> str:
@@ -618,14 +590,7 @@ def _batch_query_cell_list_op(
         total_cells = int(cells_per_system.sum().item())
         R_max = _max_radius_tuple(neighbor_search_radius)
         n_outer = compute_batch_pair_centric_n_outer(R_max, bool(half_fill))
-        if not is_pair_centric_launch_safe(total_cells, n_outer):
-            if strategy == "pair_centric":
-                _raise_unsafe_pair_centric_launch(total_cells, n_outer)
-            use_pair_centric = False
-            total_cells = None
-            n_outer = None
-            R_max = None
-        elif strategy == "auto" and not is_pair_centric_parallelism_sufficient(
+        if strategy == "auto" and not is_pair_centric_parallelism_sufficient(
             int(total_atoms), total_cells, n_outer
         ):
             use_pair_centric = False
@@ -1541,14 +1506,7 @@ def _batch_query_cell_list_optional(
         total_cells = int(cells_per_system.sum().item())
         R_max = _max_radius_tuple(neighbor_search_radius)
         n_outer = compute_batch_pair_centric_n_outer(R_max, bool(half_fill))
-        if not is_pair_centric_launch_safe(total_cells, n_outer):
-            if strategy == "pair_centric":
-                _raise_unsafe_pair_centric_launch(total_cells, n_outer)
-            use_pair_centric = False
-            total_cells = None
-            n_outer = None
-            R_max = None
-        elif strategy == "auto" and not is_pair_centric_parallelism_sufficient(
+        if strategy == "auto" and not is_pair_centric_parallelism_sufficient(
             int(total_atoms), total_cells, n_outer
         ):
             use_pair_centric = False

--- a/nvalchemiops/torch/neighbors/cell_list.py
+++ b/nvalchemiops/torch/neighbors/cell_list.py
@@ -27,10 +27,12 @@ Two query kernels share this build:
   (full-fill) path accumulates counts via ``wp.atomic_add`` on
   ``num_neighbors``, so the order of neighbors within a given row is
   unspecified.  Best at large N.
-* **pair-centric** - one CUDA block per ``(source_cell, offset)``;
-  offset zero handles same-cell pairs.  Per-emit ``atomic_add`` on
-  ``num_neighbors``.  Best at small/medium N or large cutoff (more
-  cell-level parallelism than atom-level).
+* **pair-centric** - one CUDA block per ``(source_cell, offset)`` on the
+  fast path; when the uncoarsened launch would exceed the Warp one-dimensional
+  limit, the launcher transparently coarsens multiple logical blocks per CUDA
+  block under the same ``strategy="pair_centric"`` name.  Per-emit
+  ``atomic_add`` on ``num_neighbors``.  Best at small/medium N or large cutoff
+  (more cell-level parallelism than atom-level).
 
 Auto-select uses sync-free quantities (``natom``, ``cutoff``).  See
 :func:`select_cell_list_strategy` for the 3-clause rule.  Pin a strategy
@@ -43,16 +45,13 @@ import torch
 import warp as wp
 
 from nvalchemiops.neighbors.cell_list import (
-    PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
-    compute_batch_pair_centric_n_outer,
-    get_build_cell_list_kernel,
-    is_pair_centric_launch_safe,
-    is_pair_centric_parallelism_sufficient,
-    pair_centric_launch_size,
-    select_cell_list_strategy,
+    build_cell_list as wp_build_cell_list,
 )
 from nvalchemiops.neighbors.cell_list import (
-    build_cell_list as wp_build_cell_list,
+    compute_batch_pair_centric_n_outer,
+    get_build_cell_list_kernel,
+    is_pair_centric_parallelism_sufficient,
+    select_cell_list_strategy,
 )
 from nvalchemiops.neighbors.cell_list import (
     query_cell_list as wp_query_cell_list,
@@ -93,31 +92,6 @@ __all__ = [
     "estimate_cell_list_sizes",
     "query_cell_list",
 ]
-
-
-def _pair_centric_unsafe_message(
-    total_cells: int,
-    n_outer: int,
-    block_dim: int = 64,
-) -> str:
-    """Return the unsafe pair-centric launch message."""
-    launch_size = pair_centric_launch_size(total_cells, n_outer, block_dim)
-    return (
-        "strategy='pair_centric' would require "
-        f"{launch_size} logical threads "
-        f"({int(total_cells)} cells * {int(n_outer) + 1} offsets * "
-        f"{int(block_dim)} threads), exceeding the safe linear launch limit "
-        f"of {PAIR_CENTRIC_MAX_LINEAR_LAUNCH}."
-    )
-
-
-def _raise_unsafe_pair_centric_launch(
-    total_cells: int,
-    n_outer: int,
-    block_dim: int = 64,
-) -> None:
-    """Raise when an explicit pair-centric request is unsafe."""
-    raise ValueError(_pair_centric_unsafe_message(total_cells, n_outer, block_dim))
 
 
 def _resolve_atom_centric_path(atom_centric_path: str) -> str:
@@ -665,13 +639,7 @@ def _query_cell_list_op(
         Rz = int(neighbor_search_radius[2].item())
         n_outer = compute_batch_pair_centric_n_outer((Rx, Ry, Rz), bool(half_fill))
         total_cells = int(atoms_per_cell_count.shape[0])
-        if not is_pair_centric_launch_safe(total_cells, n_outer):
-            if strategy == "pair_centric":
-                _raise_unsafe_pair_centric_launch(total_cells, n_outer)
-            chosen = "atom_centric"
-            use_pair = False
-            n_outer = None
-        elif strategy == "auto" and not is_pair_centric_parallelism_sufficient(
+        if strategy == "auto" and not is_pair_centric_parallelism_sufficient(
             int(total_atoms), total_cells, n_outer
         ):
             chosen = "atom_centric"
@@ -838,7 +806,9 @@ def query_cell_list(
         Selects which of the two cell-list query kernels to launch.  See
         :func:`select_cell_list_strategy` for the "auto" rule.  Both strategies
         return identical pair sets for either ``half_fill`` value;
-        per-row ordering inside ``neighbor_matrix`` differs.
+        per-row ordering inside ``neighbor_matrix`` differs.  Pair-centric
+        oversized grids are handled by an internal coarsened kernel variant;
+        there is no separate public strategy name for coarsening.
     atom_centric_path : {"auto", "direct", "sorted"}, default "auto"
         Selects the atom-centric implementation path when
         ``strategy="atom_centric"``.  ``"auto"`` resolves to ``"direct"``.
@@ -1590,12 +1560,7 @@ def _query_cell_list_optional(
         Rz = int(neighbor_search_radius[2].item())
         n_outer = compute_batch_pair_centric_n_outer((Rx, Ry, Rz), bool(half_fill))
         total_cells = int(atoms_per_cell_count.shape[0])
-        if not is_pair_centric_launch_safe(total_cells, n_outer):
-            if strategy == "pair_centric":
-                _raise_unsafe_pair_centric_launch(total_cells, n_outer)
-            chosen = "atom_centric"
-            n_outer = None
-        elif strategy == "auto" and not is_pair_centric_parallelism_sufficient(
+        if strategy == "auto" and not is_pair_centric_parallelism_sufficient(
             int(total_atoms), total_cells, n_outer
         ):
             chosen = "atom_centric"

--- a/test/neighbors/test_base_dispatch.py
+++ b/test/neighbors/test_base_dispatch.py
@@ -93,3 +93,22 @@ def test_is_pair_centric_parallelism_sufficient_boundary():
     assert not is_pair_centric_parallelism_sufficient(
         total_atoms=1_000_000, total_cells=1, n_outer=0
     )
+
+
+def test_pair_centric_coarsening_restores_launch_feasibility():
+    """Coarsened launch size fits the limit for canonical overflow shapes."""
+    from nvalchemiops.neighbors.cell_list import (
+        PAIR_CENTRIC_MAX_LINEAR_LAUNCH,
+        compute_batch_pair_centric_n_outer,
+        pair_centric_launch_size,
+    )
+    from nvalchemiops.neighbors.cell_list.dispatch import (
+        _pair_centric_coarsened_launch_size,
+    )
+
+    n_outer = compute_batch_pair_centric_n_outer((23, 25, 23), half_fill=False)
+    assert pair_centric_launch_size(3840, n_outer, 64) > PAIR_CENTRIC_MAX_LINEAR_LAUNCH
+    assert (
+        _pair_centric_coarsened_launch_size(3840, n_outer, 64)
+        <= PAIR_CENTRIC_MAX_LINEAR_LAUNCH
+    )

--- a/test/neighbors/test_cell_list_kernel_getters.py
+++ b/test/neighbors/test_cell_list_kernel_getters.py
@@ -30,6 +30,12 @@ from nvalchemiops.neighbors.cell_list import (
     pair_centric_launch_size,
     query_cell_list,
 )
+from nvalchemiops.neighbors.cell_list.dispatch import (
+    _pair_centric_coarsened_launch_size,
+    _pair_centric_logical_block_count,
+    _pair_centric_max_cuda_blocks,
+    _pair_centric_work_per_cuda_block,
+)
 
 
 @wp.func
@@ -134,14 +140,86 @@ def test_cell_list_query_kernel_uses_pair_fn_object_cache_key():
     assert kernel1 is not kernel3
 
 
-def test_pair_centric_launch_guard_rejects_large_batched_shape():
-    """The guard rejects an oversized batched pair-centric launch shape."""
+def test_pair_centric_uncoarsened_launch_overflow_is_not_overall_infeasible():
+    """Uncoarsened overflow is handled by coarsening, not rejection."""
     n_outer = compute_batch_pair_centric_n_outer((23, 25, 23), half_fill=False)
     launch_size = pair_centric_launch_size(3840, n_outer, 64)
+    logical_blocks = _pair_centric_logical_block_count(3840, n_outer)
+    work_per_cuda_block = _pair_centric_work_per_cuda_block(3840, n_outer, 64)
+    coarsened_launch = _pair_centric_coarsened_launch_size(3840, n_outer, 64)
 
     assert launch_size == 27_687_075_840
     assert launch_size > PAIR_CENTRIC_MAX_LINEAR_LAUNCH
     assert not is_pair_centric_launch_safe(3840, n_outer, 64)
+    assert work_per_cuda_block > 1
+    assert coarsened_launch <= PAIR_CENTRIC_MAX_LINEAR_LAUNCH
+    cuda_blocks = (logical_blocks + work_per_cuda_block - 1) // work_per_cuda_block
+    assert cuda_blocks * work_per_cuda_block >= logical_blocks
+
+
+def test_pair_centric_coarsening_helpers_fast_path_unchanged():
+    """Launch-safe shapes keep ``work_per_cuda_block == 1``."""
+    n_outer = compute_batch_pair_centric_n_outer((1, 1, 1), half_fill=False)
+
+    assert pair_centric_launch_size(64, n_outer, 64) == 110_592
+    assert is_pair_centric_launch_safe(64, n_outer, 64)
+    assert _pair_centric_work_per_cuda_block(64, n_outer, 64) == 1
+    assert _pair_centric_coarsened_launch_size(64, n_outer, 64) == 110_592
+
+
+def test_pair_centric_coarsening_helper_validation():
+    """Invalid block or launch limits raise before planning coarsening."""
+    with pytest.raises(ValueError, match="block_dim must be positive"):
+        _pair_centric_max_cuda_blocks(0)
+    with pytest.raises(ValueError, match="max_launch_size"):
+        _pair_centric_max_cuda_blocks(64, max_launch_size=32)
+    with pytest.raises(ValueError, match="block_dim must be positive"):
+        _pair_centric_work_per_cuda_block(64, 26, block_dim=0)
+    with pytest.raises(ValueError, match="max_launch_size"):
+        _pair_centric_coarsened_launch_size(64, 26, block_dim=64, max_launch_size=32)
+
+
+def test_pair_centric_coarsening_helpers_are_not_public_exports():
+    """Coarsening sizing helpers stay internal to ``cell_list.dispatch``."""
+    import nvalchemiops.neighbors.cell_list as cell_list
+
+    public = set(cell_list.__all__)
+    for name in (
+        "pair_centric_logical_block_count",
+        "pair_centric_max_cuda_blocks",
+        "pair_centric_work_per_cuda_block",
+        "pair_centric_coarsened_launch_size",
+    ):
+        assert name not in public
+        assert not hasattr(cell_list, name)
+
+
+def test_pair_centric_kernel_getter_coarsened_cache():
+    """Coarsened and uncoarsened pair-centric kernels are distinct cached objects."""
+    kernel_fast = get_query_cell_list_kernel(
+        wp.float32,
+        strategy="pair_centric",
+        batched=True,
+        return_vectors=True,
+        coarsened=False,
+    )
+    kernel_coarsened = get_query_cell_list_kernel(
+        wp.float32,
+        strategy="pair_centric",
+        batched=True,
+        return_vectors=True,
+        coarsened=True,
+    )
+    kernel_fast_again = get_query_cell_list_kernel(
+        wp.float32,
+        strategy="pair_centric",
+        batched=True,
+        return_vectors=True,
+    )
+
+    assert kernel_fast is kernel_fast_again
+    assert kernel_fast is not kernel_coarsened
+    assert "coarsened" in kernel_coarsened.key
 
 
 def test_pair_centric_launch_guard_accepts_small_batched_shape():
@@ -577,6 +655,210 @@ def test_pair_centric_partial_outputs_are_compact(device):
     assert pair_energies[0, :nn].abs().min().item() > 0.0
     assert neighbor_vectors[0, :nn].abs().max().item() > 0.0
     assert neighbor_distances[0, :nn].cpu().tolist() == pytest.approx([0.5, 0.5])
+
+
+def _neighbor_matrix_row_set_wp(
+    neighbor_matrix: torch.Tensor,
+    num_neighbors: torch.Tensor,
+) -> set[tuple[int, frozenset[int]]]:
+    """Order-independent row set for warp-launched neighbor matrices."""
+    out: set[tuple[int, frozenset[int]]] = set()
+    for i in range(neighbor_matrix.shape[0]):
+        n = int(num_neighbors[i].item())
+        if n > 0:
+            out.add((i, frozenset(int(x) for x in neighbor_matrix[i, :n].tolist())))
+    return out
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+def test_pair_centric_coarsened_matches_atom_centric(device):
+    """Coarsened pair-centric output matches atom-centric as an unordered pair set."""
+    _skip_missing_cuda(device)
+
+    positions_np = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.0, 0.0],
+            [0.0, 0.5, 0.0],
+            [3.0, 3.0, 3.0],
+        ],
+        dtype=np.float32,
+    )
+    box = 4.0
+    cutoff = 0.6
+    max_neighbors = 4
+    max_launch_size = 256
+
+    state = _build_single_smoke_state(device, positions_np, box, cutoff, max_neighbors)
+    n_outer = compute_batch_pair_centric_n_outer(
+        tuple(state["neighbor_search_radius"].cpu().tolist()),
+        half_fill=False,
+    )
+    total_cells = int(state["atoms_per_cell_count"].shape[0])
+    assert (
+        _pair_centric_work_per_cuda_block(
+            total_cells,
+            n_outer,
+            64,
+            max_launch_size=max_launch_size,
+        )
+        > 1
+    )
+
+    common_kwargs = dict(
+        positions=wp.from_torch(state["positions_t"], dtype=wp.vec3f),
+        cell=wp.from_torch(state["cell_t"], dtype=wp.mat33f),
+        pbc=wp.from_torch(state["pbc_t"], dtype=wp.bool),
+        cutoff=cutoff,
+        cells_per_dimension=wp.from_torch(state["cells_per_dimension"], dtype=wp.int32),
+        neighbor_search_radius=wp.from_torch(
+            state["neighbor_search_radius"], dtype=wp.int32
+        ),
+        atom_periodic_shifts=wp.from_torch(
+            state["atom_periodic_shifts"], dtype=wp.vec3i
+        ),
+        atom_to_cell_mapping=wp.from_torch(
+            state["atom_to_cell_mapping"], dtype=wp.vec3i
+        ),
+        atoms_per_cell_count=wp.from_torch(
+            state["atoms_per_cell_count"], dtype=wp.int32
+        ),
+        cell_atom_start_indices=wp.from_torch(
+            state["cell_atom_start_indices"], dtype=wp.int32
+        ),
+        cell_atom_list=wp.from_torch(state["cell_atom_list"], dtype=wp.int32),
+        sorted_positions=wp.from_torch(state["sorted_positions"], dtype=wp.vec3f),
+        sorted_atom_periodic_shifts=wp.from_torch(
+            state["sorted_shifts"], dtype=wp.vec3i
+        ),
+        rebuild_flags=wp.from_torch(state["rebuild_flags"], dtype=wp.bool),
+        wp_dtype=wp.float32,
+        device=device,
+        half_fill=False,
+        max_launch_size=max_launch_size,
+    )
+
+    nm_atom = state["neighbor_matrix"].clone()
+    nn_atom = state["num_neighbors"].clone()
+    query_cell_list(
+        **common_kwargs,
+        neighbor_matrix=wp.from_torch(nm_atom, dtype=wp.int32),
+        neighbor_matrix_shifts=wp.from_torch(
+            state["neighbor_matrix_shifts"], dtype=wp.vec3i
+        ),
+        num_neighbors=wp.from_torch(nn_atom, dtype=wp.int32),
+        strategy="atom_centric",
+    )
+
+    nm_pair = state["neighbor_matrix"].clone()
+    nn_pair = state["num_neighbors"].clone()
+    query_cell_list(
+        **common_kwargs,
+        neighbor_matrix=wp.from_torch(nm_pair, dtype=wp.int32),
+        neighbor_matrix_shifts=wp.from_torch(
+            state["neighbor_matrix_shifts"], dtype=wp.vec3i
+        ),
+        num_neighbors=wp.from_torch(nn_pair, dtype=wp.int32),
+        strategy="pair_centric",
+        n_outer=n_outer,
+    )
+
+    assert torch.equal(nn_atom, nn_pair)
+    assert _neighbor_matrix_row_set_wp(nm_atom, nn_atom) == _neighbor_matrix_row_set_wp(
+        nm_pair, nn_pair
+    )
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+def test_pair_centric_coarsened_partial_target_indices(device):
+    """Coarsened pair-centric partial rows match atom-centric compact outputs."""
+    _skip_missing_cuda(device)
+
+    positions_np = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.0, 0.0],
+            [0.0, 0.5, 0.0],
+            [3.0, 3.0, 3.0],
+        ],
+        dtype=np.float32,
+    )
+    box = 4.0
+    cutoff = 0.6
+    max_neighbors = 4
+    max_launch_size = 256
+
+    state = _build_single_smoke_state(device, positions_np, box, cutoff, max_neighbors)
+    n_outer = compute_batch_pair_centric_n_outer(
+        tuple(state["neighbor_search_radius"].cpu().tolist()),
+        half_fill=False,
+    )
+    target_indices = torch.tensor([0], dtype=torch.int32, device=device)
+    neighbor_matrix_atom = torch.full(
+        (1, max_neighbors), -1, dtype=torch.int32, device=device
+    )
+    neighbor_matrix_pair = neighbor_matrix_atom.clone()
+    neighbor_matrix_shifts = torch.zeros(
+        (1, max_neighbors, 3), dtype=torch.int32, device=device
+    )
+    num_neighbors_atom = torch.zeros(1, dtype=torch.int32, device=device)
+    num_neighbors_pair = torch.zeros(1, dtype=torch.int32, device=device)
+
+    common_kwargs = dict(
+        positions=wp.from_torch(state["positions_t"], dtype=wp.vec3f),
+        cell=wp.from_torch(state["cell_t"], dtype=wp.mat33f),
+        pbc=wp.from_torch(state["pbc_t"], dtype=wp.bool),
+        cutoff=cutoff,
+        cells_per_dimension=wp.from_torch(state["cells_per_dimension"], dtype=wp.int32),
+        neighbor_search_radius=wp.from_torch(
+            state["neighbor_search_radius"], dtype=wp.int32
+        ),
+        atom_periodic_shifts=wp.from_torch(
+            state["atom_periodic_shifts"], dtype=wp.vec3i
+        ),
+        atom_to_cell_mapping=wp.from_torch(
+            state["atom_to_cell_mapping"], dtype=wp.vec3i
+        ),
+        atoms_per_cell_count=wp.from_torch(
+            state["atoms_per_cell_count"], dtype=wp.int32
+        ),
+        cell_atom_start_indices=wp.from_torch(
+            state["cell_atom_start_indices"], dtype=wp.int32
+        ),
+        cell_atom_list=wp.from_torch(state["cell_atom_list"], dtype=wp.int32),
+        sorted_positions=wp.from_torch(state["sorted_positions"], dtype=wp.vec3f),
+        sorted_atom_periodic_shifts=wp.from_torch(
+            state["sorted_shifts"], dtype=wp.vec3i
+        ),
+        rebuild_flags=wp.from_torch(state["rebuild_flags"], dtype=wp.bool),
+        target_indices=wp.from_torch(target_indices, dtype=wp.int32),
+        wp_dtype=wp.float32,
+        device=device,
+        half_fill=False,
+        max_launch_size=max_launch_size,
+    )
+
+    query_cell_list(
+        **common_kwargs,
+        neighbor_matrix=wp.from_torch(neighbor_matrix_atom, dtype=wp.int32),
+        neighbor_matrix_shifts=wp.from_torch(neighbor_matrix_shifts, dtype=wp.vec3i),
+        num_neighbors=wp.from_torch(num_neighbors_atom, dtype=wp.int32),
+        strategy="atom_centric",
+    )
+    query_cell_list(
+        **common_kwargs,
+        neighbor_matrix=wp.from_torch(neighbor_matrix_pair, dtype=wp.int32),
+        neighbor_matrix_shifts=wp.from_torch(neighbor_matrix_shifts, dtype=wp.vec3i),
+        num_neighbors=wp.from_torch(num_neighbors_pair, dtype=wp.int32),
+        strategy="pair_centric",
+        n_outer=n_outer,
+    )
+
+    assert torch.equal(num_neighbors_atom, num_neighbors_pair)
+    nn = int(num_neighbors_atom.cpu().item())
+    assert nn == 2
+    assert set(neighbor_matrix_atom[0, :nn].cpu().tolist()) == {1, 2}
+    assert set(neighbor_matrix_pair[0, :nn].cpu().tolist()) == {1, 2}
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])

--- a/test/neighbors/test_factory_kernel_docstrings.py
+++ b/test/neighbors/test_factory_kernel_docstrings.py
@@ -189,8 +189,28 @@ def _assert_runtime_doc(obj: object, *expected: str) -> None:
                 strategy="pair_centric",
                 batched=True,
                 return_vectors=True,
+                coarsened=True,
             ),
-            ("dtype : f64", "strategy : pair_centric", "batched : True"),
+            (
+                "dtype : f64",
+                "strategy : pair_centric",
+                "batched : True",
+                "coarsened : True",
+            ),
+        ),
+        (
+            get_query_cell_list_kernel(
+                wp.float64,
+                strategy="pair_centric",
+                batched=True,
+                return_vectors=True,
+            ),
+            (
+                "dtype : f64",
+                "strategy : pair_centric",
+                "batched : True",
+                "coarsened : False",
+            ),
         ),
         (
             cluster_tile_kernels.get_batch_query_cluster_tile_coo_kernel(

--- a/test/neighbors/test_factory_kernel_names.py
+++ b/test/neighbors/test_factory_kernel_names.py
@@ -122,6 +122,16 @@ def _assert_kernel_name(kernel: wp.Kernel, expected: str) -> None:
                 strategy="pair_centric",
                 batched=True,
                 return_vectors=True,
+                coarsened=True,
+            ),
+            "_batch_cell_list_build_neighbor_matrix__pair_centric_coarsened_vectors__f32",
+        ),
+        (
+            get_query_cell_list_kernel(
+                wp.float32,
+                strategy="pair_centric",
+                batched=True,
+                return_vectors=True,
             ),
             "_batch_cell_list_build_neighbor_matrix__pair_centric_vectors__f32",
         ),


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Add transparent coarsening for oversized pair-centric cell-list launches so explicit and auto-selected pair-centric queries can stay under Warp's one-dimensional launch limit without adding a new public strategy name.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- Add internal pair-centric launch coarsening helpers and route single-system and batched pair-centric launchers through a shared launch plan that selects a coarsened kernel variant only when needed.
- Split pair-centric kernel generation into fast-path and coarsened variants, with the coarsened variant processing multiple logical `(source_cell, offset)` blocks per CUDA block.
- Remove launch-size-only pair-centric rejection paths from Torch and JAX wrappers while preserving CPU, graph-mode, half-fill, target-index, and parallelism restrictions.
- Update auto-dispatch cost modeling and neighbor-list documentation for internally coarsened pair-centric launches.
- Add helper, export-surface, kernel cache/name/docstring, dispatch, and GPU parity tests for pair-centric coarsening.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Targeted neighbor kernel-getter, factory name/docstring, dispatch, and pair-centric/coarsening tests passed locally.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
