### PR TITLE
fix(neighbors): derive JAX search radius from realized grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- JAX batched cell-list sizing now returns the constructed cell grid and
+  search radius for its capacity. Its new
+  `capacity_strategy="geometry"` option estimates capacity from promoted
+  per-axis grids; volume-based sizing remains the default.
+
 ## 0.4.0 - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### Fixed
 
-- JAX batched cell-list sizing now returns the constructed cell grid and
-  search radius for its capacity. Its new
-  `capacity_strategy="geometry"` option estimates capacity from promoted
-  per-axis grids; volume-based sizing remains the default.
+- JAX cell-list builds now derive search radii from their realized grids,
+  preventing missed neighbors when static capacity changes the constructed
+  grid. Batched `capacity_strategy="geometry"` preserves promoted grids for
+  all non-empty systems by reserving an equal per-system capacity; volume-based
+  sizing remains the default. Fused Warp graph calls with explicit
+  `max_total_cells` now require an explicit `neighbor_search_radius`.
 
 ## 0.4.0 - 2026-07-13
 

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -30,6 +30,7 @@ from nvalchemiops.jax.neighbors._autograd import (
     _route_pair_outputs,
 )
 from nvalchemiops.jax.neighbors.cell_list import (
+    _derive_neighbor_search_radius,
     _is_cpu_array,
     _resolve_cell_strategy,
     _validate_atom_centric_path,
@@ -980,7 +981,6 @@ def estimate_batch_cell_list_sizes(
     # Simple estimation per system
     max_total_cells = 0
     cells_per_dim_list = []
-    search_radius_list = []
 
     for sys_idx in range(num_systems):
         start_idx = batch_ptr[sys_idx]
@@ -989,7 +989,6 @@ def estimate_batch_cell_list_sizes(
 
         if num_atoms_in_sys == 0:
             cells_per_dim_list.append(jnp.ones(3, dtype=jnp.int32))
-            search_radius_list.append(jnp.ones(3, dtype=jnp.int32))
             continue
 
         # Volume estimation
@@ -1007,10 +1006,14 @@ def estimate_batch_cell_list_sizes(
 
         cells_per_dim = jnp.ceil(num_cells_est ** (1 / 3)).astype(jnp.int32)
         cells_per_dim_list.append(cells_per_dim * jnp.ones(3, dtype=jnp.int32))
-        search_radius_list.append(jnp.ones(3, dtype=jnp.int32))
 
     cells_per_dimension = jnp.stack(cells_per_dim_list, axis=0)
-    neighbor_search_radius = jnp.stack(search_radius_list, axis=0)
+    neighbor_search_radius = _derive_neighbor_search_radius(
+        cell,
+        _pbc_bool,
+        cutoff,
+        cells_per_dimension,
+    )
 
     return max_total_cells, cells_per_dimension, neighbor_search_radius
 
@@ -1117,15 +1120,14 @@ def batch_build_cell_list(
     )
 
     if max_total_cells is None:
-        max_total_cells, cells_per_dim_est, neighbor_search_radius = (
-            estimate_batch_cell_list_sizes(
-                positions, batch_ptr, batch_idx, cell, cutoff, pbc
-            )
+        max_total_cells, _, _ = estimate_batch_cell_list_sizes(
+            positions, batch_ptr, batch_idx, cell, cutoff, pbc
         )
-        # Ensure neighbor_search_radius is on the correct device
-        neighbor_search_radius = neighbor_search_radius
-    else:
-        neighbor_search_radius = jnp.ones((num_systems, 3), dtype=jnp.int32)
+
+    neighbor_search_radius = jnp.zeros(
+        (num_systems, 3),
+        dtype=jnp.int32,
+    )
 
     # Allocate cell list tensors
     (
@@ -1171,6 +1173,13 @@ def batch_build_cell_list(
         float(cutoff),
         int(max_total_cells),
         launch_dims=(num_systems,),
+    )
+
+    neighbor_search_radius = _derive_neighbor_search_radius(
+        cell,
+        pbc_bool,
+        cutoff,
+        cells_per_dimension,
     )
 
     # Step 2: Compute cells_per_system and cell_offsets

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -438,7 +438,7 @@ def _estimate_batch_max_total_cells(
             max_total_cells += system_capacity
 
     if capacity_strategy == "geometry":
-        return max(max_total_cells * num_systems, num_systems)
+        max_total_cells *= num_systems
     return max(max_total_cells, num_systems)
 
 

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -450,6 +450,12 @@ def _construct_batch_cells_per_dimension(
 ) -> jax.Array:
     """Run the authoritative construct kernel and return realized bins."""
     num_systems = cell.shape[0]
+    if max_total_cells < num_systems:
+        raise ValueError(
+            "max_total_cells must be at least num_systems "
+            f"(got max_total_cells={max_total_cells}, num_systems={num_systems})."
+        )
+
     cells_per_dimension = jnp.zeros((num_systems, 3), dtype=jnp.int32)
     empty_bool1d = jnp.zeros((0,), dtype=jnp.bool_)
     empty_i32 = jnp.zeros((0,), dtype=jnp.int32)

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import functools
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -386,6 +387,102 @@ def _normalize_batch_cell_pbc(
         pbc_out = pbc_out.astype(jnp.bool_)
 
     return cell_out, pbc_out
+
+
+def _derive_batch_promoted_cells_per_dimension(
+    cell: jax.Array,
+    pbc: jax.Array,
+    cutoff: float,
+) -> jax.Array:
+    """Derive uncapped per-axis grids for geometry capacity sizing."""
+    inverse_cell_transpose = jnp.swapaxes(jnp.linalg.inv(cell), -1, -2)
+    face_distances = 1.0 / jnp.linalg.norm(inverse_cell_transpose, axis=-1)
+    cells_per_dimension = jnp.maximum(
+        (face_distances / cutoff).astype(jnp.int32),
+        1,
+    )
+    promote_mask = pbc | (cells_per_dimension > 1)
+    for _ in range(8):
+        cells_per_dimension = jnp.where(
+            promote_mask & (cells_per_dimension < 4),
+            cells_per_dimension * 2,
+            cells_per_dimension,
+        )
+    return cells_per_dimension
+
+
+def _estimate_batch_max_total_cells(
+    batch_ptr: jax.Array,
+    cell: jax.Array,
+    pbc: jax.Array,
+    cutoff: float,
+    buffer_factor: float,
+    capacity_strategy: Literal["volume", "geometry"],
+) -> int:
+    """Estimate allocation capacity without materializing construct metadata."""
+    if capacity_strategy not in ("volume", "geometry"):
+        raise ValueError(
+            "capacity_strategy must be 'volume' or 'geometry', "
+            f"got {capacity_strategy!r}."
+        )
+
+    num_systems = batch_ptr.shape[0] - 1
+    promoted_cells_per_dimension = (
+        _derive_batch_promoted_cells_per_dimension(cell, pbc, cutoff)
+        if capacity_strategy == "geometry"
+        else None
+    )
+    max_total_cells = 0
+
+    for sys_idx in range(num_systems):
+        num_atoms_in_sys = batch_ptr[sys_idx + 1] - batch_ptr[sys_idx]
+        if num_atoms_in_sys == 0:
+            continue
+
+        if capacity_strategy == "volume":
+            volume = jnp.abs(jnp.linalg.det(cell[sys_idx]))
+            num_cells_est = int(volume / cutoff**3 * buffer_factor)
+        else:
+            cells_per_dimension = promoted_cells_per_dimension[sys_idx]
+            num_cells_est = int(
+                cells_per_dimension[0]
+                * cells_per_dimension[1]
+                * cells_per_dimension[2]
+                * buffer_factor
+            )
+
+        max_total_cells += max(num_cells_est, 8)
+
+    return max(max_total_cells, num_systems)
+
+
+def _construct_batch_cells_per_dimension(
+    cell: jax.Array,
+    pbc: jax.Array,
+    cutoff: float,
+    max_total_cells: int,
+) -> jax.Array:
+    """Run the authoritative construct kernel and return realized bins."""
+    num_systems = cell.shape[0]
+    cells_per_dimension = jnp.zeros((num_systems, 3), dtype=jnp.int32)
+    empty_bool1d = jnp.zeros((0,), dtype=jnp.bool_)
+    empty_i32 = jnp.zeros((0,), dtype=jnp.int32)
+    construct = (
+        _jax_batch_construct_bin_size_f64
+        if cell.dtype == jnp.float64
+        else _jax_batch_construct_bin_size_f32
+    )
+    (cells_per_dimension,) = construct(
+        cell,
+        empty_bool1d,
+        pbc,
+        empty_i32,
+        cells_per_dimension,
+        float(cutoff),
+        int(max_total_cells),
+        launch_dims=(num_systems,),
+    )
+    return cells_per_dimension
 
 
 # ==============================================================================
@@ -927,6 +1024,8 @@ def estimate_batch_cell_list_sizes(
     cutoff: float = 5.0,
     pbc: jax.Array | None = None,
     buffer_factor: float = 1.5,
+    *,
+    capacity_strategy: Literal["volume", "geometry"] = "volume",
 ) -> tuple[int, jax.Array, jax.Array]:
     """Estimate required batch cell list sizes.
 
@@ -946,15 +1045,35 @@ def estimate_batch_cell_list_sizes(
         PBC flags.
     buffer_factor : float, optional
         Buffer multiplier. Default is 1.5.
+    capacity_strategy : {"volume", "geometry"}, optional
+        Capacity estimation policy. ``"volume"`` (default) estimates capacity
+        from each cell's volume and the cutoff. ``"geometry"`` estimates
+        capacity from the promoted per-axis cell grid.
 
     Returns
     -------
     max_total_cells : int
         Maximum total cells to allocate.
     cells_per_dimension : jax.Array, shape (num_systems, 3)
-        Cells per dimension for each system.
+        Realized cells per dimension for each system at ``max_total_cells``.
     neighbor_search_radius : jax.Array, shape (num_systems, 3)
-        Search radius for each system.
+        Search radius derived from the realized cells per dimension.
+
+    Notes
+    -----
+    The volume policy sums ``max(int(abs(det(cell)) / cutoff**3 *
+    buffer_factor), 8)`` for non-empty systems. The geometry policy derives
+    per-axis face-distance cells, applies adaptive promotion, and sums the
+    promoted cell products scaled by ``buffer_factor``. Geometry can reserve
+    more memory and can still halve a large system in a heterogeneous batch
+    because construction applies an equal per-system capacity bound.
+
+    The returned cells and radii match ``batch_build_cell_list`` when called
+    with the returned ``max_total_cells``. To use geometry sizing for a build,
+    call this estimator with ``capacity_strategy="geometry"`` and pass its
+    capacity to ``batch_build_cell_list``. That explicit estimator-then-build
+    flow dispatches construction once per call, whereas automatic builds use
+    the private volume capacity helper and dispatch construction only once.
 
     .. warning::
 
@@ -978,36 +1097,20 @@ def estimate_batch_cell_list_sizes(
         dtype=cell_dtype,
     )
 
-    # Simple estimation per system
-    max_total_cells = 0
-    cells_per_dim_list = []
-
-    for sys_idx in range(num_systems):
-        start_idx = batch_ptr[sys_idx]
-        end_idx = batch_ptr[sys_idx + 1]
-        num_atoms_in_sys = end_idx - start_idx
-
-        if num_atoms_in_sys == 0:
-            cells_per_dim_list.append(jnp.ones(3, dtype=jnp.int32))
-            continue
-
-        # Volume estimation
-        det = jnp.linalg.det(cell[sys_idx])
-        volume = jnp.abs(det)
-
-        cell_volume = cutoff**3
-        # TODO: This estimation derives array sizes from traced input data (cell
-        # geometry), which is fundamentally incompatible with jax.jit compilation.
-        # The JAX bindings need a refactored usage pattern where sizing is always
-        # performed outside the JIT boundary, or a fixed upper-bound allocation
-        # strategy is adopted.
-        num_cells_est = max(int(volume / cell_volume * buffer_factor), 8)
-        max_total_cells += num_cells_est
-
-        cells_per_dim = jnp.ceil(num_cells_est ** (1 / 3)).astype(jnp.int32)
-        cells_per_dim_list.append(cells_per_dim * jnp.ones(3, dtype=jnp.int32))
-
-    cells_per_dimension = jnp.stack(cells_per_dim_list, axis=0)
+    max_total_cells = _estimate_batch_max_total_cells(
+        batch_ptr,
+        cell,
+        _pbc_bool,
+        cutoff,
+        buffer_factor,
+        capacity_strategy,
+    )
+    cells_per_dimension = _construct_batch_cells_per_dimension(
+        cell,
+        _pbc_bool,
+        cutoff,
+        max_total_cells,
+    )
     neighbor_search_radius = _derive_neighbor_search_radius(
         cell,
         _pbc_bool,
@@ -1120,8 +1223,13 @@ def batch_build_cell_list(
     )
 
     if max_total_cells is None:
-        max_total_cells, _, _ = estimate_batch_cell_list_sizes(
-            positions, batch_ptr, batch_idx, cell, cutoff, pbc
+        max_total_cells = _estimate_batch_max_total_cells(
+            batch_ptr,
+            cell,
+            pbc_bool,
+            cutoff,
+            1.5,
+            "volume",
         )
 
     neighbor_search_radius = jnp.zeros(
@@ -1146,11 +1254,9 @@ def batch_build_cell_list(
 
     # Select kernels based on dtype
     if positions.dtype == jnp.float64:
-        _construct = _jax_batch_construct_bin_size_f64
         _count = _jax_batch_count_atoms_per_bin_f64
         _bin = _jax_batch_bin_atoms_f64
     else:
-        _construct = _jax_batch_construct_bin_size_f32
         _count = _jax_batch_count_atoms_per_bin_f32
         _bin = _jax_batch_bin_atoms_f32
         positions = positions.astype(jnp.float32)
@@ -1164,15 +1270,11 @@ def batch_build_cell_list(
     total_atoms = positions.shape[0]
 
     # Step 1: Construct bin sizes (one thread per system)
-    (cells_per_dimension,) = _construct(
+    cells_per_dimension = _construct_batch_cells_per_dimension(
         cell,
-        empty_bool1d,
         pbc_bool,
-        empty_i32,
-        cells_per_dimension,
         float(cutoff),
-        int(max_total_cells),
-        launch_dims=(num_systems,),
+        max_total_cells,
     )
 
     neighbor_search_radius = _derive_neighbor_search_radius(

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -416,13 +416,16 @@ def _estimate_batch_max_total_cells(
 
     for sys_idx in range(num_systems):
         num_atoms_in_sys = batch_ptr[sys_idx + 1] - batch_ptr[sys_idx]
+        # Empty systems do not determine the required per-system capacity.
         if num_atoms_in_sys == 0:
             continue
 
         if capacity_strategy == "volume":
+            # Sum each non-empty system's density-based capacity estimate.
             volume = jnp.abs(jnp.linalg.det(cell[sys_idx]))
             num_cells_est = int(volume / cutoff**3 * buffer_factor)
         else:
+            # Track the largest promoted grid for equal per-system allocation.
             cells_per_dimension = promoted_cells_per_dimension[sys_idx]
             num_cells_est = int(
                 cells_per_dimension[0]
@@ -438,6 +441,7 @@ def _estimate_batch_max_total_cells(
             max_total_cells += system_capacity
 
     if capacity_strategy == "geometry":
+        # Construction divides the total capacity evenly across all systems.
         max_total_cells *= num_systems
     return max(max_total_cells, num_systems)
 

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -32,6 +32,7 @@ from nvalchemiops.jax.neighbors._autograd import (
 )
 from nvalchemiops.jax.neighbors.cell_list import (
     _derive_neighbor_search_radius,
+    _derive_promoted_cells_per_dimension,
     _is_cpu_array,
     _resolve_cell_strategy,
     _validate_atom_centric_path,
@@ -389,28 +390,6 @@ def _normalize_batch_cell_pbc(
     return cell_out, pbc_out
 
 
-def _derive_batch_promoted_cells_per_dimension(
-    cell: jax.Array,
-    pbc: jax.Array,
-    cutoff: float,
-) -> jax.Array:
-    """Derive uncapped per-axis grids for geometry capacity sizing."""
-    inverse_cell_transpose = jnp.swapaxes(jnp.linalg.inv(cell), -1, -2)
-    face_distances = 1.0 / jnp.linalg.norm(inverse_cell_transpose, axis=-1)
-    cells_per_dimension = jnp.maximum(
-        (face_distances / cutoff).astype(jnp.int32),
-        1,
-    )
-    promote_mask = pbc | (cells_per_dimension > 1)
-    for _ in range(8):
-        cells_per_dimension = jnp.where(
-            promote_mask & (cells_per_dimension < 4),
-            cells_per_dimension * 2,
-            cells_per_dimension,
-        )
-    return cells_per_dimension
-
-
 def _estimate_batch_max_total_cells(
     batch_ptr: jax.Array,
     cell: jax.Array,
@@ -428,7 +407,7 @@ def _estimate_batch_max_total_cells(
 
     num_systems = batch_ptr.shape[0] - 1
     promoted_cells_per_dimension = (
-        _derive_batch_promoted_cells_per_dimension(cell, pbc, cutoff)
+        _derive_promoted_cells_per_dimension(cell, pbc, cutoff)
         if capacity_strategy == "geometry"
         else None
     )
@@ -451,8 +430,14 @@ def _estimate_batch_max_total_cells(
                 * buffer_factor
             )
 
-        max_total_cells += max(num_cells_est, 8)
+        system_capacity = max(num_cells_est, 8)
+        if capacity_strategy == "geometry":
+            max_total_cells = max(max_total_cells, system_capacity)
+        else:
+            max_total_cells += system_capacity
 
+    if capacity_strategy == "geometry":
+        return max(max_total_cells * num_systems, num_systems)
     return max(max_total_cells, num_systems)
 
 
@@ -1048,7 +1033,8 @@ def estimate_batch_cell_list_sizes(
     capacity_strategy : {"volume", "geometry"}, optional
         Capacity estimation policy. ``"volume"`` (default) estimates capacity
         from each cell's volume and the cutoff. ``"geometry"`` estimates
-        capacity from the promoted per-axis cell grid.
+        capacity from the largest promoted per-axis grid among non-empty
+        systems, scaled by the number of systems.
 
     Returns
     -------
@@ -1063,10 +1049,14 @@ def estimate_batch_cell_list_sizes(
     -----
     The volume policy sums ``max(int(abs(det(cell)) / cutoff**3 *
     buffer_factor), 8)`` for non-empty systems. The geometry policy derives
-    per-axis face-distance cells, applies adaptive promotion, and sums the
-    promoted cell products scaled by ``buffer_factor``. Geometry can reserve
-    more memory and can still halve a large system in a heterogeneous batch
-    because construction applies an equal per-system capacity bound.
+    per-axis face-distance cells, applies adaptive promotion, then allocates
+    ``num_systems`` times the largest non-empty promoted-grid capacity. This
+    matches construction's equal per-system capacity bound, so every non-empty
+    system retains its promoted grid. Empty systems count toward the
+    per-system allocation multiplier but do not determine the largest capacity;
+    an all-empty batch allocates one cell per system. Geometry can therefore
+    reserve substantially more memory than volume sizing for heterogeneous
+    batches.
 
     The returned cells and radii match ``batch_build_cell_list`` when called
     with the returned ``max_total_cells``. To use geometry sizing for a build,

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -31,6 +31,7 @@ from nvalchemiops.jax.neighbors._autograd import (
     _route_pair_outputs,
 )
 from nvalchemiops.jax.neighbors.cell_list import (
+    _DEFAULT_CELL_LIST_BUFFER_FACTOR,
     _derive_neighbor_search_radius,
     _derive_promoted_cells_per_dimension,
     _is_cpu_array,
@@ -1008,7 +1009,7 @@ def estimate_batch_cell_list_sizes(
     cell: jax.Array | None = None,
     cutoff: float = 5.0,
     pbc: jax.Array | None = None,
-    buffer_factor: float = 1.5,
+    buffer_factor: float = _DEFAULT_CELL_LIST_BUFFER_FACTOR,
     *,
     capacity_strategy: Literal["volume", "geometry"] = "volume",
 ) -> tuple[int, jax.Array, jax.Array]:
@@ -1218,7 +1219,7 @@ def batch_build_cell_list(
             cell,
             pbc_bool,
             cutoff,
-            1.5,
+            _DEFAULT_CELL_LIST_BUFFER_FACTOR,
             "volume",
         )
 

--- a/nvalchemiops/jax/neighbors/cell_list.py
+++ b/nvalchemiops/jax/neighbors/cell_list.py
@@ -375,6 +375,9 @@ __all__ = [
     "estimate_cell_list_sizes",
 ]
 
+ADAPTIVE_MIN_CELLS = 4
+_MAX_ADAPTIVE_PROMOTION_STEPS = 8
+
 
 def _reset_query_outputs(
     neighbor_matrix,
@@ -419,6 +422,28 @@ def _derive_neighbor_search_radius(
         radius,
     )
     return radius[0] if is_single else radius
+
+
+def _derive_promoted_cells_per_dimension(
+    cell: jax.Array,
+    pbc: jax.Array,
+    cutoff: float,
+) -> jax.Array:
+    """Derive uncapped promoted grids for one or more cell geometries."""
+    inverse_cell_transpose = jnp.swapaxes(jnp.linalg.inv(cell), -1, -2)
+    face_distances = 1.0 / jnp.linalg.norm(inverse_cell_transpose, axis=-1)
+    cells_per_dimension = jnp.maximum(
+        (face_distances / cutoff).astype(jnp.int32),
+        1,
+    )
+    promote_mask = pbc.astype(jnp.bool_) | (cells_per_dimension > 1)
+    for _ in range(_MAX_ADAPTIVE_PROMOTION_STEPS):
+        cells_per_dimension = jnp.where(
+            promote_mask & (cells_per_dimension < ADAPTIVE_MIN_CELLS),
+            cells_per_dimension * 2,
+            cells_per_dimension,
+        )
+    return cells_per_dimension
 
 
 def _is_cpu_array(array: jax.Array) -> bool:
@@ -1748,29 +1773,14 @@ def estimate_cell_list_sizes(
     num_cells_est = jnp.int32(volume / cell_volume * buffer_factor)
     max_total_cells = jnp.max(jnp.array([num_cells_est, 8]))  # Minimum 8 cells
 
-    # Compute cells_per_dimension and neighbor_search_radius from cell geometry,
-    # mirroring the Warp _estimate_cell_list_sizes kernel used by the Torch
-    # path: natural cell count, ADAPTIVE_MIN_CELLS=4 promotion on PBC axes,
-    # halve-to-fit when total cells > max_total_cells, then compute
-    # neighbor_search_radius against the FINAL cells_per_dimension.
-    inverse_cell_transpose = jnp.linalg.inv(cell[0]).T
-    face_distances = 1.0 / jnp.linalg.norm(inverse_cell_transpose, axis=1)
-    cells_per_dimension = jnp.maximum(jnp.int32(face_distances / cutoff), 1)
-
     pbc_squeezed = pbc.squeeze()[:3] if pbc.ndim > 1 else pbc[:3]
-
-    # ADAPTIVE_MIN_CELLS=4: promote each PBC axis (or any axis already > 1)
-    # up to at least 4 cells so the atom-centric query has enough cell-level
-    # parallelism.  Open axes with a single cell are left alone.  Mirror the
-    # Warp ``construct_bin_size`` while-loop by repeatedly doubling.
-    ADAPTIVE_MIN_CELLS = 4
-    promote_mask = pbc_squeezed | (cells_per_dimension > 1)
-    for _ in range(8):
-        cells_per_dimension = jnp.where(
-            promote_mask & (cells_per_dimension < ADAPTIVE_MIN_CELLS),
-            cells_per_dimension * 2,
-            cells_per_dimension,
-        )
+    # Match Warp's natural-grid calculation and repeated-doubling promotion,
+    # then apply the single-system capacity clamp below.
+    cells_per_dimension = _derive_promoted_cells_per_dimension(
+        cell,
+        pbc,
+        cutoff,
+    )[0]
 
     # Halve-to-fit: if total cells exceeds max_total_cells, halve each axis
     # (floor with min=1) repeatedly until total <= max.  Mirrors the kernel's
@@ -2084,9 +2094,11 @@ def build_cell_list(
     pbc : jax.Array, shape (3,) or (1, 3), dtype=bool
         Periodic boundary condition flags.
     cells_per_dimension : jax.Array, shape (3,), dtype=int32, optional
-        OUTPUT: Number of cells in x, y, z directions. If None, allocated.
+        OUTPUT: Number of cells in x, y, z directions. If None, an output
+        buffer is allocated and populated with the constructed grid.
     neighbor_search_radius : jax.Array, shape (3,), dtype=int32, optional
-        Search radius in neighboring cells. If None, allocated.
+        Search radius in neighboring cells. If None, it is derived from the
+        constructed grid and cell face distances after construction.
     atom_periodic_shifts : jax.Array, shape (total_atoms, 3), dtype=int32, optional
         OUTPUT: Periodic boundary crossings for each atom. If None, allocated.
     atom_to_cell_mapping : jax.Array, shape (total_atoms, 3), dtype=int32, optional
@@ -2121,6 +2133,10 @@ def build_cell_list(
     -----
     When calling inside ``jax.jit``, ``max_total_cells`` **must** be provided
     to avoid calling ``estimate_cell_list_sizes``, which is not JIT-compatible.
+
+    The constructed grid may differ from the initial output buffer because
+    capacity can reduce it. When ``neighbor_search_radius`` is omitted, this
+    function derives it from that realized grid before returning.
 
     ``graph_mode="warp"`` uses a fused ``jax_callable`` that captures the full
     Warp-side build sequence. For replay-friendly usage inside ``jax.jit``,
@@ -2941,7 +2957,14 @@ def cell_list(
     max_neighbors : int, optional
         Maximum number of neighbors per atom. If None, will be estimated.
     max_total_cells : int, optional
-        Maximum number of cells to allocate. If None, will be estimated.
+        Maximum number of cells to allocate. If None, it will be estimated.
+        With ``graph_mode="warp"``, an explicit value requires an explicit
+        ``neighbor_search_radius`` because the fused query cannot inspect the
+        constructed grid between build and query.
+    neighbor_search_radius : jax.Array, shape (3,), dtype=int32, optional
+        Per-axis search radius. Normal build/query paths derive it from the
+        realized grid when omitted. Provide it when ``graph_mode="warp"`` and
+        ``max_total_cells`` is explicit.
     return_neighbor_list : bool, optional
         If True, convert result to COO neighbor list format. Default is False.
     strategy : {"auto", "atom_centric", "pair_centric"}, default "auto"
@@ -2962,7 +2985,9 @@ def cell_list(
     graph_mode : {"none", "warp"}, default="none"
         Execution mode for the underlying Warp launches. ``"warp"`` is
         intended for jitted call sites that donate and reuse the optional
-        cell-list caches and output buffers.
+        cell-list caches and output buffers. When combined with explicit
+        ``max_total_cells``, it requires a concrete
+        ``neighbor_search_radius`` because build and query are fused.
 
     Returns
     -------

--- a/nvalchemiops/jax/neighbors/cell_list.py
+++ b/nvalchemiops/jax/neighbors/cell_list.py
@@ -376,6 +376,7 @@ __all__ = [
 ]
 
 ADAPTIVE_MIN_CELLS = 4
+_DEFAULT_CELL_LIST_BUFFER_FACTOR = 1.5
 _MAX_ADAPTIVE_PROMOTION_STEPS = 8
 
 
@@ -1713,7 +1714,7 @@ def estimate_cell_list_sizes(
     cell: jax.Array,
     cutoff: float,
     pbc: jax.Array | None = None,
-    buffer_factor: float = 1.5,
+    buffer_factor: float = _DEFAULT_CELL_LIST_BUFFER_FACTOR,
 ) -> tuple[int, jax.Array, jax.Array]:
     """Estimate required cell list sizes based on atomic density.
 

--- a/nvalchemiops/jax/neighbors/cell_list.py
+++ b/nvalchemiops/jax/neighbors/cell_list.py
@@ -388,6 +388,39 @@ def _reset_query_outputs(
     neighbor_matrix_shifts.zero_()
 
 
+def _derive_neighbor_search_radius(
+    cell: jax.Array,
+    pbc: jax.Array,
+    cutoff: float,
+    cells_per_dimension: jax.Array,
+) -> jax.Array:
+    """Derive per-axis cell search radii from the realized cell grid."""
+    is_single = cells_per_dimension.ndim == 1
+    cell_batch = cell[jnp.newaxis, ...] if cell.ndim == 2 else cell
+    pbc_batch = pbc[jnp.newaxis, ...] if pbc.ndim == 1 else pbc
+    cpd_batch = (
+        cells_per_dimension[jnp.newaxis, ...] if is_single else cells_per_dimension
+    )
+    inverse_cell_transpose = jnp.swapaxes(
+        jnp.linalg.inv(cell_batch),
+        -1,
+        -2,
+    )
+    face_distances = 1.0 / jnp.linalg.norm(inverse_cell_transpose, axis=-1)
+    ratio = (
+        jnp.asarray(cutoff, dtype=face_distances.dtype)
+        * cpd_batch.astype(face_distances.dtype)
+        / face_distances
+    )
+    radius = jnp.ceil(ratio).astype(jnp.int32)
+    radius = jnp.where(
+        (cpd_batch == 1) & ~pbc_batch.astype(jnp.bool_),
+        jnp.int32(0),
+        radius,
+    )
+    return radius[0] if is_single else radius
+
+
 def _is_cpu_array(array: jax.Array) -> bool:
     """Return whether ``array`` is backed by a CPU device.
 
@@ -1728,22 +1761,16 @@ def estimate_cell_list_sizes(
 
     # ADAPTIVE_MIN_CELLS=4: promote each PBC axis (or any axis already > 1)
     # up to at least 4 cells so the atom-centric query has enough cell-level
-    # parallelism.  Open axes with a single cell are left alone.
+    # parallelism.  Open axes with a single cell are left alone.  Mirror the
+    # Warp ``construct_bin_size`` while-loop by repeatedly doubling.
     ADAPTIVE_MIN_CELLS = 4
     promote_mask = pbc_squeezed | (cells_per_dimension > 1)
-    # Bit-trick: smallest power-of-2 multiplier that brings cells_per_dim
-    # to >= ADAPTIVE_MIN_CELLS.  At cells_per_dim=1 -> multiplier=4; at 2 ->
-    # 2; at >= 4 -> 1.
-    needed_mult = jnp.where(
-        cells_per_dimension >= ADAPTIVE_MIN_CELLS,
-        1,
-        ADAPTIVE_MIN_CELLS // jnp.maximum(cells_per_dimension, 1),
-    )
-    cells_per_dimension = jnp.where(
-        promote_mask,
-        cells_per_dimension * needed_mult,
-        cells_per_dimension,
-    )
+    for _ in range(8):
+        cells_per_dimension = jnp.where(
+            promote_mask & (cells_per_dimension < ADAPTIVE_MIN_CELLS),
+            cells_per_dimension * 2,
+            cells_per_dimension,
+        )
 
     # Halve-to-fit: if total cells exceeds max_total_cells, halve each axis
     # (floor with min=1) repeatedly until total <= max.  Mirrors the kernel's
@@ -1758,10 +1785,11 @@ def estimate_cell_list_sizes(
     for _ in range(16):
         cells_per_dimension = _halve_to_fit(cells_per_dimension)
 
-    neighbor_search_radius = jnp.where(
-        (cells_per_dimension == 1) & ~pbc_squeezed,
-        jnp.zeros(3, dtype=jnp.int32),
-        jnp.int32(jnp.ceil(cutoff * cells_per_dimension / face_distances)),
+    neighbor_search_radius = _derive_neighbor_search_radius(
+        cell,
+        pbc_squeezed,
+        cutoff,
+        cells_per_dimension,
     )
 
     return max_total_cells, cells_per_dimension, neighbor_search_radius
@@ -2126,15 +2154,10 @@ def build_cell_list(
     if pbc.ndim == 1:
         pbc = pbc[jnp.newaxis, :]
 
+    derive_radius = neighbor_search_radius is None
+
     if max_total_cells is None:
-        max_total_cells, _, neighbor_search_radius_est = estimate_cell_list_sizes(
-            positions, cell, cutoff, pbc
-        )
-        if neighbor_search_radius is None:
-            neighbor_search_radius = neighbor_search_radius_est
-    else:
-        if neighbor_search_radius is None:
-            neighbor_search_radius = jnp.ones(3, dtype=jnp.int32)
+        max_total_cells, _, _ = estimate_cell_list_sizes(positions, cell, cutoff, pbc)
 
     # Allocate cell list tensors if not provided
     if cells_per_dimension is None:
@@ -2255,6 +2278,14 @@ def build_cell_list(
             cell_atom_start_indices,
             cell_atom_list,
             launch_dims=(total_atoms,),
+        )
+
+    if derive_radius:
+        neighbor_search_radius = _derive_neighbor_search_radius(
+            cell,
+            pbc_bool,
+            cutoff,
+            cells_per_dimension,
         )
 
     return (
@@ -3087,10 +3118,14 @@ def cell_list(
         max_total_cells, _, neighbor_search_radius_est = estimate_cell_list_sizes(
             positions, cell, cutoff, pbc
         )
-        if neighbor_search_radius is None:
+        if neighbor_search_radius is None and graph_mode == "warp":
             neighbor_search_radius = neighbor_search_radius_est
-    elif neighbor_search_radius is None:
-        neighbor_search_radius = jnp.ones(3, dtype=jnp.int32)
+    elif graph_mode == "warp" and neighbor_search_radius is None:
+        raise ValueError(
+            "neighbor_search_radius must be provided when graph_mode='warp' "
+            "and max_total_cells is set because the fused query needs concrete "
+            "search metadata before the build result is available."
+        )
 
     if cells_per_dimension is None:
         cells_per_dimension = jnp.ones(3, dtype=jnp.int32)

--- a/test/neighbors/bindings/jax/test_batch_cell_list.py
+++ b/test/neighbors/bindings/jax/test_batch_cell_list.py
@@ -414,6 +414,22 @@ class TestBatchCellListEdgeCases:
 class TestEstimateBatchCellListSizes:
     """Tests for batch cell-list capacity strategies and metadata."""
 
+    def test_construct_rejects_capacity_smaller_than_system_count(self):
+        """Construction rejects capacities that cannot assign one cell per system."""
+        cell = jnp.broadcast_to(jnp.eye(3, dtype=jnp.float32), (2, 3, 3))
+        pbc = jnp.ones((2, 3), dtype=jnp.bool_)
+
+        with pytest.raises(
+            ValueError,
+            match="max_total_cells must be at least num_systems",
+        ):
+            batch_cell_list_module._construct_batch_cells_per_dimension(
+                cell,
+                pbc,
+                cutoff=1.0,
+                max_total_cells=1,
+            )
+
     @staticmethod
     def _assert_metadata_matches_build(
         positions,

--- a/test/neighbors/bindings/jax/test_batch_cell_list.py
+++ b/test/neighbors/bindings/jax/test_batch_cell_list.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import importlib
 from itertools import product
 
 import jax
@@ -28,12 +29,17 @@ from nvalchemiops.jax.neighbors.batch_cell_list import (
     batch_build_cell_list,
     batch_cell_list,
     batch_query_cell_list,
+    estimate_batch_cell_list_sizes,
 )
 from nvalchemiops.jax.neighbors.batch_naive import batch_naive_neighbor_list
 
 from .conftest import requires_gpu
 
 pytestmark = requires_gpu
+
+batch_cell_list_module = importlib.import_module(
+    "nvalchemiops.jax.neighbors.batch_cell_list"
+)
 
 
 def _compact_pair_shift_set(neighbor_matrix, num_neighbors, shifts, targets):
@@ -403,6 +409,315 @@ class TestBatchCellListEdgeCases:
 
         np.testing.assert_array_equal(np.asarray(result[0]), [[1, 1, 1]])
         np.testing.assert_array_equal(np.asarray(result[6]), [[0, 0, 0]])
+
+
+class TestEstimateBatchCellListSizes:
+    """Tests for batch cell-list capacity strategies and metadata."""
+
+    @staticmethod
+    def _assert_metadata_matches_build(
+        positions,
+        cell,
+        pbc,
+        batch_idx,
+        batch_ptr,
+        cutoff,
+        *,
+        capacity_strategy="volume",
+    ):
+        """Assert estimator metadata equals the build for its capacity."""
+        max_total_cells, cells_per_dimension, neighbor_search_radius = (
+            estimate_batch_cell_list_sizes(
+                positions,
+                batch_ptr=batch_ptr,
+                batch_idx=batch_idx,
+                cell=cell,
+                cutoff=cutoff,
+                pbc=pbc,
+                capacity_strategy=capacity_strategy,
+            )
+        )
+        build_result = batch_build_cell_list(
+            positions,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            cell=cell,
+            cutoff=cutoff,
+            pbc=pbc,
+            max_total_cells=max_total_cells,
+        )
+
+        np.testing.assert_array_equal(
+            np.asarray(cells_per_dimension),
+            np.asarray(build_result[0]),
+        )
+        np.testing.assert_array_equal(
+            np.asarray(neighbor_search_radius),
+            np.asarray(build_result[6]),
+        )
+        return max_total_cells, cells_per_dimension, neighbor_search_radius
+
+    def test_volume_default_preserves_capacity_and_matches_build(self):
+        """Default and explicit volume sizing match the constructed grid."""
+        positions = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
+        cell = jnp.diag(jnp.array([3.9, 10.9, 10.9], dtype=jnp.float32)).reshape(
+            1, 3, 3
+        )
+        pbc = jnp.ones((1, 3), dtype=jnp.bool_)
+        batch_idx = jnp.zeros((1,), dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 1], dtype=jnp.int32)
+
+        default_result = self._assert_metadata_matches_build(
+            positions,
+            cell,
+            pbc,
+            batch_idx,
+            batch_ptr,
+            cutoff=1.0,
+        )
+        volume_result = self._assert_metadata_matches_build(
+            positions,
+            cell,
+            pbc,
+            batch_idx,
+            batch_ptr,
+            cutoff=1.0,
+            capacity_strategy="volume",
+        )
+
+        assert default_result[0] == volume_result[0] == 695
+        np.testing.assert_array_equal(default_result[1], [[6, 10, 10]])
+        np.testing.assert_array_equal(default_result[2], [[2, 1, 1]])
+
+    def test_geometry_retains_promoted_grid(self):
+        """Geometry capacity preserves the promoted periodic identity grid."""
+        positions = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
+        cell = jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3)
+        pbc = jnp.ones((1, 3), dtype=jnp.bool_)
+        batch_idx = jnp.zeros((1,), dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 1], dtype=jnp.int32)
+
+        volume_result = self._assert_metadata_matches_build(
+            positions,
+            cell,
+            pbc,
+            batch_idx,
+            batch_ptr,
+            cutoff=1.0,
+            capacity_strategy="volume",
+        )
+        geometry_result = self._assert_metadata_matches_build(
+            positions,
+            cell,
+            pbc,
+            batch_idx,
+            batch_ptr,
+            cutoff=1.0,
+            capacity_strategy="geometry",
+        )
+
+        assert volume_result[0] == 8
+        np.testing.assert_array_equal(volume_result[1], [[2, 2, 2]])
+        np.testing.assert_array_equal(volume_result[2], [[2, 2, 2]])
+        assert geometry_result[0] == 96
+        np.testing.assert_array_equal(geometry_result[1], [[4, 4, 4]])
+        np.testing.assert_array_equal(geometry_result[2], [[4, 4, 4]])
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    @pytest.mark.parametrize("capacity_strategy", ["volume", "geometry"])
+    def test_metadata_matches_build_mixed_geometry(self, dtype, capacity_strategy):
+        """Both strategies match builds for mixed anisotropic cells."""
+        positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.5, 0.2, 0.1],
+                [0.1, 0.3, 0.2],
+                [0.6, 0.4, 0.7],
+            ],
+            dtype=dtype,
+        )
+        cell = jnp.array(
+            [
+                [[3.9, 0.0, 0.0], [0.0, 10.9, 0.0], [0.0, 0.0, 10.9]],
+                [[6.0, 0.2, 0.1], [0.4, 7.0, 0.3], [0.2, 0.5, 8.0]],
+            ],
+            dtype=dtype,
+        )
+        pbc = jnp.array([[True, True, True], [True, False, True]])
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 2, 4], dtype=jnp.int32)
+
+        self._assert_metadata_matches_build(
+            positions,
+            cell,
+            pbc,
+            batch_idx,
+            batch_ptr,
+            cutoff=1.0,
+            capacity_strategy=capacity_strategy,
+        )
+
+    def test_volume_halve_to_fit_radius(self):
+        """Volume sizing derives radius after adaptive promotion and halving."""
+        positions = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
+        cell = (jnp.eye(3, dtype=jnp.float32) * 12.42).reshape(1, 3, 3)
+        pbc = jnp.ones((1, 3), dtype=jnp.bool_)
+        batch_idx = jnp.zeros((1,), dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 1], dtype=jnp.int32)
+
+        result = self._assert_metadata_matches_build(
+            positions,
+            cell,
+            pbc,
+            batch_idx,
+            batch_ptr,
+            cutoff=21.2,
+        )
+
+        assert result[0] == 8
+        np.testing.assert_array_equal(result[1], [[2, 2, 2]])
+        np.testing.assert_array_equal(result[2], [[4, 4, 4]])
+
+    @pytest.mark.parametrize("capacity_strategy", ["volume", "geometry"])
+    def test_empty_batch_has_minimum_capacity(self, capacity_strategy):
+        """Empty systems reserve one constructible cell per system."""
+        positions = jnp.zeros((0, 3), dtype=jnp.float32)
+        cell = jnp.broadcast_to(jnp.eye(3, dtype=jnp.float32), (2, 3, 3))
+        pbc = jnp.ones((2, 3), dtype=jnp.bool_)
+        batch_idx = jnp.zeros((0,), dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 0, 0], dtype=jnp.int32)
+
+        result = estimate_batch_cell_list_sizes(
+            positions,
+            batch_ptr=batch_ptr,
+            batch_idx=batch_idx,
+            cutoff=1.0,
+            cell=cell,
+            pbc=pbc,
+            capacity_strategy=capacity_strategy,
+        )
+
+        assert result[0] == 2
+        np.testing.assert_array_equal(result[1], [[1, 1, 1], [1, 1, 1]])
+        np.testing.assert_array_equal(result[2], [[1, 1, 1], [1, 1, 1]])
+
+    @pytest.mark.parametrize("capacity_strategy", ["volume", "geometry"])
+    def test_mixed_empty_batch_metadata_matches_build(self, capacity_strategy):
+        """Empty systems participate safely in mixed-batch construction."""
+        positions = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
+        cell = jnp.broadcast_to(jnp.eye(3, dtype=jnp.float32), (2, 3, 3))
+        pbc = jnp.ones((2, 3), dtype=jnp.bool_)
+        batch_idx = jnp.array([1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 0, 1], dtype=jnp.int32)
+
+        result = self._assert_metadata_matches_build(
+            positions,
+            cell,
+            pbc,
+            batch_idx,
+            batch_ptr,
+            cutoff=1.0,
+            capacity_strategy=capacity_strategy,
+        )
+
+        assert result[0] >= 2
+
+    @pytest.mark.parametrize(
+        ("capacity_strategy", "expected_capacity"),
+        [("volume", 8), ("geometry", 128)],
+    )
+    def test_buffer_factor_scales_capacity(
+        self,
+        capacity_strategy,
+        expected_capacity,
+    ):
+        """Both capacity policies apply the requested buffer factor."""
+        positions = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
+        cell = jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3)
+        pbc = jnp.ones((1, 3), dtype=jnp.bool_)
+        batch_idx = jnp.zeros((1,), dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 1], dtype=jnp.int32)
+
+        max_total_cells, cells_per_dimension, neighbor_search_radius = (
+            estimate_batch_cell_list_sizes(
+                positions,
+                batch_ptr=batch_ptr,
+                batch_idx=batch_idx,
+                cell=cell,
+                cutoff=1.0,
+                pbc=pbc,
+                buffer_factor=2.0,
+                capacity_strategy=capacity_strategy,
+            )
+        )
+        build_result = batch_build_cell_list(
+            positions,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            cell=cell,
+            pbc=pbc,
+            cutoff=1.0,
+            max_total_cells=max_total_cells,
+        )
+
+        assert max_total_cells == expected_capacity
+        np.testing.assert_array_equal(
+            np.asarray(cells_per_dimension),
+            np.asarray(build_result[0]),
+        )
+        np.testing.assert_array_equal(
+            np.asarray(neighbor_search_radius),
+            np.asarray(build_result[6]),
+        )
+
+    def test_invalid_capacity_strategy(self):
+        """Unknown capacity strategies raise a clear error."""
+        positions = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
+        cell = jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3)
+        pbc = jnp.ones((1, 3), dtype=jnp.bool_)
+        batch_idx = jnp.zeros((1,), dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 1], dtype=jnp.int32)
+
+        with pytest.raises(
+            ValueError,
+            match="capacity_strategy must be 'volume' or 'geometry'",
+        ):
+            estimate_batch_cell_list_sizes(
+                positions,
+                batch_ptr=batch_ptr,
+                batch_idx=batch_idx,
+                cell=cell,
+                cutoff=1.0,
+                pbc=pbc,
+                capacity_strategy="invalid",
+            )
+
+    def test_auto_build_construct_dispatches_once(self, monkeypatch):
+        """Automatic builds launch construct once after capacity sizing."""
+        calls = 0
+        original = batch_cell_list_module._construct_batch_cells_per_dimension
+
+        def counted_construct(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(
+            batch_cell_list_module,
+            "_construct_batch_cells_per_dimension",
+            counted_construct,
+        )
+        positions = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
+        batch_build_cell_list(
+            positions,
+            batch_idx=jnp.zeros((1,), dtype=jnp.int32),
+            batch_ptr=jnp.array([0, 1], dtype=jnp.int32),
+            cell=jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3),
+            pbc=jnp.ones((1, 3), dtype=jnp.bool_),
+            cutoff=1.0,
+        )
+
+        assert calls == 1
 
 
 class TestBatchCellListJIT:

--- a/test/neighbors/bindings/jax/test_batch_cell_list.py
+++ b/test/neighbors/bindings/jax/test_batch_cell_list.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from itertools import product
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -27,10 +29,27 @@ from nvalchemiops.jax.neighbors.batch_cell_list import (
     batch_cell_list,
     batch_query_cell_list,
 )
+from nvalchemiops.jax.neighbors.batch_naive import batch_naive_neighbor_list
 
 from .conftest import requires_gpu
 
 pytestmark = requires_gpu
+
+
+def _compact_pair_shift_set(neighbor_matrix, num_neighbors, shifts, targets):
+    nm = np.asarray(neighbor_matrix)
+    nn = np.asarray(num_neighbors)
+    nms = np.asarray(shifts)
+    target_values = np.asarray(targets)
+    return {
+        (
+            int(target_values[row]),
+            int(nm[row, slot]),
+            *(int(value) for value in nms[row, slot]),
+        )
+        for row in range(nm.shape[0])
+        for slot in range(int(nn[row]))
+    }
 
 
 class TestBatchCellList:
@@ -361,9 +380,107 @@ class TestBatchCellListEdgeCases:
         if int(jnp.sum(nn)) > 0:
             assert jnp.all(shifts == 0)
 
+    def test_static_max_nonperiodic_single_cell_has_zero_radius(self):
+        """Non-periodic single-cell grids should use zero search radius."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3)
+        pbc = jnp.array([[False, False, False]])
+        batch_idx = jnp.zeros((2,), dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 2], dtype=jnp.int32)
+
+        result = batch_build_cell_list(
+            positions,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            cell=cell,
+            pbc=pbc,
+            cutoff=2.0,
+            max_total_cells=1,
+        )
+
+        np.testing.assert_array_equal(np.asarray(result[0]), [[1, 1, 1]])
+        np.testing.assert_array_equal(np.asarray(result[6]), [[0, 0, 0]])
+
 
 class TestBatchCellListJIT:
     """Smoke tests for batch_cell_list compatibility with jax.jit."""
+
+    def test_jit_static_max_derives_search_radius(self):
+        """Static max_total_cells should derive search radius from realized bins."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3)
+        pbc = jnp.array([[True, True, True]])
+        batch_idx = jnp.zeros((2,), dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 2], dtype=jnp.int32)
+
+        @jax.jit
+        def jitted_build(positions, cell, pbc, batch_idx, batch_ptr):
+            return batch_build_cell_list(
+                positions,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                cell=cell,
+                pbc=pbc,
+                cutoff=0.3,
+                max_total_cells=216,
+            )
+
+        result = jitted_build(positions, cell, pbc, batch_idx, batch_ptr)
+
+        np.testing.assert_array_equal(np.asarray(result[0]), [[6, 6, 6]])
+        np.testing.assert_array_equal(np.asarray(result[6]), [[2, 2, 2]])
+
+    def test_jit_static_max_target_indices_matches_naive_all_pbc_masks(self):
+        """Compact target_indices should match naive pairs for every PBC mask."""
+        rng = np.random.default_rng(128)
+        positions_np = rng.uniform(0.0, 1.0, (128, 3)).astype(np.float32)
+        positions = jnp.asarray(positions_np)
+        cell = jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3)
+        batch_idx = jnp.zeros((128,), dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 128], dtype=jnp.int32)
+        targets = jnp.arange(0, 128, 2, dtype=jnp.int32)
+
+        @jax.jit
+        def jitted_cell_list(positions, cell, pbc, batch_idx, batch_ptr, targets):
+            return batch_cell_list(
+                positions,
+                cutoff=0.3,
+                cell=cell,
+                pbc=pbc,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                max_neighbors=128,
+                max_total_cells=216,
+                target_indices=targets,
+                strategy="atom_centric",
+            )
+
+        for mask in product((False, True), repeat=3):
+            pbc = jnp.array([list(mask)], dtype=jnp.bool_)
+            nm, nn, shifts = jitted_cell_list(
+                positions, cell, pbc, batch_idx, batch_ptr, targets
+            )
+            naive_nm, naive_nn, naive_shifts = batch_naive_neighbor_list(
+                positions,
+                cutoff=0.3,
+                cell=cell,
+                pbc=pbc,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                max_neighbors=128,
+                target_indices=targets,
+            )
+            cell_set = _compact_pair_shift_set(nm, nn, shifts, targets)
+            naive_set = _compact_pair_shift_set(
+                naive_nm, naive_nn, naive_shifts, targets
+            )
+            assert cell_set == naive_set, f"PBC mask {mask} mismatch"
 
     def test_jit_with_pbc_requires_precomputed_sizing(self):
         """The traced sizing path should fail before allocating JAX buffers."""

--- a/test/neighbors/bindings/jax/test_batch_cell_list.py
+++ b/test/neighbors/bindings/jax/test_batch_cell_list.py
@@ -523,6 +523,128 @@ class TestEstimateBatchCellListSizes:
         np.testing.assert_array_equal(geometry_result[1], [[4, 4, 4]])
         np.testing.assert_array_equal(geometry_result[2], [[4, 4, 4]])
 
+    def test_geometry_retains_each_nonempty_promoted_grid(self):
+        """Geometry sizing gives every non-empty system its promoted grid."""
+        positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.5, 0.0, 0.0],
+                [0.1, 0.0, 0.0],
+                [0.6, 0.0, 0.0],
+            ],
+            dtype=jnp.float32,
+        )
+        cell = jnp.array(
+            [
+                [[3.9, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 5.0]],
+                [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            ],
+            dtype=jnp.float32,
+        )
+        pbc = jnp.array([[True, False, True], [False, False, False]])
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 2, 4], dtype=jnp.int32)
+
+        max_total_cells, cells_per_dimension, neighbor_search_radius = (
+            estimate_batch_cell_list_sizes(
+                positions,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                cell=cell,
+                cutoff=1.0,
+                pbc=pbc,
+                capacity_strategy="geometry",
+            )
+        )
+
+        assert max_total_cells == 90
+        np.testing.assert_array_equal(
+            np.asarray(cells_per_dimension),
+            [[6, 1, 5], [1, 1, 1]],
+        )
+        np.testing.assert_array_equal(
+            np.asarray(neighbor_search_radius),
+            [[2, 0, 1], [0, 0, 0]],
+        )
+
+        cell_cache = batch_build_cell_list(
+            positions,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            cell=cell,
+            cutoff=1.0,
+            pbc=pbc,
+            max_total_cells=max_total_cells,
+        )
+        neighbor_matrix, num_neighbors, shifts = batch_query_cell_list(
+            positions,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            cell=cell,
+            cutoff=1.0,
+            pbc=pbc,
+            cells_per_dimension=cell_cache[0],
+            atom_periodic_shifts=cell_cache[1],
+            atom_to_cell_mapping=cell_cache[2],
+            atoms_per_cell_count=cell_cache[3],
+            cell_atom_start_indices=cell_cache[4],
+            cell_atom_list=cell_cache[5],
+            neighbor_search_radius=cell_cache[6],
+            max_neighbors=4,
+            strategy="atom_centric",
+        )
+        naive_matrix, naive_num_neighbors, naive_shifts = batch_naive_neighbor_list(
+            positions,
+            cutoff=1.0,
+            cell=cell,
+            pbc=pbc,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=4,
+        )
+        targets = jnp.arange(positions.shape[0], dtype=jnp.int32)
+        assert _compact_pair_shift_set(
+            neighbor_matrix,
+            num_neighbors,
+            shifts,
+            targets,
+        ) == _compact_pair_shift_set(
+            naive_matrix,
+            naive_num_neighbors,
+            naive_shifts,
+            targets,
+        )
+
+    def test_geometry_ignores_empty_system_geometry_for_capacity(self):
+        """Geometry sizing does not let an empty system increase capacity."""
+        positions = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
+        cell = jnp.array(
+            [
+                [[100.0, 0.0, 0.0], [0.0, 100.0, 0.0], [0.0, 0.0, 100.0]],
+                [[3.9, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 5.0]],
+            ],
+            dtype=jnp.float32,
+        )
+        pbc = jnp.array([[True, True, True], [True, False, True]])
+        batch_idx = jnp.array([1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 0, 1], dtype=jnp.int32)
+
+        max_total_cells, cells_per_dimension, neighbor_search_radius = (
+            estimate_batch_cell_list_sizes(
+                positions,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                cell=cell,
+                cutoff=1.0,
+                pbc=pbc,
+                capacity_strategy="geometry",
+            )
+        )
+
+        assert max_total_cells == 90
+        np.testing.assert_array_equal(cells_per_dimension[1], [6, 1, 5])
+        np.testing.assert_array_equal(neighbor_search_radius[1], [2, 0, 1])
+
     @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
     @pytest.mark.parametrize("capacity_strategy", ["volume", "geometry"])
     def test_metadata_matches_build_mixed_geometry(self, dtype, capacity_strategy):

--- a/test/neighbors/bindings/jax/test_cell_list.py
+++ b/test/neighbors/bindings/jax/test_cell_list.py
@@ -28,10 +28,26 @@ from nvalchemiops.jax.neighbors.cell_list import (
     estimate_cell_list_sizes,
     query_cell_list,
 )
+from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
 
 from .conftest import requires_gpu, requires_vesin
 
 pytestmark = requires_gpu
+
+
+def _pair_shift_set(neighbor_matrix, num_neighbors, shifts):
+    nm = np.asarray(neighbor_matrix)
+    nn = np.asarray(num_neighbors)
+    nms = np.asarray(shifts)
+    return {
+        (
+            row,
+            int(nm[row, slot]),
+            *(int(value) for value in nms[row, slot]),
+        )
+        for row in range(nm.shape[0])
+        for slot in range(int(nn[row]))
+    }
 
 
 class TestCellList:
@@ -472,6 +488,140 @@ class TestEstimateCellListSizes:
                 f"got {int(neighbor_search_radius[i])}"
             )
 
+    def test_build_static_max_derives_search_radius(self):
+        """Static max_total_cells should derive search radius from realized bins."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3)
+        pbc = jnp.array([[True, True, True]])
+
+        @jax.jit
+        def jitted_build(positions, cell, pbc):
+            return build_cell_list(
+                positions,
+                cutoff=0.3,
+                cell=cell,
+                pbc=pbc,
+                max_total_cells=216,
+            )
+
+        result = jitted_build(positions, cell, pbc)
+
+        np.testing.assert_array_equal(np.asarray(result[0]), [6, 6, 6])
+        np.testing.assert_array_equal(np.asarray(result[6]), [2, 2, 2])
+
+    def test_cell_list_static_max_matches_naive(self):
+        """Cell list with static sizing should match naive neighbor pairs."""
+        rng = np.random.default_rng(128)
+        positions_np = rng.uniform(0.0, 1.0, (128, 3)).astype(np.float32)
+        positions = jnp.asarray(positions_np)
+        cell = jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3)
+        pbc = jnp.array([[False, False, False]])
+
+        nm, nn, shifts = cell_list(
+            positions,
+            cutoff=0.3,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=128,
+            max_total_cells=216,
+            strategy="atom_centric",
+        )
+        naive_nm, naive_nn, naive_shifts = naive_neighbor_list(
+            positions,
+            cutoff=0.3,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=128,
+        )
+
+        assert _pair_shift_set(nm, nn, shifts) == _pair_shift_set(
+            naive_nm, naive_nn, naive_shifts
+        )
+
+    def test_estimate_adaptive_promotion_doubles_three_to_six(self):
+        """A natural 3-cell PBC axis must promote to 6, not stop at 4."""
+        positions = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
+        cell = jnp.diag(jnp.array([3.9, 10.9, 10.9], dtype=jnp.float32)).reshape(
+            1, 3, 3
+        )
+        pbc = jnp.array([[True, True, True]])
+
+        _, cells_per_dimension, neighbor_search_radius = estimate_cell_list_sizes(
+            positions,
+            cell,
+            cutoff=1.0,
+            pbc=pbc,
+        )
+
+        np.testing.assert_array_equal(np.asarray(cells_per_dimension), [6, 10, 10])
+        np.testing.assert_array_equal(np.asarray(neighbor_search_radius), [2, 1, 1])
+
+    def test_auto_sized_derives_radius_after_construct(self):
+        """Auto-sized builds must derive radius from realized bins, not estimate."""
+        positions = jnp.array([[0.0, 0.0, 0.0], [0.67, 0.0, 0.0]], dtype=jnp.float32)
+        cell = jnp.diag(jnp.array([3.9, 10.9, 10.9], dtype=jnp.float32)).reshape(
+            1, 3, 3
+        )
+        pbc = jnp.array([[True, True, True]])
+
+        build_result = build_cell_list(
+            positions,
+            cutoff=1.0,
+            cell=cell,
+            pbc=pbc,
+        )
+        np.testing.assert_array_equal(np.asarray(build_result[0]), [6, 10, 10])
+        np.testing.assert_array_equal(np.asarray(build_result[6]), [2, 1, 1])
+
+        nm, nn, shifts = cell_list(
+            positions,
+            cutoff=1.0,
+            cell=cell,
+            pbc=pbc,
+            strategy="atom_centric",
+        )
+        naive_nm, naive_nn, naive_shifts = naive_neighbor_list(
+            positions,
+            cutoff=1.0,
+            cell=cell,
+            pbc=pbc,
+        )
+
+        assert _pair_shift_set(nm, nn, shifts) == _pair_shift_set(
+            naive_nm, naive_nn, naive_shifts
+        )
+
+    def test_auto_sized_warp_graph_matches_default(self):
+        """Fused warp graph must use estimator radius aligned with construct."""
+        positions = jnp.array([[0.0, 0.0, 0.0], [0.67, 0.0, 0.0]], dtype=jnp.float32)
+        cell = jnp.diag(jnp.array([3.9, 10.9, 10.9], dtype=jnp.float32)).reshape(
+            1, 3, 3
+        )
+        pbc = jnp.array([[True, True, True]])
+
+        warp_nm, warp_nn, warp_shifts = cell_list(
+            positions,
+            cutoff=1.0,
+            cell=cell,
+            pbc=pbc,
+            graph_mode="warp",
+            strategy="atom_centric",
+        )
+        default_nm, default_nn, default_shifts = cell_list(
+            positions,
+            cutoff=1.0,
+            cell=cell,
+            pbc=pbc,
+            strategy="atom_centric",
+        )
+
+        assert _pair_shift_set(warp_nm, warp_nn, warp_shifts) == _pair_shift_set(
+            default_nm, default_nn, default_shifts
+        )
+
 
 def _vesin_brute_force(positions_np, cell_np, pbc_np, cutoff):
     """Compute reference neighbor list using vesin.
@@ -850,6 +1000,28 @@ class TestCellListAtomCentricDirect:
 
 class TestCellListGraphMode:
     """Graph-mode coverage for JAX cell-list bindings."""
+
+    def test_top_level_static_max_requires_explicit_radius(self):
+        """Fused warp graph mode needs explicit radius with static capacity."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3)
+        pbc = jnp.array([[True, True, True]])
+
+        with pytest.raises(
+            ValueError,
+            match="neighbor_search_radius must be provided",
+        ):
+            cell_list(
+                positions,
+                cutoff=0.3,
+                cell=cell,
+                pbc=pbc,
+                max_total_cells=216,
+                graph_mode="warp",
+            )
 
     @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
     def test_build_matches_default(self, dtype):

--- a/test/neighbors/bindings/jax/test_cell_list.py
+++ b/test/neighbors/bindings/jax/test_cell_list.py
@@ -542,22 +542,70 @@ class TestEstimateCellListSizes:
         )
 
     def test_estimate_adaptive_promotion_doubles_three_to_six(self):
-        """A natural 3-cell PBC axis must promote to 6, not stop at 4."""
+        """JAX estimates and Warp construction promote a natural three to six."""
         positions = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
         cell = jnp.diag(jnp.array([3.9, 10.9, 10.9], dtype=jnp.float32)).reshape(
             1, 3, 3
         )
         pbc = jnp.array([[True, True, True]])
 
-        _, cells_per_dimension, neighbor_search_radius = estimate_cell_list_sizes(
+        max_total_cells, cells_per_dimension, neighbor_search_radius = (
+            estimate_cell_list_sizes(
+                positions,
+                cell,
+                cutoff=1.0,
+                pbc=pbc,
+            )
+        )
+
+        build_result = build_cell_list(
             positions,
-            cell,
             cutoff=1.0,
+            cell=cell,
             pbc=pbc,
+            max_total_cells=max_total_cells,
         )
 
         np.testing.assert_array_equal(np.asarray(cells_per_dimension), [6, 10, 10])
         np.testing.assert_array_equal(np.asarray(neighbor_search_radius), [2, 1, 1])
+        np.testing.assert_array_equal(
+            np.asarray(build_result[0]),
+            cells_per_dimension,
+        )
+        np.testing.assert_array_equal(
+            np.asarray(build_result[6]),
+            neighbor_search_radius,
+        )
+
+    def test_search_radius_float32_nextafter_integer_boundary(self):
+        """Float32 radius increments immediately above an exact integer ratio."""
+        positions = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
+        cell = jnp.eye(3, dtype=jnp.float32).reshape(1, 3, 3)
+        pbc = jnp.array([[True, True, True]])
+        cutoffs = (
+            jnp.float32(0.5),
+            jnp.nextafter(jnp.float32(0.5), jnp.float32(jnp.inf)),
+        )
+
+        exact_result = build_cell_list(
+            positions,
+            cutoff=cutoffs[0],
+            cell=cell,
+            pbc=pbc,
+            max_total_cells=64,
+        )
+        above_result = build_cell_list(
+            positions,
+            cutoff=cutoffs[1],
+            cell=cell,
+            pbc=pbc,
+            max_total_cells=64,
+        )
+
+        np.testing.assert_array_equal(np.asarray(exact_result[0]), [4, 4, 4])
+        np.testing.assert_array_equal(np.asarray(above_result[0]), [4, 4, 4])
+        np.testing.assert_array_equal(np.asarray(exact_result[6]), [2, 2, 2])
+        np.testing.assert_array_equal(np.asarray(above_result[6]), [3, 3, 3])
 
     def test_auto_sized_derives_radius_after_construct(self):
         """Auto-sized builds must derive radius from realized bins, not estimate."""


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Fix JAX cell-list neighbor queries so automatically determined search radii are derived from the realized cell grid instead of placeholder or pre-build values. Align JAX adaptive cell promotion with the Warp build kernels, provide exact batched estimator metadata for selected capacity policies, and reject fused Warp graph calls that cannot determine search metadata before querying.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes https://github.com/NVIDIA/nvalchemi-toolkit-ops/issues/128.

## Changes Made

- Add a shared JAX helper that derives per-axis neighbor search radii from cell face distances, realized cell counts, cutoff, and PBC flags.
- Recompute automatic radii after single-system and batched cell-list construction while preserving explicit caller-provided radii.
- Match Warp's repeated-doubling adaptive promotion and require an explicit radius for fused Warp graph queries with static cell capacity.
- Keep volume capacity as the default while adding opt-in geometry capacity for the JAX batch estimator; estimator grids and radii now match construction for the returned capacity.
- Reserve one constructible cell per empty batch system and avoid a duplicate construct launch in automatic builds.
- Add JIT, static-capacity, adaptive-promotion, compact-target, PBC-mask, naive-parity, and fused-graph regression coverage.
- Add capacity-strategy coverage for exact grid/radius values, estimator/build parity across dtypes and cell shapes, invalid strategies, empty batches, and automatic-build construct dispatch.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

- JAX single-system and batched cell-list suites: 115 passed and 8 optional `vesin` skips.
- Targeted Torch batch cell-list estimator regressions: 8 passed and 4 slow compile cases skipped.
- Full `make pytest`: 2,412 tests passed and 437 skipped before collection stopped because optional `torchpme` was unavailable for the Torch Ewald tests.
- `make lint`: passed.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

The fused Warp graph path requires an explicit `neighbor_search_radius` when `max_total_cells` is supplied because the query launch needs concrete search metadata before build output is available.

The batch estimator defaults to volume capacity. Use `capacity_strategy="geometry"` to estimate from promoted per-axis grid geometry, then pass the returned capacity to `batch_build_cell_list`.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
