### PR TITLE
refactor(neighbors): centralize JAX registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Consolidated JAX neighbor-list registration internals behind private,
+  schema-aware lazy registries. Naive, cell-list, and cluster-tile bindings
+  preserve their existing output ABI, graph-capture behavior, and framework
+  gradient paths while avoiding eager dtype-wrapper registration at import.
+
 ## 0.4.0 - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 - Improved JAX neighbor-list import performance by deferring dtype-specific
   direct naive and cell-list Warp wrapper registration until first use.
-  Centralized and cached private cluster-tile callback and graph-preload
-  schemas and validation while preserving the public output ABI, graph-capture
-  behavior, and framework gradient paths.
+  Cluster-tile graph callbacks now use bundled callback/preload registrations
+  with lazy direct kernels for naive and cell-list paths. Public behavior is
+  unchanged.
 
 ## 0.4.0 - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## Unreleased
 
-### Fixed
+### Changed (neighbors)
 
-- Consolidated JAX neighbor-list registration internals behind private,
-  schema-aware lazy registries. Naive, cell-list, and cluster-tile bindings
-  preserve their existing output ABI, graph-capture behavior, and framework
-  gradient paths while avoiding eager dtype-wrapper registration at import.
+- Improved JAX neighbor-list import performance by deferring dtype-specific
+  direct naive and cell-list Warp wrapper registration until first use.
+  Centralized and cached private cluster-tile callback and graph-preload
+  schemas and validation while preserving the public output ABI, graph-capture
+  behavior, and framework gradient paths.
 
 ## 0.4.0 - 2026-07-13
 

--- a/nvalchemiops/jax/neighbors/_cluster_tile_preload.py
+++ b/nvalchemiops/jax/neighbors/_cluster_tile_preload.py
@@ -25,6 +25,7 @@ import warp as wp
 from nvalchemiops.jax.neighbors._registration import (
     _ClusterTileBuildJaxSpec,
     _ClusterTileQueryJaxSpec,
+    _validate_cluster_tile_build_spec,
     _validate_cluster_tile_query_spec,
 )
 from nvalchemiops.neighbors.cluster_tile.kernels import (
@@ -66,13 +67,17 @@ def _preload_cluster_tile_build_module(device_alias: str) -> None:
     """Register every build variant, then load their shared module once."""
     kernels = [
         _get_build_cluster_tiles_kernel(
-            **_ClusterTileBuildJaxSpec(False, False, selective).__dict__,
+            batched=False,
+            segmented=False,
+            selective=selective,
         )
         for selective in (False, True)
     ]
     kernels.extend(
         _get_build_cluster_tiles_kernel(
-            **_ClusterTileBuildJaxSpec(True, segmented, selective).__dict__,
+            batched=True,
+            segmented=segmented,
+            selective=selective,
         )
         for segmented, selective in (
             (False, False),
@@ -94,10 +99,7 @@ def _preload_cluster_tile_build_kernel(
     spec: _ClusterTileBuildJaxSpec,
 ) -> None:
     """Construct and load a cluster-tile build specialization."""
-    if (not spec.batched and spec.segmented) or (
-        spec.batched and spec.selective and not spec.segmented
-    ):
-        raise ValueError("invalid cluster-tile build specialization")
+    _validate_cluster_tile_build_spec(spec)
     _preload_cluster_tile_build_module(_current_warp_device_alias())
 
 

--- a/nvalchemiops/jax/neighbors/_cluster_tile_preload.py
+++ b/nvalchemiops/jax/neighbors/_cluster_tile_preload.py
@@ -18,16 +18,11 @@
 from __future__ import annotations
 
 import functools
+from typing import Any
 
 import jax
 import warp as wp
 
-from nvalchemiops.jax.neighbors._registration import (
-    _ClusterTileBuildJaxSpec,
-    _ClusterTileQueryJaxSpec,
-    _validate_cluster_tile_build_spec,
-    _validate_cluster_tile_query_spec,
-)
 from nvalchemiops.neighbors.cluster_tile.kernels import (
     TILE_GROUP_SIZE,
     _get_build_cluster_tiles_kernel,
@@ -43,11 +38,48 @@ __all__ = []
 
 
 def _current_warp_device_alias() -> str:
-    """Return the Warp alias for the device selected by JAX."""
+    """Return the Warp alias for JAX's configured default device."""
     jax_device = jax.config.jax_default_device
     if jax_device is None:
         jax_device = jax.local_devices()[0]
     return str(wp.device_from_jax(jax_device))
+
+
+def _warp_device_aliases(device_source: Any | None = None) -> tuple[str, ...]:
+    """Return Warp aliases for the device(s) selected by a JAX array.
+
+    Parameters
+    ----------
+    device_source : Any or None, optional
+        Eager or traced JAX value that identifies the intended execution
+        device. When unavailable, local accelerator devices are used.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Warp device aliases requiring kernel-module preload.
+
+    During eager execution, the source array identifies the exact device
+    whose modules must be loaded before graph capture. A traced value does
+    not expose device placement, so preload every local accelerator to cover
+    the eventual compiled execution device (or all local devices when no
+    accelerator is available).
+    """
+    if device_source is None:
+        return (_current_warp_device_alias(),)
+    try:
+        jax_devices = tuple(device_source.devices())
+    except (AttributeError, jax.errors.ConcretizationTypeError):
+        jax_devices = ()
+    if not jax_devices:
+        local_devices = tuple(jax.local_devices())
+        accelerators = tuple(
+            device
+            for device in local_devices
+            if device.platform in {"gpu", "cuda", "rocm"}
+        )
+        jax_devices = accelerators or local_devices
+    return tuple(str(wp.device_from_jax(device)) for device in jax_devices)
 
 
 def _load_kernel_modules(device, *kernels: wp.Kernel) -> None:
@@ -60,6 +92,91 @@ def _load_kernel_modules(device, *kernels: wp.Kernel) -> None:
             continue
         kernel.module.load(device, block_dim=TILE_GROUP_SIZE)
         loaded_modules.add(module_id)
+
+
+def _validate_cluster_tile_build_options(
+    *,
+    batched: bool,
+    segmented: bool,
+    selective: bool,
+) -> None:
+    """Reject unsupported cluster-tile build preload combinations.
+
+    Parameters
+    ----------
+    batched, segmented, selective : bool
+        Static build-kernel specialization options.
+
+    Raises
+    ------
+    ValueError
+        If the requested combination has no supported build kernel.
+    """
+    if not batched and segmented:
+        raise ValueError("Single-system cluster-tile builds cannot be segmented.")
+    if batched and selective and not segmented:
+        raise ValueError(
+            "Selective batched cluster-tile builds must be segmented.",
+        )
+
+
+def _validate_cluster_tile_matrix_options(
+    *,
+    batched: bool,
+    tile_segmented: bool,
+    selective: bool,
+    dual_cutoff: bool,
+    geometry: bool,
+    pair_fn: Any | None,
+) -> None:
+    """Reject unsupported cluster-tile matrix preload combinations.
+
+    Parameters
+    ----------
+    batched, tile_segmented, selective, dual_cutoff, geometry : bool
+        Static matrix-query specialization options.
+    pair_fn : Any or None
+        Optional pair callback used by the query specialization.
+
+    Raises
+    ------
+    ValueError
+        If the requested combination has no supported matrix-query kernel.
+    """
+    if not batched and tile_segmented:
+        raise ValueError("Single-system cluster-tile queries cannot tile-segment.")
+    if (geometry or pair_fn is not None) and (dual_cutoff or selective):
+        raise ValueError(
+            "Cluster-tile geometry and pair_fn require non-dual, non-selective "
+            "matrix queries.",
+        )
+
+
+def _validate_cluster_tile_coo_options(
+    *,
+    batched: bool,
+    tile_segmented: bool,
+    coo_segmented: bool,
+    selective: bool,
+) -> None:
+    """Reject unsupported cluster-tile COO preload combinations.
+
+    Parameters
+    ----------
+    batched, tile_segmented, coo_segmented, selective : bool
+        Static COO-query specialization options.
+
+    Raises
+    ------
+    ValueError
+        If the requested combination has no supported COO-query kernel.
+    """
+    if not batched and tile_segmented:
+        raise ValueError("Single-system cluster-tile queries cannot tile-segment.")
+    if coo_segmented and not selective:
+        raise ValueError("Segmented COO requires selective cluster-tile queries.")
+    if selective and not coo_segmented:
+        raise ValueError("Selective COO requires segmented COO output.")
 
 
 @functools.cache
@@ -95,47 +212,42 @@ def _preload_cluster_tile_build_module(device_alias: str) -> None:
     _load_kernel_modules(device, *kernels)
 
 
-def _preload_cluster_tile_build_kernel(
-    spec: _ClusterTileBuildJaxSpec,
-) -> None:
-    """Construct and load a cluster-tile build specialization."""
-    _validate_cluster_tile_build_spec(spec)
-    _preload_cluster_tile_build_module(_current_warp_device_alias())
+def _preload_cluster_tile_build_kernel(*, device_source: Any | None = None) -> None:
+    """Construct and load all cluster-tile build specializations.
 
-
-def _validate_cluster_tile_query_preload_spec(
-    spec: _ClusterTileQueryJaxSpec,
-    *,
-    output_format: str,
-) -> None:
-    """Validate a query preload spec for its concrete output format."""
-    _validate_cluster_tile_query_spec(spec)
-    if spec.output_format != output_format:
-        raise ValueError(
-            f"Cluster-tile {output_format} preload requires "
-            f"output_format={output_format!r}.",
-        )
+    Parameters
+    ----------
+    device_source : Any or None, optional
+        JAX value used to select devices for the preload.
+    """
+    for device_alias in _warp_device_aliases(device_source):
+        _preload_cluster_tile_build_module(device_alias)
 
 
 @functools.cache
 def _preload_cluster_tile_query_kernel_cached(
     device_alias: str,
-    spec: _ClusterTileQueryJaxSpec,
+    *,
+    batched: bool,
+    tile_segmented: bool,
+    selective: bool,
+    dual_cutoff: bool,
+    geometry: bool,
+    pair_fn: Any | None,
 ) -> None:
     """Load one matrix-query specialization once per device."""
-    _validate_cluster_tile_query_preload_spec(spec, output_format="matrix")
     getter = (
         get_batch_query_cluster_tile_kernel
-        if spec.batched
+        if batched
         else get_query_cluster_tile_kernel
     )
     kernel = getter(
-        tile_segmented=spec.tile_segmented,
-        selective=spec.selective,
-        dual_cutoff=spec.dual_cutoff,
-        return_vectors=spec.return_vectors,
-        return_distances=spec.return_distances,
-        pair_fn=spec.pair_fn,
+        tile_segmented=tile_segmented,
+        selective=selective,
+        dual_cutoff=dual_cutoff,
+        return_vectors=geometry,
+        return_distances=geometry,
+        pair_fn=pair_fn,
     )
     device = wp.get_device(device_alias)
     empty_sentinel(1, wp.int32, device)
@@ -148,34 +260,67 @@ def _preload_cluster_tile_query_kernel_cached(
 
 
 def _preload_cluster_tile_query_kernel(
-    spec: _ClusterTileQueryJaxSpec,
+    *,
+    batched: bool,
+    tile_segmented: bool = False,
+    selective: bool = False,
+    dual_cutoff: bool = False,
+    geometry: bool = False,
+    pair_fn: Any | None = None,
+    device_source: Any | None = None,
 ) -> None:
-    """Construct and load a cluster-tile matrix-query specialization."""
-    _validate_cluster_tile_query_preload_spec(spec, output_format="matrix")
-    _preload_cluster_tile_query_kernel_cached(
-        _current_warp_device_alias(),
-        spec,
+    """Construct and load a cluster-tile matrix-query specialization.
+
+    Parameters
+    ----------
+    batched, tile_segmented, selective, dual_cutoff, geometry : bool
+        Static matrix-query specialization options.
+    pair_fn : Any or None, optional
+        Pair callback used by the query specialization.
+    device_source : Any or None, optional
+        JAX value used to select devices for the preload.
+    """
+    _validate_cluster_tile_matrix_options(
+        batched=batched,
+        tile_segmented=tile_segmented,
+        selective=selective,
+        dual_cutoff=dual_cutoff,
+        geometry=geometry,
+        pair_fn=pair_fn,
     )
+    for device_alias in _warp_device_aliases(device_source):
+        _preload_cluster_tile_query_kernel_cached(
+            device_alias,
+            batched=batched,
+            tile_segmented=tile_segmented,
+            selective=selective,
+            dual_cutoff=dual_cutoff,
+            geometry=geometry,
+            pair_fn=pair_fn,
+        )
 
 
 @functools.cache
 def _preload_cluster_tile_coo_kernel_cached(
     device_alias: str,
-    spec: _ClusterTileQueryJaxSpec,
+    *,
+    batched: bool,
+    tile_segmented: bool,
+    coo_segmented: bool,
+    selective: bool,
 ) -> None:
     """Load one COO-query specialization once per device."""
-    _validate_cluster_tile_query_preload_spec(spec, output_format="coo")
-    if spec.coo_segmented:
+    if coo_segmented:
         _preload_cluster_tile_build_module(device_alias)
     getter = (
         get_batch_query_cluster_tile_coo_kernel
-        if spec.batched
+        if batched
         else get_query_cluster_tile_coo_kernel
     )
     kernel = getter(
-        tile_segmented=spec.tile_segmented,
-        coo_segmented=spec.coo_segmented,
-        selective=spec.selective,
+        tile_segmented=tile_segmented,
+        coo_segmented=coo_segmented,
+        selective=selective,
     )
     device = wp.get_device(device_alias)
     empty_sentinel(1, wp.int32, device)
@@ -187,11 +332,33 @@ def _preload_cluster_tile_coo_kernel_cached(
 
 
 def _preload_cluster_tile_coo_kernel(
-    spec: _ClusterTileQueryJaxSpec,
+    *,
+    batched: bool,
+    tile_segmented: bool = False,
+    coo_segmented: bool = False,
+    selective: bool = False,
+    device_source: Any | None = None,
 ) -> None:
-    """Construct and load a topology-only cluster-tile COO specialization."""
-    _validate_cluster_tile_query_preload_spec(spec, output_format="coo")
-    _preload_cluster_tile_coo_kernel_cached(
-        _current_warp_device_alias(),
-        spec,
+    """Construct and load a topology-only cluster-tile COO specialization.
+
+    Parameters
+    ----------
+    batched, tile_segmented, coo_segmented, selective : bool
+        Static COO-query specialization options.
+    device_source : Any or None, optional
+        JAX value used to select devices for the preload.
+    """
+    _validate_cluster_tile_coo_options(
+        batched=batched,
+        tile_segmented=tile_segmented,
+        coo_segmented=coo_segmented,
+        selective=selective,
     )
+    for device_alias in _warp_device_aliases(device_source):
+        _preload_cluster_tile_coo_kernel_cached(
+            device_alias,
+            batched=batched,
+            tile_segmented=tile_segmented,
+            coo_segmented=coo_segmented,
+            selective=selective,
+        )

--- a/nvalchemiops/jax/neighbors/_cluster_tile_preload.py
+++ b/nvalchemiops/jax/neighbors/_cluster_tile_preload.py
@@ -22,6 +22,11 @@ import functools
 import jax
 import warp as wp
 
+from nvalchemiops.jax.neighbors._registration import (
+    _ClusterTileBuildJaxSpec,
+    _ClusterTileQueryJaxSpec,
+    _validate_cluster_tile_query_spec,
+)
 from nvalchemiops.neighbors.cluster_tile.kernels import (
     TILE_GROUP_SIZE,
     _get_build_cluster_tiles_kernel,
@@ -61,17 +66,13 @@ def _preload_cluster_tile_build_module(device_alias: str) -> None:
     """Register every build variant, then load their shared module once."""
     kernels = [
         _get_build_cluster_tiles_kernel(
-            batched=False,
-            segmented=False,
-            selective=selective,
+            **_ClusterTileBuildJaxSpec(False, False, selective).__dict__,
         )
         for selective in (False, True)
     ]
     kernels.extend(
         _get_build_cluster_tiles_kernel(
-            batched=True,
-            segmented=segmented,
-            selective=selective,
+            **_ClusterTileBuildJaxSpec(True, segmented, selective).__dict__,
         )
         for segmented, selective in (
             (False, False),
@@ -90,39 +91,49 @@ def _preload_cluster_tile_build_module(device_alias: str) -> None:
 
 
 def _preload_cluster_tile_build_kernel(
-    *, batched: bool, segmented: bool, selective: bool
+    spec: _ClusterTileBuildJaxSpec,
 ) -> None:
     """Construct and load a cluster-tile build specialization."""
-    if (not batched and segmented) or (batched and selective and not segmented):
+    if (not spec.batched and spec.segmented) or (
+        spec.batched and spec.selective and not spec.segmented
+    ):
         raise ValueError("invalid cluster-tile build specialization")
     _preload_cluster_tile_build_module(_current_warp_device_alias())
+
+
+def _validate_cluster_tile_query_preload_spec(
+    spec: _ClusterTileQueryJaxSpec,
+    *,
+    output_format: str,
+) -> None:
+    """Validate a query preload spec for its concrete output format."""
+    _validate_cluster_tile_query_spec(spec)
+    if spec.output_format != output_format:
+        raise ValueError(
+            f"Cluster-tile {output_format} preload requires "
+            f"output_format={output_format!r}.",
+        )
 
 
 @functools.cache
 def _preload_cluster_tile_query_kernel_cached(
     device_alias: str,
-    *,
-    batched: bool,
-    tile_segmented: bool,
-    selective: bool,
-    dual_cutoff: bool,
-    return_vectors: bool,
-    return_distances: bool,
-    pair_fn: wp.Function | None,
+    spec: _ClusterTileQueryJaxSpec,
 ) -> None:
     """Load one matrix-query specialization once per device."""
+    _validate_cluster_tile_query_preload_spec(spec, output_format="matrix")
     getter = (
         get_batch_query_cluster_tile_kernel
-        if batched
+        if spec.batched
         else get_query_cluster_tile_kernel
     )
     kernel = getter(
-        tile_segmented=tile_segmented,
-        selective=selective,
-        dual_cutoff=dual_cutoff,
-        return_vectors=return_vectors,
-        return_distances=return_distances,
-        pair_fn=pair_fn,
+        tile_segmented=spec.tile_segmented,
+        selective=spec.selective,
+        dual_cutoff=spec.dual_cutoff,
+        return_vectors=spec.return_vectors,
+        return_distances=spec.return_distances,
+        pair_fn=spec.pair_fn,
     )
     device = wp.get_device(device_alias)
     empty_sentinel(1, wp.int32, device)
@@ -135,49 +146,34 @@ def _preload_cluster_tile_query_kernel_cached(
 
 
 def _preload_cluster_tile_query_kernel(
-    *,
-    batched: bool,
-    tile_segmented: bool,
-    selective: bool,
-    dual_cutoff: bool,
-    return_vectors: bool,
-    return_distances: bool,
-    pair_fn: wp.Function | None,
+    spec: _ClusterTileQueryJaxSpec,
 ) -> None:
     """Construct and load a cluster-tile matrix-query specialization."""
+    _validate_cluster_tile_query_preload_spec(spec, output_format="matrix")
     _preload_cluster_tile_query_kernel_cached(
         _current_warp_device_alias(),
-        batched=batched,
-        tile_segmented=tile_segmented,
-        selective=selective,
-        dual_cutoff=dual_cutoff,
-        return_vectors=return_vectors,
-        return_distances=return_distances,
-        pair_fn=pair_fn,
+        spec,
     )
 
 
 @functools.cache
 def _preload_cluster_tile_coo_kernel_cached(
     device_alias: str,
-    *,
-    batched: bool,
-    tile_segmented: bool,
-    coo_segmented: bool,
-    selective: bool,
+    spec: _ClusterTileQueryJaxSpec,
 ) -> None:
     """Load one COO-query specialization once per device."""
-    if coo_segmented:
+    _validate_cluster_tile_query_preload_spec(spec, output_format="coo")
+    if spec.coo_segmented:
         _preload_cluster_tile_build_module(device_alias)
     getter = (
         get_batch_query_cluster_tile_coo_kernel
-        if batched
+        if spec.batched
         else get_query_cluster_tile_coo_kernel
     )
     kernel = getter(
-        tile_segmented=tile_segmented,
-        coo_segmented=coo_segmented,
-        selective=selective,
+        tile_segmented=spec.tile_segmented,
+        coo_segmented=spec.coo_segmented,
+        selective=spec.selective,
     )
     device = wp.get_device(device_alias)
     empty_sentinel(1, wp.int32, device)
@@ -189,17 +185,11 @@ def _preload_cluster_tile_coo_kernel_cached(
 
 
 def _preload_cluster_tile_coo_kernel(
-    *,
-    batched: bool,
-    tile_segmented: bool,
-    coo_segmented: bool,
-    selective: bool,
+    spec: _ClusterTileQueryJaxSpec,
 ) -> None:
     """Construct and load a topology-only cluster-tile COO specialization."""
+    _validate_cluster_tile_query_preload_spec(spec, output_format="coo")
     _preload_cluster_tile_coo_kernel_cached(
         _current_warp_device_alias(),
-        batched=batched,
-        tile_segmented=tile_segmented,
-        coo_segmented=coo_segmented,
-        selective=selective,
+        spec,
     )

--- a/nvalchemiops/jax/neighbors/_registration.py
+++ b/nvalchemiops/jax/neighbors/_registration.py
@@ -1,0 +1,521 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common registration helpers for JAX neighbor bindings."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import jax.numpy as jnp
+import warp as wp
+from warp.jax_experimental import GraphMode, jax_callable, jax_kernel
+
+from nvalchemiops.neighbors.cell_list import (
+    get_build_cell_list_kernel,
+    get_cell_list_cells_per_system_kernel,
+    get_cell_list_gather_kernel,
+    get_query_cell_list_kernel,
+)
+from nvalchemiops.neighbors.naive import (
+    get_naive_neighbor_matrix_dual_cutoff_kernel,
+    get_naive_neighbor_matrix_kernel,
+)
+from nvalchemiops.neighbors.neighbor_utils import (
+    get_gather_positions_and_shifts_kernel,
+)
+
+__all__: list[str] = []
+
+_SINGLE_NO_PBC_OUTPUTS = ("neighbor_matrix1", "num_neighbors1")
+_SINGLE_PBC_OUTPUTS = (
+    "neighbor_matrix1",
+    "neighbor_matrix_shifts1",
+    "num_neighbors1",
+)
+_DUAL_NO_PBC_OUTPUTS = (
+    "neighbor_matrix1",
+    "num_neighbors1",
+    "neighbor_matrix2",
+    "num_neighbors2",
+)
+_DUAL_PBC_OUTPUTS = (
+    "neighbor_matrix1",
+    "neighbor_matrix_shifts1",
+    "num_neighbors1",
+    "neighbor_matrix2",
+    "neighbor_matrix_shifts2",
+    "num_neighbors2",
+)
+
+
+@dataclass(frozen=True)
+class _JaxOutputSchema:
+    """Describe the ordered in-place outputs of a JAX Warp registration."""
+
+    in_out_argnames: tuple[str, ...]
+
+    @property
+    def num_outputs(self) -> int:
+        """Return the number of in-place outputs."""
+        return len(self.in_out_argnames)
+
+
+@dataclass(frozen=True)
+class _NaiveJaxKernelSpec:
+    """Describe one supported direct naive JAX kernel registration."""
+
+    operation: Literal["single_cutoff", "dual_cutoff"]
+    wp_dtype: type
+    batched: bool
+    pbc_mode: Literal["none", "wrap_on_entry", "prewrapped"]
+    selective: bool
+    partial: bool
+    half_fill: bool
+    return_vectors: bool
+    return_distances: bool
+    pair_fn: Any | None
+
+
+@dataclass(frozen=True)
+class _CellListBuildJaxSpec:
+    """Describe one supported direct cell-list build JAX registration."""
+
+    stage: Literal[
+        "construct_bin_size",
+        "count_atoms",
+        "bin_atoms",
+        "gather",
+        "cells_per_system",
+    ]
+    wp_dtype: type
+    batched: bool
+
+
+@dataclass(frozen=True)
+class _CellListQueryJaxSpec:
+    """Describe one supported direct cell-list query JAX registration."""
+
+    wp_dtype: type
+    batched: bool
+    selective: bool
+    partial: bool
+    half_fill: bool
+    return_vectors: bool
+    return_distances: bool
+    pair_fn: Any | None
+    atom_centric_path: Literal["sorted", "direct"]
+
+
+@dataclass(frozen=True)
+class _ClusterTileBuildJaxSpec:
+    """Describe one supported cluster-tile build callback registration."""
+
+    batched: bool
+    segmented: bool
+    selective: bool
+
+
+@dataclass(frozen=True)
+class _ClusterTileQueryJaxSpec:
+    """Describe one supported cluster-tile query callback registration."""
+
+    batched: bool
+    output_format: Literal["matrix", "coo"]
+    tile_segmented: bool
+    coo_segmented: bool
+    selective: bool
+    dual_cutoff: bool
+    return_vectors: bool
+    return_distances: bool
+    pair_fn: Any | None
+
+
+def _register_jax_kernel(kernel: Any, output_schema: _JaxOutputSchema) -> Any:
+    """Register a Warp kernel using a shared output schema."""
+    return jax_kernel(
+        kernel,
+        num_outputs=output_schema.num_outputs,
+        in_out_argnames=list(output_schema.in_out_argnames),
+        enable_backward=False,
+    )
+
+
+def _register_jax_callable(
+    callable_obj: Callable[..., Any],
+    output_schema: _JaxOutputSchema,
+    *,
+    graph_mode: GraphMode,
+) -> Any:
+    """Register a Warp callable using a shared output schema."""
+    return jax_callable(
+        callable_obj,
+        num_outputs=output_schema.num_outputs,
+        in_out_argnames=list(output_schema.in_out_argnames),
+        graph_mode=graph_mode,
+    )
+
+
+def _validate_spec(spec: _NaiveJaxKernelSpec) -> None:
+    """Reject unsupported direct naive JAX registration combinations."""
+    if spec.operation not in {"single_cutoff", "dual_cutoff"}:
+        raise ValueError(f"Unsupported naive operation: {spec.operation!r}.")
+    if spec.wp_dtype not in {wp.float32, wp.float64}:
+        raise ValueError(f"Unsupported naive Warp dtype: {spec.wp_dtype!r}.")
+    if spec.pbc_mode not in {"none", "wrap_on_entry", "prewrapped"}:
+        raise ValueError(f"Unsupported naive PBC mode: {spec.pbc_mode!r}.")
+    if spec.return_vectors != spec.return_distances:
+        raise ValueError(
+            "Direct naive registrations require return_vectors and "
+            "return_distances together.",
+        )
+    if spec.pair_fn is not None and not spec.return_vectors:
+        raise ValueError("pair_fn requires direct pair-geometry outputs.")
+    if spec.partial and (
+        spec.operation != "single_cutoff" or not spec.return_vectors or spec.selective
+    ):
+        raise ValueError(
+            "partial direct registrations require single-cutoff non-selective "
+            "pair geometry.",
+        )
+    if spec.operation == "dual_cutoff" and (
+        spec.return_vectors
+        or spec.pair_fn is not None
+        or spec.partial
+        or spec.half_fill
+    ):
+        raise ValueError(
+            "Dual-cutoff direct registrations do not support geometry, pair_fn, "
+            "partial rows, or half_fill.",
+        )
+
+
+def _output_schema(spec: _NaiveJaxKernelSpec) -> _JaxOutputSchema:
+    """Return the ordered direct JAX output schema for ``spec``."""
+    if spec.operation == "dual_cutoff":
+        outputs = _DUAL_NO_PBC_OUTPUTS if spec.pbc_mode == "none" else _DUAL_PBC_OUTPUTS
+    else:
+        outputs = (
+            _SINGLE_NO_PBC_OUTPUTS if spec.pbc_mode == "none" else _SINGLE_PBC_OUTPUTS
+        )
+        if spec.return_vectors:
+            outputs += ("neighbor_vectors", "neighbor_distances")
+        if spec.pair_fn is not None:
+            outputs += ("pair_energies", "pair_forces")
+    return _JaxOutputSchema(outputs)
+
+
+def _validate_cell_list_build_spec(spec: _CellListBuildJaxSpec) -> None:
+    """Reject unsupported direct cell-list build registrations."""
+    if spec.wp_dtype not in {wp.float32, wp.float64}:
+        raise ValueError(f"Unsupported cell-list Warp dtype: {spec.wp_dtype!r}.")
+    if spec.stage not in {
+        "construct_bin_size",
+        "count_atoms",
+        "bin_atoms",
+        "gather",
+        "cells_per_system",
+    }:
+        raise ValueError(f"Unsupported cell-list build stage: {spec.stage!r}.")
+    if spec.stage == "cells_per_system" and not spec.batched:
+        raise ValueError("cells_per_system is only registered for batch cell lists.")
+
+
+def _cell_list_build_output_schema(spec: _CellListBuildJaxSpec) -> _JaxOutputSchema:
+    """Return the ordered in-place output schema for a build stage."""
+    if spec.stage == "construct_bin_size":
+        return _JaxOutputSchema(
+            (
+                "cells_per_dimension_batch"
+                if spec.batched
+                else "cells_per_dimension_single",
+            ),
+        )
+    if spec.stage == "count_atoms":
+        return _JaxOutputSchema(("atoms_per_cell_count", "atom_periodic_shifts"))
+    if spec.stage == "bin_atoms":
+        return _JaxOutputSchema(
+            ("atom_to_cell_mapping", "atoms_per_cell_count", "cell_atom_list"),
+        )
+    if spec.stage == "gather":
+        return _JaxOutputSchema(
+            ("sorted_positions", "sorted_shifts")
+            if spec.batched
+            else ("dst_pos", "dst_shifts"),
+        )
+    return _JaxOutputSchema(("cells_per_system",))
+
+
+@functools.cache
+def _get_cell_list_build_jax_kernel(spec: _CellListBuildJaxSpec) -> Any:
+    """Return a cached direct JAX registration for a cell-list build stage."""
+    _validate_cell_list_build_spec(spec)
+    if spec.stage == "cells_per_system":
+        kernel = get_cell_list_cells_per_system_kernel()
+    elif spec.stage == "gather":
+        kernel = (
+            get_cell_list_gather_kernel(spec.wp_dtype)
+            if spec.batched
+            else get_gather_positions_and_shifts_kernel(spec.wp_dtype)
+        )
+    else:
+        kernel = get_build_cell_list_kernel(
+            spec.stage,
+            spec.wp_dtype,
+            batched=spec.batched,
+        )
+    return _register_jax_kernel(kernel, _cell_list_build_output_schema(spec))
+
+
+def _validate_cell_list_query_spec(spec: _CellListQueryJaxSpec) -> None:
+    """Reject unsupported direct cell-list query registrations."""
+    if spec.wp_dtype not in {wp.float32, wp.float64}:
+        raise ValueError(f"Unsupported cell-list Warp dtype: {spec.wp_dtype!r}.")
+    if spec.atom_centric_path not in {"sorted", "direct"}:
+        raise ValueError(
+            f"Unsupported atom-centric cell-list path: {spec.atom_centric_path!r}.",
+        )
+    if spec.batched and spec.atom_centric_path == "direct":
+        raise ValueError("The direct atom-centric path is only available unbatched.")
+    if spec.return_vectors != spec.return_distances:
+        raise ValueError(
+            "Direct cell-list registrations require return_vectors and "
+            "return_distances together.",
+        )
+    if spec.pair_fn is not None and not spec.return_vectors:
+        raise ValueError("pair_fn requires direct pair-geometry outputs.")
+
+
+def _cell_list_query_output_schema(spec: _CellListQueryJaxSpec) -> _JaxOutputSchema:
+    """Return the ordered in-place output schema for a query stage."""
+    outputs = (
+        "neighbor_matrix",
+        "neighbor_matrix_shifts",
+        "num_neighbors",
+    )
+    if spec.return_vectors:
+        outputs += ("neighbor_vectors", "neighbor_distances")
+    if spec.pair_fn is not None:
+        outputs += ("pair_energies", "pair_forces")
+    return _JaxOutputSchema(outputs)
+
+
+@functools.cache
+def _get_cell_list_query_jax_kernel(spec: _CellListQueryJaxSpec) -> Any:
+    """Return a cached direct JAX registration for a cell-list query."""
+    _validate_cell_list_query_spec(spec)
+    kernel = get_query_cell_list_kernel(
+        spec.wp_dtype,
+        strategy="atom_centric",
+        batched=spec.batched,
+        selective=spec.selective,
+        partial=spec.partial,
+        half_fill=spec.half_fill,
+        return_vectors=spec.return_vectors,
+        return_distances=spec.return_distances,
+        pair_fn=spec.pair_fn,
+        atom_centric_path=spec.atom_centric_path,
+    )
+    return _register_jax_kernel(kernel, _cell_list_query_output_schema(spec))
+
+
+@functools.cache
+def _get_naive_jax_kernel(spec: _NaiveJaxKernelSpec) -> Any:
+    """Return a cached direct JAX registration for a supported naive spec."""
+    _validate_spec(spec)
+    if spec.operation == "dual_cutoff":
+        kernel = get_naive_neighbor_matrix_dual_cutoff_kernel(
+            spec.wp_dtype,
+            pbc_mode=spec.pbc_mode,
+            batched=spec.batched,
+            selective=spec.selective,
+        )
+    else:
+        kernel = get_naive_neighbor_matrix_kernel(
+            spec.wp_dtype,
+            pbc_mode=spec.pbc_mode,
+            batched=spec.batched,
+            selective=spec.selective,
+            partial=spec.partial,
+            half_fill=spec.half_fill,
+            return_vectors=spec.return_vectors,
+            return_distances=spec.return_distances,
+            pair_fn=spec.pair_fn,
+        )
+    return _register_jax_kernel(kernel, _output_schema(spec))
+
+
+def _validate_cluster_tile_build_spec(spec: _ClusterTileBuildJaxSpec) -> None:
+    """Reject unsupported cluster-tile build callback combinations."""
+    if not spec.batched and spec.segmented:
+        raise ValueError("Single-system cluster-tile builds cannot be segmented.")
+    if spec.batched and spec.selective and not spec.segmented:
+        raise ValueError(
+            "Selective batched cluster-tile builds must be segmented.",
+        )
+
+
+def _cluster_tile_build_output_schema(
+    spec: _ClusterTileBuildJaxSpec,
+) -> _JaxOutputSchema:
+    """Return the ordered in-place ABI for a cluster-tile build callback."""
+    outputs = (
+        "group_ctr_x",
+        "group_ctr_y",
+        "group_ctr_z",
+        "group_ext_x",
+        "group_ext_y",
+        "group_ext_z",
+        "num_tiles",
+    )
+    if spec.batched and spec.selective:
+        outputs += ("tile_counts",)
+    outputs += ("tile_row_group", "tile_col_group")
+    if spec.batched:
+        outputs += ("tile_system",)
+    return _JaxOutputSchema(outputs)
+
+
+@functools.cache
+def _get_cluster_tile_build_jax_callable(
+    spec: _ClusterTileBuildJaxSpec,
+    callback: Callable[..., Any],
+) -> Any:
+    """Return a cached WARP graph callback for a cluster-tile build."""
+    _validate_cluster_tile_build_spec(spec)
+    return _register_jax_callable(
+        callback,
+        _cluster_tile_build_output_schema(spec),
+        graph_mode=GraphMode.WARP,
+    )
+
+
+def _validate_cluster_tile_query_spec(spec: _ClusterTileQueryJaxSpec) -> None:
+    """Reject unsupported cluster-tile query callback combinations."""
+    if spec.output_format not in {"matrix", "coo"}:
+        raise ValueError(
+            f"Unsupported cluster-tile output format: {spec.output_format!r}."
+        )
+    if not spec.batched and spec.tile_segmented:
+        raise ValueError("Single-system cluster-tile queries cannot tile-segment.")
+    if spec.tile_segmented and not spec.batched:
+        raise ValueError("Cluster-tile tile segmentation is only batched.")
+    if spec.output_format == "matrix":
+        if spec.coo_segmented:
+            raise ValueError("Matrix cluster-tile queries cannot use COO segments.")
+        if spec.return_vectors != spec.return_distances:
+            raise ValueError(
+                "Cluster-tile geometry requires vectors and distances together.",
+            )
+        if (spec.return_vectors or spec.pair_fn is not None) and (
+            spec.dual_cutoff or spec.selective
+        ):
+            raise ValueError(
+                "Cluster-tile geometry and pair_fn require non-dual, non-selective "
+                "matrix queries.",
+            )
+        return
+    if (
+        spec.dual_cutoff
+        or spec.return_vectors
+        or spec.return_distances
+        or spec.pair_fn is not None
+    ):
+        raise ValueError("COO cluster-tile callbacks support topology output only.")
+    if spec.coo_segmented and not spec.selective:
+        raise ValueError(
+            "Segmented COO requires selective cluster-tile queries.",
+        )
+    if spec.selective and not spec.coo_segmented:
+        raise ValueError("Selective COO requires segmented COO output.")
+
+
+def _cluster_tile_query_output_schema(
+    spec: _ClusterTileQueryJaxSpec,
+) -> _JaxOutputSchema:
+    """Return the ordered in-place ABI for a cluster-tile query callback."""
+    if spec.output_format == "coo":
+        outputs = ("pair_counter",)
+        if spec.coo_segmented:
+            outputs += ("pair_counts",)
+        return _JaxOutputSchema(outputs + ("coo_list", "coo_shifts"))
+
+    outputs = ("neighbor_matrix", "num_neighbors", "neighbor_matrix_shifts")
+    if spec.dual_cutoff:
+        outputs += (
+            "neighbor_matrix2",
+            "num_neighbors2",
+            "neighbor_matrix_shifts2",
+        )
+    if spec.return_vectors:
+        outputs += ("neighbor_vectors", "neighbor_distances")
+    if spec.pair_fn is not None:
+        outputs += ("pair_energies", "pair_forces")
+    return _JaxOutputSchema(outputs)
+
+
+@functools.cache
+def _get_cluster_tile_query_jax_callable(
+    spec: _ClusterTileQueryJaxSpec,
+    callback: Callable[..., Any],
+) -> Any:
+    """Return a cached WARP graph callback for a cluster-tile query."""
+    _validate_cluster_tile_query_spec(spec)
+    return _register_jax_callable(
+        callback,
+        _cluster_tile_query_output_schema(spec),
+        graph_mode=GraphMode.WARP,
+    )
+
+
+class _LazyDtypeRegistrations:
+    """Lazily construct JAX wrappers for declared JAX-to-Warp dtype mappings."""
+
+    def __init__(
+        self,
+        factory: Callable[[Any], Any],
+        dtype_map: Mapping[object, Any],
+        *,
+        cache_key: Callable[[Any], object] | None = None,
+    ) -> None:
+        self._factory = factory
+        self._dtype_map = {
+            jnp.dtype(jax_dtype): wp_dtype for jax_dtype, wp_dtype in dtype_map.items()
+        }
+        self._cache_key = cache_key or (lambda wp_dtype: wp_dtype)
+        self._cache: dict[object, Any] = {}
+
+    def __contains__(self, jax_dtype: object) -> bool:
+        """Return whether a dtype has a supported Warp registration."""
+        try:
+            return jnp.dtype(jax_dtype) in self._dtype_map
+        except (TypeError, ValueError):
+            return False
+
+    def __getitem__(self, jax_dtype: object) -> Any:
+        """Return the lazily registered wrapper for a supported JAX dtype."""
+        try:
+            normalized_dtype = jnp.dtype(jax_dtype)
+        except (TypeError, ValueError) as error:
+            raise KeyError(jax_dtype) from error
+
+        wp_dtype = self._dtype_map[normalized_dtype]
+        cache_key = self._cache_key(wp_dtype)
+        if cache_key not in self._cache:
+            self._cache[cache_key] = self._factory(wp_dtype)
+        return self._cache[cache_key]

--- a/nvalchemiops/jax/neighbors/_registration.py
+++ b/nvalchemiops/jax/neighbors/_registration.py
@@ -107,7 +107,7 @@ class _CellListBuildJaxSpec:
     batched: bool
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _CellListQueryJaxSpec:
     """Describe one supported direct cell-list query JAX registration."""
 
@@ -131,7 +131,7 @@ class _ClusterTileBuildJaxSpec:
     selective: bool
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _ClusterTileQueryJaxSpec:
     """Describe one supported cluster-tile query callback registration."""
 

--- a/nvalchemiops/jax/neighbors/_registration.py
+++ b/nvalchemiops/jax/neighbors/_registration.py
@@ -413,8 +413,6 @@ def _validate_cluster_tile_query_spec(spec: _ClusterTileQueryJaxSpec) -> None:
         )
     if not spec.batched and spec.tile_segmented:
         raise ValueError("Single-system cluster-tile queries cannot tile-segment.")
-    if spec.tile_segmented and not spec.batched:
-        raise ValueError("Cluster-tile tile segmentation is only batched.")
     if spec.output_format == "matrix":
         if spec.coo_segmented:
             raise ValueError("Matrix cluster-tile queries cannot use COO segments.")

--- a/nvalchemiops/jax/neighbors/_registration.py
+++ b/nvalchemiops/jax/neighbors/_registration.py
@@ -26,6 +26,14 @@ import jax.numpy as jnp
 import warp as wp
 from warp.jax_experimental import GraphMode, jax_callable, jax_kernel
 
+from nvalchemiops.jax.neighbors._cluster_tile_preload import (
+    _preload_cluster_tile_build_kernel,
+    _preload_cluster_tile_coo_kernel,
+    _preload_cluster_tile_query_kernel,
+    _validate_cluster_tile_build_options,
+    _validate_cluster_tile_coo_options,
+    _validate_cluster_tile_matrix_options,
+)
 from nvalchemiops.neighbors.cell_list import (
     get_build_cell_list_kernel,
     get_cell_list_cells_per_system_kernel,
@@ -41,6 +49,12 @@ from nvalchemiops.neighbors.neighbor_utils import (
 )
 
 __all__: list[str] = []
+
+_Outputs = tuple[str, ...]
+
+_NAIVE_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
+_CELL_LIST_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
+_CELLS_PER_SYSTEM_CACHE_KEY = "cells_per_system"
 
 _SINGLE_NO_PBC_OUTPUTS = ("neighbor_matrix1", "num_neighbors1")
 _SINGLE_PBC_OUTPUTS = (
@@ -64,317 +78,95 @@ _DUAL_PBC_OUTPUTS = (
 )
 
 
-@dataclass(frozen=True)
-class _JaxOutputSchema:
-    """Describe the ordered in-place outputs of a JAX Warp registration."""
+def _register_jax_kernel(kernel: Any, outputs: _Outputs) -> Any:
+    """Register a Warp kernel using a shared output tuple.
 
-    in_out_argnames: tuple[str, ...]
+    Parameters
+    ----------
+    kernel : Any
+        Warp kernel to expose to JAX.
+    outputs : tuple[str, ...]
+        Ordered names of the kernel's in-place output arguments.
 
-    @property
-    def num_outputs(self) -> int:
-        """Return the number of in-place outputs."""
-        return len(self.in_out_argnames)
-
-
-@dataclass(frozen=True)
-class _NaiveJaxKernelSpec:
-    """Describe one supported direct naive JAX kernel registration."""
-
-    operation: Literal["single_cutoff", "dual_cutoff"]
-    wp_dtype: type
-    batched: bool
-    pbc_mode: Literal["none", "wrap_on_entry", "prewrapped"]
-    selective: bool
-    partial: bool
-    half_fill: bool
-    return_vectors: bool
-    return_distances: bool
-    pair_fn: Any | None
-
-
-@dataclass(frozen=True)
-class _CellListBuildJaxSpec:
-    """Describe one supported direct cell-list build JAX registration."""
-
-    stage: Literal[
-        "construct_bin_size",
-        "count_atoms",
-        "bin_atoms",
-        "gather",
-        "cells_per_system",
-    ]
-    wp_dtype: type
-    batched: bool
-
-
-@dataclass(frozen=True, kw_only=True)
-class _CellListQueryJaxSpec:
-    """Describe one supported direct cell-list query JAX registration."""
-
-    wp_dtype: type
-    batched: bool
-    selective: bool
-    partial: bool
-    half_fill: bool
-    return_vectors: bool
-    return_distances: bool
-    pair_fn: Any | None
-    atom_centric_path: Literal["sorted", "direct"]
-
-
-@dataclass(frozen=True)
-class _ClusterTileBuildJaxSpec:
-    """Describe one supported cluster-tile build callback registration."""
-
-    batched: bool
-    segmented: bool
-    selective: bool
-
-
-@dataclass(frozen=True, kw_only=True)
-class _ClusterTileQueryJaxSpec:
-    """Describe one supported cluster-tile query callback registration."""
-
-    batched: bool
-    output_format: Literal["matrix", "coo"]
-    tile_segmented: bool
-    coo_segmented: bool
-    selective: bool
-    dual_cutoff: bool
-    return_vectors: bool
-    return_distances: bool
-    pair_fn: Any | None
-
-
-def _register_jax_kernel(kernel: Any, output_schema: _JaxOutputSchema) -> Any:
-    """Register a Warp kernel using a shared output schema."""
+    Returns
+    -------
+    Any
+        The registered JAX kernel wrapper.
+    """
     return jax_kernel(
         kernel,
-        num_outputs=output_schema.num_outputs,
-        in_out_argnames=list(output_schema.in_out_argnames),
+        num_outputs=len(outputs),
+        in_out_argnames=list(outputs),
         enable_backward=False,
     )
 
 
 def _register_jax_callable(
     callable_obj: Callable[..., Any],
-    output_schema: _JaxOutputSchema,
+    outputs: _Outputs,
     *,
     graph_mode: GraphMode,
 ) -> Any:
-    """Register a Warp callable using a shared output schema."""
+    """Register a Warp callable using a shared output tuple.
+
+    Parameters
+    ----------
+    callable_obj : Callable[..., Any]
+        Warp callable to expose to JAX.
+    outputs : tuple[str, ...]
+        Ordered names of the callable's in-place output arguments.
+    graph_mode : GraphMode
+        Execution mode used by Warp graph capture.
+
+    Returns
+    -------
+    Any
+        The registered JAX callable wrapper.
+    """
     return jax_callable(
         callable_obj,
-        num_outputs=output_schema.num_outputs,
-        in_out_argnames=list(output_schema.in_out_argnames),
+        num_outputs=len(outputs),
+        in_out_argnames=list(outputs),
         graph_mode=graph_mode,
     )
 
 
-def _validate_spec(spec: _NaiveJaxKernelSpec) -> None:
-    """Reject unsupported direct naive JAX registration combinations."""
-    if spec.operation not in {"single_cutoff", "dual_cutoff"}:
-        raise ValueError(f"Unsupported naive operation: {spec.operation!r}.")
-    if spec.wp_dtype not in {wp.float32, wp.float64}:
-        raise ValueError(f"Unsupported naive Warp dtype: {spec.wp_dtype!r}.")
-    if spec.pbc_mode not in {"none", "wrap_on_entry", "prewrapped"}:
-        raise ValueError(f"Unsupported naive PBC mode: {spec.pbc_mode!r}.")
-    if spec.return_vectors != spec.return_distances:
-        raise ValueError(
-            "Direct naive registrations require return_vectors and "
-            "return_distances together.",
-        )
-    if spec.pair_fn is not None and not spec.return_vectors:
-        raise ValueError("pair_fn requires direct pair-geometry outputs.")
-    if spec.partial and (
-        spec.operation != "single_cutoff" or not spec.return_vectors or spec.selective
-    ):
-        raise ValueError(
-            "partial direct registrations require single-cutoff non-selective "
-            "pair geometry.",
-        )
-    if spec.operation == "dual_cutoff" and (
-        spec.return_vectors
-        or spec.pair_fn is not None
-        or spec.partial
-        or spec.half_fill
-    ):
-        raise ValueError(
-            "Dual-cutoff direct registrations do not support geometry, pair_fn, "
-            "partial rows, or half_fill.",
-        )
+@dataclass(frozen=True)
+class _GraphRegistration:
+    """Bundle one Warp graph callable with its matching preload operation.
+
+    Parameters
+    ----------
+    callable : Any
+        Registered JAX callable for the graph operation.
+    preload : Callable[..., None]
+        Callable that loads the operation's Warp modules before graph capture.
+    """
+
+    callable: Any
+    preload: Callable[..., None]
 
 
-def _output_schema(spec: _NaiveJaxKernelSpec) -> _JaxOutputSchema:
-    """Return the ordered direct JAX output schema for ``spec``."""
-    if spec.operation == "dual_cutoff":
-        outputs = _DUAL_NO_PBC_OUTPUTS if spec.pbc_mode == "none" else _DUAL_PBC_OUTPUTS
-    else:
-        outputs = (
-            _SINGLE_NO_PBC_OUTPUTS if spec.pbc_mode == "none" else _SINGLE_PBC_OUTPUTS
-        )
-        if spec.return_vectors:
-            outputs += ("neighbor_vectors", "neighbor_distances")
-        if spec.pair_fn is not None:
-            outputs += ("pair_energies", "pair_forces")
-    return _JaxOutputSchema(outputs)
+def _cluster_tile_build_outputs(
+    *,
+    batched: bool,
+    selective: bool,
+) -> _Outputs:
+    """Return the ordered in-place ABI for a cluster-tile build callback.
 
+    Parameters
+    ----------
+    batched : bool
+        Whether the callback operates on multiple systems.
+    selective : bool
+        Whether the callback produces per-tile counts.
 
-def _validate_cell_list_build_spec(spec: _CellListBuildJaxSpec) -> None:
-    """Reject unsupported direct cell-list build registrations."""
-    if spec.wp_dtype not in {wp.float32, wp.float64}:
-        raise ValueError(f"Unsupported cell-list Warp dtype: {spec.wp_dtype!r}.")
-    if spec.stage not in {
-        "construct_bin_size",
-        "count_atoms",
-        "bin_atoms",
-        "gather",
-        "cells_per_system",
-    }:
-        raise ValueError(f"Unsupported cell-list build stage: {spec.stage!r}.")
-    if spec.stage == "cells_per_system" and not spec.batched:
-        raise ValueError("cells_per_system is only registered for batch cell lists.")
-
-
-def _cell_list_build_output_schema(spec: _CellListBuildJaxSpec) -> _JaxOutputSchema:
-    """Return the ordered in-place output schema for a build stage."""
-    if spec.stage == "construct_bin_size":
-        return _JaxOutputSchema(
-            (
-                "cells_per_dimension_batch"
-                if spec.batched
-                else "cells_per_dimension_single",
-            ),
-        )
-    if spec.stage == "count_atoms":
-        return _JaxOutputSchema(("atoms_per_cell_count", "atom_periodic_shifts"))
-    if spec.stage == "bin_atoms":
-        return _JaxOutputSchema(
-            ("atom_to_cell_mapping", "atoms_per_cell_count", "cell_atom_list"),
-        )
-    if spec.stage == "gather":
-        return _JaxOutputSchema(
-            ("sorted_positions", "sorted_shifts")
-            if spec.batched
-            else ("dst_pos", "dst_shifts"),
-        )
-    return _JaxOutputSchema(("cells_per_system",))
-
-
-@functools.cache
-def _get_cell_list_build_jax_kernel(spec: _CellListBuildJaxSpec) -> Any:
-    """Return a cached direct JAX registration for a cell-list build stage."""
-    _validate_cell_list_build_spec(spec)
-    if spec.stage == "cells_per_system":
-        kernel = get_cell_list_cells_per_system_kernel()
-    elif spec.stage == "gather":
-        kernel = (
-            get_cell_list_gather_kernel(spec.wp_dtype)
-            if spec.batched
-            else get_gather_positions_and_shifts_kernel(spec.wp_dtype)
-        )
-    else:
-        kernel = get_build_cell_list_kernel(
-            spec.stage,
-            spec.wp_dtype,
-            batched=spec.batched,
-        )
-    return _register_jax_kernel(kernel, _cell_list_build_output_schema(spec))
-
-
-def _validate_cell_list_query_spec(spec: _CellListQueryJaxSpec) -> None:
-    """Reject unsupported direct cell-list query registrations."""
-    if spec.wp_dtype not in {wp.float32, wp.float64}:
-        raise ValueError(f"Unsupported cell-list Warp dtype: {spec.wp_dtype!r}.")
-    if spec.atom_centric_path not in {"sorted", "direct"}:
-        raise ValueError(
-            f"Unsupported atom-centric cell-list path: {spec.atom_centric_path!r}.",
-        )
-    if spec.batched and spec.atom_centric_path == "direct":
-        raise ValueError("The direct atom-centric path is only available unbatched.")
-    if spec.return_vectors != spec.return_distances:
-        raise ValueError(
-            "Direct cell-list registrations require return_vectors and "
-            "return_distances together.",
-        )
-    if spec.pair_fn is not None and not spec.return_vectors:
-        raise ValueError("pair_fn requires direct pair-geometry outputs.")
-
-
-def _cell_list_query_output_schema(spec: _CellListQueryJaxSpec) -> _JaxOutputSchema:
-    """Return the ordered in-place output schema for a query stage."""
-    outputs = (
-        "neighbor_matrix",
-        "neighbor_matrix_shifts",
-        "num_neighbors",
-    )
-    if spec.return_vectors:
-        outputs += ("neighbor_vectors", "neighbor_distances")
-    if spec.pair_fn is not None:
-        outputs += ("pair_energies", "pair_forces")
-    return _JaxOutputSchema(outputs)
-
-
-@functools.cache
-def _get_cell_list_query_jax_kernel(spec: _CellListQueryJaxSpec) -> Any:
-    """Return a cached direct JAX registration for a cell-list query."""
-    _validate_cell_list_query_spec(spec)
-    kernel = get_query_cell_list_kernel(
-        spec.wp_dtype,
-        strategy="atom_centric",
-        batched=spec.batched,
-        selective=spec.selective,
-        partial=spec.partial,
-        half_fill=spec.half_fill,
-        return_vectors=spec.return_vectors,
-        return_distances=spec.return_distances,
-        pair_fn=spec.pair_fn,
-        atom_centric_path=spec.atom_centric_path,
-    )
-    return _register_jax_kernel(kernel, _cell_list_query_output_schema(spec))
-
-
-@functools.cache
-def _get_naive_jax_kernel(spec: _NaiveJaxKernelSpec) -> Any:
-    """Return a cached direct JAX registration for a supported naive spec."""
-    _validate_spec(spec)
-    if spec.operation == "dual_cutoff":
-        kernel = get_naive_neighbor_matrix_dual_cutoff_kernel(
-            spec.wp_dtype,
-            pbc_mode=spec.pbc_mode,
-            batched=spec.batched,
-            selective=spec.selective,
-        )
-    else:
-        kernel = get_naive_neighbor_matrix_kernel(
-            spec.wp_dtype,
-            pbc_mode=spec.pbc_mode,
-            batched=spec.batched,
-            selective=spec.selective,
-            partial=spec.partial,
-            half_fill=spec.half_fill,
-            return_vectors=spec.return_vectors,
-            return_distances=spec.return_distances,
-            pair_fn=spec.pair_fn,
-        )
-    return _register_jax_kernel(kernel, _output_schema(spec))
-
-
-def _validate_cluster_tile_build_spec(spec: _ClusterTileBuildJaxSpec) -> None:
-    """Reject unsupported cluster-tile build callback combinations."""
-    if not spec.batched and spec.segmented:
-        raise ValueError("Single-system cluster-tile builds cannot be segmented.")
-    if spec.batched and spec.selective and not spec.segmented:
-        raise ValueError(
-            "Selective batched cluster-tile builds must be segmented.",
-        )
-
-
-def _cluster_tile_build_output_schema(
-    spec: _ClusterTileBuildJaxSpec,
-) -> _JaxOutputSchema:
-    """Return the ordered in-place ABI for a cluster-tile build callback."""
-    outputs = (
+    Returns
+    -------
+    tuple[str, ...]
+        Ordered names of the callback's in-place output arguments.
+    """
+    outputs: _Outputs = (
         "group_ctr_x",
         "group_ctr_y",
         "group_ctr_z",
@@ -383,115 +175,223 @@ def _cluster_tile_build_output_schema(
         "group_ext_z",
         "num_tiles",
     )
-    if spec.batched and spec.selective:
+    if batched and selective:
         outputs += ("tile_counts",)
     outputs += ("tile_row_group", "tile_col_group")
-    if spec.batched:
+    if batched:
         outputs += ("tile_system",)
-    return _JaxOutputSchema(outputs)
+    return outputs
 
 
-@functools.cache
-def _get_cluster_tile_build_jax_callable(
-    spec: _ClusterTileBuildJaxSpec,
-    callback: Callable[..., Any],
-) -> Any:
-    """Return a cached WARP graph callback for a cluster-tile build."""
-    _validate_cluster_tile_build_spec(spec)
-    return _register_jax_callable(
-        callback,
-        _cluster_tile_build_output_schema(spec),
-        graph_mode=GraphMode.WARP,
+def _cluster_tile_matrix_outputs(
+    *,
+    dual_cutoff: bool,
+    geometry: bool,
+    pair_fn: Any | None,
+) -> _Outputs:
+    """Return the ordered in-place ABI for a cluster-tile matrix callback.
+
+    Parameters
+    ----------
+    dual_cutoff : bool
+        Whether the callback emits a second neighbor matrix.
+    geometry : bool
+        Whether the callback emits pair vectors and distances.
+    pair_fn : Any or None
+        Pair callback whose energy and force outputs are emitted when supplied.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Ordered names of the callback's in-place output arguments.
+    """
+    outputs: _Outputs = (
+        "neighbor_matrix",
+        "num_neighbors",
+        "neighbor_matrix_shifts",
     )
-
-
-def _validate_cluster_tile_query_spec(spec: _ClusterTileQueryJaxSpec) -> None:
-    """Reject unsupported cluster-tile query callback combinations."""
-    if spec.output_format not in {"matrix", "coo"}:
-        raise ValueError(
-            f"Unsupported cluster-tile output format: {spec.output_format!r}."
-        )
-    if not spec.batched and spec.tile_segmented:
-        raise ValueError("Single-system cluster-tile queries cannot tile-segment.")
-    if spec.output_format == "matrix":
-        if spec.coo_segmented:
-            raise ValueError("Matrix cluster-tile queries cannot use COO segments.")
-        if spec.return_vectors != spec.return_distances:
-            raise ValueError(
-                "Cluster-tile geometry requires vectors and distances together.",
-            )
-        if (spec.return_vectors or spec.pair_fn is not None) and (
-            spec.dual_cutoff or spec.selective
-        ):
-            raise ValueError(
-                "Cluster-tile geometry and pair_fn require non-dual, non-selective "
-                "matrix queries.",
-            )
-        return
-    if (
-        spec.dual_cutoff
-        or spec.return_vectors
-        or spec.return_distances
-        or spec.pair_fn is not None
-    ):
-        raise ValueError("COO cluster-tile callbacks support topology output only.")
-    if spec.coo_segmented and not spec.selective:
-        raise ValueError(
-            "Segmented COO requires selective cluster-tile queries.",
-        )
-    if spec.selective and not spec.coo_segmented:
-        raise ValueError("Selective COO requires segmented COO output.")
-
-
-def _cluster_tile_query_output_schema(
-    spec: _ClusterTileQueryJaxSpec,
-) -> _JaxOutputSchema:
-    """Return the ordered in-place ABI for a cluster-tile query callback."""
-    if spec.output_format == "coo":
-        outputs = ("pair_counter",)
-        if spec.coo_segmented:
-            outputs += ("pair_counts",)
-        return _JaxOutputSchema(outputs + ("coo_list", "coo_shifts"))
-
-    outputs = ("neighbor_matrix", "num_neighbors", "neighbor_matrix_shifts")
-    if spec.dual_cutoff:
+    if dual_cutoff:
         outputs += (
             "neighbor_matrix2",
             "num_neighbors2",
             "neighbor_matrix_shifts2",
         )
-    if spec.return_vectors:
+    if geometry:
         outputs += ("neighbor_vectors", "neighbor_distances")
-    if spec.pair_fn is not None:
+    if pair_fn is not None:
         outputs += ("pair_energies", "pair_forces")
-    return _JaxOutputSchema(outputs)
+    return outputs
 
 
-@functools.cache
-def _get_cluster_tile_query_jax_callable(
-    spec: _ClusterTileQueryJaxSpec,
+def _cluster_tile_coo_outputs(*, coo_segmented: bool) -> _Outputs:
+    """Return the ordered in-place ABI for a cluster-tile COO callback.
+
+    Parameters
+    ----------
+    coo_segmented : bool
+        Whether the callback emits per-segment pair counts.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Ordered names of the callback's in-place output arguments.
+    """
+    outputs: _Outputs = ("pair_counter",)
+    if coo_segmented:
+        outputs += ("pair_counts",)
+    return outputs + ("coo_list", "coo_shifts")
+
+
+def _cluster_tile_build_registration(
     callback: Callable[..., Any],
-) -> Any:
-    """Return a cached WARP graph callback for a cluster-tile query."""
-    _validate_cluster_tile_query_spec(spec)
-    return _register_jax_callable(
+    *,
+    batched: bool,
+    segmented: bool,
+    selective: bool,
+) -> _GraphRegistration:
+    """Build a Warp graph registration for a cluster-tile build callback.
+
+    Parameters
+    ----------
+    callback : Callable[..., Any]
+        Warp callback to register.
+    batched : bool
+        Whether the callback operates on multiple systems.
+    segmented : bool
+        Whether the tile storage is segmented by system.
+    selective : bool
+        Whether the callback operates on a selected subset of atoms.
+
+    Returns
+    -------
+    _GraphRegistration
+        Registered callback and its matching preload operation.
+    """
+    _validate_cluster_tile_build_options(
+        batched=batched,
+        segmented=segmented,
+        selective=selective,
+    )
+    registered = _register_jax_callable(
         callback,
-        _cluster_tile_query_output_schema(spec),
+        _cluster_tile_build_outputs(batched=batched, selective=selective),
         graph_mode=GraphMode.WARP,
+    )
+    return _GraphRegistration(
+        callable=registered,
+        preload=_preload_cluster_tile_build_kernel,
     )
 
 
-class _LazyDtypeRegistrations:
+def _cluster_tile_matrix_registration(
+    callback: Callable[..., Any],
+    *,
+    batched: bool,
+    tile_segmented: bool = False,
+    selective: bool = False,
+    dual_cutoff: bool = False,
+    geometry: bool = False,
+    pair_fn: Any | None = None,
+) -> _GraphRegistration:
+    """Build a Warp graph registration for a cluster-tile matrix query.
+
+    Parameters
+    ----------
+    callback : Callable[..., Any]
+        Warp callback to register.
+    batched, tile_segmented, selective, dual_cutoff, geometry : bool
+        Static kernel specialization options.
+    pair_fn : Any or None
+        Optional pair callback used by the query specialization.
+
+    Returns
+    -------
+    _GraphRegistration
+        Registered callback and its matching preload operation.
+    """
+    _validate_cluster_tile_matrix_options(
+        batched=batched,
+        tile_segmented=tile_segmented,
+        selective=selective,
+        dual_cutoff=dual_cutoff,
+        geometry=geometry,
+        pair_fn=pair_fn,
+    )
+    registered = _register_jax_callable(
+        callback,
+        _cluster_tile_matrix_outputs(
+            dual_cutoff=dual_cutoff,
+            geometry=geometry,
+            pair_fn=pair_fn,
+        ),
+        graph_mode=GraphMode.WARP,
+    )
+    preload = functools.partial(
+        _preload_cluster_tile_query_kernel,
+        batched=batched,
+        tile_segmented=tile_segmented,
+        selective=selective,
+        dual_cutoff=dual_cutoff,
+        geometry=geometry,
+        pair_fn=pair_fn,
+    )
+    return _GraphRegistration(callable=registered, preload=preload)
+
+
+def _cluster_tile_coo_registration(
+    callback: Callable[..., Any],
+    *,
+    batched: bool,
+    tile_segmented: bool = False,
+    coo_segmented: bool = False,
+    selective: bool = False,
+) -> _GraphRegistration:
+    """Build a Warp graph registration for a cluster-tile COO query.
+
+    Parameters
+    ----------
+    callback : Callable[..., Any]
+        Warp callback to register.
+    batched, tile_segmented, coo_segmented, selective : bool
+        Static kernel specialization options.
+
+    Returns
+    -------
+    _GraphRegistration
+        Registered callback and its matching preload operation.
+    """
+    _validate_cluster_tile_coo_options(
+        batched=batched,
+        tile_segmented=tile_segmented,
+        coo_segmented=coo_segmented,
+        selective=selective,
+    )
+    registered = _register_jax_callable(
+        callback,
+        _cluster_tile_coo_outputs(coo_segmented=coo_segmented),
+        graph_mode=GraphMode.WARP,
+    )
+    preload = functools.partial(
+        _preload_cluster_tile_coo_kernel,
+        batched=batched,
+        tile_segmented=tile_segmented,
+        coo_segmented=coo_segmented,
+        selective=selective,
+    )
+    return _GraphRegistration(callable=registered, preload=preload)
+
+
+class _LazyJaxKernel:
     """Lazily construct JAX wrappers for declared JAX-to-Warp dtype mappings."""
 
     def __init__(
         self,
-        factory: Callable[[Any], Any],
-        dtype_map: Mapping[object, Any],
+        build: Callable[[type], tuple[Any, _Outputs]],
+        dtype_map: Mapping[object, type],
         *,
-        cache_key: Callable[[Any], object] | None = None,
+        cache_key: Callable[[type], object] | None = None,
     ) -> None:
-        self._factory = factory
+        self._build = build
         self._dtype_map = {
             jnp.dtype(jax_dtype): wp_dtype for jax_dtype, wp_dtype in dtype_map.items()
         }
@@ -512,8 +412,288 @@ class _LazyDtypeRegistrations:
         except (TypeError, ValueError) as error:
             raise KeyError(jax_dtype) from error
 
+        if normalized_dtype not in self._dtype_map:
+            raise KeyError(jax_dtype)
+
         wp_dtype = self._dtype_map[normalized_dtype]
-        cache_key = self._cache_key(wp_dtype)
-        if cache_key not in self._cache:
-            self._cache[cache_key] = self._factory(wp_dtype)
-        return self._cache[cache_key]
+        key = self._cache_key(wp_dtype)
+        if key not in self._cache:
+            kernel, outputs = self._build(wp_dtype)
+            self._cache[key] = _register_jax_kernel(kernel, outputs)
+        return self._cache[key]
+
+
+def _naive_outputs(
+    *,
+    operation: Literal["single_cutoff", "dual_cutoff"],
+    pbc_mode: Literal["none", "wrap_on_entry", "prewrapped"],
+    geometry: bool,
+    pair_fn: Any | None,
+) -> _Outputs:
+    """Return the ordered direct naive JAX output tuple for static options."""
+    if operation == "dual_cutoff":
+        outputs = _DUAL_NO_PBC_OUTPUTS if pbc_mode == "none" else _DUAL_PBC_OUTPUTS
+    else:
+        outputs = _SINGLE_NO_PBC_OUTPUTS if pbc_mode == "none" else _SINGLE_PBC_OUTPUTS
+        if geometry:
+            outputs += ("neighbor_vectors", "neighbor_distances")
+        if pair_fn is not None:
+            outputs += ("pair_energies", "pair_forces")
+    return outputs
+
+
+def _validate_lazy_naive_options(
+    *,
+    operation: Literal["single_cutoff", "dual_cutoff"],
+    pbc_mode: Literal["none", "wrap_on_entry", "prewrapped"],
+    selective: bool,
+    partial: bool,
+    half_fill: bool,
+    geometry: bool,
+    pair_fn: Any | None,
+) -> None:
+    """Reject unsupported direct naive JAX registration combinations."""
+    if operation not in {"single_cutoff", "dual_cutoff"}:
+        raise ValueError(f"Unsupported naive operation: {operation!r}.")
+    if pbc_mode not in {"none", "wrap_on_entry", "prewrapped"}:
+        raise ValueError(f"Unsupported naive PBC mode: {pbc_mode!r}.")
+    if pair_fn is not None and not geometry:
+        raise ValueError("pair_fn requires direct pair-geometry outputs.")
+    if partial and (operation != "single_cutoff" or not geometry or selective):
+        raise ValueError(
+            "partial direct registrations require single-cutoff non-selective "
+            "pair geometry.",
+        )
+    if operation == "dual_cutoff" and (
+        geometry or pair_fn is not None or partial or half_fill
+    ):
+        raise ValueError(
+            "Dual-cutoff direct registrations do not support geometry, pair_fn, "
+            "partial rows, or half_fill.",
+        )
+
+
+def _lazy_naive_kernel(
+    *,
+    operation: Literal["single_cutoff", "dual_cutoff"],
+    batched: bool,
+    pbc_mode: Literal["none", "wrap_on_entry", "prewrapped"],
+    selective: bool = False,
+    partial: bool = False,
+    half_fill: bool = False,
+    geometry: bool = False,
+    pair_fn: Any | None = None,
+) -> _LazyJaxKernel:
+    """Return a lazy direct naive JAX registration for static options."""
+
+    def build(wp_dtype: type) -> tuple[Any, _Outputs]:
+        _validate_lazy_naive_options(
+            operation=operation,
+            pbc_mode=pbc_mode,
+            selective=selective,
+            partial=partial,
+            half_fill=half_fill,
+            geometry=geometry,
+            pair_fn=pair_fn,
+        )
+        if wp_dtype not in {wp.float32, wp.float64}:
+            raise ValueError(f"Unsupported naive Warp dtype: {wp_dtype!r}.")
+        if operation == "dual_cutoff":
+            kernel = get_naive_neighbor_matrix_dual_cutoff_kernel(
+                wp_dtype,
+                pbc_mode=pbc_mode,
+                batched=batched,
+                selective=selective,
+            )
+        else:
+            kernel = get_naive_neighbor_matrix_kernel(
+                wp_dtype,
+                pbc_mode=pbc_mode,
+                batched=batched,
+                selective=selective,
+                partial=partial,
+                half_fill=half_fill,
+                return_vectors=geometry,
+                return_distances=geometry,
+                pair_fn=pair_fn,
+            )
+        outputs = _naive_outputs(
+            operation=operation,
+            pbc_mode=pbc_mode,
+            geometry=geometry,
+            pair_fn=pair_fn,
+        )
+        return kernel, outputs
+
+    return _LazyJaxKernel(build, _NAIVE_DTYPE_MAP)
+
+
+def _cell_list_build_outputs(
+    stage: Literal[
+        "construct_bin_size",
+        "count_atoms",
+        "bin_atoms",
+        "gather",
+        "cells_per_system",
+    ],
+    batched: bool,
+) -> _Outputs:
+    """Return the ordered in-place output tuple for a build stage."""
+    if stage == "construct_bin_size":
+        return (
+            "cells_per_dimension_batch" if batched else "cells_per_dimension_single",
+        )
+    if stage == "count_atoms":
+        return ("atoms_per_cell_count", "atom_periodic_shifts")
+    if stage == "bin_atoms":
+        return ("atom_to_cell_mapping", "atoms_per_cell_count", "cell_atom_list")
+    if stage == "gather":
+        return (
+            ("sorted_positions", "sorted_shifts")
+            if batched
+            else ("dst_pos", "dst_shifts")
+        )
+    return ("cells_per_system",)
+
+
+def _validate_lazy_cell_list_build_options(
+    *,
+    stage: Literal[
+        "construct_bin_size",
+        "count_atoms",
+        "bin_atoms",
+        "gather",
+        "cells_per_system",
+    ],
+    batched: bool,
+) -> None:
+    """Reject unsupported direct cell-list build registrations."""
+    if stage not in {
+        "construct_bin_size",
+        "count_atoms",
+        "bin_atoms",
+        "gather",
+        "cells_per_system",
+    }:
+        raise ValueError(f"Unsupported cell-list build stage: {stage!r}.")
+    if stage == "cells_per_system" and not batched:
+        raise ValueError("cells_per_system is only registered for batch cell lists.")
+
+
+def _lazy_cell_list_build_kernel(
+    *,
+    stage: Literal[
+        "construct_bin_size",
+        "count_atoms",
+        "bin_atoms",
+        "gather",
+        "cells_per_system",
+    ],
+    batched: bool,
+) -> _LazyJaxKernel:
+    """Return a lazy direct cell-list build JAX registration."""
+    cache_key = (
+        (lambda wp_dtype: _CELLS_PER_SYSTEM_CACHE_KEY)
+        if stage == "cells_per_system"
+        else None
+    )
+
+    def build(wp_dtype: type) -> tuple[Any, _Outputs]:
+        _validate_lazy_cell_list_build_options(stage=stage, batched=batched)
+        if wp_dtype not in {wp.float32, wp.float64}:
+            raise ValueError(f"Unsupported cell-list Warp dtype: {wp_dtype!r}.")
+        if stage == "cells_per_system":
+            kernel = get_cell_list_cells_per_system_kernel()
+        elif stage == "gather":
+            kernel = (
+                get_cell_list_gather_kernel(wp_dtype)
+                if batched
+                else get_gather_positions_and_shifts_kernel(wp_dtype)
+            )
+        else:
+            kernel = get_build_cell_list_kernel(
+                stage,
+                wp_dtype,
+                batched=batched,
+            )
+        return kernel, _cell_list_build_outputs(stage, batched)
+
+    return _LazyJaxKernel(
+        build,
+        _CELL_LIST_DTYPE_MAP,
+        cache_key=cache_key,
+    )
+
+
+def _cell_list_query_outputs(
+    *,
+    geometry: bool,
+    pair_fn: Any | None,
+) -> _Outputs:
+    """Return the ordered in-place output tuple for a query registration."""
+    outputs: _Outputs = (
+        "neighbor_matrix",
+        "neighbor_matrix_shifts",
+        "num_neighbors",
+    )
+    if geometry:
+        outputs += ("neighbor_vectors", "neighbor_distances")
+    if pair_fn is not None:
+        outputs += ("pair_energies", "pair_forces")
+    return outputs
+
+
+def _validate_lazy_cell_list_query_options(
+    *,
+    batched: bool,
+    geometry: bool,
+    pair_fn: Any | None,
+    atom_centric_path: Literal["sorted", "direct"],
+) -> None:
+    """Reject unsupported direct cell-list query registrations."""
+    if atom_centric_path not in {"sorted", "direct"}:
+        raise ValueError(
+            f"Unsupported atom-centric cell-list path: {atom_centric_path!r}.",
+        )
+    if batched and atom_centric_path == "direct":
+        raise ValueError("The direct atom-centric path is only available unbatched.")
+    if pair_fn is not None and not geometry:
+        raise ValueError("pair_fn requires direct pair-geometry outputs.")
+
+
+def _lazy_cell_list_query_kernel(
+    *,
+    batched: bool,
+    selective: bool = True,
+    partial: bool = False,
+    half_fill: bool = False,
+    geometry: bool = False,
+    pair_fn: Any | None = None,
+    atom_centric_path: Literal["sorted", "direct"] = "sorted",
+) -> _LazyJaxKernel:
+    """Return a lazy direct cell-list query JAX registration."""
+
+    def build(wp_dtype: type) -> tuple[Any, _Outputs]:
+        _validate_lazy_cell_list_query_options(
+            batched=batched,
+            geometry=geometry,
+            pair_fn=pair_fn,
+            atom_centric_path=atom_centric_path,
+        )
+        if wp_dtype not in {wp.float32, wp.float64}:
+            raise ValueError(f"Unsupported cell-list Warp dtype: {wp_dtype!r}.")
+        kernel = get_query_cell_list_kernel(
+            wp_dtype,
+            strategy="atom_centric",
+            batched=batched,
+            selective=selective,
+            partial=partial,
+            half_fill=half_fill,
+            return_vectors=geometry,
+            return_distances=geometry,
+            pair_fn=pair_fn,
+            atom_centric_path=atom_centric_path,
+        )
+        return kernel, _cell_list_query_outputs(geometry=geometry, pair_fn=pair_fn)
+
+    return _LazyJaxKernel(build, _CELL_LIST_DTYPE_MAP)

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -30,11 +30,8 @@ from nvalchemiops.jax.neighbors._autograd import (
     _route_pair_outputs,
 )
 from nvalchemiops.jax.neighbors._registration import (
-    _CellListBuildJaxSpec,
-    _CellListQueryJaxSpec,
-    _get_cell_list_build_jax_kernel,
-    _get_cell_list_query_jax_kernel,
-    _LazyDtypeRegistrations,
+    _lazy_cell_list_build_kernel,
+    _lazy_cell_list_query_kernel,
 )
 from nvalchemiops.jax.neighbors.cell_list import (
     _is_cpu_array,
@@ -65,23 +62,10 @@ from nvalchemiops.neighbors.output_args import (
 # JAX Kernel Wrappers
 # ==============================================================================
 
-_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
 
-
-def _cells_per_system_cache_key(_: type) -> str:
-    """Return the shared cache key for the dtype-independent build kernel."""
-    return "cells_per_system"
-
-
-def _build_registry(stage: str) -> _LazyDtypeRegistrations:
+def _build_registry(stage: str):
     """Create lazy dtype registrations for one batched build stage."""
-    return _LazyDtypeRegistrations(
-        lambda wp_dtype: _get_cell_list_build_jax_kernel(
-            _CellListBuildJaxSpec(stage, wp_dtype, True),
-        ),
-        _DTYPE_MAP,
-        cache_key=_cells_per_system_cache_key if stage == "cells_per_system" else None,
-    )
+    return _lazy_cell_list_build_kernel(stage=stage, batched=True)
 
 
 _BATCH_CELL_LIST_BUILD_REGISTRATIONS = {
@@ -96,33 +80,24 @@ _BATCH_CELL_LIST_BUILD_REGISTRATIONS = {
 }
 
 
-def _query_registry(
-    *, half_fill: bool, return_geometry: bool
-) -> _LazyDtypeRegistrations:
+def _query_registry(*, half_fill: bool, geometry: bool):
     """Create lazy direct registrations for a static batched query."""
-    return _LazyDtypeRegistrations(
-        lambda wp_dtype: _get_cell_list_query_jax_kernel(
-            _CellListQueryJaxSpec(
-                wp_dtype=wp_dtype,
-                batched=True,
-                selective=True,
-                partial=False,
-                half_fill=half_fill,
-                return_vectors=return_geometry,
-                return_distances=return_geometry,
-                pair_fn=None,
-                atom_centric_path="sorted",
-            ),
-        ),
-        _DTYPE_MAP,
+    return _lazy_cell_list_query_kernel(
+        batched=True,
+        selective=True,
+        partial=False,
+        half_fill=half_fill,
+        geometry=geometry,
+        pair_fn=None,
+        atom_centric_path="sorted",
     )
 
 
 _BATCH_CELL_LIST_QUERY_REGISTRATIONS = {
-    (False, False): _query_registry(half_fill=False, return_geometry=False),
-    (True, False): _query_registry(half_fill=True, return_geometry=False),
-    (False, True): _query_registry(half_fill=False, return_geometry=True),
-    (True, True): _query_registry(half_fill=True, return_geometry=True),
+    (False, False): _query_registry(half_fill=False, geometry=False),
+    (True, False): _query_registry(half_fill=True, geometry=False),
+    (False, True): _query_registry(half_fill=False, geometry=True),
+    (True, True): _query_registry(half_fill=True, geometry=True),
 }
 
 
@@ -131,19 +106,16 @@ def _get_jax_batch_cell_list_pair_outputs_kernel(
     pair_fn, wp_dtype, partial, half_fill: bool = False
 ):
     """Return a cached sorted direct registration for batched pair outputs."""
-    return _get_cell_list_query_jax_kernel(
-        _CellListQueryJaxSpec(
-            wp_dtype=wp_dtype,
-            batched=True,
-            selective=True,
-            partial=bool(partial),
-            half_fill=bool(half_fill),
-            return_vectors=True,
-            return_distances=True,
-            pair_fn=pair_fn,
-            atom_centric_path="sorted",
-        ),
-    )
+    jax_dtype = jnp.float64 if wp_dtype == wp.float64 else jnp.float32
+    return _lazy_cell_list_query_kernel(
+        batched=True,
+        selective=True,
+        partial=bool(partial),
+        half_fill=bool(half_fill),
+        geometry=True,
+        pair_fn=pair_fn,
+        atom_centric_path="sorted",
+    )[jax_dtype]
 
 
 __all__ = [
@@ -1261,10 +1233,6 @@ def batch_query_cell_list(
     # and non-selective (controlled by ``rebuild_flags``).
     if positions.dtype != jnp.float64:
         positions = positions.astype(jnp.float32)
-    _gather_kernel = _BATCH_CELL_LIST_BUILD_REGISTRATIONS["gather"][positions.dtype]
-    _sorted_build_kernel = _BATCH_CELL_LIST_QUERY_REGISTRATIONS[
-        (bool(half_fill), False)
-    ][positions.dtype]
 
     if cell.dtype != positions.dtype:
         cell = cell.astype(positions.dtype)
@@ -1474,6 +1442,10 @@ def batch_query_cell_list(
         )
         return neighbor_matrix, num_neighbors, neighbor_matrix_shifts
 
+    _gather_kernel = _BATCH_CELL_LIST_BUILD_REGISTRATIONS["gather"][positions.dtype]
+    _sorted_build_kernel = _BATCH_CELL_LIST_QUERY_REGISTRATIONS[
+        (bool(half_fill), False)
+    ][positions.dtype]
     sorted_positions = jnp.zeros((total_atoms, 3), dtype=positions.dtype)
     sorted_atom_periodic_shifts = jnp.zeros((total_atoms, 3), dtype=jnp.int32)
     sorted_positions, sorted_atom_periodic_shifts = _gather_kernel(
@@ -1574,7 +1546,6 @@ def _batch_cell_list_pair_outputs_forward(
     cell = jax.lax.stop_gradient(cell)
 
     f64 = positions.dtype == jnp.float64
-    gather_kernel = _BATCH_CELL_LIST_BUILD_REGISTRATIONS["gather"][positions.dtype]
 
     total_atoms = positions.shape[0]
     num_systems = pbc_bool.shape[0]
@@ -1713,6 +1684,7 @@ def _batch_cell_list_pair_outputs_forward(
             else jnp.zeros((0,), dtype=jnp.int32)
         )
 
+        gather_kernel = _BATCH_CELL_LIST_BUILD_REGISTRATIONS["gather"][positions.dtype]
         sorted_positions = jnp.zeros((total_atoms, 3), dtype=positions.dtype)
         sorted_atom_periodic_shifts = jnp.zeros((total_atoms, 3), dtype=jnp.int32)
         sorted_positions, sorted_atom_periodic_shifts = gather_kernel(

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -22,12 +22,19 @@ import functools
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import GraphMode, jax_callable, jax_kernel
+from warp.jax_experimental import GraphMode, jax_callable
 
 from nvalchemiops.jax.neighbors._autograd import (
     _build_index_residuals,
     _NeighborForwardOutput,
     _route_pair_outputs,
+)
+from nvalchemiops.jax.neighbors._registration import (
+    _CellListBuildJaxSpec,
+    _CellListQueryJaxSpec,
+    _get_cell_list_build_jax_kernel,
+    _get_cell_list_query_jax_kernel,
+    _LazyDtypeRegistrations,
 )
 from nvalchemiops.jax.neighbors.cell_list import (
     _is_cpu_array,
@@ -47,10 +54,6 @@ from nvalchemiops.neighbors.cell_list import (
 )
 from nvalchemiops.neighbors.cell_list import (
     compute_batch_pair_centric_n_outer,
-    get_build_cell_list_kernel,
-    get_cell_list_cells_per_system_kernel,
-    get_cell_list_gather_kernel,
-    get_query_cell_list_kernel,
     is_pair_centric_parallelism_sufficient,
 )
 from nvalchemiops.neighbors.neighbor_utils import estimate_max_neighbors
@@ -62,279 +65,84 @@ from nvalchemiops.neighbors.output_args import (
 # JAX Kernel Wrappers
 # ==============================================================================
 
-# Build step 1: Construct bin sizes (per system)
-_jax_batch_construct_bin_size_f32 = jax_kernel(
-    get_build_cell_list_kernel("construct_bin_size", wp.float32, batched=True),
-    num_outputs=1,
-    in_out_argnames=["cells_per_dimension_batch"],
-    enable_backward=False,
-)
-_jax_batch_construct_bin_size_f64 = jax_kernel(
-    get_build_cell_list_kernel("construct_bin_size", wp.float64, batched=True),
-    num_outputs=1,
-    in_out_argnames=["cells_per_dimension_batch"],
-    enable_backward=False,
-)
+_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
 
-# Helper: Compute cells per system
-_jax_compute_cells_per_system = jax_kernel(
-    get_cell_list_cells_per_system_kernel(),
-    num_outputs=1,
-    in_out_argnames=["cells_per_system"],
-    enable_backward=False,
-)
 
-# Build step 2: Count atoms per bin
-_jax_batch_count_atoms_per_bin_f32 = jax_kernel(
-    get_build_cell_list_kernel("count_atoms", wp.float32, batched=True),
-    num_outputs=2,
-    in_out_argnames=["atoms_per_cell_count", "atom_periodic_shifts"],
-    enable_backward=False,
-)
-_jax_batch_count_atoms_per_bin_f64 = jax_kernel(
-    get_build_cell_list_kernel("count_atoms", wp.float64, batched=True),
-    num_outputs=2,
-    in_out_argnames=["atoms_per_cell_count", "atom_periodic_shifts"],
-    enable_backward=False,
-)
+def _cells_per_system_cache_key(_: type) -> str:
+    """Return the shared cache key for the dtype-independent build kernel."""
+    return "cells_per_system"
 
-# Build step 3: Bin atoms into cells
-_jax_batch_bin_atoms_f32 = jax_kernel(
-    get_build_cell_list_kernel("bin_atoms", wp.float32, batched=True),
-    num_outputs=3,
-    in_out_argnames=["atom_to_cell_mapping", "atoms_per_cell_count", "cell_atom_list"],
-    enable_backward=False,
-)
-_jax_batch_bin_atoms_f64 = jax_kernel(
-    get_build_cell_list_kernel("bin_atoms", wp.float64, batched=True),
-    num_outputs=3,
-    in_out_argnames=["atom_to_cell_mapping", "atoms_per_cell_count", "cell_atom_list"],
-    enable_backward=False,
-)
 
-# Gather: pack positions + atom_periodic_shifts into per-cell-contiguous layout
-# (cell_atom_list permutation) for coalesced reads by the sorted-build kernel.
-_jax_batch_gather_positions_by_cell_f32 = jax_kernel(
-    get_cell_list_gather_kernel(wp.float32),
-    num_outputs=2,
-    in_out_argnames=["sorted_positions", "sorted_shifts"],
-    enable_backward=False,
-)
-_jax_batch_gather_positions_by_cell_f64 = jax_kernel(
-    get_cell_list_gather_kernel(wp.float64),
-    num_outputs=2,
-    in_out_argnames=["sorted_positions", "sorted_shifts"],
-    enable_backward=False,
-)
+def _build_registry(stage: str) -> _LazyDtypeRegistrations:
+    """Create lazy dtype registrations for one batched build stage."""
+    return _LazyDtypeRegistrations(
+        lambda wp_dtype: _get_cell_list_build_jax_kernel(
+            _CellListBuildJaxSpec(stage, wp_dtype, True),
+        ),
+        _DTYPE_MAP,
+        cache_key=_cells_per_system_cache_key if stage == "cells_per_system" else None,
+    )
 
-# Query: sorted-reads atom-centric batch neighbor matrix kernel.  The same
-# kernel handles selective and non-selective callers via the ``rebuild_flags``
-# array (always-True for non-selective; per-system bool array otherwise).
-_jax_batch_build_neighbor_matrix_local_count_sorted_f32 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float32,
-        strategy="atom_centric",
-        batched=True,
-        selective=True,
-        partial=False,
-        return_vectors=False,
-        return_distances=False,
-        pair_fn=None,
-    ),
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
-    enable_backward=False,
-)
-_jax_batch_build_neighbor_matrix_local_count_sorted_f64 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float64,
-        strategy="atom_centric",
-        batched=True,
-        selective=True,
-        partial=False,
-        return_vectors=False,
-        return_distances=False,
-        pair_fn=None,
-    ),
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
-    enable_backward=False,
-)
 
-# Half-fill variants of the sorted-build kernel.  ``half_fill`` is a compile-time
-# specialization in the Warp factory (the runtime ``half_fill`` arg is an ignored
-# ABI placeholder), so honoring ``half_fill=True`` requires a distinct kernel.
-_jax_batch_build_neighbor_matrix_local_count_sorted_half_f32 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float32,
-        strategy="atom_centric",
-        batched=True,
-        selective=True,
-        partial=False,
-        half_fill=True,
-        return_vectors=False,
-        return_distances=False,
-        pair_fn=None,
-    ),
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
-    enable_backward=False,
-)
-_jax_batch_build_neighbor_matrix_local_count_sorted_half_f64 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float64,
-        strategy="atom_centric",
-        batched=True,
-        selective=True,
-        partial=False,
-        half_fill=True,
-        return_vectors=False,
-        return_distances=False,
-        pair_fn=None,
-    ),
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
-    enable_backward=False,
-)
+_BATCH_CELL_LIST_BUILD_REGISTRATIONS = {
+    stage: _build_registry(stage)
+    for stage in (
+        "construct_bin_size",
+        "count_atoms",
+        "bin_atoms",
+        "gather",
+        "cells_per_system",
+    )
+}
 
-# Pair-output variants — consumed by the autograd path when
-# ``return_distances`` / ``return_vectors`` is set.  The bytes written into
-# ``neighbor_vectors`` / ``neighbor_distances`` are differentiable via the
-# JAX autograd primitive in :mod:`nvalchemiops.jax.neighbors._autograd`.
-_jax_batch_build_neighbor_matrix_local_count_sorted_pair_f32 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float32,
-        strategy="atom_centric",
-        batched=True,
-        selective=True,
-        partial=False,
-        return_vectors=True,
-        return_distances=True,
-        pair_fn=None,
-    ),
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "neighbor_matrix_shifts",
-        "num_neighbors",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_batch_build_neighbor_matrix_local_count_sorted_pair_f64 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float64,
-        strategy="atom_centric",
-        batched=True,
-        selective=True,
-        partial=False,
-        return_vectors=True,
-        return_distances=True,
-        pair_fn=None,
-    ),
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "neighbor_matrix_shifts",
-        "num_neighbors",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
 
-# Half-fill specializations of the atom-centric geometry pair-output kernel
-# (selected when ``half_fill=True``; ``half_fill`` is a compile-time constant).
-_jax_batch_build_neighbor_matrix_local_count_sorted_pair_half_f32 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float32,
-        strategy="atom_centric",
-        batched=True,
-        selective=True,
-        partial=False,
-        return_vectors=True,
-        return_distances=True,
-        pair_fn=None,
-        half_fill=True,
-    ),
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "neighbor_matrix_shifts",
-        "num_neighbors",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_batch_build_neighbor_matrix_local_count_sorted_pair_half_f64 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float64,
-        strategy="atom_centric",
-        batched=True,
-        selective=True,
-        partial=False,
-        return_vectors=True,
-        return_distances=True,
-        pair_fn=None,
-        half_fill=True,
-    ),
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "neighbor_matrix_shifts",
-        "num_neighbors",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
+def _query_registry(
+    *, half_fill: bool, return_geometry: bool
+) -> _LazyDtypeRegistrations:
+    """Create lazy direct registrations for a static batched query."""
+    return _LazyDtypeRegistrations(
+        lambda wp_dtype: _get_cell_list_query_jax_kernel(
+            _CellListQueryJaxSpec(
+                wp_dtype,
+                True,
+                True,
+                False,
+                half_fill,
+                return_geometry,
+                return_geometry,
+                None,
+                "sorted",
+            ),
+        ),
+        _DTYPE_MAP,
+    )
+
+
+_BATCH_CELL_LIST_QUERY_REGISTRATIONS = {
+    (False, False): _query_registry(half_fill=False, return_geometry=False),
+    (True, False): _query_registry(half_fill=True, return_geometry=False),
+    (False, True): _query_registry(half_fill=False, return_geometry=True),
+    (True, True): _query_registry(half_fill=True, return_geometry=True),
+}
 
 
 @functools.cache
 def _get_jax_batch_cell_list_pair_outputs_kernel(
     pair_fn, wp_dtype, partial, half_fill: bool = False
 ):
-    """Build (and cache) a ``jax_kernel`` for a batched cell-list atom-centric
-    ``sorted`` pair-output kernel.
-
-    Mirrors the geometry registration above, optionally with ``pair_fn`` set
-    (so the kernel's ``HAS_PAIR_FN`` body runs and ``pair_energies`` /
-    ``pair_forces`` are registered as additional outputs) and/or
-    ``partial=True`` (the ``target_indices`` path: output row ``r`` maps to atom
-    ``target_indices[r]``, launched ``(num_targets,)``).  Cached by
-    ``(pair_fn identity, wp_dtype, partial)``; one recompile per distinct
-    ``(pair_fn, partial)`` combination.
-
-    With ``pair_fn`` the kernel has 7 outputs (geometry + ``pe`` / ``pf``);
-    without it, 5 (geometry only).
-    """
-    kernel = get_query_cell_list_kernel(
-        wp_dtype,
-        strategy="atom_centric",
-        batched=True,
-        selective=True,
-        partial=bool(partial),
-        return_vectors=True,
-        return_distances=True,
-        pair_fn=pair_fn,
-        half_fill=bool(half_fill),
-    )
-    in_out_argnames = [
-        "neighbor_matrix",
-        "neighbor_matrix_shifts",
-        "num_neighbors",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ]
-    if pair_fn is not None:
-        in_out_argnames += ["pair_energies", "pair_forces"]
-    return jax_kernel(
-        kernel,
-        num_outputs=len(in_out_argnames),
-        in_out_argnames=in_out_argnames,
-        enable_backward=False,
+    """Return a cached sorted direct registration for batched pair outputs."""
+    return _get_cell_list_query_jax_kernel(
+        _CellListQueryJaxSpec(
+            wp_dtype,
+            True,
+            True,
+            bool(partial),
+            bool(half_fill),
+            True,
+            True,
+            pair_fn,
+            "sorted",
+        ),
     )
 
 
@@ -1142,16 +950,17 @@ def batch_build_cell_list(
         neighbor_search_radius,
     )
 
-    # Select kernels based on dtype
-    if positions.dtype == jnp.float64:
-        _construct = _jax_batch_construct_bin_size_f64
-        _count = _jax_batch_count_atoms_per_bin_f64
-        _bin = _jax_batch_bin_atoms_f64
-    else:
-        _construct = _jax_batch_construct_bin_size_f32
-        _count = _jax_batch_count_atoms_per_bin_f32
-        _bin = _jax_batch_bin_atoms_f32
+    # Select kernels based on dtype.
+    if positions.dtype != jnp.float64:
         positions = positions.astype(jnp.float32)
+    _construct = _BATCH_CELL_LIST_BUILD_REGISTRATIONS["construct_bin_size"][
+        positions.dtype
+    ]
+    _count = _BATCH_CELL_LIST_BUILD_REGISTRATIONS["count_atoms"][positions.dtype]
+    _bin = _BATCH_CELL_LIST_BUILD_REGISTRATIONS["bin_atoms"][positions.dtype]
+    _cells_per_system = _BATCH_CELL_LIST_BUILD_REGISTRATIONS["cells_per_system"][
+        positions.dtype
+    ]
 
     if cell.dtype != positions.dtype:
         cell = cell.astype(positions.dtype)
@@ -1175,7 +984,7 @@ def batch_build_cell_list(
 
     # Step 2: Compute cells_per_system and cell_offsets
     cells_per_system = jnp.zeros(num_systems, dtype=jnp.int32)
-    (cells_per_system,) = _jax_compute_cells_per_system(
+    (cells_per_system,) = _cells_per_system(
         cells_per_dimension,
         cells_per_system,
         launch_dims=(num_systems,),
@@ -1450,21 +1259,12 @@ def batch_query_cell_list(
 
     # Select kernels based on dtype; same sorted-reads kernel for selective
     # and non-selective (controlled by ``rebuild_flags``).
-    if positions.dtype == jnp.float64:
-        _gather_kernel = _jax_batch_gather_positions_by_cell_f64
-        _sorted_build_kernel = (
-            _jax_batch_build_neighbor_matrix_local_count_sorted_half_f64
-            if half_fill
-            else _jax_batch_build_neighbor_matrix_local_count_sorted_f64
-        )
-    else:
-        _gather_kernel = _jax_batch_gather_positions_by_cell_f32
-        _sorted_build_kernel = (
-            _jax_batch_build_neighbor_matrix_local_count_sorted_half_f32
-            if half_fill
-            else _jax_batch_build_neighbor_matrix_local_count_sorted_f32
-        )
+    if positions.dtype != jnp.float64:
         positions = positions.astype(jnp.float32)
+    _gather_kernel = _BATCH_CELL_LIST_BUILD_REGISTRATIONS["gather"][positions.dtype]
+    _sorted_build_kernel = _BATCH_CELL_LIST_QUERY_REGISTRATIONS[
+        (bool(half_fill), False)
+    ][positions.dtype]
 
     if cell.dtype != positions.dtype:
         cell = cell.astype(positions.dtype)
@@ -1774,11 +1574,7 @@ def _batch_cell_list_pair_outputs_forward(
     cell = jax.lax.stop_gradient(cell)
 
     f64 = positions.dtype == jnp.float64
-    gather_kernel = (
-        _jax_batch_gather_positions_by_cell_f64
-        if f64
-        else _jax_batch_gather_positions_by_cell_f32
-    )
+    gather_kernel = _BATCH_CELL_LIST_BUILD_REGISTRATIONS["gather"][positions.dtype]
 
     total_atoms = positions.shape[0]
     num_systems = pbc_bool.shape[0]
@@ -1904,17 +1700,13 @@ def _batch_cell_list_pair_outputs_forward(
                 pair_fn, wp_dtype, is_partial, half_fill
             )
         elif half_fill:
-            pair_kernel = (
-                _jax_batch_build_neighbor_matrix_local_count_sorted_pair_half_f64
-                if f64
-                else _jax_batch_build_neighbor_matrix_local_count_sorted_pair_half_f32
-            )
+            pair_kernel = _BATCH_CELL_LIST_QUERY_REGISTRATIONS[(True, True)][
+                positions.dtype
+            ]
         else:
-            pair_kernel = (
-                _jax_batch_build_neighbor_matrix_local_count_sorted_pair_f64
-                if f64
-                else _jax_batch_build_neighbor_matrix_local_count_sorted_pair_f32
-            )
+            pair_kernel = _BATCH_CELL_LIST_QUERY_REGISTRATIONS[(False, True)][
+                positions.dtype
+            ]
         ti_arg = (
             jnp.asarray(target_indices, dtype=jnp.int32)
             if is_partial

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -103,15 +103,15 @@ def _query_registry(
     return _LazyDtypeRegistrations(
         lambda wp_dtype: _get_cell_list_query_jax_kernel(
             _CellListQueryJaxSpec(
-                wp_dtype,
-                True,
-                True,
-                False,
-                half_fill,
-                return_geometry,
-                return_geometry,
-                None,
-                "sorted",
+                wp_dtype=wp_dtype,
+                batched=True,
+                selective=True,
+                partial=False,
+                half_fill=half_fill,
+                return_vectors=return_geometry,
+                return_distances=return_geometry,
+                pair_fn=None,
+                atom_centric_path="sorted",
             ),
         ),
         _DTYPE_MAP,
@@ -133,15 +133,15 @@ def _get_jax_batch_cell_list_pair_outputs_kernel(
     """Return a cached sorted direct registration for batched pair outputs."""
     return _get_cell_list_query_jax_kernel(
         _CellListQueryJaxSpec(
-            wp_dtype,
-            True,
-            True,
-            bool(partial),
-            bool(half_fill),
-            True,
-            True,
-            pair_fn,
-            "sorted",
+            wp_dtype=wp_dtype,
+            batched=True,
+            selective=True,
+            partial=bool(partial),
+            half_fill=bool(half_fill),
+            return_vectors=True,
+            return_distances=True,
+            pair_fn=pair_fn,
+            atom_centric_path="sorted",
         ),
     )
 

--- a/nvalchemiops/jax/neighbors/batch_cluster_tile.py
+++ b/nvalchemiops/jax/neighbors/batch_cluster_tile.py
@@ -31,12 +31,17 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import warp as wp
-from warp.jax_experimental import GraphMode, jax_callable
 
 from nvalchemiops.jax.neighbors._cluster_tile_preload import (
     _preload_cluster_tile_build_kernel,
     _preload_cluster_tile_coo_kernel,
     _preload_cluster_tile_query_kernel,
+)
+from nvalchemiops.jax.neighbors._registration import (
+    _ClusterTileBuildJaxSpec,
+    _ClusterTileQueryJaxSpec,
+    _get_cluster_tile_build_jax_callable,
+    _get_cluster_tile_query_jax_callable,
 )
 from nvalchemiops.neighbors.cluster_tile import (
     TILE_GROUP_SIZE,
@@ -893,103 +898,71 @@ def _batch_query_cluster_tile_coo_segmented_callback(
     )
 
 
-_jax_batch_build_cluster_tile_list = jax_callable(
+_BATCH_CLUSTER_TILE_BUILD_SPEC = _ClusterTileBuildJaxSpec(
+    batched=True,
+    segmented=False,
+    selective=False,
+)
+_BATCH_CLUSTER_TILE_BUILD_SELECTIVE_SPEC = _ClusterTileBuildJaxSpec(
+    batched=True,
+    segmented=True,
+    selective=True,
+)
+
+_jax_batch_build_cluster_tile_list = _get_cluster_tile_build_jax_callable(
+    _BATCH_CLUSTER_TILE_BUILD_SPEC,
     _batch_build_cluster_tile_list_callback,
-    num_outputs=10,
-    in_out_argnames=[
-        "group_ctr_x",
-        "group_ctr_y",
-        "group_ctr_z",
-        "group_ext_x",
-        "group_ext_y",
-        "group_ext_z",
-        "num_tiles",
-        "tile_row_group",
-        "tile_col_group",
-        "tile_system",
-    ],
-    graph_mode=GraphMode.WARP,
 )
-
-_jax_batch_build_cluster_tile_list_selective = jax_callable(
+_jax_batch_build_cluster_tile_list_selective = _get_cluster_tile_build_jax_callable(
+    _BATCH_CLUSTER_TILE_BUILD_SELECTIVE_SPEC,
     _batch_build_cluster_tile_list_selective_callback,
-    num_outputs=11,
-    in_out_argnames=[
-        "group_ctr_x",
-        "group_ctr_y",
-        "group_ctr_z",
-        "group_ext_x",
-        "group_ext_y",
-        "group_ext_z",
-        "num_tiles",
-        "tile_counts",
-        "tile_row_group",
-        "tile_col_group",
-        "tile_system",
-    ],
-    graph_mode=GraphMode.WARP,
+)
+_BATCH_CLUSTER_TILE_QUERY_MATRIX_SPEC = _ClusterTileQueryJaxSpec(
+    True, "matrix", False, False, False, False, False, False, None
+)
+_BATCH_CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC = _ClusterTileQueryJaxSpec(
+    True, "matrix", True, False, True, False, False, False, None
+)
+_BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC = _ClusterTileQueryJaxSpec(
+    True, "matrix", False, False, False, True, False, False, None
+)
+_BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC = _ClusterTileQueryJaxSpec(
+    True, "matrix", True, False, True, True, False, False, None
+)
+_BATCH_CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC = _ClusterTileQueryJaxSpec(
+    True, "matrix", False, False, False, False, True, True, None
+)
+_BATCH_CLUSTER_TILE_QUERY_COO_SPEC = _ClusterTileQueryJaxSpec(
+    True, "coo", False, False, False, False, False, False, None
+)
+_BATCH_CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC = _ClusterTileQueryJaxSpec(
+    True, "coo", True, True, True, False, False, False, None
 )
 
-
-_jax_batch_query_cluster_tile = jax_callable(
+_jax_batch_query_cluster_tile = _get_cluster_tile_query_jax_callable(
+    _BATCH_CLUSTER_TILE_QUERY_MATRIX_SPEC,
     _batch_query_cluster_tile_callback,
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "num_neighbors", "neighbor_matrix_shifts"],
-    graph_mode=GraphMode.WARP,
 )
-
-_jax_batch_query_cluster_tile_selective = jax_callable(
+_jax_batch_query_cluster_tile_selective = _get_cluster_tile_query_jax_callable(
+    _BATCH_CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC,
     _batch_query_cluster_tile_selective_callback,
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "num_neighbors", "neighbor_matrix_shifts"],
-    graph_mode=GraphMode.WARP,
 )
-
-_jax_batch_query_cluster_tile_dual = jax_callable(
+_jax_batch_query_cluster_tile_dual = _get_cluster_tile_query_jax_callable(
+    _BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC,
     _batch_query_cluster_tile_dual_callback,
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "num_neighbors",
-        "neighbor_matrix_shifts",
-        "neighbor_matrix2",
-        "num_neighbors2",
-        "neighbor_matrix_shifts2",
-    ],
-    graph_mode=GraphMode.WARP,
 )
-
-_jax_batch_query_cluster_tile_dual_selective = jax_callable(
+_jax_batch_query_cluster_tile_dual_selective = _get_cluster_tile_query_jax_callable(
+    _BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC,
     _batch_query_cluster_tile_dual_selective_callback,
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "num_neighbors",
-        "neighbor_matrix_shifts",
-        "neighbor_matrix2",
-        "num_neighbors2",
-        "neighbor_matrix_shifts2",
-    ],
-    graph_mode=GraphMode.WARP,
 )
-
-
-_jax_batch_query_cluster_tile_pair = jax_callable(
+_jax_batch_query_cluster_tile_pair = _get_cluster_tile_query_jax_callable(
+    _BATCH_CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC,
     _batch_query_cluster_tile_pair_callback,
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "num_neighbors",
-        "neighbor_matrix_shifts",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    graph_mode=GraphMode.WARP,
 )
 
 
 @functools.cache
-def _get_jax_batch_cluster_tile_pair_fn_callable(pair_fn):
+def _get_jax_batch_cluster_tile_pair_fn_callable(spec: _ClusterTileQueryJaxSpec):
     """Build (and cache) a batched ``jax_callable`` closing over ``pair_fn`` for the
     cluster-tile pair-output -> matrix kernel.
 
@@ -1043,40 +1016,25 @@ def _get_jax_batch_cluster_tile_pair_fn_callable(pair_fn):
             return_distances=True,
             neighbor_vectors=neighbor_vectors,
             neighbor_distances=neighbor_distances,
-            pair_fn=pair_fn,
+            pair_fn=spec.pair_fn,
             pair_params=pair_params,
             pair_energies=pair_energies,
             pair_forces=pair_forces,
         )
 
-    return jax_callable(
+    return _get_cluster_tile_query_jax_callable(
+        spec,
         _callback,
-        num_outputs=7,
-        in_out_argnames=[
-            "neighbor_matrix",
-            "num_neighbors",
-            "neighbor_matrix_shifts",
-            "neighbor_vectors",
-            "neighbor_distances",
-            "pair_energies",
-            "pair_forces",
-        ],
-        graph_mode=GraphMode.WARP,
     )
 
 
-_jax_batch_query_cluster_tile_coo = jax_callable(
+_jax_batch_query_cluster_tile_coo = _get_cluster_tile_query_jax_callable(
+    _BATCH_CLUSTER_TILE_QUERY_COO_SPEC,
     _batch_query_cluster_tile_coo_callback,
-    num_outputs=3,
-    in_out_argnames=["pair_counter", "coo_list", "coo_shifts"],
-    graph_mode=GraphMode.WARP,
 )
-
-_jax_batch_query_cluster_tile_coo_segmented = jax_callable(
+_jax_batch_query_cluster_tile_coo_segmented = _get_cluster_tile_query_jax_callable(
+    _BATCH_CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC,
     _batch_query_cluster_tile_coo_segmented_callback,
-    num_outputs=4,
-    in_out_argnames=["pair_counter", "pair_counts", "coo_list", "coo_shifts"],
-    graph_mode=GraphMode.WARP,
 )
 
 
@@ -1224,9 +1182,7 @@ def batch_build_cluster_tile_list(
 
     if rebuild_flags is None:
         _preload_cluster_tile_build_kernel(
-            batched=True,
-            segmented=False,
-            selective=False,
+            _BATCH_CLUSTER_TILE_BUILD_SPEC,
         )
         (
             group_ctr_x,
@@ -1266,9 +1222,7 @@ def batch_build_cluster_tile_list(
                 "batched cluster_tile builds"
             )
         _preload_cluster_tile_build_kernel(
-            batched=True,
-            segmented=True,
-            selective=True,
+            _BATCH_CLUSTER_TILE_BUILD_SELECTIVE_SPEC,
         )
         rf = rebuild_flags.astype(jnp.bool_)
         (
@@ -1485,15 +1439,22 @@ def batch_query_cluster_tile(
             )
         if batch_idx is None:
             raise ValueError("batch_idx is required when rebuild_flags is provided")
-    _preload_cluster_tile_query_kernel(
-        batched=True,
-        tile_segmented=selective,
-        selective=selective,
-        dual_cutoff=dual_cutoff,
-        return_vectors=has_pair_outputs,
-        return_distances=has_pair_outputs,
-        pair_fn=pair_fn,
+    query_spec = (
+        _ClusterTileQueryJaxSpec(
+            True, "matrix", False, False, False, False, True, True, pair_fn
+        )
+        if pair_fn is not None
+        else _BATCH_CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC
+        if has_pair_outputs
+        else _BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC
+        if dual_cutoff and selective
+        else _BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC
+        if dual_cutoff
+        else _BATCH_CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC
+        if selective
+        else _BATCH_CLUSTER_TILE_QUERY_MATRIX_SPEC
     )
+    _preload_cluster_tile_query_kernel(query_spec)
     if fill_value is None:
         fill_value = natom
     inv_cell_batch = jnp.linalg.inv(cell_batch)
@@ -1554,7 +1515,7 @@ def batch_query_cluster_tile(
             if pair_forces is None:
                 pair_forces = jnp.zeros((natom, max_neighbors, 3), dtype=jnp.float32)
             pair_params_arg = jnp.asarray(pair_params, dtype=jnp.float32)
-            pair_callable = _get_jax_batch_cluster_tile_pair_fn_callable(pair_fn)
+            pair_callable = _get_jax_batch_cluster_tile_pair_fn_callable(query_spec)
             (
                 neighbor_matrix,
                 num_neighbors,
@@ -1849,12 +1810,12 @@ def batch_query_cluster_tile_coo(
         raise ValueError("rebuild_flags requires pair_offsets and pair_counts")
     if rebuild_flags is not None and (tile_offsets is None or tile_counts is None):
         raise ValueError("rebuild_flags requires tile_offsets and tile_counts")
-    _preload_cluster_tile_coo_kernel(
-        batched=True,
-        tile_segmented=segmented,
-        coo_segmented=segmented,
-        selective=segmented,
+    query_spec = (
+        _BATCH_CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC
+        if segmented
+        else _BATCH_CLUSTER_TILE_QUERY_COO_SPEC
     )
+    _preload_cluster_tile_coo_kernel(query_spec)
 
     inv_cell_batch = jnp.linalg.inv(cell_batch)
     pair_counter = jnp.zeros(1, dtype=jnp.int32)

--- a/nvalchemiops/jax/neighbors/batch_cluster_tile.py
+++ b/nvalchemiops/jax/neighbors/batch_cluster_tile.py
@@ -918,25 +918,81 @@ _jax_batch_build_cluster_tile_list_selective = _get_cluster_tile_build_jax_calla
     _batch_build_cluster_tile_list_selective_callback,
 )
 _BATCH_CLUSTER_TILE_QUERY_MATRIX_SPEC = _ClusterTileQueryJaxSpec(
-    True, "matrix", False, False, False, False, False, False, None
+    batched=True,
+    output_format="matrix",
+    tile_segmented=False,
+    coo_segmented=False,
+    selective=False,
+    dual_cutoff=False,
+    return_vectors=False,
+    return_distances=False,
+    pair_fn=None,
 )
 _BATCH_CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC = _ClusterTileQueryJaxSpec(
-    True, "matrix", True, False, True, False, False, False, None
+    batched=True,
+    output_format="matrix",
+    tile_segmented=True,
+    coo_segmented=False,
+    selective=True,
+    dual_cutoff=False,
+    return_vectors=False,
+    return_distances=False,
+    pair_fn=None,
 )
 _BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC = _ClusterTileQueryJaxSpec(
-    True, "matrix", False, False, False, True, False, False, None
+    batched=True,
+    output_format="matrix",
+    tile_segmented=False,
+    coo_segmented=False,
+    selective=False,
+    dual_cutoff=True,
+    return_vectors=False,
+    return_distances=False,
+    pair_fn=None,
 )
 _BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC = _ClusterTileQueryJaxSpec(
-    True, "matrix", True, False, True, True, False, False, None
+    batched=True,
+    output_format="matrix",
+    tile_segmented=True,
+    coo_segmented=False,
+    selective=True,
+    dual_cutoff=True,
+    return_vectors=False,
+    return_distances=False,
+    pair_fn=None,
 )
 _BATCH_CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC = _ClusterTileQueryJaxSpec(
-    True, "matrix", False, False, False, False, True, True, None
+    batched=True,
+    output_format="matrix",
+    tile_segmented=False,
+    coo_segmented=False,
+    selective=False,
+    dual_cutoff=False,
+    return_vectors=True,
+    return_distances=True,
+    pair_fn=None,
 )
 _BATCH_CLUSTER_TILE_QUERY_COO_SPEC = _ClusterTileQueryJaxSpec(
-    True, "coo", False, False, False, False, False, False, None
+    batched=True,
+    output_format="coo",
+    tile_segmented=False,
+    coo_segmented=False,
+    selective=False,
+    dual_cutoff=False,
+    return_vectors=False,
+    return_distances=False,
+    pair_fn=None,
 )
 _BATCH_CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC = _ClusterTileQueryJaxSpec(
-    True, "coo", True, True, True, False, False, False, None
+    batched=True,
+    output_format="coo",
+    tile_segmented=True,
+    coo_segmented=True,
+    selective=True,
+    dual_cutoff=False,
+    return_vectors=False,
+    return_distances=False,
+    pair_fn=None,
 )
 
 _jax_batch_query_cluster_tile = _get_cluster_tile_query_jax_callable(
@@ -1441,7 +1497,15 @@ def batch_query_cluster_tile(
             raise ValueError("batch_idx is required when rebuild_flags is provided")
     query_spec = (
         _ClusterTileQueryJaxSpec(
-            True, "matrix", False, False, False, False, True, True, pair_fn
+            batched=True,
+            output_format="matrix",
+            tile_segmented=False,
+            coo_segmented=False,
+            selective=False,
+            dual_cutoff=False,
+            return_vectors=True,
+            return_distances=True,
+            pair_fn=pair_fn,
         )
         if pair_fn is not None
         else _BATCH_CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC

--- a/nvalchemiops/jax/neighbors/batch_cluster_tile.py
+++ b/nvalchemiops/jax/neighbors/batch_cluster_tile.py
@@ -32,16 +32,11 @@ import jax.numpy as jnp
 import numpy as np
 import warp as wp
 
-from nvalchemiops.jax.neighbors._cluster_tile_preload import (
-    _preload_cluster_tile_build_kernel,
-    _preload_cluster_tile_coo_kernel,
-    _preload_cluster_tile_query_kernel,
-)
 from nvalchemiops.jax.neighbors._registration import (
-    _ClusterTileBuildJaxSpec,
-    _ClusterTileQueryJaxSpec,
-    _get_cluster_tile_build_jax_callable,
-    _get_cluster_tile_query_jax_callable,
+    _cluster_tile_build_registration,
+    _cluster_tile_coo_registration,
+    _cluster_tile_matrix_registration,
+    _GraphRegistration,
 )
 from nvalchemiops.neighbors.cluster_tile import (
     TILE_GROUP_SIZE,
@@ -898,135 +893,66 @@ def _batch_query_cluster_tile_coo_segmented_callback(
     )
 
 
-_BATCH_CLUSTER_TILE_BUILD_SPEC = _ClusterTileBuildJaxSpec(
-    batched=True,
-    segmented=False,
-    selective=False,
-)
-_BATCH_CLUSTER_TILE_BUILD_SELECTIVE_SPEC = _ClusterTileBuildJaxSpec(
-    batched=True,
-    segmented=True,
-    selective=True,
-)
+_BATCH_CLUSTER_TILE_BUILDS: dict[str, _GraphRegistration] = {
+    "full": _cluster_tile_build_registration(
+        _batch_build_cluster_tile_list_callback,
+        batched=True,
+        segmented=False,
+        selective=False,
+    ),
+    "selective": _cluster_tile_build_registration(
+        _batch_build_cluster_tile_list_selective_callback,
+        batched=True,
+        segmented=True,
+        selective=True,
+    ),
+}
 
-_jax_batch_build_cluster_tile_list = _get_cluster_tile_build_jax_callable(
-    _BATCH_CLUSTER_TILE_BUILD_SPEC,
-    _batch_build_cluster_tile_list_callback,
-)
-_jax_batch_build_cluster_tile_list_selective = _get_cluster_tile_build_jax_callable(
-    _BATCH_CLUSTER_TILE_BUILD_SELECTIVE_SPEC,
-    _batch_build_cluster_tile_list_selective_callback,
-)
-_BATCH_CLUSTER_TILE_QUERY_MATRIX_SPEC = _ClusterTileQueryJaxSpec(
-    batched=True,
-    output_format="matrix",
-    tile_segmented=False,
-    coo_segmented=False,
-    selective=False,
-    dual_cutoff=False,
-    return_vectors=False,
-    return_distances=False,
-    pair_fn=None,
-)
-_BATCH_CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC = _ClusterTileQueryJaxSpec(
-    batched=True,
-    output_format="matrix",
-    tile_segmented=True,
-    coo_segmented=False,
-    selective=True,
-    dual_cutoff=False,
-    return_vectors=False,
-    return_distances=False,
-    pair_fn=None,
-)
-_BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC = _ClusterTileQueryJaxSpec(
-    batched=True,
-    output_format="matrix",
-    tile_segmented=False,
-    coo_segmented=False,
-    selective=False,
-    dual_cutoff=True,
-    return_vectors=False,
-    return_distances=False,
-    pair_fn=None,
-)
-_BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC = _ClusterTileQueryJaxSpec(
-    batched=True,
-    output_format="matrix",
-    tile_segmented=True,
-    coo_segmented=False,
-    selective=True,
-    dual_cutoff=True,
-    return_vectors=False,
-    return_distances=False,
-    pair_fn=None,
-)
-_BATCH_CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC = _ClusterTileQueryJaxSpec(
-    batched=True,
-    output_format="matrix",
-    tile_segmented=False,
-    coo_segmented=False,
-    selective=False,
-    dual_cutoff=False,
-    return_vectors=True,
-    return_distances=True,
-    pair_fn=None,
-)
-_BATCH_CLUSTER_TILE_QUERY_COO_SPEC = _ClusterTileQueryJaxSpec(
-    batched=True,
-    output_format="coo",
-    tile_segmented=False,
-    coo_segmented=False,
-    selective=False,
-    dual_cutoff=False,
-    return_vectors=False,
-    return_distances=False,
-    pair_fn=None,
-)
-_BATCH_CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC = _ClusterTileQueryJaxSpec(
-    batched=True,
-    output_format="coo",
-    tile_segmented=True,
-    coo_segmented=True,
-    selective=True,
-    dual_cutoff=False,
-    return_vectors=False,
-    return_distances=False,
-    pair_fn=None,
-)
-
-_jax_batch_query_cluster_tile = _get_cluster_tile_query_jax_callable(
-    _BATCH_CLUSTER_TILE_QUERY_MATRIX_SPEC,
-    _batch_query_cluster_tile_callback,
-)
-_jax_batch_query_cluster_tile_selective = _get_cluster_tile_query_jax_callable(
-    _BATCH_CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC,
-    _batch_query_cluster_tile_selective_callback,
-)
-_jax_batch_query_cluster_tile_dual = _get_cluster_tile_query_jax_callable(
-    _BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC,
-    _batch_query_cluster_tile_dual_callback,
-)
-_jax_batch_query_cluster_tile_dual_selective = _get_cluster_tile_query_jax_callable(
-    _BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC,
-    _batch_query_cluster_tile_dual_selective_callback,
-)
-_jax_batch_query_cluster_tile_pair = _get_cluster_tile_query_jax_callable(
-    _BATCH_CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC,
-    _batch_query_cluster_tile_pair_callback,
-)
+_BATCH_CLUSTER_TILE_QUERIES: dict[str, _GraphRegistration] = {
+    "matrix": _cluster_tile_matrix_registration(
+        _batch_query_cluster_tile_callback,
+        batched=True,
+    ),
+    "matrix_selective": _cluster_tile_matrix_registration(
+        _batch_query_cluster_tile_selective_callback,
+        batched=True,
+        tile_segmented=True,
+        selective=True,
+    ),
+    "matrix_dual": _cluster_tile_matrix_registration(
+        _batch_query_cluster_tile_dual_callback,
+        batched=True,
+        dual_cutoff=True,
+    ),
+    "matrix_dual_selective": _cluster_tile_matrix_registration(
+        _batch_query_cluster_tile_dual_selective_callback,
+        batched=True,
+        tile_segmented=True,
+        selective=True,
+        dual_cutoff=True,
+    ),
+    "matrix_geometry": _cluster_tile_matrix_registration(
+        _batch_query_cluster_tile_pair_callback,
+        batched=True,
+        geometry=True,
+    ),
+    "coo": _cluster_tile_coo_registration(
+        _batch_query_cluster_tile_coo_callback,
+        batched=True,
+    ),
+    "coo_segmented": _cluster_tile_coo_registration(
+        _batch_query_cluster_tile_coo_segmented_callback,
+        batched=True,
+        tile_segmented=True,
+        coo_segmented=True,
+        selective=True,
+    ),
+}
 
 
 @functools.cache
-def _get_jax_batch_cluster_tile_pair_fn_callable(spec: _ClusterTileQueryJaxSpec):
-    """Build (and cache) a batched ``jax_callable`` closing over ``pair_fn`` for the
-    cluster-tile pair-output -> matrix kernel.
-
-    Batched analogue of
-    ``cluster_tile._get_jax_cluster_tile_pair_fn_callable``: adds the ``pair_params``
-    input + ``pair_energies`` / ``pair_forces`` outputs.  Cached by ``pair_fn``
-    identity; fp32-only.
-    """
+def _get_jax_batch_cluster_tile_pair_fn_registration(pair_fn) -> _GraphRegistration:
+    """Build (and cache) a batched graph registration closing over ``pair_fn``."""
 
     def _callback(
         sorted_atom_index: wp.array(dtype=wp.int32),
@@ -1072,26 +998,18 @@ def _get_jax_batch_cluster_tile_pair_fn_callable(spec: _ClusterTileQueryJaxSpec)
             return_distances=True,
             neighbor_vectors=neighbor_vectors,
             neighbor_distances=neighbor_distances,
-            pair_fn=spec.pair_fn,
+            pair_fn=pair_fn,
             pair_params=pair_params,
             pair_energies=pair_energies,
             pair_forces=pair_forces,
         )
 
-    return _get_cluster_tile_query_jax_callable(
-        spec,
+    return _cluster_tile_matrix_registration(
         _callback,
+        batched=True,
+        geometry=True,
+        pair_fn=pair_fn,
     )
-
-
-_jax_batch_query_cluster_tile_coo = _get_cluster_tile_query_jax_callable(
-    _BATCH_CLUSTER_TILE_QUERY_COO_SPEC,
-    _batch_query_cluster_tile_coo_callback,
-)
-_jax_batch_query_cluster_tile_coo_segmented = _get_cluster_tile_query_jax_callable(
-    _BATCH_CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC,
-    _batch_query_cluster_tile_coo_segmented_callback,
-)
 
 
 # =============================================================================
@@ -1237,9 +1155,8 @@ def batch_build_cluster_tile_list(
         tile_system = jnp.zeros(max_tiles, dtype=jnp.int32)
 
     if rebuild_flags is None:
-        _preload_cluster_tile_build_kernel(
-            _BATCH_CLUSTER_TILE_BUILD_SPEC,
-        )
+        build_registration = _BATCH_CLUSTER_TILE_BUILDS["full"]
+        build_registration.preload(device_source=sorted_pos_x)
         (
             group_ctr_x,
             group_ctr_y,
@@ -1251,7 +1168,7 @@ def batch_build_cluster_tile_list(
             tile_row_group,
             tile_col_group,
             tile_system,
-        ) = _jax_batch_build_cluster_tile_list(
+        ) = build_registration.callable(
             sorted_pos_x,
             sorted_pos_y,
             sorted_pos_z,
@@ -1277,9 +1194,8 @@ def batch_build_cluster_tile_list(
                 "rebuild_flags requires tile_offsets and tile_counts for "
                 "batched cluster_tile builds"
             )
-        _preload_cluster_tile_build_kernel(
-            _BATCH_CLUSTER_TILE_BUILD_SELECTIVE_SPEC,
-        )
+        build_registration = _BATCH_CLUSTER_TILE_BUILDS["selective"]
+        build_registration.preload(device_source=sorted_pos_x)
         rf = rebuild_flags.astype(jnp.bool_)
         (
             group_ctr_x,
@@ -1293,7 +1209,7 @@ def batch_build_cluster_tile_list(
             tile_row_group,
             tile_col_group,
             tile_system,
-        ) = _jax_batch_build_cluster_tile_list_selective(
+        ) = build_registration.callable(
             sorted_pos_x,
             sorted_pos_y,
             sorted_pos_z,
@@ -1495,30 +1411,19 @@ def batch_query_cluster_tile(
             )
         if batch_idx is None:
             raise ValueError("batch_idx is required when rebuild_flags is provided")
-    query_spec = (
-        _ClusterTileQueryJaxSpec(
-            batched=True,
-            output_format="matrix",
-            tile_segmented=False,
-            coo_segmented=False,
-            selective=False,
-            dual_cutoff=False,
-            return_vectors=True,
-            return_distances=True,
-            pair_fn=pair_fn,
-        )
-        if pair_fn is not None
-        else _BATCH_CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC
-        if has_pair_outputs
-        else _BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC
-        if dual_cutoff and selective
-        else _BATCH_CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC
-        if dual_cutoff
-        else _BATCH_CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC
-        if selective
-        else _BATCH_CLUSTER_TILE_QUERY_MATRIX_SPEC
-    )
-    _preload_cluster_tile_query_kernel(query_spec)
+    if pair_fn is not None:
+        query_registration = _get_jax_batch_cluster_tile_pair_fn_registration(pair_fn)
+    elif has_pair_outputs:
+        query_registration = _BATCH_CLUSTER_TILE_QUERIES["matrix_geometry"]
+    elif dual_cutoff and selective:
+        query_registration = _BATCH_CLUSTER_TILE_QUERIES["matrix_dual_selective"]
+    elif dual_cutoff:
+        query_registration = _BATCH_CLUSTER_TILE_QUERIES["matrix_dual"]
+    elif selective:
+        query_registration = _BATCH_CLUSTER_TILE_QUERIES["matrix_selective"]
+    else:
+        query_registration = _BATCH_CLUSTER_TILE_QUERIES["matrix"]
+    query_registration.preload(device_source=sorted_pos_x)
     if fill_value is None:
         fill_value = natom
     inv_cell_batch = jnp.linalg.inv(cell_batch)
@@ -1579,7 +1484,6 @@ def batch_query_cluster_tile(
             if pair_forces is None:
                 pair_forces = jnp.zeros((natom, max_neighbors, 3), dtype=jnp.float32)
             pair_params_arg = jnp.asarray(pair_params, dtype=jnp.float32)
-            pair_callable = _get_jax_batch_cluster_tile_pair_fn_callable(query_spec)
             (
                 neighbor_matrix,
                 num_neighbors,
@@ -1588,7 +1492,7 @@ def batch_query_cluster_tile(
                 neighbor_distances,
                 pair_energies,
                 pair_forces,
-            ) = pair_callable(
+            ) = query_registration.callable(
                 sorted_atom_index,
                 sorted_pos_x,
                 sorted_pos_y,
@@ -1628,7 +1532,7 @@ def batch_query_cluster_tile(
             neighbor_matrix_shifts,
             neighbor_vectors,
             neighbor_distances,
-        ) = _jax_batch_query_cluster_tile_pair(
+        ) = query_registration.callable(
             sorted_atom_index,
             sorted_pos_x,
             sorted_pos_y,
@@ -1666,7 +1570,7 @@ def batch_query_cluster_tile(
             neighbor_matrix2,
             num_neighbors2,
             neighbor_matrix_shifts2,
-        ) = _jax_batch_query_cluster_tile_dual_selective(
+        ) = query_registration.callable(
             sorted_atom_index,
             sorted_pos_x,
             sorted_pos_y,
@@ -1698,7 +1602,7 @@ def batch_query_cluster_tile(
             neighbor_matrix2,
             num_neighbors2,
             neighbor_matrix_shifts2,
-        ) = _jax_batch_query_cluster_tile_dual(
+        ) = query_registration.callable(
             sorted_atom_index,
             sorted_pos_x,
             sorted_pos_y,
@@ -1721,7 +1625,7 @@ def batch_query_cluster_tile(
         )
     elif selective:
         neighbor_matrix, num_neighbors, neighbor_matrix_shifts = (
-            _jax_batch_query_cluster_tile_selective(
+            query_registration.callable(
                 sorted_atom_index,
                 sorted_pos_x,
                 sorted_pos_y,
@@ -1744,7 +1648,7 @@ def batch_query_cluster_tile(
         )
     else:
         neighbor_matrix, num_neighbors, neighbor_matrix_shifts = (
-            _jax_batch_query_cluster_tile(
+            query_registration.callable(
                 sorted_atom_index,
                 sorted_pos_x,
                 sorted_pos_y,
@@ -1874,12 +1778,10 @@ def batch_query_cluster_tile_coo(
         raise ValueError("rebuild_flags requires pair_offsets and pair_counts")
     if rebuild_flags is not None and (tile_offsets is None or tile_counts is None):
         raise ValueError("rebuild_flags requires tile_offsets and tile_counts")
-    query_spec = (
-        _BATCH_CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC
-        if segmented
-        else _BATCH_CLUSTER_TILE_QUERY_COO_SPEC
-    )
-    _preload_cluster_tile_coo_kernel(query_spec)
+    coo_registration = _BATCH_CLUSTER_TILE_QUERIES[
+        "coo_segmented" if segmented else "coo"
+    ]
+    coo_registration.preload(device_source=sorted_pos_x)
 
     inv_cell_batch = jnp.linalg.inv(cell_batch)
     pair_counter = jnp.zeros(1, dtype=jnp.int32)
@@ -1897,37 +1799,35 @@ def batch_query_cluster_tile_coo(
             if rebuild_flags is not None
             else jnp.ones_like(pair_counts, dtype=jnp.bool_)
         )
-        pair_counter, pair_counts, coo_list, coo_shifts = (
-            _jax_batch_query_cluster_tile_coo_segmented(
-                sorted_atom_index,
-                sorted_pos_x,
-                sorted_pos_y,
-                sorted_pos_z,
-                cell_batch,
-                inv_cell_batch,
-                num_tiles,
-                tile_offsets.astype(jnp.int32),
-                tile_counts.astype(jnp.int32),
-                rf,
-                tile_row_group,
-                tile_col_group,
-                tile_system,
-                pair_counter,
-                pair_offsets.astype(jnp.int32),
-                pair_counts.astype(jnp.int32),
-                coo_list,
-                coo_shifts,
-                float(cutoff),
-                int(natom),
-                int(max_pairs),
-            )
+        pair_counter, pair_counts, coo_list, coo_shifts = coo_registration.callable(
+            sorted_atom_index,
+            sorted_pos_x,
+            sorted_pos_y,
+            sorted_pos_z,
+            cell_batch,
+            inv_cell_batch,
+            num_tiles,
+            tile_offsets.astype(jnp.int32),
+            tile_counts.astype(jnp.int32),
+            rf,
+            tile_row_group,
+            tile_col_group,
+            tile_system,
+            pair_counter,
+            pair_offsets.astype(jnp.int32),
+            pair_counts.astype(jnp.int32),
+            coo_list,
+            coo_shifts,
+            float(cutoff),
+            int(natom),
+            int(max_pairs),
         )
         del pair_counter
         return coo_list.T, pair_offsets, pair_counts, coo_shifts
 
     coo_list = jnp.zeros((max_pairs, 2), dtype=jnp.int32)
     coo_shifts = jnp.zeros((max_pairs, 3), dtype=jnp.int32)
-    pair_counter, coo_list, coo_shifts = _jax_batch_query_cluster_tile_coo(
+    pair_counter, coo_list, coo_shifts = coo_registration.callable(
         sorted_atom_index,
         sorted_pos_x,
         sorted_pos_y,

--- a/nvalchemiops/jax/neighbors/batch_naive.py
+++ b/nvalchemiops/jax/neighbors/batch_naive.py
@@ -30,15 +30,16 @@ from nvalchemiops.jax.neighbors._autograd import (
     _route_pair_outputs,
 )
 from nvalchemiops.jax.neighbors._dispatch import _is_jax_cpu_array
+from nvalchemiops.jax.neighbors._registration import (
+    _get_naive_jax_kernel,
+    _LazyDtypeRegistrations,
+    _NaiveJaxKernelSpec,
+)
 from nvalchemiops.jax.neighbors.neighbor_utils import (
-    build_naive_kernel_tables,
     compute_naive_num_shifts,
     coo_pack_pair_geometry,
     get_neighbor_list_from_neighbor_matrix,
     prepare_batch_idx_ptr,
-)
-from nvalchemiops.neighbors.naive import (
-    get_naive_neighbor_matrix_kernel as _get_naive_kernel,
 )
 from nvalchemiops.neighbors.naive.launchers import (
     _launch_naive_neighbor_matrix_no_pbc,
@@ -49,348 +50,61 @@ from nvalchemiops.neighbors.neighbor_utils import (
     get_wrap_positions_kernel,
 )
 
-_DTYPE_TO_BATCH_NAIVE_KERNELS = (wp.float32, wp.float64)
-(
-    _fill_batch_naive_neighbor_matrix_kernels,
-    _fill_batch_naive_neighbor_matrix_selective_kernels,
-    _fill_batch_naive_neighbor_matrix_pbc_kernels,
-    _fill_batch_naive_neighbor_matrix_pbc_selective_kernels,
-    _fill_batch_naive_neighbor_matrix_pbc_prewrapped_kernels,
-    _fill_batch_naive_neighbor_matrix_pbc_prewrapped_selective_kernels,
-) = build_naive_kernel_tables(
-    "single_cutoff", batched=True, dtypes=_DTYPE_TO_BATCH_NAIVE_KERNELS
-)
+# Direct jax_kernel registrations are constructed lazily. Tile callables and
+# wrap-position kernels remain eager because they are not factory direct wrappers.
+_DIRECT_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
 
-(
-    _fill_batch_naive_neighbor_matrix_half_kernels,
-    _fill_batch_naive_neighbor_matrix_selective_half_kernels,
-    _fill_batch_naive_neighbor_matrix_pbc_half_kernels,
-    _fill_batch_naive_neighbor_matrix_pbc_selective_half_kernels,
-    _fill_batch_naive_neighbor_matrix_pbc_prewrapped_half_kernels,
-    _fill_batch_naive_neighbor_matrix_pbc_prewrapped_selective_half_kernels,
-) = build_naive_kernel_tables(
-    "single_cutoff",
-    batched=True,
-    dtypes=_DTYPE_TO_BATCH_NAIVE_KERNELS,
-    half_fill=True,
-)
 
-# Pair-output kernel tables (autograd path).  Same factory with
-# return_vectors / return_distances flipped on.
-#
-# The PBC variant is hard-wired to ``pbc_mode='wrap_on_entry'``; the
-# autograd path silently ignores the public ``wrap_positions`` kwarg
-# (the kernel is idempotent on already-wrapped positions and correct on
-# raw positions).
-
-_fill_batch_naive_pair_kernels = {
-    t: _get_naive_kernel(
-        t,
-        pbc_mode="none",
-        batched=True,
-        selective=False,
-        return_vectors=True,
-        return_distances=True,
+def _direct_batch_naive_kernel_registrations(
+    *,
+    pbc_mode: str,
+    selective: bool = False,
+    half_fill: bool = False,
+    partial: bool = False,
+    return_vectors: bool = False,
+    return_distances: bool = False,
+) -> _LazyDtypeRegistrations:
+    """Build lazy direct registrations for one batched naive specialization."""
+    return _LazyDtypeRegistrations(
+        lambda wp_dtype: _get_naive_jax_kernel(
+            _NaiveJaxKernelSpec(
+                operation="single_cutoff",
+                wp_dtype=wp_dtype,
+                batched=True,
+                pbc_mode=pbc_mode,
+                selective=selective,
+                partial=partial,
+                half_fill=half_fill,
+                return_vectors=return_vectors,
+                return_distances=return_distances,
+                pair_fn=None,
+            )
+        ),
+        _DIRECT_DTYPE_MAP,
     )
-    for t in _DTYPE_TO_BATCH_NAIVE_KERNELS
+
+
+_DIRECT_BATCH_NAIVE_KERNELS = {
+    (pbc_mode, selective, half_fill): _direct_batch_naive_kernel_registrations(
+        pbc_mode=pbc_mode, selective=selective, half_fill=half_fill
+    )
+    for pbc_mode in ("none", "wrap_on_entry", "prewrapped")
+    for selective in (False, True)
+    for half_fill in (False, True)
 }
-_fill_batch_naive_pbc_pair_kernels = {
-    t: _get_naive_kernel(
-        t,
-        pbc_mode="wrap_on_entry",
-        batched=True,
-        selective=False,
+_DIRECT_BATCH_NAIVE_GEOMETRY_KERNELS = {
+    (pbc_mode, half_fill): _direct_batch_naive_kernel_registrations(
+        pbc_mode=pbc_mode,
+        half_fill=half_fill,
         return_vectors=True,
         return_distances=True,
     )
-    for t in _DTYPE_TO_BATCH_NAIVE_KERNELS
-}
-
-# Half-fill specializations of the pair-output kernels (selected when
-# ``half_fill=True``; ``half_fill`` is a compile-time constant in the factory).
-_fill_batch_naive_pair_half_kernels = {
-    t: _get_naive_kernel(
-        t,
-        pbc_mode="none",
-        batched=True,
-        selective=False,
-        return_vectors=True,
-        return_distances=True,
-        half_fill=True,
-    )
-    for t in _DTYPE_TO_BATCH_NAIVE_KERNELS
-}
-_fill_batch_naive_pbc_pair_half_kernels = {
-    t: _get_naive_kernel(
-        t,
-        pbc_mode="wrap_on_entry",
-        batched=True,
-        selective=False,
-        return_vectors=True,
-        return_distances=True,
-        half_fill=True,
-    )
-    for t in _DTYPE_TO_BATCH_NAIVE_KERNELS
+    for pbc_mode in ("none", "wrap_on_entry")
+    for half_fill in (False, True)
 }
 
 
 __all__ = ["batch_naive_neighbor_list"]
-
-# ==============================================================================
-# JAX Kernel Wrappers
-# ==============================================================================
-
-# No-PBC batch naive neighbor matrix kernel wrappers
-_jax_fill_batch_naive_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_kernels[wp.float32],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_kernels[wp.float64],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# PBC batch naive neighbor matrix kernel wrappers
-_jax_fill_batch_naive_pbc_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# Selective no-PBC batch naive neighbor matrix kernel wrappers
-_jax_fill_batch_naive_selective_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_selective_kernels[wp.float32],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_selective_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_selective_kernels[wp.float64],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# Selective PBC batch naive neighbor matrix kernel wrappers
-_jax_fill_batch_naive_pbc_selective_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_selective_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_selective_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_selective_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# Prewrapped PBC batch naive neighbor matrix kernel wrappers
-_jax_fill_batch_naive_pbc_prewrapped_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_prewrapped_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_prewrapped_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_prewrapped_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_prewrapped_selective_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_prewrapped_selective_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_prewrapped_selective_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_prewrapped_selective_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# Half-fill batch naive neighbor matrix kernel wrappers
-_jax_fill_batch_naive_half_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_half_kernels[wp.float32],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_half_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_half_kernels[wp.float64],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_half_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_half_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_half_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_half_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_selective_half_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_selective_half_kernels[wp.float32],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_selective_half_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_selective_half_kernels[wp.float64],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_selective_half_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_selective_half_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_selective_half_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_selective_half_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_prewrapped_half_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_prewrapped_half_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_prewrapped_half_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_prewrapped_half_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_prewrapped_selective_half_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_prewrapped_selective_half_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_prewrapped_selective_half_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_prewrapped_selective_half_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# Pair-output variants (autograd path).
-_jax_fill_batch_naive_pair_f32 = jax_kernel(
-    _fill_batch_naive_pair_kernels[wp.float32],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pair_f64 = jax_kernel(
-    _fill_batch_naive_pair_kernels[wp.float64],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_pair_f32 = jax_kernel(
-    _fill_batch_naive_pbc_pair_kernels[wp.float32],
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_pair_f64 = jax_kernel(
-    _fill_batch_naive_pbc_pair_kernels[wp.float64],
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-
-# Half-fill geometry-only pair-output callables (same I/O as the full-fill ones).
-_jax_fill_batch_naive_pair_half_f32 = jax_kernel(
-    _fill_batch_naive_pair_half_kernels[wp.float32],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pair_half_f64 = jax_kernel(
-    _fill_batch_naive_pair_half_kernels[wp.float64],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_pair_half_f32 = jax_kernel(
-    _fill_batch_naive_pbc_pair_half_kernels[wp.float32],
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_naive_pbc_pair_half_f64 = jax_kernel(
-    _fill_batch_naive_pbc_pair_half_kernels[wp.float64],
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
 
 
 @functools.cache
@@ -398,36 +112,19 @@ def _get_jax_batch_naive_pair_kernel(
     wp_dtype, pbc_mode: str, half_fill: bool = False, partial: bool = False
 ):
     """Build a geometry-output batched naive kernel for optional partial rows."""
-    kernel = _get_naive_kernel(
-        wp_dtype,
-        pbc_mode=pbc_mode,
-        batched=True,
-        selective=False,
-        partial=partial,
-        return_vectors=True,
-        return_distances=True,
-        half_fill=half_fill,
-    )
-    if pbc_mode == "none":
-        in_out_argnames = [
-            "neighbor_matrix1",
-            "num_neighbors1",
-            "neighbor_vectors",
-            "neighbor_distances",
-        ]
-    else:
-        in_out_argnames = [
-            "neighbor_matrix1",
-            "neighbor_matrix_shifts1",
-            "num_neighbors1",
-            "neighbor_vectors",
-            "neighbor_distances",
-        ]
-    return jax_kernel(
-        kernel,
-        num_outputs=len(in_out_argnames),
-        in_out_argnames=in_out_argnames,
-        enable_backward=False,
+    return _get_naive_jax_kernel(
+        _NaiveJaxKernelSpec(
+            operation="single_cutoff",
+            wp_dtype=wp_dtype,
+            batched=True,
+            pbc_mode=pbc_mode,
+            selective=False,
+            partial=partial,
+            half_fill=half_fill,
+            return_vectors=True,
+            return_distances=True,
+            pair_fn=None,
+        )
     )
 
 
@@ -448,41 +145,19 @@ def _get_jax_batch_naive_pair_fn_kernel(
     by ``(pair_fn identity, wp_dtype, pbc_mode)``; one recompile per distinct
     ``pair_fn``.
     """
-    kernel = _get_naive_kernel(
-        wp_dtype,
-        pbc_mode=pbc_mode,
-        batched=True,
-        selective=False,
-        partial=partial,
-        return_vectors=True,
-        return_distances=True,
-        pair_fn=pair_fn,
-        half_fill=half_fill,
-    )
-    if pbc_mode == "none":
-        in_out_argnames = [
-            "neighbor_matrix1",
-            "num_neighbors1",
-            "neighbor_vectors",
-            "neighbor_distances",
-            "pair_energies",
-            "pair_forces",
-        ]
-    else:  # "wrap_on_entry"
-        in_out_argnames = [
-            "neighbor_matrix1",
-            "neighbor_matrix_shifts1",
-            "num_neighbors1",
-            "neighbor_vectors",
-            "neighbor_distances",
-            "pair_energies",
-            "pair_forces",
-        ]
-    return jax_kernel(
-        kernel,
-        num_outputs=len(in_out_argnames),
-        in_out_argnames=in_out_argnames,
-        enable_backward=False,
+    return _get_naive_jax_kernel(
+        _NaiveJaxKernelSpec(
+            operation="single_cutoff",
+            wp_dtype=wp_dtype,
+            batched=True,
+            pbc_mode=pbc_mode,
+            selective=False,
+            partial=partial,
+            half_fill=half_fill,
+            return_vectors=True,
+            return_distances=True,
+            pair_fn=pair_fn,
+        )
     )
 
 
@@ -840,18 +515,10 @@ def _batch_naive_pair_outputs_forward(
             kernel = _get_jax_batch_naive_pair_kernel(
                 wp_dtype, "none", half_fill, is_partial
             )
-        elif half_fill:
-            kernel = (
-                _jax_fill_batch_naive_pair_half_f64
-                if f64
-                else _jax_fill_batch_naive_pair_half_f32
-            )
         else:
-            kernel = (
-                _jax_fill_batch_naive_pair_f64
-                if f64
-                else _jax_fill_batch_naive_pair_f32
-            )
+            kernel = _DIRECT_BATCH_NAIVE_GEOMETRY_KERNELS[("none", bool(half_fill))][
+                positions.dtype
+            ]
         outs = kernel(
             positions,
             empty_offsets,
@@ -890,18 +557,10 @@ def _batch_naive_pair_outputs_forward(
             kernel = _get_jax_batch_naive_pair_kernel(
                 wp_dtype, "wrap_on_entry", half_fill, is_partial
             )
-        elif half_fill:
-            kernel = (
-                _jax_fill_batch_naive_pbc_pair_half_f64
-                if f64
-                else _jax_fill_batch_naive_pbc_pair_half_f32
-            )
         else:
-            kernel = (
-                _jax_fill_batch_naive_pbc_pair_f64
-                if f64
-                else _jax_fill_batch_naive_pbc_pair_f32
-            )
+            kernel = _DIRECT_BATCH_NAIVE_GEOMETRY_KERNELS[
+                ("wrap_on_entry", bool(half_fill))
+            ][positions.dtype]
         if shift_range_per_dimension is None or num_shifts_per_system is None:
             shift_range_per_dimension, num_shifts_per_system, _ = (
                 compute_naive_num_shifts(cell, cutoff, pbc)
@@ -1460,48 +1119,30 @@ def batch_naive_neighbor_list(
             else:
                 return neighbor_matrix, num_neighbors
 
-    # Select kernel based on dtype and static half-fill specialization.
+    # Select lazy direct registrations by dtype and static specialization.
     if positions.dtype == jnp.float64:
-        if half_fill:
-            _jax_fill = _jax_fill_batch_naive_half_f64
-            _jax_fill_pbc = _jax_fill_batch_naive_pbc_half_f64
-            _jax_fill_selective = _jax_fill_batch_naive_selective_half_f64
-            _jax_fill_pbc_selective = _jax_fill_batch_naive_pbc_selective_half_f64
-            _jax_fill_pbc_prewrapped = _jax_fill_batch_naive_pbc_prewrapped_half_f64
-            _jax_fill_pbc_prewrapped_selective = (
-                _jax_fill_batch_naive_pbc_prewrapped_selective_half_f64
-            )
-        else:
-            _jax_fill = _jax_fill_batch_naive_f64
-            _jax_fill_pbc = _jax_fill_batch_naive_pbc_f64
-            _jax_fill_selective = _jax_fill_batch_naive_selective_f64
-            _jax_fill_pbc_selective = _jax_fill_batch_naive_pbc_selective_f64
-            _jax_fill_pbc_prewrapped = _jax_fill_batch_naive_pbc_prewrapped_f64
-            _jax_fill_pbc_prewrapped_selective = (
-                _jax_fill_batch_naive_pbc_prewrapped_selective_f64
-            )
         _jax_wrap_batch = _jax_wrap_positions_batch_f64
     else:
-        if half_fill:
-            _jax_fill = _jax_fill_batch_naive_half_f32
-            _jax_fill_pbc = _jax_fill_batch_naive_pbc_half_f32
-            _jax_fill_selective = _jax_fill_batch_naive_selective_half_f32
-            _jax_fill_pbc_selective = _jax_fill_batch_naive_pbc_selective_half_f32
-            _jax_fill_pbc_prewrapped = _jax_fill_batch_naive_pbc_prewrapped_half_f32
-            _jax_fill_pbc_prewrapped_selective = (
-                _jax_fill_batch_naive_pbc_prewrapped_selective_half_f32
-            )
-        else:
-            _jax_fill = _jax_fill_batch_naive_f32
-            _jax_fill_pbc = _jax_fill_batch_naive_pbc_f32
-            _jax_fill_selective = _jax_fill_batch_naive_selective_f32
-            _jax_fill_pbc_selective = _jax_fill_batch_naive_pbc_selective_f32
-            _jax_fill_pbc_prewrapped = _jax_fill_batch_naive_pbc_prewrapped_f32
-            _jax_fill_pbc_prewrapped_selective = (
-                _jax_fill_batch_naive_pbc_prewrapped_selective_f32
-            )
         _jax_wrap_batch = _jax_wrap_positions_batch_f32
         positions = positions.astype(jnp.float32)
+    _jax_fill = _DIRECT_BATCH_NAIVE_KERNELS[("none", False, bool(half_fill))][
+        positions.dtype
+    ]
+    _jax_fill_pbc = _DIRECT_BATCH_NAIVE_KERNELS[
+        ("wrap_on_entry", False, bool(half_fill))
+    ][positions.dtype]
+    _jax_fill_pbc_prewrapped = _DIRECT_BATCH_NAIVE_KERNELS[
+        ("prewrapped", False, bool(half_fill))
+    ][positions.dtype]
+    _jax_fill_selective = _DIRECT_BATCH_NAIVE_KERNELS[("none", True, bool(half_fill))][
+        positions.dtype
+    ]
+    _jax_fill_pbc_selective = _DIRECT_BATCH_NAIVE_KERNELS[
+        ("wrap_on_entry", True, bool(half_fill))
+    ][positions.dtype]
+    _jax_fill_pbc_prewrapped_selective = _DIRECT_BATCH_NAIVE_KERNELS[
+        ("prewrapped", True, bool(half_fill))
+    ][positions.dtype]
 
     positions = jax.lax.stop_gradient(positions)
     if cell is not None:

--- a/nvalchemiops/jax/neighbors/batch_naive.py
+++ b/nvalchemiops/jax/neighbors/batch_naive.py
@@ -30,11 +30,7 @@ from nvalchemiops.jax.neighbors._autograd import (
     _route_pair_outputs,
 )
 from nvalchemiops.jax.neighbors._dispatch import _is_jax_cpu_array
-from nvalchemiops.jax.neighbors._registration import (
-    _get_naive_jax_kernel,
-    _LazyDtypeRegistrations,
-    _NaiveJaxKernelSpec,
-)
+from nvalchemiops.jax.neighbors._registration import _lazy_naive_kernel
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     compute_naive_num_shifts,
     coo_pack_pair_geometry,
@@ -52,7 +48,6 @@ from nvalchemiops.neighbors.neighbor_utils import (
 
 # Direct jax_kernel registrations are constructed lazily. Tile callables and
 # wrap-position kernels remain eager because they are not factory direct wrappers.
-_DIRECT_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
 
 
 def _direct_batch_naive_kernel_registrations(
@@ -61,26 +56,18 @@ def _direct_batch_naive_kernel_registrations(
     selective: bool = False,
     half_fill: bool = False,
     partial: bool = False,
-    return_vectors: bool = False,
-    return_distances: bool = False,
-) -> _LazyDtypeRegistrations:
+    geometry: bool = False,
+):
     """Build lazy direct registrations for one batched naive specialization."""
-    return _LazyDtypeRegistrations(
-        lambda wp_dtype: _get_naive_jax_kernel(
-            _NaiveJaxKernelSpec(
-                operation="single_cutoff",
-                wp_dtype=wp_dtype,
-                batched=True,
-                pbc_mode=pbc_mode,
-                selective=selective,
-                partial=partial,
-                half_fill=half_fill,
-                return_vectors=return_vectors,
-                return_distances=return_distances,
-                pair_fn=None,
-            )
-        ),
-        _DIRECT_DTYPE_MAP,
+    return _lazy_naive_kernel(
+        operation="single_cutoff",
+        batched=True,
+        pbc_mode=pbc_mode,
+        selective=selective,
+        partial=partial,
+        half_fill=half_fill,
+        geometry=geometry,
+        pair_fn=None,
     )
 
 
@@ -96,8 +83,7 @@ _DIRECT_BATCH_NAIVE_GEOMETRY_KERNELS = {
     (pbc_mode, half_fill): _direct_batch_naive_kernel_registrations(
         pbc_mode=pbc_mode,
         half_fill=half_fill,
-        return_vectors=True,
-        return_distances=True,
+        geometry=True,
     )
     for pbc_mode in ("none", "wrap_on_entry")
     for half_fill in (False, True)
@@ -112,20 +98,17 @@ def _get_jax_batch_naive_pair_kernel(
     wp_dtype, pbc_mode: str, half_fill: bool = False, partial: bool = False
 ):
     """Build a geometry-output batched naive kernel for optional partial rows."""
-    return _get_naive_jax_kernel(
-        _NaiveJaxKernelSpec(
-            operation="single_cutoff",
-            wp_dtype=wp_dtype,
-            batched=True,
-            pbc_mode=pbc_mode,
-            selective=False,
-            partial=partial,
-            half_fill=half_fill,
-            return_vectors=True,
-            return_distances=True,
-            pair_fn=None,
-        )
-    )
+    jax_dtype = jnp.float64 if wp_dtype == wp.float64 else jnp.float32
+    return _lazy_naive_kernel(
+        operation="single_cutoff",
+        batched=True,
+        pbc_mode=pbc_mode,
+        selective=False,
+        partial=partial,
+        half_fill=half_fill,
+        geometry=True,
+        pair_fn=None,
+    )[jax_dtype]
 
 
 @functools.cache
@@ -145,20 +128,17 @@ def _get_jax_batch_naive_pair_fn_kernel(
     by ``(pair_fn identity, wp_dtype, pbc_mode)``; one recompile per distinct
     ``pair_fn``.
     """
-    return _get_naive_jax_kernel(
-        _NaiveJaxKernelSpec(
-            operation="single_cutoff",
-            wp_dtype=wp_dtype,
-            batched=True,
-            pbc_mode=pbc_mode,
-            selective=False,
-            partial=partial,
-            half_fill=half_fill,
-            return_vectors=True,
-            return_distances=True,
-            pair_fn=pair_fn,
-        )
-    )
+    jax_dtype = jnp.float64 if wp_dtype == wp.float64 else jnp.float32
+    return _lazy_naive_kernel(
+        operation="single_cutoff",
+        batched=True,
+        pbc_mode=pbc_mode,
+        selective=False,
+        partial=partial,
+        half_fill=half_fill,
+        geometry=True,
+        pair_fn=pair_fn,
+    )[jax_dtype]
 
 
 # Wrap positions batch kernel wrappers
@@ -1119,30 +1099,12 @@ def batch_naive_neighbor_list(
             else:
                 return neighbor_matrix, num_neighbors
 
-    # Select lazy direct registrations by dtype and static specialization.
+    # Select wrap kernel by dtype; direct naive registrations resolve at launch.
     if positions.dtype == jnp.float64:
         _jax_wrap_batch = _jax_wrap_positions_batch_f64
     else:
         _jax_wrap_batch = _jax_wrap_positions_batch_f32
         positions = positions.astype(jnp.float32)
-    _jax_fill = _DIRECT_BATCH_NAIVE_KERNELS[("none", False, bool(half_fill))][
-        positions.dtype
-    ]
-    _jax_fill_pbc = _DIRECT_BATCH_NAIVE_KERNELS[
-        ("wrap_on_entry", False, bool(half_fill))
-    ][positions.dtype]
-    _jax_fill_pbc_prewrapped = _DIRECT_BATCH_NAIVE_KERNELS[
-        ("prewrapped", False, bool(half_fill))
-    ][positions.dtype]
-    _jax_fill_selective = _DIRECT_BATCH_NAIVE_KERNELS[("none", True, bool(half_fill))][
-        positions.dtype
-    ]
-    _jax_fill_pbc_selective = _DIRECT_BATCH_NAIVE_KERNELS[
-        ("wrap_on_entry", True, bool(half_fill))
-    ][positions.dtype]
-    _jax_fill_pbc_prewrapped_selective = _DIRECT_BATCH_NAIVE_KERNELS[
-        ("prewrapped", True, bool(half_fill))
-    ][positions.dtype]
 
     positions = jax.lax.stop_gradient(positions)
     if cell is not None:
@@ -1240,7 +1202,9 @@ def batch_naive_neighbor_list(
             num_neighbors = jnp.where(
                 atom_rebuild, jnp.zeros_like(num_neighbors), num_neighbors
             )
-            neighbor_matrix, num_neighbors = _jax_fill_selective(
+            neighbor_matrix, num_neighbors = _DIRECT_BATCH_NAIVE_KERNELS[
+                ("none", True, bool(half_fill))
+            ][positions.dtype](
                 positions,
                 empty_offsets,
                 float(cutoff * cutoff),
@@ -1266,7 +1230,9 @@ def batch_naive_neighbor_list(
                 launch_dims=(1, 1, total_atoms),
             )
         else:
-            neighbor_matrix, num_neighbors = _jax_fill(
+            neighbor_matrix, num_neighbors = _DIRECT_BATCH_NAIVE_KERNELS[
+                ("none", False, bool(half_fill))
+            ][positions.dtype](
                 positions,
                 empty_offsets,
                 float(cutoff * cutoff),
@@ -1339,7 +1305,9 @@ def batch_naive_neighbor_list(
                     atom_rebuild, jnp.zeros_like(num_neighbors), num_neighbors
                 )
                 neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
-                    _jax_fill_pbc_selective(
+                    _DIRECT_BATCH_NAIVE_KERNELS[
+                        ("wrap_on_entry", True, bool(half_fill))
+                    ][positions.dtype](
                         positions_wrapped,
                         per_atom_cell_offsets,
                         float(cutoff * cutoff),
@@ -1370,34 +1338,38 @@ def batch_naive_neighbor_list(
                     )
                 )
             else:
-                neighbor_matrix, neighbor_matrix_shifts, num_neighbors = _jax_fill_pbc(
-                    positions_wrapped,
-                    per_atom_cell_offsets,
-                    float(cutoff * cutoff),
-                    0.0,
-                    cell,
-                    shift_range_per_dimension,
-                    num_shifts_per_system,
-                    batch_idx_i32,
-                    batch_ptr_i32,
-                    empty_target_indices,
-                    neighbor_matrix,
-                    neighbor_matrix_shifts,
-                    num_neighbors,
-                    empty_matrix,
-                    empty_shifts,
-                    empty_num_neighbors,
-                    empty_vectors,
-                    empty_distances,
-                    empty_pair_params,
-                    empty_energies,
-                    empty_forces,
-                    empty_rebuild_flags,
-                    launch_dims=(
-                        num_systems,
-                        max_shifts_per_system,
-                        max_atoms_per_system,
-                    ),
+                neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
+                    _DIRECT_BATCH_NAIVE_KERNELS[
+                        ("wrap_on_entry", False, bool(half_fill))
+                    ][positions.dtype](
+                        positions_wrapped,
+                        per_atom_cell_offsets,
+                        float(cutoff * cutoff),
+                        0.0,
+                        cell,
+                        shift_range_per_dimension,
+                        num_shifts_per_system,
+                        batch_idx_i32,
+                        batch_ptr_i32,
+                        empty_target_indices,
+                        neighbor_matrix,
+                        neighbor_matrix_shifts,
+                        num_neighbors,
+                        empty_matrix,
+                        empty_shifts,
+                        empty_num_neighbors,
+                        empty_vectors,
+                        empty_distances,
+                        empty_pair_params,
+                        empty_energies,
+                        empty_forces,
+                        empty_rebuild_flags,
+                        launch_dims=(
+                            num_systems,
+                            max_shifts_per_system,
+                            max_atoms_per_system,
+                        ),
+                    )
                 )
         else:
             if rebuild_flags is not None:
@@ -1407,7 +1379,9 @@ def batch_naive_neighbor_list(
                     atom_rebuild, jnp.zeros_like(num_neighbors), num_neighbors
                 )
                 neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
-                    _jax_fill_pbc_prewrapped_selective(
+                    _DIRECT_BATCH_NAIVE_KERNELS[("prewrapped", True, bool(half_fill))][
+                        positions.dtype
+                    ](
                         positions,
                         empty_offsets,
                         float(cutoff * cutoff),
@@ -1439,7 +1413,9 @@ def batch_naive_neighbor_list(
                 )
             else:
                 neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
-                    _jax_fill_pbc_prewrapped(
+                    _DIRECT_BATCH_NAIVE_KERNELS[("prewrapped", False, bool(half_fill))][
+                        positions.dtype
+                    ](
                         positions,
                         empty_offsets,
                         float(cutoff * cutoff),

--- a/nvalchemiops/jax/neighbors/batch_naive.py
+++ b/nvalchemiops/jax/neighbors/batch_naive.py
@@ -50,37 +50,22 @@ from nvalchemiops.neighbors.neighbor_utils import (
 # wrap-position kernels remain eager because they are not factory direct wrappers.
 
 
-def _direct_batch_naive_kernel_registrations(
-    *,
-    pbc_mode: str,
-    selective: bool = False,
-    half_fill: bool = False,
-    partial: bool = False,
-    geometry: bool = False,
-):
-    """Build lazy direct registrations for one batched naive specialization."""
-    return _lazy_naive_kernel(
+_DIRECT_BATCH_NAIVE_KERNELS = {
+    (pbc_mode, selective, half_fill): _lazy_naive_kernel(
         operation="single_cutoff",
         batched=True,
         pbc_mode=pbc_mode,
         selective=selective,
-        partial=partial,
         half_fill=half_fill,
-        geometry=geometry,
-        pair_fn=None,
-    )
-
-
-_DIRECT_BATCH_NAIVE_KERNELS = {
-    (pbc_mode, selective, half_fill): _direct_batch_naive_kernel_registrations(
-        pbc_mode=pbc_mode, selective=selective, half_fill=half_fill
     )
     for pbc_mode in ("none", "wrap_on_entry", "prewrapped")
     for selective in (False, True)
     for half_fill in (False, True)
 }
 _DIRECT_BATCH_NAIVE_GEOMETRY_KERNELS = {
-    (pbc_mode, half_fill): _direct_batch_naive_kernel_registrations(
+    (pbc_mode, half_fill): _lazy_naive_kernel(
+        operation="single_cutoff",
+        batched=True,
         pbc_mode=pbc_mode,
         half_fill=half_fill,
         geometry=True,

--- a/nvalchemiops/jax/neighbors/batch_naive_dual_cutoff.py
+++ b/nvalchemiops/jax/neighbors/batch_naive_dual_cutoff.py
@@ -33,20 +33,12 @@ from nvalchemiops.neighbors.neighbor_utils import (
     get_wrap_positions_kernel,
 )
 
-
-def _direct_dual_registrations(*, pbc_mode: str, selective: bool = False):
-    """Build lazy direct registrations for one dual-cutoff specialization."""
-    return _lazy_naive_kernel(
+_DIRECT_BATCH_NAIVE_DUAL_KERNELS = {
+    (pbc_mode, selective): _lazy_naive_kernel(
         operation="dual_cutoff",
         batched=True,
         pbc_mode=pbc_mode,
         selective=selective,
-    )
-
-
-_DIRECT_BATCH_NAIVE_DUAL_KERNELS = {
-    (pbc_mode, selective): _direct_dual_registrations(
-        pbc_mode=pbc_mode, selective=selective
     )
     for pbc_mode in ("none", "wrap_on_entry", "prewrapped")
     for selective in (False, True)

--- a/nvalchemiops/jax/neighbors/batch_naive_dual_cutoff.py
+++ b/nvalchemiops/jax/neighbors/batch_naive_dual_cutoff.py
@@ -22,8 +22,12 @@ import jax.numpy as jnp
 import warp as wp
 from warp.jax_experimental import jax_kernel
 
+from nvalchemiops.jax.neighbors._registration import (
+    _get_naive_jax_kernel,
+    _LazyDtypeRegistrations,
+    _NaiveJaxKernelSpec,
+)
 from nvalchemiops.jax.neighbors.neighbor_utils import (
-    build_naive_kernel_tables,
     compute_naive_num_shifts,
     get_neighbor_list_from_neighbor_matrix,
     prepare_batch_idx_ptr,
@@ -33,185 +37,46 @@ from nvalchemiops.neighbors.neighbor_utils import (
     get_wrap_positions_kernel,
 )
 
-_DTYPE_TO_BATCH_NAIVE_DUAL_KERNELS = (wp.float32, wp.float64)
-(
-    _fill_batch_naive_neighbor_matrix_dual_cutoff_kernels,
-    _fill_batch_naive_neighbor_matrix_dual_cutoff_selective_kernels,
-    _fill_batch_naive_neighbor_matrix_pbc_dual_cutoff_kernels,
-    _fill_batch_naive_neighbor_matrix_pbc_dual_cutoff_selective_kernels,
-    _fill_batch_naive_neighbor_matrix_pbc_dual_cutoff_prewrapped_kernels,
-    _fill_batch_naive_neighbor_matrix_pbc_dual_cutoff_prewrapped_selective_kernels,
-) = build_naive_kernel_tables(
-    "dual_cutoff", batched=True, dtypes=_DTYPE_TO_BATCH_NAIVE_DUAL_KERNELS
-)
+_DIRECT_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
+
+
+def _direct_dual_registrations(
+    *, pbc_mode: str, selective: bool = False
+) -> _LazyDtypeRegistrations:
+    """Build lazy direct registrations for one dual-cutoff specialization."""
+    return _LazyDtypeRegistrations(
+        lambda wp_dtype: _get_naive_jax_kernel(
+            _NaiveJaxKernelSpec(
+                operation="dual_cutoff",
+                wp_dtype=wp_dtype,
+                batched=True,
+                pbc_mode=pbc_mode,
+                selective=selective,
+                partial=False,
+                half_fill=False,
+                return_vectors=False,
+                return_distances=False,
+                pair_fn=None,
+            )
+        ),
+        _DIRECT_DTYPE_MAP,
+    )
+
+
+_DIRECT_BATCH_NAIVE_DUAL_KERNELS = {
+    (pbc_mode, selective): _direct_dual_registrations(
+        pbc_mode=pbc_mode, selective=selective
+    )
+    for pbc_mode in ("none", "wrap_on_entry", "prewrapped")
+    for selective in (False, True)
+}
+
 
 __all__ = ["batch_naive_neighbor_list_dual_cutoff"]
 
 # ==============================================================================
 # JAX Kernel Wrappers
 # ==============================================================================
-
-# No-PBC batch naive dual cutoff neighbor matrix kernel wrappers
-_jax_fill_batch_dual_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_dual_cutoff_kernels[wp.float32],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_dual_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_dual_cutoff_kernels[wp.float64],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-
-# PBC batch naive dual cutoff neighbor matrix kernel wrappers
-_jax_fill_batch_dual_pbc_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_dual_cutoff_kernels[wp.float32],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_dual_pbc_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_dual_cutoff_kernels[wp.float64],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-
-# Selective batch dual cutoff neighbor matrix kernel wrappers
-_jax_fill_batch_dual_selective_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_dual_cutoff_selective_kernels[wp.float32],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_dual_selective_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_dual_cutoff_selective_kernels[wp.float64],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-
-# Selective PBC batch dual cutoff neighbor matrix kernel wrappers
-_jax_fill_batch_dual_pbc_selective_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_dual_cutoff_selective_kernels[wp.float32],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_dual_pbc_selective_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_dual_cutoff_selective_kernels[wp.float64],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-
-# Prewrapped PBC batch dual cutoff neighbor matrix kernel wrappers
-_jax_fill_batch_dual_pbc_prewrapped_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_dual_cutoff_prewrapped_kernels[wp.float32],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_dual_pbc_prewrapped_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_dual_cutoff_prewrapped_kernels[wp.float64],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_dual_pbc_prewrapped_selective_f32 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_dual_cutoff_prewrapped_selective_kernels[
-        wp.float32
-    ],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_batch_dual_pbc_prewrapped_selective_f64 = jax_kernel(
-    _fill_batch_naive_neighbor_matrix_pbc_dual_cutoff_prewrapped_selective_kernels[
-        wp.float64
-    ],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
 
 # Wrap positions batch kernel wrappers
 _jax_wrap_positions_batch_f32 = jax_kernel(
@@ -510,28 +375,29 @@ def batch_naive_neighbor_list_dual_cutoff(
                     num_neighbors2,
                 )
 
-    # Select kernel based on dtype
+    # Select lazy direct registrations by dtype. Public ``half_fill`` remains
+    # intentionally absent from dual low-level specializations.
     if positions.dtype == jnp.float64:
-        _jax_fill = _jax_fill_batch_dual_f64
-        _jax_fill_pbc = _jax_fill_batch_dual_pbc_f64
-        _jax_fill_selective = _jax_fill_batch_dual_selective_f64
-        _jax_fill_pbc_selective = _jax_fill_batch_dual_pbc_selective_f64
-        _jax_fill_pbc_prewrapped = _jax_fill_batch_dual_pbc_prewrapped_f64
-        _jax_fill_pbc_prewrapped_selective = (
-            _jax_fill_batch_dual_pbc_prewrapped_selective_f64
-        )
         _jax_wrap_batch = _jax_wrap_positions_batch_f64
     else:
-        _jax_fill = _jax_fill_batch_dual_f32
-        _jax_fill_pbc = _jax_fill_batch_dual_pbc_f32
-        _jax_fill_selective = _jax_fill_batch_dual_selective_f32
-        _jax_fill_pbc_selective = _jax_fill_batch_dual_pbc_selective_f32
-        _jax_fill_pbc_prewrapped = _jax_fill_batch_dual_pbc_prewrapped_f32
-        _jax_fill_pbc_prewrapped_selective = (
-            _jax_fill_batch_dual_pbc_prewrapped_selective_f32
-        )
         _jax_wrap_batch = _jax_wrap_positions_batch_f32
         positions = positions.astype(jnp.float32)
+    _jax_fill = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("none", False)][positions.dtype]
+    _jax_fill_pbc = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("wrap_on_entry", False)][
+        positions.dtype
+    ]
+    _jax_fill_selective = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("none", True)][
+        positions.dtype
+    ]
+    _jax_fill_pbc_selective = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("wrap_on_entry", True)][
+        positions.dtype
+    ]
+    _jax_fill_pbc_prewrapped = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("prewrapped", False)][
+        positions.dtype
+    ]
+    _jax_fill_pbc_prewrapped_selective = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[
+        ("prewrapped", True)
+    ][positions.dtype]
 
     total_atoms = positions.shape[0]
     num_systems = batch_ptr.shape[0] - 1

--- a/nvalchemiops/jax/neighbors/batch_naive_dual_cutoff.py
+++ b/nvalchemiops/jax/neighbors/batch_naive_dual_cutoff.py
@@ -22,11 +22,7 @@ import jax.numpy as jnp
 import warp as wp
 from warp.jax_experimental import jax_kernel
 
-from nvalchemiops.jax.neighbors._registration import (
-    _get_naive_jax_kernel,
-    _LazyDtypeRegistrations,
-    _NaiveJaxKernelSpec,
-)
+from nvalchemiops.jax.neighbors._registration import _lazy_naive_kernel
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     compute_naive_num_shifts,
     get_neighbor_list_from_neighbor_matrix,
@@ -37,29 +33,14 @@ from nvalchemiops.neighbors.neighbor_utils import (
     get_wrap_positions_kernel,
 )
 
-_DIRECT_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
 
-
-def _direct_dual_registrations(
-    *, pbc_mode: str, selective: bool = False
-) -> _LazyDtypeRegistrations:
+def _direct_dual_registrations(*, pbc_mode: str, selective: bool = False):
     """Build lazy direct registrations for one dual-cutoff specialization."""
-    return _LazyDtypeRegistrations(
-        lambda wp_dtype: _get_naive_jax_kernel(
-            _NaiveJaxKernelSpec(
-                operation="dual_cutoff",
-                wp_dtype=wp_dtype,
-                batched=True,
-                pbc_mode=pbc_mode,
-                selective=selective,
-                partial=False,
-                half_fill=False,
-                return_vectors=False,
-                return_distances=False,
-                pair_fn=None,
-            )
-        ),
-        _DIRECT_DTYPE_MAP,
+    return _lazy_naive_kernel(
+        operation="dual_cutoff",
+        batched=True,
+        pbc_mode=pbc_mode,
+        selective=selective,
     )
 
 
@@ -375,29 +356,12 @@ def batch_naive_neighbor_list_dual_cutoff(
                     num_neighbors2,
                 )
 
-    # Select lazy direct registrations by dtype. Public ``half_fill`` remains
-    # intentionally absent from dual low-level specializations.
+    # Select wrap kernel by dtype; direct naive registrations resolve at launch.
     if positions.dtype == jnp.float64:
         _jax_wrap_batch = _jax_wrap_positions_batch_f64
     else:
         _jax_wrap_batch = _jax_wrap_positions_batch_f32
         positions = positions.astype(jnp.float32)
-    _jax_fill = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("none", False)][positions.dtype]
-    _jax_fill_pbc = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("wrap_on_entry", False)][
-        positions.dtype
-    ]
-    _jax_fill_selective = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("none", True)][
-        positions.dtype
-    ]
-    _jax_fill_pbc_selective = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("wrap_on_entry", True)][
-        positions.dtype
-    ]
-    _jax_fill_pbc_prewrapped = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("prewrapped", False)][
-        positions.dtype
-    ]
-    _jax_fill_pbc_prewrapped_selective = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[
-        ("prewrapped", True)
-    ][positions.dtype]
 
     total_atoms = positions.shape[0]
     num_systems = batch_ptr.shape[0] - 1
@@ -433,7 +397,7 @@ def batch_naive_neighbor_list_dual_cutoff(
                 atom_rebuild, jnp.zeros_like(num_neighbors2), num_neighbors2
             )
             neighbor_matrix1, num_neighbors1, neighbor_matrix2, num_neighbors2 = (
-                _jax_fill_selective(
+                _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("none", True)][positions.dtype](
                     positions,
                     empty_offsets,
                     float(cutoff1 * cutoff1),
@@ -461,7 +425,7 @@ def batch_naive_neighbor_list_dual_cutoff(
             )
         else:
             neighbor_matrix1, num_neighbors1, neighbor_matrix2, num_neighbors2 = (
-                _jax_fill(
+                _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("none", False)][positions.dtype](
                     positions,
                     empty_offsets,
                     float(cutoff1 * cutoff1),
@@ -545,7 +509,9 @@ def batch_naive_neighbor_list_dual_cutoff(
                     neighbor_matrix2,
                     neighbor_matrix_shifts2,
                     num_neighbors2,
-                ) = _jax_fill_pbc_selective(
+                ) = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("wrap_on_entry", True)][
+                    positions.dtype
+                ](
                     positions_wrapped,
                     per_atom_cell_offsets,
                     float(cutoff1 * cutoff1),
@@ -582,7 +548,9 @@ def batch_naive_neighbor_list_dual_cutoff(
                     neighbor_matrix2,
                     neighbor_matrix_shifts2,
                     num_neighbors2,
-                ) = _jax_fill_pbc(
+                ) = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("wrap_on_entry", False)][
+                    positions.dtype
+                ](
                     positions_wrapped,
                     per_atom_cell_offsets,
                     float(cutoff1 * cutoff1),
@@ -628,7 +596,9 @@ def batch_naive_neighbor_list_dual_cutoff(
                     neighbor_matrix2,
                     neighbor_matrix_shifts2,
                     num_neighbors2,
-                ) = _jax_fill_pbc_prewrapped_selective(
+                ) = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("prewrapped", True)][
+                    positions.dtype
+                ](
                     positions,
                     empty_offsets,
                     float(cutoff1 * cutoff1),
@@ -665,7 +635,9 @@ def batch_naive_neighbor_list_dual_cutoff(
                     neighbor_matrix2,
                     neighbor_matrix_shifts2,
                     num_neighbors2,
-                ) = _jax_fill_pbc_prewrapped(
+                ) = _DIRECT_BATCH_NAIVE_DUAL_KERNELS[("prewrapped", False)][
+                    positions.dtype
+                ](
                     positions,
                     empty_offsets,
                     float(cutoff1 * cutoff1),

--- a/nvalchemiops/jax/neighbors/cell_list.py
+++ b/nvalchemiops/jax/neighbors/cell_list.py
@@ -23,12 +23,19 @@ from typing import Literal
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import GraphMode, jax_callable, jax_kernel
+from warp.jax_experimental import GraphMode, jax_callable
 
 from nvalchemiops.jax.neighbors._autograd import (
     _build_index_residuals,
     _NeighborForwardOutput,
     _route_pair_outputs,
+)
+from nvalchemiops.jax.neighbors._registration import (
+    _CellListBuildJaxSpec,
+    _CellListQueryJaxSpec,
+    _get_cell_list_build_jax_kernel,
+    _get_cell_list_query_jax_kernel,
+    _LazyDtypeRegistrations,
 )
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     _validate_graph_mode,
@@ -40,8 +47,6 @@ from nvalchemiops.neighbors.cell_list import (
 )
 from nvalchemiops.neighbors.cell_list import (
     compute_batch_pair_centric_n_outer,
-    get_build_cell_list_kernel,
-    get_query_cell_list_kernel,
     is_pair_centric_parallelism_sufficient,
     select_cell_list_strategy,
 )
@@ -50,7 +55,6 @@ from nvalchemiops.neighbors.cell_list import (
 )
 from nvalchemiops.neighbors.neighbor_utils import (
     estimate_max_neighbors,
-    get_gather_positions_and_shifts_kernel,
     selective_zero_num_neighbors_single,
 )
 from nvalchemiops.neighbors.output_args import (
@@ -61,310 +65,86 @@ from nvalchemiops.neighbors.output_args import (
 # JAX Kernel Wrappers
 # ==============================================================================
 
-# Build step 1: Construct bin sizes
-_jax_construct_bin_size_f32 = jax_kernel(
-    get_build_cell_list_kernel("construct_bin_size", wp.float32),
-    num_outputs=1,
-    in_out_argnames=["cells_per_dimension_single"],
-    enable_backward=False,
-)
-_jax_construct_bin_size_f64 = jax_kernel(
-    get_build_cell_list_kernel("construct_bin_size", wp.float64),
-    num_outputs=1,
-    in_out_argnames=["cells_per_dimension_single"],
-    enable_backward=False,
-)
-
-# Build step 2: Count atoms per bin
-_jax_count_atoms_per_bin_f32 = jax_kernel(
-    get_build_cell_list_kernel("count_atoms", wp.float32),
-    num_outputs=2,
-    in_out_argnames=["atoms_per_cell_count", "atom_periodic_shifts"],
-    enable_backward=False,
-)
-_jax_count_atoms_per_bin_f64 = jax_kernel(
-    get_build_cell_list_kernel("count_atoms", wp.float64),
-    num_outputs=2,
-    in_out_argnames=["atoms_per_cell_count", "atom_periodic_shifts"],
-    enable_backward=False,
-)
-
-# Build step 3: Bin atoms into cells
-_jax_bin_atoms_f32 = jax_kernel(
-    get_build_cell_list_kernel("bin_atoms", wp.float32),
-    num_outputs=3,
-    in_out_argnames=["atom_to_cell_mapping", "atoms_per_cell_count", "cell_atom_list"],
-    enable_backward=False,
-)
-_jax_bin_atoms_f64 = jax_kernel(
-    get_build_cell_list_kernel("bin_atoms", wp.float64),
-    num_outputs=3,
-    in_out_argnames=["atom_to_cell_mapping", "atoms_per_cell_count", "cell_atom_list"],
-    enable_backward=False,
-)
-
-# Gather: pack positions + atom_periodic_shifts into per-cell-contiguous layout
-# (cell_atom_list permutation) for coalesced reads by the sorted-build kernel.
-_jax_gather_fused_f32 = jax_kernel(
-    get_gather_positions_and_shifts_kernel(wp.float32),
-    num_outputs=2,
-    in_out_argnames=["dst_pos", "dst_shifts"],
-    enable_backward=False,
-)
-_jax_gather_fused_f64 = jax_kernel(
-    get_gather_positions_and_shifts_kernel(wp.float64),
-    num_outputs=2,
-    in_out_argnames=["dst_pos", "dst_shifts"],
-    enable_backward=False,
-)
-
-# Query: sorted-reads atom-centric neighbor matrix kernel.  The selective
-# kernel is the same Warp kernel; selective callers pass a non-trivial
-# ``rebuild_flags``, non-selective callers pass a 1-element always-True flag.
-_jax_build_neighbor_matrix_local_count_sorted_f32 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float32,
-        strategy="atom_centric",
-        batched=False,
-        selective=True,
-        partial=False,
-        return_vectors=False,
-        return_distances=False,
-        pair_fn=None,
-    ),
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
-    enable_backward=False,
-)
-_jax_build_neighbor_matrix_local_count_sorted_f64 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float64,
-        strategy="atom_centric",
-        batched=False,
-        selective=True,
-        partial=False,
-        return_vectors=False,
-        return_distances=False,
-        pair_fn=None,
-    ),
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
-    enable_backward=False,
-)
-
-# Direct-reads atom-centric query kernel (``atom_centric_path="direct"``).  Reads
-# ``positions`` in original order and skips the sorted gather; the kernel ignores the
-# ``sorted_positions`` / ``sorted_atom_periodic_shifts`` arrays (pass 0-length sentinels).
-# Full-fill only -- the symmetric-full-fill optimization does not apply to half_fill or
-# pair outputs, which keep the sorted kernel.
-_jax_build_neighbor_matrix_local_count_direct_f32 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float32,
-        strategy="atom_centric",
-        batched=False,
-        selective=True,
-        partial=False,
-        return_vectors=False,
-        return_distances=False,
-        pair_fn=None,
-        atom_centric_path="direct",
-    ),
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
-    enable_backward=False,
-)
-_jax_build_neighbor_matrix_local_count_direct_f64 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float64,
-        strategy="atom_centric",
-        batched=False,
-        selective=True,
-        partial=False,
-        return_vectors=False,
-        return_distances=False,
-        pair_fn=None,
-        atom_centric_path="direct",
-    ),
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
-    enable_backward=False,
-)
-
-# Half-fill variants of the sorted-build kernel.  ``half_fill`` is a compile-time
-# specialization in the Warp factory (the runtime ``half_fill`` arg is an ignored
-# ABI placeholder), so honoring ``half_fill=True`` requires a distinct kernel.
-_jax_build_neighbor_matrix_local_count_sorted_half_f32 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float32,
-        strategy="atom_centric",
-        batched=False,
-        selective=True,
-        partial=False,
-        half_fill=True,
-        return_vectors=False,
-        return_distances=False,
-        pair_fn=None,
-    ),
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
-    enable_backward=False,
-)
-_jax_build_neighbor_matrix_local_count_sorted_half_f64 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float64,
-        strategy="atom_centric",
-        batched=False,
-        selective=True,
-        partial=False,
-        half_fill=True,
-        return_vectors=False,
-        return_distances=False,
-        pair_fn=None,
-    ),
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "neighbor_matrix_shifts", "num_neighbors"],
-    enable_backward=False,
-)
+_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
 
 
-# Pair-output variants of the sorted-build kernel.  Used by the autograd path
-# when ``return_distances`` / ``return_vectors`` is set; the bytes the kernel
-# writes into ``neighbor_vectors`` / ``neighbor_distances`` are consumed by
-# the JAX autograd primitive in :mod:`nvalchemiops.jax.neighbors._autograd`.
-_jax_build_neighbor_matrix_local_count_sorted_pair_f32 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float32,
-        strategy="atom_centric",
-        batched=False,
-        selective=True,
-        partial=False,
-        return_vectors=True,
-        return_distances=True,
-        pair_fn=None,
-    ),
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "neighbor_matrix_shifts",
-        "num_neighbors",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_build_neighbor_matrix_local_count_sorted_pair_f64 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float64,
-        strategy="atom_centric",
-        batched=False,
-        selective=True,
-        partial=False,
-        return_vectors=True,
-        return_distances=True,
-        pair_fn=None,
-    ),
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "neighbor_matrix_shifts",
-        "num_neighbors",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
+def _build_registry(stage: str) -> _LazyDtypeRegistrations:
+    """Create lazy dtype registrations for a single-system build stage."""
+    return _LazyDtypeRegistrations(
+        lambda wp_dtype: _get_cell_list_build_jax_kernel(
+            _CellListBuildJaxSpec(stage, wp_dtype, False),
+        ),
+        _DTYPE_MAP,
+    )
 
-# Half-fill specializations of the atom-centric geometry pair-output kernel
-# (``half_fill`` is a compile-time constant; selected when ``half_fill=True``).
-_jax_build_neighbor_matrix_local_count_sorted_pair_half_f32 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float32,
-        strategy="atom_centric",
-        batched=False,
-        selective=True,
-        partial=False,
-        return_vectors=True,
-        return_distances=True,
-        pair_fn=None,
-        half_fill=True,
+
+_CELL_LIST_BUILD_REGISTRATIONS = {
+    stage: _build_registry(stage)
+    for stage in ("construct_bin_size", "count_atoms", "bin_atoms", "gather")
+}
+
+
+def _query_registry(
+    *,
+    half_fill: bool,
+    return_geometry: bool,
+    atom_centric_path: Literal["sorted", "direct"],
+) -> _LazyDtypeRegistrations:
+    """Create lazy direct registrations for a static atom-centric query."""
+    return _LazyDtypeRegistrations(
+        lambda wp_dtype: _get_cell_list_query_jax_kernel(
+            _CellListQueryJaxSpec(
+                wp_dtype,
+                False,
+                True,
+                False,
+                half_fill,
+                return_geometry,
+                return_geometry,
+                None,
+                atom_centric_path,
+            ),
+        ),
+        _DTYPE_MAP,
+    )
+
+
+_CELL_LIST_QUERY_REGISTRATIONS = {
+    (False, False, "sorted"): _query_registry(
+        half_fill=False, return_geometry=False, atom_centric_path="sorted"
     ),
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "neighbor_matrix_shifts",
-        "num_neighbors",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_build_neighbor_matrix_local_count_sorted_pair_half_f64 = jax_kernel(
-    get_query_cell_list_kernel(
-        wp.float64,
-        strategy="atom_centric",
-        batched=False,
-        selective=True,
-        partial=False,
-        return_vectors=True,
-        return_distances=True,
-        pair_fn=None,
-        half_fill=True,
+    (True, False, "sorted"): _query_registry(
+        half_fill=True, return_geometry=False, atom_centric_path="sorted"
     ),
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "neighbor_matrix_shifts",
-        "num_neighbors",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
+    (False, False, "direct"): _query_registry(
+        half_fill=False, return_geometry=False, atom_centric_path="direct"
+    ),
+    (False, True, "sorted"): _query_registry(
+        half_fill=False, return_geometry=True, atom_centric_path="sorted"
+    ),
+    (True, True, "sorted"): _query_registry(
+        half_fill=True, return_geometry=True, atom_centric_path="sorted"
+    ),
+}
 
 
 @functools.cache
 def _get_jax_cell_list_pair_outputs_kernel(
     pair_fn, wp_dtype, partial, half_fill: bool = False
 ):
-    """Build (and cache) a ``jax_kernel`` for a cell-list atom-centric ``sorted``
-    pair-output kernel.
-
-    Mirrors the module-level geometry registration above, optionally with
-    ``pair_fn`` set (so the kernel's ``HAS_PAIR_FN`` body runs and
-    ``pair_energies`` / ``pair_forces`` are registered as additional outputs)
-    and/or ``partial=True`` (the ``target_indices`` path: output row ``r`` maps
-    to atom ``target_indices[r]``, launched ``(num_targets,)``).  Cached by
-    ``(pair_fn identity, wp_dtype, partial)``; one recompile per distinct
-    ``(pair_fn, partial)`` combination.
-
-    With ``pair_fn`` the kernel has 7 outputs (geometry + ``pe`` / ``pf``);
-    without it, 5 (geometry only).
-    """
-    kernel = get_query_cell_list_kernel(
-        wp_dtype,
-        strategy="atom_centric",
-        batched=False,
-        selective=True,
-        partial=bool(partial),
-        return_vectors=True,
-        return_distances=True,
-        pair_fn=pair_fn,
-        half_fill=bool(half_fill),
-    )
-    in_out_argnames = [
-        "neighbor_matrix",
-        "neighbor_matrix_shifts",
-        "num_neighbors",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ]
-    if pair_fn is not None:
-        in_out_argnames += ["pair_energies", "pair_forces"]
-    return jax_kernel(
-        kernel,
-        num_outputs=len(in_out_argnames),
-        in_out_argnames=in_out_argnames,
-        enable_backward=False,
+    """Return a cached sorted direct registration for pair-output queries."""
+    return _get_cell_list_query_jax_kernel(
+        _CellListQueryJaxSpec(
+            wp_dtype,
+            False,
+            True,
+            bool(partial),
+            bool(half_fill),
+            True,
+            True,
+            pair_fn,
+            "sorted",
+        ),
     )
 
 
@@ -1818,7 +1598,8 @@ def _cell_list_pair_outputs_forward(
     cell = jax.lax.stop_gradient(cell)
 
     f64 = positions.dtype == jnp.float64
-    gather_kernel = _jax_gather_fused_f64 if f64 else _jax_gather_fused_f32
+    wp_dtype = wp.float64 if f64 else wp.float32
+    gather_kernel = _CELL_LIST_BUILD_REGISTRATIONS["gather"][positions.dtype]
 
     total_atoms = positions.shape[0]
     # Output rows: ``num_targets`` for the partial (``target_indices``) path,
@@ -1832,7 +1613,6 @@ def _cell_list_pair_outputs_forward(
     has_pair_fn = pair_fn is not None
     is_partial = target_indices is not None
     is_pair_centric = strategy == "pair_centric"
-    wp_dtype = wp.float64 if f64 else wp.float32
     if has_pair_fn:
         pp_arg = jnp.asarray(pair_params, dtype=positions.dtype)
         pe = jnp.zeros((num_rows, max_neighbors), dtype=positions.dtype)
@@ -1921,17 +1701,13 @@ def _cell_list_pair_outputs_forward(
                 pair_fn, wp_dtype, is_partial, half_fill
             )
         elif half_fill:
-            pair_kernel = (
-                _jax_build_neighbor_matrix_local_count_sorted_pair_half_f64
-                if f64
-                else _jax_build_neighbor_matrix_local_count_sorted_pair_half_f32
-            )
+            pair_kernel = _CELL_LIST_QUERY_REGISTRATIONS[(True, True, "sorted")][
+                positions.dtype
+            ]
         else:
-            pair_kernel = (
-                _jax_build_neighbor_matrix_local_count_sorted_pair_f64
-                if f64
-                else _jax_build_neighbor_matrix_local_count_sorted_pair_f32
-            )
+            pair_kernel = _CELL_LIST_QUERY_REGISTRATIONS[(False, True, "sorted")][
+                positions.dtype
+            ]
         ti_arg = (
             jnp.asarray(target_indices, dtype=jnp.int32)
             if is_partial
@@ -2152,16 +1928,14 @@ def build_cell_list(
     if cell_atom_list is None:
         cell_atom_list = jnp.zeros(positions.shape[0], dtype=jnp.int32)
 
-    # Select kernels based on dtype
-    if positions.dtype == jnp.float64:
-        _construct_bin_size = _jax_construct_bin_size_f64
-        _count_atoms = _jax_count_atoms_per_bin_f64
-        _bin_atoms = _jax_bin_atoms_f64
-    else:
-        _construct_bin_size = _jax_construct_bin_size_f32
-        _count_atoms = _jax_count_atoms_per_bin_f32
-        _bin_atoms = _jax_bin_atoms_f32
+    # Select kernels based on dtype.
+    if positions.dtype != jnp.float64:
         positions = positions.astype(jnp.float32)
+    _construct_bin_size = _CELL_LIST_BUILD_REGISTRATIONS["construct_bin_size"][
+        positions.dtype
+    ]
+    _count_atoms = _CELL_LIST_BUILD_REGISTRATIONS["count_atoms"][positions.dtype]
+    _bin_atoms = _CELL_LIST_BUILD_REGISTRATIONS["bin_atoms"][positions.dtype]
 
     # Ensure cell dtype matches positions dtype so Warp kernel dispatch is consistent
     if cell.dtype != positions.dtype:
@@ -2634,23 +2408,16 @@ def query_cell_list(
     use_direct = (
         atom_centric_path == "direct" and not half_fill and graph_mode == "none"
     )
-    if positions.dtype == jnp.float64:
-        _gather_kernel = _jax_gather_fused_f64
-        if use_direct:
-            _build_kernel = _jax_build_neighbor_matrix_local_count_direct_f64
-        elif half_fill:
-            _build_kernel = _jax_build_neighbor_matrix_local_count_sorted_half_f64
-        else:
-            _build_kernel = _jax_build_neighbor_matrix_local_count_sorted_f64
-    else:
-        _gather_kernel = _jax_gather_fused_f32
-        if use_direct:
-            _build_kernel = _jax_build_neighbor_matrix_local_count_direct_f32
-        elif half_fill:
-            _build_kernel = _jax_build_neighbor_matrix_local_count_sorted_half_f32
-        else:
-            _build_kernel = _jax_build_neighbor_matrix_local_count_sorted_f32
+    if positions.dtype != jnp.float64:
         positions = positions.astype(jnp.float32)
+    _gather_kernel = _CELL_LIST_BUILD_REGISTRATIONS["gather"][positions.dtype]
+    _build_kernel = _CELL_LIST_QUERY_REGISTRATIONS[
+        (
+            bool(half_fill),
+            False,
+            "direct" if use_direct else "sorted",
+        )
+    ][positions.dtype]
 
     # Ensure cell dtype matches positions dtype so Warp kernel dispatch is consistent
     if cell.dtype != positions.dtype:

--- a/nvalchemiops/jax/neighbors/cell_list.py
+++ b/nvalchemiops/jax/neighbors/cell_list.py
@@ -94,15 +94,15 @@ def _query_registry(
     return _LazyDtypeRegistrations(
         lambda wp_dtype: _get_cell_list_query_jax_kernel(
             _CellListQueryJaxSpec(
-                wp_dtype,
-                False,
-                True,
-                False,
-                half_fill,
-                return_geometry,
-                return_geometry,
-                None,
-                atom_centric_path,
+                wp_dtype=wp_dtype,
+                batched=False,
+                selective=True,
+                partial=False,
+                half_fill=half_fill,
+                return_vectors=return_geometry,
+                return_distances=return_geometry,
+                pair_fn=None,
+                atom_centric_path=atom_centric_path,
             ),
         ),
         _DTYPE_MAP,
@@ -135,15 +135,15 @@ def _get_jax_cell_list_pair_outputs_kernel(
     """Return a cached sorted direct registration for pair-output queries."""
     return _get_cell_list_query_jax_kernel(
         _CellListQueryJaxSpec(
-            wp_dtype,
-            False,
-            True,
-            bool(partial),
-            bool(half_fill),
-            True,
-            True,
-            pair_fn,
-            "sorted",
+            wp_dtype=wp_dtype,
+            batched=False,
+            selective=True,
+            partial=bool(partial),
+            half_fill=bool(half_fill),
+            return_vectors=True,
+            return_distances=True,
+            pair_fn=pair_fn,
+            atom_centric_path="sorted",
         ),
     )
 

--- a/nvalchemiops/jax/neighbors/cell_list.py
+++ b/nvalchemiops/jax/neighbors/cell_list.py
@@ -31,11 +31,8 @@ from nvalchemiops.jax.neighbors._autograd import (
     _route_pair_outputs,
 )
 from nvalchemiops.jax.neighbors._registration import (
-    _CellListBuildJaxSpec,
-    _CellListQueryJaxSpec,
-    _get_cell_list_build_jax_kernel,
-    _get_cell_list_query_jax_kernel,
-    _LazyDtypeRegistrations,
+    _lazy_cell_list_build_kernel,
+    _lazy_cell_list_query_kernel,
 )
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     _validate_graph_mode,
@@ -65,17 +62,10 @@ from nvalchemiops.neighbors.output_args import (
 # JAX Kernel Wrappers
 # ==============================================================================
 
-_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
 
-
-def _build_registry(stage: str) -> _LazyDtypeRegistrations:
+def _build_registry(stage: str):
     """Create lazy dtype registrations for a single-system build stage."""
-    return _LazyDtypeRegistrations(
-        lambda wp_dtype: _get_cell_list_build_jax_kernel(
-            _CellListBuildJaxSpec(stage, wp_dtype, False),
-        ),
-        _DTYPE_MAP,
-    )
+    return _lazy_cell_list_build_kernel(stage=stage, batched=False)
 
 
 _CELL_LIST_BUILD_REGISTRATIONS = {
@@ -87,43 +77,36 @@ _CELL_LIST_BUILD_REGISTRATIONS = {
 def _query_registry(
     *,
     half_fill: bool,
-    return_geometry: bool,
+    geometry: bool,
     atom_centric_path: Literal["sorted", "direct"],
-) -> _LazyDtypeRegistrations:
+):
     """Create lazy direct registrations for a static atom-centric query."""
-    return _LazyDtypeRegistrations(
-        lambda wp_dtype: _get_cell_list_query_jax_kernel(
-            _CellListQueryJaxSpec(
-                wp_dtype=wp_dtype,
-                batched=False,
-                selective=True,
-                partial=False,
-                half_fill=half_fill,
-                return_vectors=return_geometry,
-                return_distances=return_geometry,
-                pair_fn=None,
-                atom_centric_path=atom_centric_path,
-            ),
-        ),
-        _DTYPE_MAP,
+    return _lazy_cell_list_query_kernel(
+        batched=False,
+        selective=True,
+        partial=False,
+        half_fill=half_fill,
+        geometry=geometry,
+        pair_fn=None,
+        atom_centric_path=atom_centric_path,
     )
 
 
 _CELL_LIST_QUERY_REGISTRATIONS = {
     (False, False, "sorted"): _query_registry(
-        half_fill=False, return_geometry=False, atom_centric_path="sorted"
+        half_fill=False, geometry=False, atom_centric_path="sorted"
     ),
     (True, False, "sorted"): _query_registry(
-        half_fill=True, return_geometry=False, atom_centric_path="sorted"
+        half_fill=True, geometry=False, atom_centric_path="sorted"
     ),
     (False, False, "direct"): _query_registry(
-        half_fill=False, return_geometry=False, atom_centric_path="direct"
+        half_fill=False, geometry=False, atom_centric_path="direct"
     ),
     (False, True, "sorted"): _query_registry(
-        half_fill=False, return_geometry=True, atom_centric_path="sorted"
+        half_fill=False, geometry=True, atom_centric_path="sorted"
     ),
     (True, True, "sorted"): _query_registry(
-        half_fill=True, return_geometry=True, atom_centric_path="sorted"
+        half_fill=True, geometry=True, atom_centric_path="sorted"
     ),
 }
 
@@ -133,19 +116,16 @@ def _get_jax_cell_list_pair_outputs_kernel(
     pair_fn, wp_dtype, partial, half_fill: bool = False
 ):
     """Return a cached sorted direct registration for pair-output queries."""
-    return _get_cell_list_query_jax_kernel(
-        _CellListQueryJaxSpec(
-            wp_dtype=wp_dtype,
-            batched=False,
-            selective=True,
-            partial=bool(partial),
-            half_fill=bool(half_fill),
-            return_vectors=True,
-            return_distances=True,
-            pair_fn=pair_fn,
-            atom_centric_path="sorted",
-        ),
-    )
+    jax_dtype = jnp.float64 if wp_dtype == wp.float64 else jnp.float32
+    return _lazy_cell_list_query_kernel(
+        batched=False,
+        selective=True,
+        partial=bool(partial),
+        half_fill=bool(half_fill),
+        geometry=True,
+        pair_fn=pair_fn,
+        atom_centric_path="sorted",
+    )[jax_dtype]
 
 
 __all__ = [
@@ -1599,7 +1579,6 @@ def _cell_list_pair_outputs_forward(
 
     f64 = positions.dtype == jnp.float64
     wp_dtype = wp.float64 if f64 else wp.float32
-    gather_kernel = _CELL_LIST_BUILD_REGISTRATIONS["gather"][positions.dtype]
 
     total_atoms = positions.shape[0]
     # Output rows: ``num_targets`` for the partial (``target_indices``) path,
@@ -1713,6 +1692,7 @@ def _cell_list_pair_outputs_forward(
             if is_partial
             else jnp.zeros((0,), dtype=jnp.int32)
         )
+        gather_kernel = _CELL_LIST_BUILD_REGISTRATIONS["gather"][positions.dtype]
         sorted_positions = jnp.zeros((total_atoms, 3), dtype=positions.dtype)
         sorted_atom_periodic_shifts = jnp.zeros((total_atoms, 3), dtype=jnp.int32)
         sorted_positions, sorted_atom_periodic_shifts = gather_kernel(
@@ -1931,11 +1911,6 @@ def build_cell_list(
     # Select kernels based on dtype.
     if positions.dtype != jnp.float64:
         positions = positions.astype(jnp.float32)
-    _construct_bin_size = _CELL_LIST_BUILD_REGISTRATIONS["construct_bin_size"][
-        positions.dtype
-    ]
-    _count_atoms = _CELL_LIST_BUILD_REGISTRATIONS["count_atoms"][positions.dtype]
-    _bin_atoms = _CELL_LIST_BUILD_REGISTRATIONS["bin_atoms"][positions.dtype]
 
     # Ensure cell dtype matches positions dtype so Warp kernel dispatch is consistent
     if cell.dtype != positions.dtype:
@@ -1976,6 +1951,11 @@ def build_cell_list(
             float(cutoff),
         )
     else:
+        _construct_bin_size = _CELL_LIST_BUILD_REGISTRATIONS["construct_bin_size"][
+            positions.dtype
+        ]
+        _count_atoms = _CELL_LIST_BUILD_REGISTRATIONS["count_atoms"][positions.dtype]
+        _bin_atoms = _CELL_LIST_BUILD_REGISTRATIONS["bin_atoms"][positions.dtype]
         # Step 1: Construct bin sizes
         (cells_per_dimension,) = _construct_bin_size(
             cell,
@@ -2410,14 +2390,6 @@ def query_cell_list(
     )
     if positions.dtype != jnp.float64:
         positions = positions.astype(jnp.float32)
-    _gather_kernel = _CELL_LIST_BUILD_REGISTRATIONS["gather"][positions.dtype]
-    _build_kernel = _CELL_LIST_QUERY_REGISTRATIONS[
-        (
-            bool(half_fill),
-            False,
-            "direct" if use_direct else "sorted",
-        )
-    ][positions.dtype]
 
     # Ensure cell dtype matches positions dtype so Warp kernel dispatch is consistent
     if cell.dtype != positions.dtype:
@@ -2581,6 +2553,7 @@ def query_cell_list(
             # Sorted path: gather positions/shifts into cell order for coalesced
             # reads.  The direct kernel reads ``positions`` directly and ignores the
             # sorted arrays, so it skips the gather (matching the Torch binding).
+            _gather_kernel = _CELL_LIST_BUILD_REGISTRATIONS["gather"][positions.dtype]
             sorted_positions, sorted_atom_periodic_shifts = _gather_kernel(
                 positions,
                 atom_periodic_shifts,
@@ -2589,6 +2562,13 @@ def query_cell_list(
                 sorted_atom_periodic_shifts,
                 launch_dims=(total_atoms,),
             )
+        _build_kernel = _CELL_LIST_QUERY_REGISTRATIONS[
+            (
+                bool(half_fill),
+                False,
+                "direct" if use_direct else "sorted",
+            )
+        ][positions.dtype]
         neighbor_matrix, neighbor_matrix_shifts, num_neighbors = _build_kernel(
             positions,
             atom_periodic_shifts,

--- a/nvalchemiops/jax/neighbors/cluster_tile.py
+++ b/nvalchemiops/jax/neighbors/cluster_tile.py
@@ -688,25 +688,81 @@ _jax_build_cluster_tile_list_selective = _get_cluster_tile_build_jax_callable(
 )
 
 _CLUSTER_TILE_QUERY_MATRIX_SPEC = _ClusterTileQueryJaxSpec(
-    False, "matrix", False, False, False, False, False, False, None
+    batched=False,
+    output_format="matrix",
+    tile_segmented=False,
+    coo_segmented=False,
+    selective=False,
+    dual_cutoff=False,
+    return_vectors=False,
+    return_distances=False,
+    pair_fn=None,
 )
 _CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC = _ClusterTileQueryJaxSpec(
-    False, "matrix", False, False, True, False, False, False, None
+    batched=False,
+    output_format="matrix",
+    tile_segmented=False,
+    coo_segmented=False,
+    selective=True,
+    dual_cutoff=False,
+    return_vectors=False,
+    return_distances=False,
+    pair_fn=None,
 )
 _CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC = _ClusterTileQueryJaxSpec(
-    False, "matrix", False, False, False, True, False, False, None
+    batched=False,
+    output_format="matrix",
+    tile_segmented=False,
+    coo_segmented=False,
+    selective=False,
+    dual_cutoff=True,
+    return_vectors=False,
+    return_distances=False,
+    pair_fn=None,
 )
 _CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC = _ClusterTileQueryJaxSpec(
-    False, "matrix", False, False, True, True, False, False, None
+    batched=False,
+    output_format="matrix",
+    tile_segmented=False,
+    coo_segmented=False,
+    selective=True,
+    dual_cutoff=True,
+    return_vectors=False,
+    return_distances=False,
+    pair_fn=None,
 )
 _CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC = _ClusterTileQueryJaxSpec(
-    False, "matrix", False, False, False, False, True, True, None
+    batched=False,
+    output_format="matrix",
+    tile_segmented=False,
+    coo_segmented=False,
+    selective=False,
+    dual_cutoff=False,
+    return_vectors=True,
+    return_distances=True,
+    pair_fn=None,
 )
 _CLUSTER_TILE_QUERY_COO_SPEC = _ClusterTileQueryJaxSpec(
-    False, "coo", False, False, False, False, False, False, None
+    batched=False,
+    output_format="coo",
+    tile_segmented=False,
+    coo_segmented=False,
+    selective=False,
+    dual_cutoff=False,
+    return_vectors=False,
+    return_distances=False,
+    pair_fn=None,
 )
 _CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC = _ClusterTileQueryJaxSpec(
-    False, "coo", False, True, True, False, False, False, None
+    batched=False,
+    output_format="coo",
+    tile_segmented=False,
+    coo_segmented=True,
+    selective=True,
+    dual_cutoff=False,
+    return_vectors=False,
+    return_distances=False,
+    pair_fn=None,
 )
 
 _jax_query_cluster_tile = _get_cluster_tile_query_jax_callable(
@@ -1169,7 +1225,15 @@ def query_cluster_tile(
         )
     query_spec = (
         _ClusterTileQueryJaxSpec(
-            False, "matrix", False, False, False, False, True, True, pair_fn
+            batched=False,
+            output_format="matrix",
+            tile_segmented=False,
+            coo_segmented=False,
+            selective=False,
+            dual_cutoff=False,
+            return_vectors=True,
+            return_distances=True,
+            pair_fn=pair_fn,
         )
         if pair_fn is not None
         else _CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC

--- a/nvalchemiops/jax/neighbors/cluster_tile.py
+++ b/nvalchemiops/jax/neighbors/cluster_tile.py
@@ -34,7 +34,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import warp as wp
-from warp.jax_experimental import GraphMode, jax_callable
 
 from nvalchemiops.jax.neighbors._autograd import (
     _build_index_residuals,
@@ -45,6 +44,12 @@ from nvalchemiops.jax.neighbors._cluster_tile_preload import (
     _preload_cluster_tile_build_kernel,
     _preload_cluster_tile_coo_kernel,
     _preload_cluster_tile_query_kernel,
+)
+from nvalchemiops.jax.neighbors._registration import (
+    _ClusterTileBuildJaxSpec,
+    _ClusterTileQueryJaxSpec,
+    _get_cluster_tile_build_jax_callable,
+    _get_cluster_tile_query_jax_callable,
 )
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     coo_pack_pair_geometry,
@@ -662,100 +667,72 @@ def _query_cluster_tile_coo_segmented_callback(
     )
 
 
-_jax_build_cluster_tile_list = jax_callable(
+_CLUSTER_TILE_BUILD_SPEC = _ClusterTileBuildJaxSpec(
+    batched=False,
+    segmented=False,
+    selective=False,
+)
+_CLUSTER_TILE_BUILD_SELECTIVE_SPEC = _ClusterTileBuildJaxSpec(
+    batched=False,
+    segmented=False,
+    selective=True,
+)
+
+_jax_build_cluster_tile_list = _get_cluster_tile_build_jax_callable(
+    _CLUSTER_TILE_BUILD_SPEC,
     _build_cluster_tile_list_callback,
-    num_outputs=9,
-    in_out_argnames=[
-        "group_ctr_x",
-        "group_ctr_y",
-        "group_ctr_z",
-        "group_ext_x",
-        "group_ext_y",
-        "group_ext_z",
-        "num_tiles",
-        "tile_row_group",
-        "tile_col_group",
-    ],
-    graph_mode=GraphMode.WARP,
 )
-
-_jax_build_cluster_tile_list_selective = jax_callable(
+_jax_build_cluster_tile_list_selective = _get_cluster_tile_build_jax_callable(
+    _CLUSTER_TILE_BUILD_SELECTIVE_SPEC,
     _build_cluster_tile_list_selective_callback,
-    num_outputs=9,
-    in_out_argnames=[
-        "group_ctr_x",
-        "group_ctr_y",
-        "group_ctr_z",
-        "group_ext_x",
-        "group_ext_y",
-        "group_ext_z",
-        "num_tiles",
-        "tile_row_group",
-        "tile_col_group",
-    ],
-    graph_mode=GraphMode.WARP,
 )
 
+_CLUSTER_TILE_QUERY_MATRIX_SPEC = _ClusterTileQueryJaxSpec(
+    False, "matrix", False, False, False, False, False, False, None
+)
+_CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC = _ClusterTileQueryJaxSpec(
+    False, "matrix", False, False, True, False, False, False, None
+)
+_CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC = _ClusterTileQueryJaxSpec(
+    False, "matrix", False, False, False, True, False, False, None
+)
+_CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC = _ClusterTileQueryJaxSpec(
+    False, "matrix", False, False, True, True, False, False, None
+)
+_CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC = _ClusterTileQueryJaxSpec(
+    False, "matrix", False, False, False, False, True, True, None
+)
+_CLUSTER_TILE_QUERY_COO_SPEC = _ClusterTileQueryJaxSpec(
+    False, "coo", False, False, False, False, False, False, None
+)
+_CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC = _ClusterTileQueryJaxSpec(
+    False, "coo", False, True, True, False, False, False, None
+)
 
-_jax_query_cluster_tile = jax_callable(
+_jax_query_cluster_tile = _get_cluster_tile_query_jax_callable(
+    _CLUSTER_TILE_QUERY_MATRIX_SPEC,
     _query_cluster_tile_callback,
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "num_neighbors", "neighbor_matrix_shifts"],
-    graph_mode=GraphMode.WARP,
 )
-
-_jax_query_cluster_tile_selective = jax_callable(
+_jax_query_cluster_tile_selective = _get_cluster_tile_query_jax_callable(
+    _CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC,
     _query_cluster_tile_selective_callback,
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix", "num_neighbors", "neighbor_matrix_shifts"],
-    graph_mode=GraphMode.WARP,
 )
-
-_jax_query_cluster_tile_dual = jax_callable(
+_jax_query_cluster_tile_dual = _get_cluster_tile_query_jax_callable(
+    _CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC,
     _query_cluster_tile_dual_callback,
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "num_neighbors",
-        "neighbor_matrix_shifts",
-        "neighbor_matrix2",
-        "num_neighbors2",
-        "neighbor_matrix_shifts2",
-    ],
-    graph_mode=GraphMode.WARP,
 )
-
-_jax_query_cluster_tile_dual_selective = jax_callable(
+_jax_query_cluster_tile_dual_selective = _get_cluster_tile_query_jax_callable(
+    _CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC,
     _query_cluster_tile_dual_selective_callback,
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "num_neighbors",
-        "neighbor_matrix_shifts",
-        "neighbor_matrix2",
-        "num_neighbors2",
-        "neighbor_matrix_shifts2",
-    ],
-    graph_mode=GraphMode.WARP,
 )
-
-
-_jax_query_cluster_tile_pair = jax_callable(
+_jax_query_cluster_tile_pair = _get_cluster_tile_query_jax_callable(
+    _CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC,
     _query_cluster_tile_pair_callback,
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix",
-        "num_neighbors",
-        "neighbor_matrix_shifts",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    graph_mode=GraphMode.WARP,
 )
 
 
 @functools.cache
-def _get_jax_cluster_tile_pair_fn_callable(pair_fn):
+def _get_jax_cluster_tile_pair_fn_callable(spec: _ClusterTileQueryJaxSpec):
     """Build (and cache) a ``jax_callable`` that closes over ``pair_fn`` for the
     cluster-tile pair-output -> matrix kernel.
 
@@ -808,40 +785,25 @@ def _get_jax_cluster_tile_pair_fn_callable(pair_fn):
             return_distances=True,
             neighbor_vectors=neighbor_vectors,
             neighbor_distances=neighbor_distances,
-            pair_fn=pair_fn,
+            pair_fn=spec.pair_fn,
             pair_params=pair_params,
             pair_energies=pair_energies,
             pair_forces=pair_forces,
         )
 
-    return jax_callable(
+    return _get_cluster_tile_query_jax_callable(
+        spec,
         _callback,
-        num_outputs=7,
-        in_out_argnames=[
-            "neighbor_matrix",
-            "num_neighbors",
-            "neighbor_matrix_shifts",
-            "neighbor_vectors",
-            "neighbor_distances",
-            "pair_energies",
-            "pair_forces",
-        ],
-        graph_mode=GraphMode.WARP,
     )
 
 
-_jax_query_cluster_tile_coo = jax_callable(
+_jax_query_cluster_tile_coo = _get_cluster_tile_query_jax_callable(
+    _CLUSTER_TILE_QUERY_COO_SPEC,
     _query_cluster_tile_coo_callback,
-    num_outputs=3,
-    in_out_argnames=["pair_counter", "coo_list", "coo_shifts"],
-    graph_mode=GraphMode.WARP,
 )
-
-_jax_query_cluster_tile_coo_segmented = jax_callable(
+_jax_query_cluster_tile_coo_segmented = _get_cluster_tile_query_jax_callable(
+    _CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC,
     _query_cluster_tile_coo_segmented_callback,
-    num_outputs=4,
-    in_out_argnames=["pair_counter", "pair_counts", "coo_list", "coo_shifts"],
-    graph_mode=GraphMode.WARP,
 )
 
 
@@ -978,9 +940,7 @@ def build_cluster_tile_list(
 
     if rebuild_flags is None:
         _preload_cluster_tile_build_kernel(
-            batched=False,
-            segmented=False,
-            selective=False,
+            _CLUSTER_TILE_BUILD_SPEC,
         )
         (
             group_ctr_x,
@@ -1011,9 +971,7 @@ def build_cluster_tile_list(
         )
     else:
         _preload_cluster_tile_build_kernel(
-            batched=False,
-            segmented=False,
-            selective=True,
+            _CLUSTER_TILE_BUILD_SELECTIVE_SPEC,
         )
         rf = rebuild_flags.flatten()[:1].astype(jnp.bool_)
         (
@@ -1209,15 +1167,22 @@ def query_cluster_tile(
             "features in this pass and cannot be combined with "
             "return_distances or return_vectors.",
         )
-    _preload_cluster_tile_query_kernel(
-        batched=False,
-        tile_segmented=False,
-        selective=selective,
-        dual_cutoff=dual_cutoff,
-        return_vectors=has_pair_outputs,
-        return_distances=has_pair_outputs,
-        pair_fn=pair_fn,
+    query_spec = (
+        _ClusterTileQueryJaxSpec(
+            False, "matrix", False, False, False, False, True, True, pair_fn
+        )
+        if pair_fn is not None
+        else _CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC
+        if has_pair_outputs
+        else _CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC
+        if dual_cutoff and selective
+        else _CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC
+        if dual_cutoff
+        else _CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC
+        if selective
+        else _CLUSTER_TILE_QUERY_MATRIX_SPEC
     )
+    _preload_cluster_tile_query_kernel(query_spec)
     if fill_value is None:
         fill_value = natom
     cell_n = _normalize_cell(cell, jnp.float32)
@@ -1277,7 +1242,7 @@ def query_cluster_tile(
             if pair_forces is None:
                 pair_forces = jnp.zeros((natom, max_neighbors, 3), dtype=jnp.float32)
             pair_params_arg = jnp.asarray(pair_params, dtype=jnp.float32)
-            pair_callable = _get_jax_cluster_tile_pair_fn_callable(pair_fn)
+            pair_callable = _get_jax_cluster_tile_pair_fn_callable(query_spec)
             (
                 neighbor_matrix,
                 num_neighbors,
@@ -1556,12 +1521,12 @@ def query_cluster_tile_coo(
         raise ValueError("Pass both 'pair_offsets' and 'pair_counts', or neither.")
     if rebuild_flags is not None and not segmented:
         raise ValueError("rebuild_flags requires pair_offsets and pair_counts")
-    _preload_cluster_tile_coo_kernel(
-        batched=False,
-        tile_segmented=False,
-        coo_segmented=segmented,
-        selective=segmented,
+    query_spec = (
+        _CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC
+        if segmented
+        else _CLUSTER_TILE_QUERY_COO_SPEC
     )
+    _preload_cluster_tile_coo_kernel(query_spec)
 
     cell_n = _normalize_cell(cell, jnp.float32)
     inv_cell_n = jnp.linalg.inv(cell_n[0])[jnp.newaxis, :, :]

--- a/nvalchemiops/jax/neighbors/cluster_tile.py
+++ b/nvalchemiops/jax/neighbors/cluster_tile.py
@@ -40,16 +40,11 @@ from nvalchemiops.jax.neighbors._autograd import (
     _NeighborForwardOutput,
     _route_pair_outputs,
 )
-from nvalchemiops.jax.neighbors._cluster_tile_preload import (
-    _preload_cluster_tile_build_kernel,
-    _preload_cluster_tile_coo_kernel,
-    _preload_cluster_tile_query_kernel,
-)
 from nvalchemiops.jax.neighbors._registration import (
-    _ClusterTileBuildJaxSpec,
-    _ClusterTileQueryJaxSpec,
-    _get_cluster_tile_build_jax_callable,
-    _get_cluster_tile_query_jax_callable,
+    _cluster_tile_build_registration,
+    _cluster_tile_coo_registration,
+    _cluster_tile_matrix_registration,
+    _GraphRegistration,
 )
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     coo_pack_pair_geometry,
@@ -667,137 +662,63 @@ def _query_cluster_tile_coo_segmented_callback(
     )
 
 
-_CLUSTER_TILE_BUILD_SPEC = _ClusterTileBuildJaxSpec(
-    batched=False,
-    segmented=False,
-    selective=False,
-)
-_CLUSTER_TILE_BUILD_SELECTIVE_SPEC = _ClusterTileBuildJaxSpec(
-    batched=False,
-    segmented=False,
-    selective=True,
-)
+_CLUSTER_TILE_BUILDS: dict[str, _GraphRegistration] = {
+    "full": _cluster_tile_build_registration(
+        _build_cluster_tile_list_callback,
+        batched=False,
+        segmented=False,
+        selective=False,
+    ),
+    "selective": _cluster_tile_build_registration(
+        _build_cluster_tile_list_selective_callback,
+        batched=False,
+        segmented=False,
+        selective=True,
+    ),
+}
 
-_jax_build_cluster_tile_list = _get_cluster_tile_build_jax_callable(
-    _CLUSTER_TILE_BUILD_SPEC,
-    _build_cluster_tile_list_callback,
-)
-_jax_build_cluster_tile_list_selective = _get_cluster_tile_build_jax_callable(
-    _CLUSTER_TILE_BUILD_SELECTIVE_SPEC,
-    _build_cluster_tile_list_selective_callback,
-)
-
-_CLUSTER_TILE_QUERY_MATRIX_SPEC = _ClusterTileQueryJaxSpec(
-    batched=False,
-    output_format="matrix",
-    tile_segmented=False,
-    coo_segmented=False,
-    selective=False,
-    dual_cutoff=False,
-    return_vectors=False,
-    return_distances=False,
-    pair_fn=None,
-)
-_CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC = _ClusterTileQueryJaxSpec(
-    batched=False,
-    output_format="matrix",
-    tile_segmented=False,
-    coo_segmented=False,
-    selective=True,
-    dual_cutoff=False,
-    return_vectors=False,
-    return_distances=False,
-    pair_fn=None,
-)
-_CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC = _ClusterTileQueryJaxSpec(
-    batched=False,
-    output_format="matrix",
-    tile_segmented=False,
-    coo_segmented=False,
-    selective=False,
-    dual_cutoff=True,
-    return_vectors=False,
-    return_distances=False,
-    pair_fn=None,
-)
-_CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC = _ClusterTileQueryJaxSpec(
-    batched=False,
-    output_format="matrix",
-    tile_segmented=False,
-    coo_segmented=False,
-    selective=True,
-    dual_cutoff=True,
-    return_vectors=False,
-    return_distances=False,
-    pair_fn=None,
-)
-_CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC = _ClusterTileQueryJaxSpec(
-    batched=False,
-    output_format="matrix",
-    tile_segmented=False,
-    coo_segmented=False,
-    selective=False,
-    dual_cutoff=False,
-    return_vectors=True,
-    return_distances=True,
-    pair_fn=None,
-)
-_CLUSTER_TILE_QUERY_COO_SPEC = _ClusterTileQueryJaxSpec(
-    batched=False,
-    output_format="coo",
-    tile_segmented=False,
-    coo_segmented=False,
-    selective=False,
-    dual_cutoff=False,
-    return_vectors=False,
-    return_distances=False,
-    pair_fn=None,
-)
-_CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC = _ClusterTileQueryJaxSpec(
-    batched=False,
-    output_format="coo",
-    tile_segmented=False,
-    coo_segmented=True,
-    selective=True,
-    dual_cutoff=False,
-    return_vectors=False,
-    return_distances=False,
-    pair_fn=None,
-)
-
-_jax_query_cluster_tile = _get_cluster_tile_query_jax_callable(
-    _CLUSTER_TILE_QUERY_MATRIX_SPEC,
-    _query_cluster_tile_callback,
-)
-_jax_query_cluster_tile_selective = _get_cluster_tile_query_jax_callable(
-    _CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC,
-    _query_cluster_tile_selective_callback,
-)
-_jax_query_cluster_tile_dual = _get_cluster_tile_query_jax_callable(
-    _CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC,
-    _query_cluster_tile_dual_callback,
-)
-_jax_query_cluster_tile_dual_selective = _get_cluster_tile_query_jax_callable(
-    _CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC,
-    _query_cluster_tile_dual_selective_callback,
-)
-_jax_query_cluster_tile_pair = _get_cluster_tile_query_jax_callable(
-    _CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC,
-    _query_cluster_tile_pair_callback,
-)
+_CLUSTER_TILE_QUERIES: dict[str, _GraphRegistration] = {
+    "matrix": _cluster_tile_matrix_registration(
+        _query_cluster_tile_callback,
+        batched=False,
+    ),
+    "matrix_selective": _cluster_tile_matrix_registration(
+        _query_cluster_tile_selective_callback,
+        batched=False,
+        selective=True,
+    ),
+    "matrix_dual": _cluster_tile_matrix_registration(
+        _query_cluster_tile_dual_callback,
+        batched=False,
+        dual_cutoff=True,
+    ),
+    "matrix_dual_selective": _cluster_tile_matrix_registration(
+        _query_cluster_tile_dual_selective_callback,
+        batched=False,
+        selective=True,
+        dual_cutoff=True,
+    ),
+    "matrix_geometry": _cluster_tile_matrix_registration(
+        _query_cluster_tile_pair_callback,
+        batched=False,
+        geometry=True,
+    ),
+    "coo": _cluster_tile_coo_registration(
+        _query_cluster_tile_coo_callback,
+        batched=False,
+    ),
+    "coo_segmented": _cluster_tile_coo_registration(
+        _query_cluster_tile_coo_segmented_callback,
+        batched=False,
+        coo_segmented=True,
+        selective=True,
+    ),
+}
 
 
 @functools.cache
-def _get_jax_cluster_tile_pair_fn_callable(spec: _ClusterTileQueryJaxSpec):
-    """Build (and cache) a ``jax_callable`` that closes over ``pair_fn`` for the
-    cluster-tile pair-output -> matrix kernel.
-
-    Same as ``_jax_query_cluster_tile_pair`` but the callback closes over
-    ``pair_fn`` (which cannot cross the JAX trace boundary as data) and adds the
-    ``pair_params`` input + ``pair_energies`` / ``pair_forces`` outputs.  Cached by
-    ``pair_fn`` identity; one recompile per distinct ``pair_fn``.  fp32-only, like
-    the rest of the cluster-tile JAX binding.
-    """
+def _get_jax_cluster_tile_pair_fn_registration(pair_fn) -> _GraphRegistration:
+    """Build (and cache) a graph registration that closes over ``pair_fn``."""
 
     def _callback(
         sorted_atom_index: wp.array(dtype=wp.int32),
@@ -841,26 +762,18 @@ def _get_jax_cluster_tile_pair_fn_callable(spec: _ClusterTileQueryJaxSpec):
             return_distances=True,
             neighbor_vectors=neighbor_vectors,
             neighbor_distances=neighbor_distances,
-            pair_fn=spec.pair_fn,
+            pair_fn=pair_fn,
             pair_params=pair_params,
             pair_energies=pair_energies,
             pair_forces=pair_forces,
         )
 
-    return _get_cluster_tile_query_jax_callable(
-        spec,
+    return _cluster_tile_matrix_registration(
         _callback,
+        batched=False,
+        geometry=True,
+        pair_fn=pair_fn,
     )
-
-
-_jax_query_cluster_tile_coo = _get_cluster_tile_query_jax_callable(
-    _CLUSTER_TILE_QUERY_COO_SPEC,
-    _query_cluster_tile_coo_callback,
-)
-_jax_query_cluster_tile_coo_segmented = _get_cluster_tile_query_jax_callable(
-    _CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC,
-    _query_cluster_tile_coo_segmented_callback,
-)
 
 
 # =============================================================================
@@ -995,9 +908,8 @@ def build_cluster_tile_list(
         tile_col_group = jnp.zeros(max_tiles, dtype=jnp.int32)
 
     if rebuild_flags is None:
-        _preload_cluster_tile_build_kernel(
-            _CLUSTER_TILE_BUILD_SPEC,
-        )
+        build_registration = _CLUSTER_TILE_BUILDS["full"]
+        build_registration.preload(device_source=sorted_pos_x)
         (
             group_ctr_x,
             group_ctr_y,
@@ -1008,7 +920,7 @@ def build_cluster_tile_list(
             num_tiles,
             tile_row_group,
             tile_col_group,
-        ) = _jax_build_cluster_tile_list(
+        ) = build_registration.callable(
             sorted_pos_x,
             sorted_pos_y,
             sorted_pos_z,
@@ -1026,9 +938,8 @@ def build_cluster_tile_list(
             float(cutoff),
         )
     else:
-        _preload_cluster_tile_build_kernel(
-            _CLUSTER_TILE_BUILD_SELECTIVE_SPEC,
-        )
+        build_registration = _CLUSTER_TILE_BUILDS["selective"]
+        build_registration.preload(device_source=sorted_pos_x)
         rf = rebuild_flags.flatten()[:1].astype(jnp.bool_)
         (
             group_ctr_x,
@@ -1040,7 +951,7 @@ def build_cluster_tile_list(
             num_tiles,
             tile_row_group,
             tile_col_group,
-        ) = _jax_build_cluster_tile_list_selective(
+        ) = build_registration.callable(
             sorted_pos_x,
             sorted_pos_y,
             sorted_pos_z,
@@ -1223,30 +1134,19 @@ def query_cluster_tile(
             "features in this pass and cannot be combined with "
             "return_distances or return_vectors.",
         )
-    query_spec = (
-        _ClusterTileQueryJaxSpec(
-            batched=False,
-            output_format="matrix",
-            tile_segmented=False,
-            coo_segmented=False,
-            selective=False,
-            dual_cutoff=False,
-            return_vectors=True,
-            return_distances=True,
-            pair_fn=pair_fn,
-        )
-        if pair_fn is not None
-        else _CLUSTER_TILE_QUERY_MATRIX_PAIR_SPEC
-        if has_pair_outputs
-        else _CLUSTER_TILE_QUERY_MATRIX_DUAL_SELECTIVE_SPEC
-        if dual_cutoff and selective
-        else _CLUSTER_TILE_QUERY_MATRIX_DUAL_SPEC
-        if dual_cutoff
-        else _CLUSTER_TILE_QUERY_MATRIX_SELECTIVE_SPEC
-        if selective
-        else _CLUSTER_TILE_QUERY_MATRIX_SPEC
-    )
-    _preload_cluster_tile_query_kernel(query_spec)
+    if pair_fn is not None:
+        query_registration = _get_jax_cluster_tile_pair_fn_registration(pair_fn)
+    elif has_pair_outputs:
+        query_registration = _CLUSTER_TILE_QUERIES["matrix_geometry"]
+    elif dual_cutoff and selective:
+        query_registration = _CLUSTER_TILE_QUERIES["matrix_dual_selective"]
+    elif dual_cutoff:
+        query_registration = _CLUSTER_TILE_QUERIES["matrix_dual"]
+    elif selective:
+        query_registration = _CLUSTER_TILE_QUERIES["matrix_selective"]
+    else:
+        query_registration = _CLUSTER_TILE_QUERIES["matrix"]
+    query_registration.preload(device_source=sorted_pos_x)
     if fill_value is None:
         fill_value = natom
     cell_n = _normalize_cell(cell, jnp.float32)
@@ -1306,7 +1206,6 @@ def query_cluster_tile(
             if pair_forces is None:
                 pair_forces = jnp.zeros((natom, max_neighbors, 3), dtype=jnp.float32)
             pair_params_arg = jnp.asarray(pair_params, dtype=jnp.float32)
-            pair_callable = _get_jax_cluster_tile_pair_fn_callable(query_spec)
             (
                 neighbor_matrix,
                 num_neighbors,
@@ -1315,7 +1214,7 @@ def query_cluster_tile(
                 neighbor_distances,
                 pair_energies,
                 pair_forces,
-            ) = pair_callable(
+            ) = query_registration.callable(
                 sorted_atom_index,
                 sorted_pos_x,
                 sorted_pos_y,
@@ -1354,7 +1253,7 @@ def query_cluster_tile(
             neighbor_matrix_shifts,
             neighbor_vectors,
             neighbor_distances,
-        ) = _jax_query_cluster_tile_pair(
+        ) = query_registration.callable(
             sorted_atom_index,
             sorted_pos_x,
             sorted_pos_y,
@@ -1391,7 +1290,7 @@ def query_cluster_tile(
             neighbor_matrix2,
             num_neighbors2,
             neighbor_matrix_shifts2,
-        ) = _jax_query_cluster_tile_dual_selective(
+        ) = query_registration.callable(
             sorted_atom_index,
             sorted_pos_x,
             sorted_pos_y,
@@ -1420,7 +1319,7 @@ def query_cluster_tile(
             neighbor_matrix2,
             num_neighbors2,
             neighbor_matrix_shifts2,
-        ) = _jax_query_cluster_tile_dual(
+        ) = query_registration.callable(
             sorted_atom_index,
             sorted_pos_x,
             sorted_pos_y,
@@ -1442,7 +1341,7 @@ def query_cluster_tile(
         )
     elif selective:
         neighbor_matrix, num_neighbors, neighbor_matrix_shifts = (
-            _jax_query_cluster_tile_selective(
+            query_registration.callable(
                 sorted_atom_index,
                 sorted_pos_x,
                 sorted_pos_y,
@@ -1462,7 +1361,7 @@ def query_cluster_tile(
         )
     else:
         neighbor_matrix, num_neighbors, neighbor_matrix_shifts = (
-            _jax_query_cluster_tile(
+            query_registration.callable(
                 sorted_atom_index,
                 sorted_pos_x,
                 sorted_pos_y,
@@ -1585,12 +1484,8 @@ def query_cluster_tile_coo(
         raise ValueError("Pass both 'pair_offsets' and 'pair_counts', or neither.")
     if rebuild_flags is not None and not segmented:
         raise ValueError("rebuild_flags requires pair_offsets and pair_counts")
-    query_spec = (
-        _CLUSTER_TILE_QUERY_COO_SEGMENTED_SPEC
-        if segmented
-        else _CLUSTER_TILE_QUERY_COO_SPEC
-    )
-    _preload_cluster_tile_coo_kernel(query_spec)
+    coo_registration = _CLUSTER_TILE_QUERIES["coo_segmented" if segmented else "coo"]
+    coo_registration.preload(device_source=sorted_pos_x)
 
     cell_n = _normalize_cell(cell, jnp.float32)
     inv_cell_n = jnp.linalg.inv(cell_n[0])[jnp.newaxis, :, :]
@@ -1608,34 +1503,32 @@ def query_cluster_tile_coo(
             rf = jnp.ones(1, dtype=jnp.bool_)
         else:
             rf = rebuild_flags.flatten()[:1].astype(jnp.bool_)
-        pair_counter, pair_counts, coo_list, coo_shifts = (
-            _jax_query_cluster_tile_coo_segmented(
-                sorted_atom_index,
-                sorted_pos_x,
-                sorted_pos_y,
-                sorted_pos_z,
-                num_tiles,
-                tile_row_group,
-                tile_col_group,
-                cell_n,
-                inv_cell_n,
-                rf,
-                pair_counter,
-                pair_offsets.astype(jnp.int32),
-                pair_counts.astype(jnp.int32),
-                coo_list,
-                coo_shifts,
-                float(cutoff),
-                int(natom),
-                int(max_pairs),
-            )
+        pair_counter, pair_counts, coo_list, coo_shifts = coo_registration.callable(
+            sorted_atom_index,
+            sorted_pos_x,
+            sorted_pos_y,
+            sorted_pos_z,
+            num_tiles,
+            tile_row_group,
+            tile_col_group,
+            cell_n,
+            inv_cell_n,
+            rf,
+            pair_counter,
+            pair_offsets.astype(jnp.int32),
+            pair_counts.astype(jnp.int32),
+            coo_list,
+            coo_shifts,
+            float(cutoff),
+            int(natom),
+            int(max_pairs),
         )
         del pair_counter
         return coo_list.T, pair_offsets, pair_counts, coo_shifts
 
     coo_list = jnp.zeros((max_pairs, 2), dtype=jnp.int32)
     coo_shifts = jnp.zeros((max_pairs, 3), dtype=jnp.int32)
-    pair_counter, coo_list, coo_shifts = _jax_query_cluster_tile_coo(
+    pair_counter, coo_list, coo_shifts = coo_registration.callable(
         sorted_atom_index,
         sorted_pos_x,
         sorted_pos_y,

--- a/nvalchemiops/jax/neighbors/naive.py
+++ b/nvalchemiops/jax/neighbors/naive.py
@@ -82,37 +82,22 @@ _DTYPE_TO_NAIVE_KERNELS = (wp.float32, wp.float64)
 # build_naive_kernel_tables tables below remain for GraphMode.WARP callbacks.
 
 
-def _direct_naive_kernel_registrations(
-    *,
-    pbc_mode: str,
-    selective: bool = False,
-    half_fill: bool = False,
-    partial: bool = False,
-    geometry: bool = False,
-):
-    """Build lazy direct registrations for one static naive specialization."""
-    return _lazy_naive_kernel(
+_DIRECT_NAIVE_KERNELS = {
+    (pbc_mode, selective, half_fill): _lazy_naive_kernel(
         operation="single_cutoff",
         batched=False,
         pbc_mode=pbc_mode,
         selective=selective,
-        partial=partial,
         half_fill=half_fill,
-        geometry=geometry,
-        pair_fn=None,
-    )
-
-
-_DIRECT_NAIVE_KERNELS = {
-    (pbc_mode, selective, half_fill): _direct_naive_kernel_registrations(
-        pbc_mode=pbc_mode, selective=selective, half_fill=half_fill
     )
     for pbc_mode in ("none", "wrap_on_entry", "prewrapped")
     for selective in (False, True)
     for half_fill in (False, True)
 }
 _DIRECT_NAIVE_GEOMETRY_KERNELS = {
-    (pbc_mode, half_fill): _direct_naive_kernel_registrations(
+    (pbc_mode, half_fill): _lazy_naive_kernel(
+        operation="single_cutoff",
+        batched=False,
         pbc_mode=pbc_mode,
         half_fill=half_fill,
         geometry=True,

--- a/nvalchemiops/jax/neighbors/naive.py
+++ b/nvalchemiops/jax/neighbors/naive.py
@@ -31,15 +31,17 @@ from nvalchemiops.jax.neighbors._autograd import (
     _route_pair_outputs,
 )
 from nvalchemiops.jax.neighbors._dispatch import _is_jax_cpu_array
+from nvalchemiops.jax.neighbors._registration import (
+    _get_naive_jax_kernel,
+    _LazyDtypeRegistrations,
+    _NaiveJaxKernelSpec,
+)
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     _validate_graph_mode,
     build_naive_kernel_tables,
     compute_naive_num_shifts,
     coo_pack_pair_geometry,
     get_neighbor_list_from_neighbor_matrix,
-)
-from nvalchemiops.neighbors.naive import (
-    get_naive_neighbor_matrix_kernel as _get_naive_kernel,
 )
 from nvalchemiops.neighbors.naive.launchers import (
     _launch_naive_neighbor_matrix_no_pbc,
@@ -80,368 +82,78 @@ _DTYPE_TO_NAIVE_KERNELS = (wp.float32, wp.float64)
     half_fill=True,
 )
 
-# Pair-output variants — produced by the same factory but with
-# ``return_vectors`` / ``return_distances`` flipped on.  Used by the
-# autograd path in :mod:`nvalchemiops.jax.neighbors._autograd`.
-#
-# The PBC variant is hard-wired to ``pbc_mode='wrap_on_entry'``.  The kernel
-# is idempotent on already-wrapped positions and produces correct shifts
-# for raw (unwrapped) positions as well, so the autograd path silently
-# ignores the public ``wrap_positions`` kwarg.  Callers who pre-wrap to save
-# the two extra kernel launches lose that optimization on the autograd
-# path but retain numerical equivalence.
+# Direct jax_kernel registrations are constructed lazily.  The retained
+# build_naive_kernel_tables tables below remain for GraphMode.WARP callbacks.
+_DIRECT_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
 
-_fill_naive_pair_kernels = {
-    t: _get_naive_kernel(
-        t,
-        pbc_mode="none",
-        batched=False,
-        selective=False,
+
+def _direct_naive_kernel_registrations(
+    *,
+    pbc_mode: str,
+    selective: bool = False,
+    half_fill: bool = False,
+    partial: bool = False,
+    return_vectors: bool = False,
+    return_distances: bool = False,
+) -> _LazyDtypeRegistrations:
+    """Build lazy direct registrations for one static naive specialization."""
+    return _LazyDtypeRegistrations(
+        lambda wp_dtype: _get_naive_jax_kernel(
+            _NaiveJaxKernelSpec(
+                operation="single_cutoff",
+                wp_dtype=wp_dtype,
+                batched=False,
+                pbc_mode=pbc_mode,
+                selective=selective,
+                partial=partial,
+                half_fill=half_fill,
+                return_vectors=return_vectors,
+                return_distances=return_distances,
+                pair_fn=None,
+            )
+        ),
+        _DIRECT_DTYPE_MAP,
+    )
+
+
+_DIRECT_NAIVE_KERNELS = {
+    (pbc_mode, selective, half_fill): _direct_naive_kernel_registrations(
+        pbc_mode=pbc_mode, selective=selective, half_fill=half_fill
+    )
+    for pbc_mode in ("none", "wrap_on_entry", "prewrapped")
+    for selective in (False, True)
+    for half_fill in (False, True)
+}
+_DIRECT_NAIVE_GEOMETRY_KERNELS = {
+    (pbc_mode, half_fill): _direct_naive_kernel_registrations(
+        pbc_mode=pbc_mode,
+        half_fill=half_fill,
         return_vectors=True,
         return_distances=True,
     )
-    for t in _DTYPE_TO_NAIVE_KERNELS
+    for pbc_mode in ("none", "wrap_on_entry")
+    for half_fill in (False, True)
 }
-_fill_naive_pbc_pair_kernels = {
-    t: _get_naive_kernel(
-        t,
-        pbc_mode="wrap_on_entry",
-        batched=False,
-        selective=False,
-        return_vectors=True,
-        return_distances=True,
-    )
-    for t in _DTYPE_TO_NAIVE_KERNELS
-}
-
-# Half-fill specializations of the pair-output kernels (``half_fill`` is a
-# compile-time constant in the Warp factory, so honoring it needs a distinct
-# kernel).  Selected by the forward when ``half_fill=True``.
-_fill_naive_pair_half_kernels = {
-    t: _get_naive_kernel(
-        t,
-        pbc_mode="none",
-        batched=False,
-        selective=False,
-        return_vectors=True,
-        return_distances=True,
-        half_fill=True,
-    )
-    for t in _DTYPE_TO_NAIVE_KERNELS
-}
-_fill_naive_pbc_pair_half_kernels = {
-    t: _get_naive_kernel(
-        t,
-        pbc_mode="wrap_on_entry",
-        batched=False,
-        selective=False,
-        return_vectors=True,
-        return_distances=True,
-        half_fill=True,
-    )
-    for t in _DTYPE_TO_NAIVE_KERNELS
-}
-
-__all__ = ["naive_neighbor_list"]
-
-# ==============================================================================
-# JAX Kernel Wrappers
-# ==============================================================================
-
-# No-PBC naive neighbor matrix kernel wrappers
-_jax_fill_naive_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_kernels[wp.float32],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_kernels[wp.float64],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# PBC naive neighbor matrix kernel wrappers
-_jax_fill_naive_pbc_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# Selective no-PBC naive neighbor matrix kernel wrappers
-_jax_fill_naive_selective_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_selective_kernels[wp.float32],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_selective_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_selective_kernels[wp.float64],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# Selective PBC naive neighbor matrix kernel wrappers
-_jax_fill_naive_pbc_selective_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_selective_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_selective_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_selective_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# PBC prewrapped naive neighbor matrix kernel wrappers
-_jax_fill_naive_pbc_prewrapped_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_prewrapped_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_prewrapped_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_prewrapped_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# Selective PBC prewrapped naive neighbor matrix kernel wrappers
-_jax_fill_naive_pbc_prewrapped_selective_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_prewrapped_selective_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_prewrapped_selective_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_prewrapped_selective_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# Half-fill naive neighbor matrix kernel wrappers
-_jax_fill_naive_half_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_half_kernels[wp.float32],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_half_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_half_kernels[wp.float64],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_half_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_half_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_half_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_half_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_selective_half_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_selective_half_kernels[wp.float32],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_selective_half_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_selective_half_kernels[wp.float64],
-    num_outputs=2,
-    in_out_argnames=["neighbor_matrix1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_selective_half_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_selective_half_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_selective_half_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_selective_half_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_prewrapped_half_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_prewrapped_half_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_prewrapped_half_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_prewrapped_half_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_prewrapped_selective_half_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_prewrapped_selective_half_kernels[wp.float32],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_prewrapped_selective_half_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_prewrapped_selective_half_kernels[wp.float64],
-    num_outputs=3,
-    in_out_argnames=["neighbor_matrix1", "neighbor_matrix_shifts1", "num_neighbors1"],
-    enable_backward=False,
-)
-
-# Pair-output kernel wrappers (no PBC).  Returns 4 outputs: neighbor_matrix,
-# num_neighbors, neighbor_vectors, neighbor_distances.
-_jax_fill_naive_pair_f32 = jax_kernel(
-    _fill_naive_pair_kernels[wp.float32],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_fill_naive_pair_f64 = jax_kernel(
-    _fill_naive_pair_kernels[wp.float64],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-
-# Pair-output kernel wrappers (PBC, wrap-on-entry mode).  Returns 5 outputs:
-# adds neighbor_matrix_shifts.
-_jax_fill_naive_pbc_pair_f32 = jax_kernel(
-    _fill_naive_pbc_pair_kernels[wp.float32],
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_pair_f64 = jax_kernel(
-    _fill_naive_pbc_pair_kernels[wp.float64],
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-
-# Half-fill geometry-only pair-output callables (same I/O as the full-fill ones).
-_jax_fill_naive_pair_half_f32 = jax_kernel(
-    _fill_naive_pair_half_kernels[wp.float32],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_fill_naive_pair_half_f64 = jax_kernel(
-    _fill_naive_pair_half_kernels[wp.float64],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_pair_half_f32 = jax_kernel(
-    _fill_naive_pbc_pair_half_kernels[wp.float32],
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
-_jax_fill_naive_pbc_pair_half_f64 = jax_kernel(
-    _fill_naive_pbc_pair_half_kernels[wp.float64],
-    num_outputs=5,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_vectors",
-        "neighbor_distances",
-    ],
-    enable_backward=False,
-)
 
 
 @functools.cache
 def _get_jax_naive_pair_kernel(
     wp_dtype, pbc_mode: str, half_fill: bool = False, partial: bool = False
 ):
-    """Build a geometry-output naive kernel for optional partial rows."""
-    kernel = _get_naive_kernel(
-        wp_dtype,
-        pbc_mode=pbc_mode,
-        batched=False,
-        selective=False,
-        partial=partial,
-        return_vectors=True,
-        return_distances=True,
-        half_fill=half_fill,
-    )
-    if pbc_mode == "none":
-        in_out_argnames = [
-            "neighbor_matrix1",
-            "num_neighbors1",
-            "neighbor_vectors",
-            "neighbor_distances",
-        ]
-    else:
-        in_out_argnames = [
-            "neighbor_matrix1",
-            "neighbor_matrix_shifts1",
-            "num_neighbors1",
-            "neighbor_vectors",
-            "neighbor_distances",
-        ]
-    return jax_kernel(
-        kernel,
-        num_outputs=len(in_out_argnames),
-        in_out_argnames=in_out_argnames,
-        enable_backward=False,
+    """Return a cached direct geometry registration for optional partial rows."""
+    return _get_naive_jax_kernel(
+        _NaiveJaxKernelSpec(
+            operation="single_cutoff",
+            wp_dtype=wp_dtype,
+            batched=False,
+            pbc_mode=pbc_mode,
+            selective=False,
+            partial=partial,
+            half_fill=half_fill,
+            return_vectors=True,
+            return_distances=True,
+            pair_fn=None,
+        )
     )
 
 
@@ -453,56 +165,28 @@ def _get_jax_naive_pair_fn_kernel(
     half_fill: bool = False,
     partial: bool = False,
 ):
-    """Build (and cache) a ``jax_kernel`` for a ``pair_fn``-specialized naive kernel.
-
-    The naive kernel signature always carries ``pair_params`` / ``pair_energies`` /
-    ``pair_forces`` slots; specializing the factory with ``pair_fn`` flips the
-    compile-time ``HAS_PAIR_FN`` constant on so the body actually evaluates the user
-    function and writes the energy/force buffers.  Here we register those two buffers
-    as additional outputs (so JAX returns them).
-
-    Cached by ``(pair_fn identity, wp_dtype, pbc_mode)`` — Warp ``@wp.func`` objects
-    are hashable by identity, so a module-scope singleton ``pair_fn`` recompiles only
-    once.  ``jax_kernel`` (rather than ``jax_callable``) mirrors the geometry-only
-    pair-output path above: the kernel is fully specialized, so no launcher closure is
-    needed.
-    """
-    kernel = _get_naive_kernel(
-        wp_dtype,
-        pbc_mode=pbc_mode,
-        batched=False,
-        selective=False,
-        partial=partial,
-        return_vectors=True,
-        return_distances=True,
-        pair_fn=pair_fn,
-        half_fill=half_fill,
+    """Return a cached pair-function direct naive registration."""
+    return _get_naive_jax_kernel(
+        _NaiveJaxKernelSpec(
+            operation="single_cutoff",
+            wp_dtype=wp_dtype,
+            batched=False,
+            pbc_mode=pbc_mode,
+            selective=False,
+            partial=partial,
+            half_fill=half_fill,
+            return_vectors=True,
+            return_distances=True,
+            pair_fn=pair_fn,
+        )
     )
-    if pbc_mode == "none":
-        in_out_argnames = [
-            "neighbor_matrix1",
-            "num_neighbors1",
-            "neighbor_vectors",
-            "neighbor_distances",
-            "pair_energies",
-            "pair_forces",
-        ]
-    else:  # "wrap_on_entry"
-        in_out_argnames = [
-            "neighbor_matrix1",
-            "neighbor_matrix_shifts1",
-            "num_neighbors1",
-            "neighbor_vectors",
-            "neighbor_distances",
-            "pair_energies",
-            "pair_forces",
-        ]
-    return jax_kernel(
-        kernel,
-        num_outputs=len(in_out_argnames),
-        in_out_argnames=in_out_argnames,
-        enable_backward=False,
-    )
+
+
+__all__ = ["naive_neighbor_list"]
+
+# ==============================================================================
+# JAX Kernel Wrappers
+# ==============================================================================
 
 
 # Wrap positions single kernel wrappers
@@ -1630,11 +1314,9 @@ def _naive_pair_outputs_forward(
         elif is_partial:
             kernel = _get_jax_naive_pair_kernel(wp_dtype, "none", half_fill, is_partial)
         elif half_fill:
-            kernel = (
-                _jax_fill_naive_pair_half_f64 if f64 else _jax_fill_naive_pair_half_f32
-            )
+            kernel = _DIRECT_NAIVE_GEOMETRY_KERNELS[("none", True)][positions.dtype]
         else:
-            kernel = _jax_fill_naive_pair_f64 if f64 else _jax_fill_naive_pair_f32
+            kernel = _DIRECT_NAIVE_GEOMETRY_KERNELS[("none", False)][positions.dtype]
         outs = kernel(
             positions,
             empty_offsets,
@@ -1674,15 +1356,13 @@ def _naive_pair_outputs_forward(
                 wp_dtype, "wrap_on_entry", half_fill, is_partial
             )
         elif half_fill:
-            kernel = (
-                _jax_fill_naive_pbc_pair_half_f64
-                if f64
-                else _jax_fill_naive_pbc_pair_half_f32
-            )
+            kernel = _DIRECT_NAIVE_GEOMETRY_KERNELS[("wrap_on_entry", True)][
+                positions.dtype
+            ]
         else:
-            kernel = (
-                _jax_fill_naive_pbc_pair_f64 if f64 else _jax_fill_naive_pbc_pair_f32
-            )
+            kernel = _DIRECT_NAIVE_GEOMETRY_KERNELS[("wrap_on_entry", False)][
+                positions.dtype
+            ]
         if cell.ndim == 2:
             cell = cell[jnp.newaxis, :, :]
         if pbc.ndim == 1:
@@ -2423,48 +2103,28 @@ def naive_neighbor_list(
             else:
                 return neighbor_matrix, num_neighbors
 
-    # Select kernel based on dtype and static half-fill specialization.
+    # Select lazy direct registrations by dtype and static specialization.
     if positions.dtype == jnp.float64:
-        if half_fill:
-            _jax_fill = _jax_fill_naive_half_f64
-            _jax_fill_pbc = _jax_fill_naive_pbc_half_f64
-            _jax_fill_pbc_prewrapped = _jax_fill_naive_pbc_prewrapped_half_f64
-            _jax_fill_selective = _jax_fill_naive_selective_half_f64
-            _jax_fill_pbc_selective = _jax_fill_naive_pbc_selective_half_f64
-            _jax_fill_pbc_prewrapped_selective = (
-                _jax_fill_naive_pbc_prewrapped_selective_half_f64
-            )
-        else:
-            _jax_fill = _jax_fill_naive_f64
-            _jax_fill_pbc = _jax_fill_naive_pbc_f64
-            _jax_fill_pbc_prewrapped = _jax_fill_naive_pbc_prewrapped_f64
-            _jax_fill_selective = _jax_fill_naive_selective_f64
-            _jax_fill_pbc_selective = _jax_fill_naive_pbc_selective_f64
-            _jax_fill_pbc_prewrapped_selective = (
-                _jax_fill_naive_pbc_prewrapped_selective_f64
-            )
         _jax_wrap_single = _jax_wrap_positions_single_f64
     else:
-        if half_fill:
-            _jax_fill = _jax_fill_naive_half_f32
-            _jax_fill_pbc = _jax_fill_naive_pbc_half_f32
-            _jax_fill_pbc_prewrapped = _jax_fill_naive_pbc_prewrapped_half_f32
-            _jax_fill_selective = _jax_fill_naive_selective_half_f32
-            _jax_fill_pbc_selective = _jax_fill_naive_pbc_selective_half_f32
-            _jax_fill_pbc_prewrapped_selective = (
-                _jax_fill_naive_pbc_prewrapped_selective_half_f32
-            )
-        else:
-            _jax_fill = _jax_fill_naive_f32
-            _jax_fill_pbc = _jax_fill_naive_pbc_f32
-            _jax_fill_pbc_prewrapped = _jax_fill_naive_pbc_prewrapped_f32
-            _jax_fill_selective = _jax_fill_naive_selective_f32
-            _jax_fill_pbc_selective = _jax_fill_naive_pbc_selective_f32
-            _jax_fill_pbc_prewrapped_selective = (
-                _jax_fill_naive_pbc_prewrapped_selective_f32
-            )
         _jax_wrap_single = _jax_wrap_positions_single_f32
         positions = positions.astype(jnp.float32)
+    _jax_fill = _DIRECT_NAIVE_KERNELS[("none", False, bool(half_fill))][positions.dtype]
+    _jax_fill_pbc = _DIRECT_NAIVE_KERNELS[("wrap_on_entry", False, bool(half_fill))][
+        positions.dtype
+    ]
+    _jax_fill_pbc_prewrapped = _DIRECT_NAIVE_KERNELS[
+        ("prewrapped", False, bool(half_fill))
+    ][positions.dtype]
+    _jax_fill_selective = _DIRECT_NAIVE_KERNELS[("none", True, bool(half_fill))][
+        positions.dtype
+    ]
+    _jax_fill_pbc_selective = _DIRECT_NAIVE_KERNELS[
+        ("wrap_on_entry", True, bool(half_fill))
+    ][positions.dtype]
+    _jax_fill_pbc_prewrapped_selective = _DIRECT_NAIVE_KERNELS[
+        ("prewrapped", True, bool(half_fill))
+    ][positions.dtype]
 
     positions = jax.lax.stop_gradient(positions)
     if cell is not None:

--- a/nvalchemiops/jax/neighbors/naive.py
+++ b/nvalchemiops/jax/neighbors/naive.py
@@ -31,11 +31,7 @@ from nvalchemiops.jax.neighbors._autograd import (
     _route_pair_outputs,
 )
 from nvalchemiops.jax.neighbors._dispatch import _is_jax_cpu_array
-from nvalchemiops.jax.neighbors._registration import (
-    _get_naive_jax_kernel,
-    _LazyDtypeRegistrations,
-    _NaiveJaxKernelSpec,
-)
+from nvalchemiops.jax.neighbors._registration import _lazy_naive_kernel
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     _validate_graph_mode,
     build_naive_kernel_tables,
@@ -84,7 +80,6 @@ _DTYPE_TO_NAIVE_KERNELS = (wp.float32, wp.float64)
 
 # Direct jax_kernel registrations are constructed lazily.  The retained
 # build_naive_kernel_tables tables below remain for GraphMode.WARP callbacks.
-_DIRECT_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
 
 
 def _direct_naive_kernel_registrations(
@@ -93,26 +88,18 @@ def _direct_naive_kernel_registrations(
     selective: bool = False,
     half_fill: bool = False,
     partial: bool = False,
-    return_vectors: bool = False,
-    return_distances: bool = False,
-) -> _LazyDtypeRegistrations:
+    geometry: bool = False,
+):
     """Build lazy direct registrations for one static naive specialization."""
-    return _LazyDtypeRegistrations(
-        lambda wp_dtype: _get_naive_jax_kernel(
-            _NaiveJaxKernelSpec(
-                operation="single_cutoff",
-                wp_dtype=wp_dtype,
-                batched=False,
-                pbc_mode=pbc_mode,
-                selective=selective,
-                partial=partial,
-                half_fill=half_fill,
-                return_vectors=return_vectors,
-                return_distances=return_distances,
-                pair_fn=None,
-            )
-        ),
-        _DIRECT_DTYPE_MAP,
+    return _lazy_naive_kernel(
+        operation="single_cutoff",
+        batched=False,
+        pbc_mode=pbc_mode,
+        selective=selective,
+        partial=partial,
+        half_fill=half_fill,
+        geometry=geometry,
+        pair_fn=None,
     )
 
 
@@ -128,8 +115,7 @@ _DIRECT_NAIVE_GEOMETRY_KERNELS = {
     (pbc_mode, half_fill): _direct_naive_kernel_registrations(
         pbc_mode=pbc_mode,
         half_fill=half_fill,
-        return_vectors=True,
-        return_distances=True,
+        geometry=True,
     )
     for pbc_mode in ("none", "wrap_on_entry")
     for half_fill in (False, True)
@@ -141,20 +127,17 @@ def _get_jax_naive_pair_kernel(
     wp_dtype, pbc_mode: str, half_fill: bool = False, partial: bool = False
 ):
     """Return a cached direct geometry registration for optional partial rows."""
-    return _get_naive_jax_kernel(
-        _NaiveJaxKernelSpec(
-            operation="single_cutoff",
-            wp_dtype=wp_dtype,
-            batched=False,
-            pbc_mode=pbc_mode,
-            selective=False,
-            partial=partial,
-            half_fill=half_fill,
-            return_vectors=True,
-            return_distances=True,
-            pair_fn=None,
-        )
-    )
+    jax_dtype = jnp.float64 if wp_dtype == wp.float64 else jnp.float32
+    return _lazy_naive_kernel(
+        operation="single_cutoff",
+        batched=False,
+        pbc_mode=pbc_mode,
+        selective=False,
+        partial=partial,
+        half_fill=half_fill,
+        geometry=True,
+        pair_fn=None,
+    )[jax_dtype]
 
 
 @functools.cache
@@ -166,20 +149,17 @@ def _get_jax_naive_pair_fn_kernel(
     partial: bool = False,
 ):
     """Return a cached pair-function direct naive registration."""
-    return _get_naive_jax_kernel(
-        _NaiveJaxKernelSpec(
-            operation="single_cutoff",
-            wp_dtype=wp_dtype,
-            batched=False,
-            pbc_mode=pbc_mode,
-            selective=False,
-            partial=partial,
-            half_fill=half_fill,
-            return_vectors=True,
-            return_distances=True,
-            pair_fn=pair_fn,
-        )
-    )
+    jax_dtype = jnp.float64 if wp_dtype == wp.float64 else jnp.float32
+    return _lazy_naive_kernel(
+        operation="single_cutoff",
+        batched=False,
+        pbc_mode=pbc_mode,
+        selective=False,
+        partial=partial,
+        half_fill=half_fill,
+        geometry=True,
+        pair_fn=pair_fn,
+    )[jax_dtype]
 
 
 __all__ = ["naive_neighbor_list"]
@@ -2103,28 +2083,12 @@ def naive_neighbor_list(
             else:
                 return neighbor_matrix, num_neighbors
 
-    # Select lazy direct registrations by dtype and static specialization.
+    # Select wrap kernel by dtype; direct naive registrations resolve at launch.
     if positions.dtype == jnp.float64:
         _jax_wrap_single = _jax_wrap_positions_single_f64
     else:
         _jax_wrap_single = _jax_wrap_positions_single_f32
         positions = positions.astype(jnp.float32)
-    _jax_fill = _DIRECT_NAIVE_KERNELS[("none", False, bool(half_fill))][positions.dtype]
-    _jax_fill_pbc = _DIRECT_NAIVE_KERNELS[("wrap_on_entry", False, bool(half_fill))][
-        positions.dtype
-    ]
-    _jax_fill_pbc_prewrapped = _DIRECT_NAIVE_KERNELS[
-        ("prewrapped", False, bool(half_fill))
-    ][positions.dtype]
-    _jax_fill_selective = _DIRECT_NAIVE_KERNELS[("none", True, bool(half_fill))][
-        positions.dtype
-    ]
-    _jax_fill_pbc_selective = _DIRECT_NAIVE_KERNELS[
-        ("wrap_on_entry", True, bool(half_fill))
-    ][positions.dtype]
-    _jax_fill_pbc_prewrapped_selective = _DIRECT_NAIVE_KERNELS[
-        ("prewrapped", True, bool(half_fill))
-    ][positions.dtype]
 
     positions = jax.lax.stop_gradient(positions)
     if cell is not None:
@@ -2323,7 +2287,9 @@ def naive_neighbor_list(
             num_neighbors = jnp.where(
                 rf[0], jnp.zeros_like(num_neighbors), num_neighbors
             )
-            neighbor_matrix, num_neighbors = _jax_fill_selective(
+            neighbor_matrix, num_neighbors = _DIRECT_NAIVE_KERNELS[
+                ("none", True, bool(half_fill))
+            ][positions.dtype](
                 positions,
                 empty_offsets,
                 cutoff_sq,
@@ -2349,7 +2315,9 @@ def naive_neighbor_list(
                 launch_dims=(1, 1, total_atoms),
             )
         else:
-            neighbor_matrix, num_neighbors = _jax_fill(
+            neighbor_matrix, num_neighbors = _DIRECT_NAIVE_KERNELS[
+                ("none", False, bool(half_fill))
+            ][positions.dtype](
                 positions,
                 empty_offsets,
                 cutoff_sq,
@@ -2402,7 +2370,9 @@ def naive_neighbor_list(
                     rf[0], jnp.zeros_like(num_neighbors), num_neighbors
                 )
                 neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
-                    _jax_fill_pbc_selective(
+                    _DIRECT_NAIVE_KERNELS[("wrap_on_entry", True, bool(half_fill))][
+                        positions.dtype
+                    ](
                         positions_wrapped,
                         per_atom_cell_offsets,
                         cutoff_sq,
@@ -2429,30 +2399,34 @@ def naive_neighbor_list(
                     )
                 )
             else:
-                neighbor_matrix, neighbor_matrix_shifts, num_neighbors = _jax_fill_pbc(
-                    positions_wrapped,
-                    per_atom_cell_offsets,
-                    cutoff_sq,
-                    0.0,
-                    cell,
-                    shift_range_per_dimension,
-                    empty_num_shifts,
-                    empty_batch_idx,
-                    empty_batch_ptr,
-                    empty_target_indices,
-                    neighbor_matrix,
-                    neighbor_matrix_shifts,
-                    num_neighbors,
-                    empty_matrix,
-                    empty_shifts,
-                    empty_num_neighbors,
-                    empty_vectors,
-                    empty_distances,
-                    empty_pair_params,
-                    empty_energies,
-                    empty_forces,
-                    empty_rebuild_flags,
-                    launch_dims=(1, max_shifts_per_system, total_atoms),
+                neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
+                    _DIRECT_NAIVE_KERNELS[("wrap_on_entry", False, bool(half_fill))][
+                        positions.dtype
+                    ](
+                        positions_wrapped,
+                        per_atom_cell_offsets,
+                        cutoff_sq,
+                        0.0,
+                        cell,
+                        shift_range_per_dimension,
+                        empty_num_shifts,
+                        empty_batch_idx,
+                        empty_batch_ptr,
+                        empty_target_indices,
+                        neighbor_matrix,
+                        neighbor_matrix_shifts,
+                        num_neighbors,
+                        empty_matrix,
+                        empty_shifts,
+                        empty_num_neighbors,
+                        empty_vectors,
+                        empty_distances,
+                        empty_pair_params,
+                        empty_energies,
+                        empty_forces,
+                        empty_rebuild_flags,
+                        launch_dims=(1, max_shifts_per_system, total_atoms),
+                    )
                 )
         else:
             if rebuild_flags is not None:
@@ -2461,7 +2435,9 @@ def naive_neighbor_list(
                     rf[0], jnp.zeros_like(num_neighbors), num_neighbors
                 )
                 neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
-                    _jax_fill_pbc_prewrapped_selective(
+                    _DIRECT_NAIVE_KERNELS[("prewrapped", True, bool(half_fill))][
+                        positions.dtype
+                    ](
                         positions,
                         empty_offsets,
                         cutoff_sq,
@@ -2489,7 +2465,9 @@ def naive_neighbor_list(
                 )
             else:
                 neighbor_matrix, neighbor_matrix_shifts, num_neighbors = (
-                    _jax_fill_pbc_prewrapped(
+                    _DIRECT_NAIVE_KERNELS[("prewrapped", False, bool(half_fill))][
+                        positions.dtype
+                    ](
                         positions,
                         empty_offsets,
                         cutoff_sq,

--- a/nvalchemiops/jax/neighbors/naive_dual_cutoff.py
+++ b/nvalchemiops/jax/neighbors/naive_dual_cutoff.py
@@ -22,8 +22,12 @@ import jax.numpy as jnp
 import warp as wp
 from warp.jax_experimental import jax_kernel
 
+from nvalchemiops.jax.neighbors._registration import (
+    _get_naive_jax_kernel,
+    _LazyDtypeRegistrations,
+    _NaiveJaxKernelSpec,
+)
 from nvalchemiops.jax.neighbors.neighbor_utils import (
-    build_naive_kernel_tables,
     compute_naive_num_shifts,
     get_neighbor_list_from_neighbor_matrix,
 )
@@ -32,185 +36,46 @@ from nvalchemiops.neighbors.neighbor_utils import (
     get_wrap_positions_kernel,
 )
 
-_DTYPE_TO_NAIVE_DUAL_KERNELS = (wp.float32, wp.float64)
-(
-    _fill_naive_neighbor_matrix_dual_cutoff_kernels,
-    _fill_naive_neighbor_matrix_dual_cutoff_selective_kernels,
-    _fill_naive_neighbor_matrix_pbc_dual_cutoff_kernels,
-    _fill_naive_neighbor_matrix_pbc_dual_cutoff_selective_kernels,
-    _fill_naive_neighbor_matrix_pbc_dual_cutoff_prewrapped_kernels,
-    _fill_naive_neighbor_matrix_pbc_dual_cutoff_prewrapped_selective_kernels,
-) = build_naive_kernel_tables(
-    "dual_cutoff", batched=False, dtypes=_DTYPE_TO_NAIVE_DUAL_KERNELS
-)
+_DIRECT_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
+
+
+def _direct_dual_registrations(
+    *, pbc_mode: str, selective: bool = False
+) -> _LazyDtypeRegistrations:
+    """Build lazy direct registrations for one dual-cutoff specialization."""
+    return _LazyDtypeRegistrations(
+        lambda wp_dtype: _get_naive_jax_kernel(
+            _NaiveJaxKernelSpec(
+                operation="dual_cutoff",
+                wp_dtype=wp_dtype,
+                batched=False,
+                pbc_mode=pbc_mode,
+                selective=selective,
+                partial=False,
+                half_fill=False,
+                return_vectors=False,
+                return_distances=False,
+                pair_fn=None,
+            )
+        ),
+        _DIRECT_DTYPE_MAP,
+    )
+
+
+_DIRECT_NAIVE_DUAL_KERNELS = {
+    (pbc_mode, selective): _direct_dual_registrations(
+        pbc_mode=pbc_mode, selective=selective
+    )
+    for pbc_mode in ("none", "wrap_on_entry", "prewrapped")
+    for selective in (False, True)
+}
+
 
 __all__ = ["naive_neighbor_list_dual_cutoff"]
 
 # ==============================================================================
 # JAX Kernel Wrappers
 # ==============================================================================
-
-# No-PBC dual cutoff neighbor matrix kernel wrappers
-_jax_fill_dual_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_dual_cutoff_kernels[wp.float32],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_dual_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_dual_cutoff_kernels[wp.float64],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-
-# PBC dual cutoff neighbor matrix kernel wrappers
-_jax_fill_dual_pbc_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_dual_cutoff_kernels[wp.float32],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_dual_pbc_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_dual_cutoff_kernels[wp.float64],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-
-# Selective dual cutoff neighbor matrix kernel wrappers
-_jax_fill_dual_selective_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_dual_cutoff_selective_kernels[wp.float32],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_dual_selective_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_dual_cutoff_selective_kernels[wp.float64],
-    num_outputs=4,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-
-# Selective PBC dual cutoff neighbor matrix kernel wrappers
-_jax_fill_dual_pbc_selective_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_dual_cutoff_selective_kernels[wp.float32],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_dual_pbc_selective_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_dual_cutoff_selective_kernels[wp.float64],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-
-# Prewrapped PBC dual cutoff neighbor matrix kernel wrappers
-_jax_fill_dual_pbc_prewrapped_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_dual_cutoff_prewrapped_kernels[wp.float32],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_dual_pbc_prewrapped_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_dual_cutoff_prewrapped_kernels[wp.float64],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_dual_pbc_prewrapped_selective_f32 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_dual_cutoff_prewrapped_selective_kernels[
-        wp.float32
-    ],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
-_jax_fill_dual_pbc_prewrapped_selective_f64 = jax_kernel(
-    _fill_naive_neighbor_matrix_pbc_dual_cutoff_prewrapped_selective_kernels[
-        wp.float64
-    ],
-    num_outputs=6,
-    in_out_argnames=[
-        "neighbor_matrix1",
-        "neighbor_matrix_shifts1",
-        "num_neighbors1",
-        "neighbor_matrix2",
-        "neighbor_matrix_shifts2",
-        "num_neighbors2",
-    ],
-    enable_backward=False,
-)
 
 # Wrap positions single kernel wrappers
 _jax_wrap_positions_single_f32 = jax_kernel(
@@ -483,24 +348,27 @@ def naive_neighbor_list_dual_cutoff(
                     num_neighbors2,
                 )
 
-    # Select kernel based on dtype
+    # Select lazy direct registrations by dtype. Public ``half_fill`` remains
+    # intentionally absent from dual low-level specializations.
     if positions.dtype == jnp.float64:
-        _jax_fill = _jax_fill_dual_f64
-        _jax_fill_pbc = _jax_fill_dual_pbc_f64
-        _jax_fill_selective = _jax_fill_dual_selective_f64
-        _jax_fill_pbc_selective = _jax_fill_dual_pbc_selective_f64
-        _jax_fill_pbc_prewrapped = _jax_fill_dual_pbc_prewrapped_f64
-        _jax_fill_pbc_prewrapped_selective = _jax_fill_dual_pbc_prewrapped_selective_f64
         _jax_wrap_single = _jax_wrap_positions_single_f64
     else:
-        _jax_fill = _jax_fill_dual_f32
-        _jax_fill_pbc = _jax_fill_dual_pbc_f32
-        _jax_fill_selective = _jax_fill_dual_selective_f32
-        _jax_fill_pbc_selective = _jax_fill_dual_pbc_selective_f32
-        _jax_fill_pbc_prewrapped = _jax_fill_dual_pbc_prewrapped_f32
-        _jax_fill_pbc_prewrapped_selective = _jax_fill_dual_pbc_prewrapped_selective_f32
         _jax_wrap_single = _jax_wrap_positions_single_f32
         positions = positions.astype(jnp.float32)
+    _jax_fill = _DIRECT_NAIVE_DUAL_KERNELS[("none", False)][positions.dtype]
+    _jax_fill_pbc = _DIRECT_NAIVE_DUAL_KERNELS[("wrap_on_entry", False)][
+        positions.dtype
+    ]
+    _jax_fill_selective = _DIRECT_NAIVE_DUAL_KERNELS[("none", True)][positions.dtype]
+    _jax_fill_pbc_selective = _DIRECT_NAIVE_DUAL_KERNELS[("wrap_on_entry", True)][
+        positions.dtype
+    ]
+    _jax_fill_pbc_prewrapped = _DIRECT_NAIVE_DUAL_KERNELS[("prewrapped", False)][
+        positions.dtype
+    ]
+    _jax_fill_pbc_prewrapped_selective = _DIRECT_NAIVE_DUAL_KERNELS[
+        ("prewrapped", True)
+    ][positions.dtype]
 
     total_atoms = positions.shape[0]
     (

--- a/nvalchemiops/jax/neighbors/naive_dual_cutoff.py
+++ b/nvalchemiops/jax/neighbors/naive_dual_cutoff.py
@@ -22,11 +22,7 @@ import jax.numpy as jnp
 import warp as wp
 from warp.jax_experimental import jax_kernel
 
-from nvalchemiops.jax.neighbors._registration import (
-    _get_naive_jax_kernel,
-    _LazyDtypeRegistrations,
-    _NaiveJaxKernelSpec,
-)
+from nvalchemiops.jax.neighbors._registration import _lazy_naive_kernel
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     compute_naive_num_shifts,
     get_neighbor_list_from_neighbor_matrix,
@@ -36,29 +32,14 @@ from nvalchemiops.neighbors.neighbor_utils import (
     get_wrap_positions_kernel,
 )
 
-_DIRECT_DTYPE_MAP = {jnp.float32: wp.float32, jnp.float64: wp.float64}
 
-
-def _direct_dual_registrations(
-    *, pbc_mode: str, selective: bool = False
-) -> _LazyDtypeRegistrations:
+def _direct_dual_registrations(*, pbc_mode: str, selective: bool = False):
     """Build lazy direct registrations for one dual-cutoff specialization."""
-    return _LazyDtypeRegistrations(
-        lambda wp_dtype: _get_naive_jax_kernel(
-            _NaiveJaxKernelSpec(
-                operation="dual_cutoff",
-                wp_dtype=wp_dtype,
-                batched=False,
-                pbc_mode=pbc_mode,
-                selective=selective,
-                partial=False,
-                half_fill=False,
-                return_vectors=False,
-                return_distances=False,
-                pair_fn=None,
-            )
-        ),
-        _DIRECT_DTYPE_MAP,
+    return _lazy_naive_kernel(
+        operation="dual_cutoff",
+        batched=False,
+        pbc_mode=pbc_mode,
+        selective=selective,
     )
 
 
@@ -348,27 +329,12 @@ def naive_neighbor_list_dual_cutoff(
                     num_neighbors2,
                 )
 
-    # Select lazy direct registrations by dtype. Public ``half_fill`` remains
-    # intentionally absent from dual low-level specializations.
+    # Select wrap kernel by dtype; direct naive registrations resolve at launch.
     if positions.dtype == jnp.float64:
         _jax_wrap_single = _jax_wrap_positions_single_f64
     else:
         _jax_wrap_single = _jax_wrap_positions_single_f32
         positions = positions.astype(jnp.float32)
-    _jax_fill = _DIRECT_NAIVE_DUAL_KERNELS[("none", False)][positions.dtype]
-    _jax_fill_pbc = _DIRECT_NAIVE_DUAL_KERNELS[("wrap_on_entry", False)][
-        positions.dtype
-    ]
-    _jax_fill_selective = _DIRECT_NAIVE_DUAL_KERNELS[("none", True)][positions.dtype]
-    _jax_fill_pbc_selective = _DIRECT_NAIVE_DUAL_KERNELS[("wrap_on_entry", True)][
-        positions.dtype
-    ]
-    _jax_fill_pbc_prewrapped = _DIRECT_NAIVE_DUAL_KERNELS[("prewrapped", False)][
-        positions.dtype
-    ]
-    _jax_fill_pbc_prewrapped_selective = _DIRECT_NAIVE_DUAL_KERNELS[
-        ("prewrapped", True)
-    ][positions.dtype]
 
     total_atoms = positions.shape[0]
     (
@@ -400,7 +366,7 @@ def naive_neighbor_list_dual_cutoff(
                 rf[0], jnp.zeros_like(num_neighbors2), num_neighbors2
             )
             neighbor_matrix1, num_neighbors1, neighbor_matrix2, num_neighbors2 = (
-                _jax_fill_selective(
+                _DIRECT_NAIVE_DUAL_KERNELS[("none", True)][positions.dtype](
                     positions,
                     empty_offsets,
                     float(cutoff1 * cutoff1),
@@ -428,7 +394,7 @@ def naive_neighbor_list_dual_cutoff(
             )
         else:
             neighbor_matrix1, num_neighbors1, neighbor_matrix2, num_neighbors2 = (
-                _jax_fill(
+                _DIRECT_NAIVE_DUAL_KERNELS[("none", False)][positions.dtype](
                     positions,
                     empty_offsets,
                     float(cutoff1 * cutoff1),
@@ -498,7 +464,7 @@ def naive_neighbor_list_dual_cutoff(
                     neighbor_matrix2,
                     neighbor_matrix_shifts2,
                     num_neighbors2,
-                ) = _jax_fill_pbc_prewrapped_selective(
+                ) = _DIRECT_NAIVE_DUAL_KERNELS[("prewrapped", True)][positions.dtype](
                     positions,
                     empty_offsets,
                     float(cutoff1 * cutoff1),
@@ -531,7 +497,7 @@ def naive_neighbor_list_dual_cutoff(
                     neighbor_matrix2,
                     neighbor_matrix_shifts2,
                     num_neighbors2,
-                ) = _jax_fill_pbc_prewrapped(
+                ) = _DIRECT_NAIVE_DUAL_KERNELS[("prewrapped", False)][positions.dtype](
                     positions,
                     empty_offsets,
                     float(cutoff1 * cutoff1),

--- a/nvalchemiops/jax/neighbors/naive_dual_cutoff.py
+++ b/nvalchemiops/jax/neighbors/naive_dual_cutoff.py
@@ -32,20 +32,12 @@ from nvalchemiops.neighbors.neighbor_utils import (
     get_wrap_positions_kernel,
 )
 
-
-def _direct_dual_registrations(*, pbc_mode: str, selective: bool = False):
-    """Build lazy direct registrations for one dual-cutoff specialization."""
-    return _lazy_naive_kernel(
+_DIRECT_NAIVE_DUAL_KERNELS = {
+    (pbc_mode, selective): _lazy_naive_kernel(
         operation="dual_cutoff",
         batched=False,
         pbc_mode=pbc_mode,
         selective=selective,
-    )
-
-
-_DIRECT_NAIVE_DUAL_KERNELS = {
-    (pbc_mode, selective): _direct_dual_registrations(
-        pbc_mode=pbc_mode, selective=selective
     )
     for pbc_mode in ("none", "wrap_on_entry", "prewrapped")
     for selective in (False, True)

--- a/test/neighbors/bindings/jax/test_batch_cell_list.py
+++ b/test/neighbors/bindings/jax/test_batch_cell_list.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -31,6 +33,8 @@ from nvalchemiops.jax.neighbors.batch_cell_list import (
 from .conftest import requires_gpu
 
 pytestmark = requires_gpu
+
+batch_cell_list_module = import_module("nvalchemiops.jax.neighbors.batch_cell_list")
 
 
 class TestBatchCellList:
@@ -1274,3 +1278,173 @@ class TestJaxBatchCellListAutograd:
                 max_neighbors=8,
                 pair_params=jnp.ones((pos.shape[0], 1), dtype=pos.dtype),
             )
+
+
+class TestRegistrationLaziness:
+    """Test public batched cell-list registration cache materialization."""
+
+    @staticmethod
+    def _registrations():
+        """Return every lazy batched cell-list registration."""
+        return tuple(
+            registration
+            for registrations in (
+                batch_cell_list_module._BATCH_CELL_LIST_BUILD_REGISTRATIONS,
+                batch_cell_list_module._BATCH_CELL_LIST_QUERY_REGISTRATIONS,
+            )
+            for registration in registrations.values()
+        )
+
+    @pytest.fixture(autouse=True)
+    def _restore_registration_caches(self):
+        """Restore process-global registration caches after each laziness test."""
+        snapshots = [
+            (registration, dict(registration._cache))
+            for registration in self._registrations()
+        ]
+        try:
+            yield
+        finally:
+            for registration, cache in snapshots:
+                registration._cache.clear()
+                registration._cache.update(cache)
+
+    def _clear_registration_caches(self) -> None:
+        """Clear lazy batched cell-list registration caches before assertions."""
+        for registration in self._registrations():
+            registration._cache.clear()
+
+    @staticmethod
+    def _inputs(dtype=jnp.float32):
+        """Return a two-system public batch-cell-list input."""
+        positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.5, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
+                [0.5, 0.0, 0.0],
+            ],
+            dtype=dtype,
+        )
+        return (
+            positions,
+            jnp.array([0, 0, 1, 1], dtype=jnp.int32),
+            jnp.array([0, 2, 4], dtype=jnp.int32),
+            jnp.broadcast_to(jnp.eye(3, dtype=dtype), (2, 3, 3)),
+            jnp.ones((2, 3), dtype=jnp.bool_),
+        )
+
+    def test_atom_centric_populates_selected_registries(self) -> None:
+        """Public batch dispatch materializes only its required wrappers."""
+        self._clear_registration_caches()
+        positions, batch_idx, batch_ptr, cell, pbc = self._inputs()
+
+        _neighbor_matrix, num_neighbors, _shifts = batch_cell_list(
+            positions,
+            1.0,
+            cell,
+            pbc,
+            batch_idx,
+            batch_ptr,
+            max_neighbors=4,
+            max_total_cells=8,
+            strategy="atom_centric",
+        )
+
+        assert int(num_neighbors.sum()) > 0
+        assert {
+            stage
+            for stage, registration in batch_cell_list_module._BATCH_CELL_LIST_BUILD_REGISTRATIONS.items()
+            if len(registration._cache) == 1
+        } == {
+            "construct_bin_size",
+            "count_atoms",
+            "bin_atoms",
+            "cells_per_system",
+            "gather",
+        }
+        assert {
+            key
+            for key, registration in batch_cell_list_module._BATCH_CELL_LIST_QUERY_REGISTRATIONS.items()
+            if len(registration._cache) == 1
+        } == {(False, False)}
+
+    def test_pair_centric_leaves_atom_centric_registration_caches_empty(self) -> None:
+        """Batched pair-centric dispatch does not construct atom-centric wrappers."""
+        self._clear_registration_caches()
+        positions, batch_idx, batch_ptr, cell, pbc = self._inputs()
+
+        _neighbor_matrix, num_neighbors, _shifts = batch_cell_list(
+            positions,
+            1.0,
+            cell,
+            pbc,
+            batch_idx,
+            batch_ptr,
+            max_neighbors=4,
+            max_total_cells=8,
+            strategy="pair_centric",
+        )
+
+        assert int(num_neighbors.sum()) > 0
+        assert (
+            batch_cell_list_module._BATCH_CELL_LIST_BUILD_REGISTRATIONS["gather"]._cache
+            == {}
+        )
+        for (
+            registration
+        ) in batch_cell_list_module._BATCH_CELL_LIST_QUERY_REGISTRATIONS.values():
+            assert registration._cache == {}
+
+    def test_pair_centric_pair_outputs_leave_direct_caches_empty(self) -> None:
+        """Batched pair-output dispatch does not construct gather wrappers."""
+        self._clear_registration_caches()
+        positions, batch_idx, batch_ptr, cell, pbc = self._inputs()
+
+        *_outputs, distances = batch_cell_list(
+            positions,
+            1.0,
+            cell,
+            pbc,
+            batch_idx,
+            batch_ptr,
+            max_neighbors=4,
+            max_total_cells=8,
+            strategy="pair_centric",
+            return_distances=True,
+        )
+
+        distances.block_until_ready()
+        assert (
+            batch_cell_list_module._BATCH_CELL_LIST_BUILD_REGISTRATIONS["gather"]._cache
+            == {}
+        )
+        for (
+            registration
+        ) in batch_cell_list_module._BATCH_CELL_LIST_QUERY_REGISTRATIONS.values():
+            assert registration._cache == {}
+
+    def test_cells_per_system_reuses_one_wrapper_across_dtypes(self) -> None:
+        """The dtype-independent build stage shares one cached wrapper."""
+        self._clear_registration_caches()
+        for dtype in (jnp.float32, jnp.float64):
+            positions, batch_idx, batch_ptr, cell, pbc = self._inputs(dtype)
+            outputs = batch_build_cell_list(
+                positions,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                cell=cell,
+                pbc=pbc,
+                cutoff=1.0,
+                max_total_cells=8,
+            )
+            outputs[0].block_until_ready()
+
+        assert (
+            len(
+                batch_cell_list_module._BATCH_CELL_LIST_BUILD_REGISTRATIONS[
+                    "cells_per_system"
+                ]._cache
+            )
+            == 1
+        )

--- a/test/neighbors/bindings/jax/test_batch_cluster_tile.py
+++ b/test/neighbors/bindings/jax/test_batch_cluster_tile.py
@@ -17,15 +17,20 @@
 
 from __future__ import annotations
 
+import functools
+
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
+from nvalchemiops.jax.neighbors import _cluster_tile_preload
 from nvalchemiops.jax.neighbors.batch_cluster_tile import (
+    _BATCH_CLUSTER_TILE_QUERIES,
     TILE_GROUP_SIZE,
     _batch_tile_buffer_max_tiles_per_group,
     allocate_batch_cluster_tile_list,
+    batch_build_cluster_tile_list,
     batch_cluster_tile_neighbor_list,
     estimate_batch_cluster_tile_list_sizes,
     estimate_batch_cluster_tile_segments,
@@ -55,6 +60,15 @@ def _make_batch(
         bp.append(bp[-1] + sz)
     batch_ptr = jnp.array(bp, dtype=jnp.int32)
     return positions, cell_batch, batch_ptr
+
+
+def _traced_preload_device_count() -> int:
+    """Return how many local devices a traced graph callback must preload."""
+    local_devices = tuple(jax.local_devices())
+    accelerators = tuple(
+        device for device in local_devices if device.platform in {"gpu", "cuda", "rocm"}
+    )
+    return len(accelerators or local_devices)
 
 
 class TestJaxBatchClusterTileValidation:
@@ -234,6 +248,213 @@ class TestBatchTileNeighborListFormats:
         assert len(out) == 11
         num_tiles = out[0]
         assert int(num_tiles[0]) > 0
+
+
+class TestBatchClusterTileGraphPreload:
+    """Exercise batched WARP graph callbacks after kernel preload."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_preload_caches(self, monkeypatch) -> None:
+        """Keep graph-preload cache entries local to each regression test."""
+        for cache_name in (
+            "_preload_cluster_tile_query_kernel_cached",
+            "_preload_cluster_tile_coo_kernel_cached",
+        ):
+            original = getattr(_cluster_tile_preload, cache_name)
+            monkeypatch.setattr(
+                _cluster_tile_preload,
+                cache_name,
+                functools.cache(original.__wrapped__),
+            )
+
+    def test_jitted_matrix_query_preloads_and_executes_warp_graph_callback(self):
+        """A public batched matrix query preloads and executes under JIT."""
+        _cluster_tile_preload._preload_cluster_tile_query_kernel_cached.cache_clear()
+        positions, cell_batch, batch_ptr = _make_batch([32], [4.0], seed=5)
+
+        @jax.jit
+        def query(positions):
+            return batch_cluster_tile_neighbor_list(
+                positions,
+                1.0,
+                cell_batch,
+                batch_ptr,
+                max_neighbors=32,
+            )
+
+        neighbor_matrix, num_neighbors, _shifts = query(positions)
+        neighbor_matrix.block_until_ready()
+        assert (
+            _cluster_tile_preload._preload_cluster_tile_query_kernel_cached.cache_info().currsize
+            == _traced_preload_device_count()
+        )
+        assert int(num_neighbors.sum()) > 0
+
+        second = query(positions)
+        second[0].block_until_ready()
+        assert (
+            _cluster_tile_preload._preload_cluster_tile_query_kernel_cached.cache_info().currsize
+            == _traced_preload_device_count()
+        )
+
+    def test_jitted_segmented_coo_registration_preloads_and_executes(self):
+        """Segmented batched COO graph callback executes under JIT with fixed buffers."""
+        _cluster_tile_preload._preload_cluster_tile_coo_kernel_cached.cache_clear()
+        positions, cell_batch, batch_ptr = _make_batch([32, 64], [6.0, 6.0], seed=36)
+        cutoff = 2.0
+        max_neighbors = 64
+        tile_state = batch_cluster_tile_neighbor_list(
+            positions,
+            cutoff,
+            cell_batch,
+            batch_ptr,
+            format="tile",
+        )
+        (
+            num_tiles,
+            tile_row_group,
+            tile_col_group,
+            tile_system,
+            sorted_atom_index,
+            sorted_pos_x,
+            sorted_pos_y,
+            sorted_pos_z,
+            _batch_idx_sorted,
+            _batch_ptr_padded,
+            _group_ptr,
+        ) = tile_state
+        _tile_caps, tile_offsets, _pair_caps, pair_offsets = (
+            estimate_batch_cluster_tile_segments(batch_ptr, max_neighbors=max_neighbors)
+        )
+        max_pairs = int(pair_offsets[-1])
+        rebuild_flags = jnp.array([True, True], dtype=jnp.bool_)
+        tile_counts = jnp.zeros(2, dtype=jnp.int32)
+        (
+            sorted_atom_index,
+            _sort_inv,
+            sorted_pos_x,
+            sorted_pos_y,
+            sorted_pos_z,
+            _batch_idx_sorted,
+            _batch_ptr_padded,
+            _group_system,
+            _group_ptr,
+            _group_ctr_x,
+            _group_ctr_y,
+            _group_ctr_z,
+            _group_ext_x,
+            _group_ext_y,
+            _group_ext_z,
+            num_tiles,
+            tile_row_group,
+            tile_col_group,
+            tile_system,
+            tile_counts,
+        ) = batch_build_cluster_tile_list(
+            positions,
+            cutoff,
+            cell_batch,
+            batch_ptr,
+            rebuild_flags=rebuild_flags,
+            tile_offsets=tile_offsets,
+            tile_counts=tile_counts,
+            num_tiles=num_tiles,
+            tile_row_group=tile_row_group,
+            tile_col_group=tile_col_group,
+            tile_system=tile_system,
+        )
+        pair_counts = jnp.zeros(2, dtype=jnp.int32)
+        pair_counter = jnp.zeros(1, dtype=jnp.int32)
+        neighbor_list = jnp.zeros((2, max_pairs), dtype=jnp.int32)
+        coo_list = neighbor_list.T.copy()
+        coo_shifts = jnp.zeros((max_pairs, 3), dtype=jnp.int32)
+        inv_cell_batch = jnp.linalg.inv(cell_batch)
+        registration = _BATCH_CLUSTER_TILE_QUERIES["coo_segmented"]
+
+        @jax.jit
+        def query(
+            sorted_atom_index,
+            sorted_pos_x,
+            sorted_pos_y,
+            sorted_pos_z,
+            num_tiles,
+            tile_row_group,
+            tile_col_group,
+            tile_system,
+            pair_counter,
+            pair_offsets,
+            pair_counts,
+            coo_list,
+            coo_shifts,
+        ):
+            registration.preload()
+            return registration.callable(
+                sorted_atom_index,
+                sorted_pos_x,
+                sorted_pos_y,
+                sorted_pos_z,
+                cell_batch,
+                inv_cell_batch,
+                num_tiles,
+                tile_offsets,
+                tile_counts,
+                rebuild_flags,
+                tile_row_group,
+                tile_col_group,
+                tile_system,
+                pair_counter,
+                pair_offsets,
+                pair_counts,
+                coo_list,
+                coo_shifts,
+                cutoff,
+                positions.shape[0],
+                max_pairs,
+            )
+
+        pair_counter, pair_counts, coo_list, coo_shifts = query(
+            sorted_atom_index,
+            sorted_pos_x,
+            sorted_pos_y,
+            sorted_pos_z,
+            num_tiles,
+            tile_row_group,
+            tile_col_group,
+            tile_system,
+            pair_counter,
+            pair_offsets,
+            pair_counts,
+            coo_list,
+            coo_shifts,
+        )
+        pair_counts.block_until_ready()
+        assert (
+            _cluster_tile_preload._preload_cluster_tile_coo_kernel_cached.cache_info().currsize
+            == 1
+        )
+        assert pair_counts.shape == (2,)
+        assert int(pair_counts.sum()) > 0
+
+        pair_counter2, pair_counts2, coo_list2, coo_shifts2 = query(
+            sorted_atom_index,
+            sorted_pos_x,
+            sorted_pos_y,
+            sorted_pos_z,
+            num_tiles,
+            tile_row_group,
+            tile_col_group,
+            tile_system,
+            pair_counter,
+            pair_offsets,
+            pair_counts,
+            coo_list,
+            coo_shifts,
+        )
+        pair_counts2.block_until_ready()
+        assert (
+            _cluster_tile_preload._preload_cluster_tile_coo_kernel_cached.cache_info().currsize
+            == 1
+        )
 
 
 class TestBatchTileNeighborListErrors:

--- a/test/neighbors/bindings/jax/test_batch_naive.py
+++ b/test/neighbors/bindings/jax/test_batch_naive.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -28,6 +30,8 @@ from nvalchemiops.jax.neighbors.neighbor_utils import compute_naive_num_shifts
 from .conftest import requires_gpu
 
 pytestmark = requires_gpu
+
+batch_naive_module = import_module("nvalchemiops.jax.neighbors.batch_naive")
 
 
 def _distances_from_neighbor_list(
@@ -1089,3 +1093,86 @@ class TestJaxBatchNaiveAutograd:
             assert row_a == row_b
         assert jnp.isfinite(d_b).all().item()
         assert jnp.isfinite(v_b).all().item()
+
+
+class TestRegistrationLaziness:
+    """Regression tests for lazy direct batched naive registry construction."""
+
+    @staticmethod
+    def _direct_registrations():
+        """Return every direct batched naive lazy registration."""
+        return tuple(
+            registration
+            for registrations in (
+                batch_naive_module._DIRECT_BATCH_NAIVE_KERNELS,
+                batch_naive_module._DIRECT_BATCH_NAIVE_GEOMETRY_KERNELS,
+            )
+            for registration in registrations.values()
+        )
+
+    @pytest.fixture(autouse=True)
+    def _restore_direct_caches(self):
+        """Restore process-global direct caches after each laziness test."""
+        snapshots = [
+            (registration, dict(registration._cache))
+            for registration in self._direct_registrations()
+        ]
+        try:
+            yield
+        finally:
+            for registration, cache in snapshots:
+                registration._cache.clear()
+                registration._cache.update(cache)
+
+    def _clear_direct_caches(self) -> None:
+        """Clear lazy direct batched naive wrapper caches before each check."""
+        for registration in self._direct_registrations():
+            registration._cache.clear()
+
+    def test_direct_no_pbc_caches_one_wrapper(self) -> None:
+        """Direct scalar no-PBC should register exactly one dtype wrapper."""
+        self._clear_direct_caches()
+        positions = jnp.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]], dtype=jnp.float32)
+        batch_idx = jnp.array([0, 0], dtype=jnp.int32)
+        batch_naive_neighbor_list(
+            positions,
+            1.0,
+            batch_idx=batch_idx,
+            max_neighbors=4,
+        )
+
+        assert (
+            len(
+                batch_naive_module._DIRECT_BATCH_NAIVE_KERNELS[
+                    ("none", False, False)
+                ]._cache
+            )
+            == 1
+        )
+        for key, registration in batch_naive_module._DIRECT_BATCH_NAIVE_KERNELS.items():
+            if key != ("none", False, False):
+                assert len(registration._cache) == 0
+        for (
+            registration
+        ) in batch_naive_module._DIRECT_BATCH_NAIVE_GEOMETRY_KERNELS.values():
+            assert len(registration._cache) == 0
+
+    def test_tile_path_leaves_direct_caches_empty(self) -> None:
+        """Tile dispatch should not touch direct batched naive registry caches."""
+        self._clear_direct_caches()
+        positions = jnp.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]], dtype=jnp.float32)
+        batch_idx = jnp.array([0, 0], dtype=jnp.int32)
+        batch_naive_neighbor_list(
+            positions,
+            1.0,
+            batch_idx=batch_idx,
+            max_neighbors=4,
+            strategy="tile",
+        )
+
+        for registrations in (
+            batch_naive_module._DIRECT_BATCH_NAIVE_KERNELS,
+            batch_naive_module._DIRECT_BATCH_NAIVE_GEOMETRY_KERNELS,
+        ):
+            for registration in registrations.values():
+                assert len(registration._cache) == 0

--- a/test/neighbors/bindings/jax/test_batch_naive_dual_cutoff.py
+++ b/test/neighbors/bindings/jax/test_batch_naive_dual_cutoff.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -31,6 +33,8 @@ from .conftest import (
 )
 
 pytestmark = requires_gpu
+
+dual_module = import_module("nvalchemiops.jax.neighbors.batch_naive_dual_cutoff")
 
 
 def _active_neighbor_shift_rows(
@@ -457,3 +461,53 @@ class TestBatchNaiveDualCutoffSelectiveRebuildFlags:
             assert _active_neighbor_shift_rows(
                 out_nm2, out_shifts2, ref_nn2, atom_index
             ) == _active_neighbor_shift_rows(ref_nm2, ref_shifts2, ref_nn2, atom_index)
+
+
+class TestRegistrationLaziness:
+    """Regression tests for lazy direct batched dual-cutoff registry construction."""
+
+    @staticmethod
+    def _direct_registrations():
+        """Return every direct batched dual-cutoff lazy registration."""
+        return tuple(dual_module._DIRECT_BATCH_NAIVE_DUAL_KERNELS.values())
+
+    @pytest.fixture(autouse=True)
+    def _restore_direct_caches(self):
+        """Restore process-global direct caches after each laziness test."""
+        snapshots = [
+            (registration, dict(registration._cache))
+            for registration in self._direct_registrations()
+        ]
+        try:
+            yield
+        finally:
+            for registration, cache in snapshots:
+                registration._cache.clear()
+                registration._cache.update(cache)
+
+    def _clear_direct_caches(self) -> None:
+        """Clear lazy direct batched dual-cutoff wrapper caches before each check."""
+        for registration in self._direct_registrations():
+            registration._cache.clear()
+
+    def test_direct_no_pbc_caches_one_wrapper(self) -> None:
+        """Direct scalar no-PBC should register exactly one dtype wrapper."""
+        self._clear_direct_caches()
+        positions = jnp.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]], dtype=jnp.float32)
+        batch_idx = jnp.array([0, 0], dtype=jnp.int32)
+        batch_naive_neighbor_list_dual_cutoff(
+            positions,
+            0.75,
+            1.0,
+            batch_idx=batch_idx,
+            max_neighbors1=4,
+            max_neighbors2=4,
+        )
+
+        assert (
+            len(dual_module._DIRECT_BATCH_NAIVE_DUAL_KERNELS[("none", False)]._cache)
+            == 1
+        )
+        for key, registration in dual_module._DIRECT_BATCH_NAIVE_DUAL_KERNELS.items():
+            if key != ("none", False):
+                assert len(registration._cache) == 0

--- a/test/neighbors/bindings/jax/test_cell_list.py
+++ b/test/neighbors/bindings/jax/test_cell_list.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -32,6 +34,8 @@ from nvalchemiops.jax.neighbors.cell_list import (
 from .conftest import requires_gpu, requires_vesin
 
 pytestmark = requires_gpu
+
+cell_list_module = import_module("nvalchemiops.jax.neighbors.cell_list")
 
 
 class TestCellList:
@@ -1701,3 +1705,145 @@ class TestJaxCellListAutograd:
                 return_distances=True,
                 graph_mode="warp",
             )
+
+
+class TestRegistrationLaziness:
+    """Test public cell-list registration cache materialization."""
+
+    @staticmethod
+    def _registrations():
+        """Return every lazy cell-list registration."""
+        return tuple(
+            registration
+            for registrations in (
+                cell_list_module._CELL_LIST_BUILD_REGISTRATIONS,
+                cell_list_module._CELL_LIST_QUERY_REGISTRATIONS,
+            )
+            for registration in registrations.values()
+        )
+
+    @pytest.fixture(autouse=True)
+    def _restore_registration_caches(self):
+        """Restore process-global registration caches after each laziness test."""
+        snapshots = [
+            (registration, dict(registration._cache))
+            for registration in self._registrations()
+        ]
+        try:
+            yield
+        finally:
+            for registration, cache in snapshots:
+                registration._cache.clear()
+                registration._cache.update(cache)
+
+    def _clear_registration_caches(self) -> None:
+        """Clear lazy cell-list registration caches before each assertion."""
+        for registration in self._registrations():
+            registration._cache.clear()
+
+    def test_atom_centric_direct_populates_selected_registries(self) -> None:
+        """Public direct dispatch materializes only its required wrappers."""
+        self._clear_registration_caches()
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32)
+        pbc = jnp.ones(3, dtype=jnp.bool_)
+
+        _neighbor_matrix, num_neighbors, _shifts = cell_list(
+            positions,
+            1.0,
+            cell,
+            pbc,
+            max_neighbors=4,
+            max_total_cells=8,
+            strategy="atom_centric",
+            atom_centric_path="direct",
+        )
+
+        assert int(num_neighbors.sum()) > 0
+        assert {
+            stage
+            for stage, registration in cell_list_module._CELL_LIST_BUILD_REGISTRATIONS.items()
+            if len(registration._cache) == 1
+        } == {"construct_bin_size", "count_atoms", "bin_atoms"}
+        assert {
+            key
+            for key, registration in cell_list_module._CELL_LIST_QUERY_REGISTRATIONS.items()
+            if len(registration._cache) == 1
+        } == {(False, False, "direct")}
+
+    def test_pair_centric_leaves_direct_registration_caches_empty(self) -> None:
+        """Pair-centric dispatch does not construct atom-centric wrappers."""
+        self._clear_registration_caches()
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32)
+        pbc = jnp.ones(3, dtype=jnp.bool_)
+
+        _neighbor_matrix, num_neighbors, _shifts = cell_list(
+            positions,
+            1.0,
+            cell,
+            pbc,
+            max_neighbors=4,
+            max_total_cells=8,
+            strategy="pair_centric",
+        )
+
+        assert int(num_neighbors.sum()) > 0
+        assert cell_list_module._CELL_LIST_BUILD_REGISTRATIONS["gather"]._cache == {}
+        for registration in cell_list_module._CELL_LIST_QUERY_REGISTRATIONS.values():
+            assert registration._cache == {}
+
+    def test_pair_centric_pair_outputs_leave_direct_caches_empty(self) -> None:
+        """Pair-centric pair-output dispatch does not construct gather wrappers."""
+        self._clear_registration_caches()
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32)
+        pbc = jnp.ones(3, dtype=jnp.bool_)
+
+        *_outputs, distances = cell_list(
+            positions,
+            1.0,
+            cell,
+            pbc,
+            max_neighbors=4,
+            max_total_cells=8,
+            strategy="pair_centric",
+            return_distances=True,
+        )
+
+        distances.block_until_ready()
+        assert cell_list_module._CELL_LIST_BUILD_REGISTRATIONS["gather"]._cache == {}
+        for registration in cell_list_module._CELL_LIST_QUERY_REGISTRATIONS.values():
+            assert registration._cache == {}
+
+    def test_warp_graph_path_leaves_direct_registration_caches_empty(self) -> None:
+        """WARP graph dispatch does not construct direct build/query wrappers."""
+        self._clear_registration_caches()
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32)
+        pbc = jnp.ones(3, dtype=jnp.bool_)
+
+        outputs = build_cell_list(
+            positions,
+            1.0,
+            cell,
+            pbc,
+            max_total_cells=8,
+            graph_mode="warp",
+        )
+
+        outputs[0].block_until_ready()
+        for registration in self._registrations():
+            assert registration._cache == {}

--- a/test/neighbors/bindings/jax/test_cluster_tile.py
+++ b/test/neighbors/bindings/jax/test_cluster_tile.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import functools
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -24,7 +26,9 @@ import pytest
 
 from nvalchemiops.jax.neighbors import _cluster_tile_preload
 from nvalchemiops.jax.neighbors.cluster_tile import (
+    _CLUSTER_TILE_QUERIES,
     TILE_GROUP_SIZE,
+    build_cluster_tile_list,
     cluster_tile_neighbor_list,
     estimate_cluster_tile_list_sizes,
 )
@@ -36,6 +40,15 @@ pytestmark = requires_gpu
 
 def _orthorhombic_cell(cell_size: float, dtype=jnp.float32) -> jax.Array:
     return jnp.eye(3, dtype=dtype) * cell_size
+
+
+def _traced_preload_device_count() -> int:
+    """Return how many local devices a traced graph callback must preload."""
+    local_devices = tuple(jax.local_devices())
+    accelerators = tuple(
+        device for device in local_devices if device.platform in {"gpu", "cuda", "rocm"}
+    )
+    return len(accelerators or local_devices)
 
 
 def _row_neighbor_set(row: jax.Array, n: int) -> set[int]:
@@ -179,6 +192,20 @@ class TestTileNeighborListCorrectness:
 class TestClusterTileGraphPreload:
     """Exercise the public WARP graph callback after its kernel preload."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_preload_caches(self, monkeypatch) -> None:
+        """Keep graph-preload cache entries local to each regression test."""
+        for cache_name in (
+            "_preload_cluster_tile_query_kernel_cached",
+            "_preload_cluster_tile_coo_kernel_cached",
+        ):
+            original = getattr(_cluster_tile_preload, cache_name)
+            monkeypatch.setattr(
+                _cluster_tile_preload,
+                cache_name,
+                functools.cache(original.__wrapped__),
+            )
+
     def test_jitted_matrix_query_preloads_and_executes_warp_graph_callback(self):
         """A public matrix query preloads and executes under JAX graph capture."""
         _cluster_tile_preload._preload_cluster_tile_query_kernel_cached.cache_clear()
@@ -202,9 +229,141 @@ class TestClusterTileGraphPreload:
 
         assert (
             _cluster_tile_preload._preload_cluster_tile_query_kernel_cached.cache_info().currsize
-            == 1
+            == _traced_preload_device_count()
         )
         assert int(num_neighbors.sum()) > 0
+
+    def test_jitted_matrix_query_reuses_preload_cache(self):
+        """Repeated jitted matrix queries keep one preload cache entry."""
+        _cluster_tile_preload._preload_cluster_tile_query_kernel_cached.cache_clear()
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]] * 16,
+            dtype=jnp.float32,
+        )
+        cell = _orthorhombic_cell(4.0)
+
+        @jax.jit
+        def query(positions):
+            return cluster_tile_neighbor_list(
+                positions,
+                1.0,
+                cell,
+                max_neighbors=32,
+            )
+
+        first = query(positions)
+        first[0].block_until_ready()
+        second = query(positions)
+        second[0].block_until_ready()
+
+        assert (
+            _cluster_tile_preload._preload_cluster_tile_query_kernel_cached.cache_info().currsize
+            == _traced_preload_device_count()
+        )
+        assert int(second[1].sum()) > 0
+
+    def test_jitted_compact_coo_registration_preloads_and_executes(self):
+        """Compact COO graph callback executes under JIT with fixed buffers."""
+        _cluster_tile_preload._preload_cluster_tile_coo_kernel_cached.cache_clear()
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]] * 16,
+            dtype=jnp.float32,
+        )
+        cell = _orthorhombic_cell(4.0)
+        (
+            sorted_atom_index,
+            _morton,
+            sorted_pos_x,
+            sorted_pos_y,
+            sorted_pos_z,
+            _group_ctr_x,
+            _group_ctr_y,
+            _group_ctr_z,
+            _group_ext_x,
+            _group_ext_y,
+            _group_ext_z,
+            num_tiles,
+            tile_row_group,
+            tile_col_group,
+        ) = build_cluster_tile_list(positions, 1.0, cell)
+        max_pairs = 256
+        pair_counter = jnp.zeros(1, dtype=jnp.int32)
+        coo_list = jnp.zeros((max_pairs, 2), dtype=jnp.int32)
+        coo_shifts = jnp.zeros((max_pairs, 3), dtype=jnp.int32)
+        registration = _CLUSTER_TILE_QUERIES["coo"]
+
+        cell_n = cell[jnp.newaxis, :, :]
+        inv_cell_n = jnp.linalg.inv(cell_n[0])[jnp.newaxis, :, :]
+
+        @jax.jit
+        def query(
+            sorted_atom_index,
+            sorted_pos_x,
+            sorted_pos_y,
+            sorted_pos_z,
+            num_tiles,
+            tile_row_group,
+            tile_col_group,
+            pair_counter,
+            coo_list,
+            coo_shifts,
+        ):
+            registration.preload()
+            return registration.callable(
+                sorted_atom_index,
+                sorted_pos_x,
+                sorted_pos_y,
+                sorted_pos_z,
+                num_tiles,
+                tile_row_group,
+                tile_col_group,
+                cell_n,
+                inv_cell_n,
+                pair_counter,
+                coo_list,
+                coo_shifts,
+                1.0,
+                positions.shape[0],
+                max_pairs,
+            )
+
+        pair_counter, coo_list, coo_shifts = query(
+            sorted_atom_index,
+            sorted_pos_x,
+            sorted_pos_y,
+            sorted_pos_z,
+            num_tiles,
+            tile_row_group,
+            tile_col_group,
+            pair_counter,
+            coo_list,
+            coo_shifts,
+        )
+        coo_list.block_until_ready()
+        assert (
+            _cluster_tile_preload._preload_cluster_tile_coo_kernel_cached.cache_info().currsize
+            == 1
+        )
+        assert int(pair_counter[0]) > 0
+
+        pair_counter2, coo_list2, coo_shifts2 = query(
+            sorted_atom_index,
+            sorted_pos_x,
+            sorted_pos_y,
+            sorted_pos_z,
+            num_tiles,
+            tile_row_group,
+            tile_col_group,
+            pair_counter,
+            coo_list,
+            coo_shifts,
+        )
+        coo_list2.block_until_ready()
+        assert (
+            _cluster_tile_preload._preload_cluster_tile_coo_kernel_cached.cache_info().currsize
+            == 1
+        )
+        assert int(pair_counter2[0]) > 0
 
 
 class TestTileNeighborListFormats:

--- a/test/neighbors/bindings/jax/test_cluster_tile.py
+++ b/test/neighbors/bindings/jax/test_cluster_tile.py
@@ -22,6 +22,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+from nvalchemiops.jax.neighbors import _cluster_tile_preload
 from nvalchemiops.jax.neighbors.cluster_tile import (
     TILE_GROUP_SIZE,
     cluster_tile_neighbor_list,
@@ -173,6 +174,37 @@ class TestTileNeighborListCorrectness:
         # Shape sanity; no negative counts.
         assert nm.shape == (33, 32)
         assert bool(jnp.all(nn >= 0))
+
+
+class TestClusterTileGraphPreload:
+    """Exercise the public WARP graph callback after its kernel preload."""
+
+    def test_jitted_matrix_query_preloads_and_executes_warp_graph_callback(self):
+        """A public matrix query preloads and executes under JAX graph capture."""
+        _cluster_tile_preload._preload_cluster_tile_query_kernel_cached.cache_clear()
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]] * 16,
+            dtype=jnp.float32,
+        )
+        cell = _orthorhombic_cell(4.0)
+
+        @jax.jit
+        def query(positions):
+            return cluster_tile_neighbor_list(
+                positions,
+                1.0,
+                cell,
+                max_neighbors=32,
+            )
+
+        neighbor_matrix, num_neighbors, _shifts = query(positions)
+        neighbor_matrix.block_until_ready()
+
+        assert (
+            _cluster_tile_preload._preload_cluster_tile_query_kernel_cached.cache_info().currsize
+            == 1
+        )
+        assert int(num_neighbors.sum()) > 0
 
 
 class TestTileNeighborListFormats:

--- a/test/neighbors/bindings/jax/test_naive.py
+++ b/test/neighbors/bindings/jax/test_naive.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import functools
+from importlib import import_module
 
 import jax
 import jax.numpy as jnp
@@ -30,6 +31,8 @@ from nvalchemiops.jax.neighbors.neighbor_utils import compute_naive_num_shifts
 from .conftest import requires_gpu
 
 pytestmark = requires_gpu
+
+naive_module = import_module("nvalchemiops.jax.neighbors.naive")
 
 
 class TestNaiveNeighborList:
@@ -1424,3 +1427,111 @@ class TestJaxNaiveAutograd:
             assert row_a == row_b
         assert jnp.isfinite(d_b).all().item()
         assert jnp.isfinite(v_b).all().item()
+
+
+class TestRegistrationLaziness:
+    """Regression tests for lazy direct naive registry construction."""
+
+    @staticmethod
+    def _direct_registrations():
+        """Return every direct naive lazy registration."""
+        return tuple(
+            registration
+            for registrations in (
+                naive_module._DIRECT_NAIVE_KERNELS,
+                naive_module._DIRECT_NAIVE_GEOMETRY_KERNELS,
+            )
+            for registration in registrations.values()
+        )
+
+    @pytest.fixture(autouse=True)
+    def _restore_direct_caches(self):
+        """Restore process-global direct caches after each laziness test."""
+        snapshots = [
+            (registration, dict(registration._cache))
+            for registration in self._direct_registrations()
+        ]
+        try:
+            yield
+        finally:
+            for registration, cache in snapshots:
+                registration._cache.clear()
+                registration._cache.update(cache)
+
+    def _clear_direct_caches(self) -> None:
+        """Clear lazy direct naive wrapper caches before each laziness check."""
+        for registration in self._direct_registrations():
+            registration._cache.clear()
+
+    def test_direct_no_pbc_caches_one_wrapper(self) -> None:
+        """Direct scalar no-PBC should register exactly one dtype wrapper."""
+        self._clear_direct_caches()
+        positions = jnp.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]], dtype=jnp.float32)
+        naive_neighbor_list(positions, 1.0, max_neighbors=4)
+
+        assert (
+            len(naive_module._DIRECT_NAIVE_KERNELS[("none", False, False)]._cache) == 1
+        )
+        for key, registration in naive_module._DIRECT_NAIVE_KERNELS.items():
+            if key != ("none", False, False):
+                assert len(registration._cache) == 0
+        for registration in naive_module._DIRECT_NAIVE_GEOMETRY_KERNELS.values():
+            assert len(registration._cache) == 0
+
+    def test_jitted_direct_first_use_caches_one_wrapper(self) -> None:
+        """Direct registration remains lazy when its first use is traced."""
+        self._clear_direct_caches()
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        jitted_neighbor_counts = jax.jit(
+            lambda positions: naive_neighbor_list(
+                positions,
+                1.0,
+                max_neighbors=4,
+            )[1]
+        )
+
+        num_neighbors = jitted_neighbor_counts(positions)
+        num_neighbors.block_until_ready()
+
+        assert int(num_neighbors.sum()) > 0
+        assert (
+            len(naive_module._DIRECT_NAIVE_KERNELS[("none", False, False)]._cache) == 1
+        )
+
+    def test_tile_path_leaves_direct_caches_empty(self) -> None:
+        """Tile dispatch should not touch direct naive registry caches."""
+        self._clear_direct_caches()
+        positions = jnp.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]], dtype=jnp.float32)
+        naive_neighbor_list(positions, 1.0, max_neighbors=4, strategy="tile")
+
+        for registrations in (
+            naive_module._DIRECT_NAIVE_KERNELS,
+            naive_module._DIRECT_NAIVE_GEOMETRY_KERNELS,
+        ):
+            for registration in registrations.values():
+                assert len(registration._cache) == 0
+
+    def test_warp_graph_path_leaves_direct_caches_empty(self) -> None:
+        """Warp graph dispatch should not touch direct naive registry caches."""
+        self._clear_direct_caches()
+        positions, cutoff, cell, pbc, max_neighbors = _make_naive_inputs(
+            jnp.float32,
+            pbc_enabled=False,
+            wrap_positions=False,
+        )
+        naive_neighbor_list(
+            positions,
+            cutoff,
+            max_neighbors=max_neighbors,
+            graph_mode="warp",
+        )
+
+        for registrations in (
+            naive_module._DIRECT_NAIVE_KERNELS,
+            naive_module._DIRECT_NAIVE_GEOMETRY_KERNELS,
+        ):
+            for registration in registrations.values():
+                assert len(registration._cache) == 0

--- a/test/neighbors/bindings/jax/test_naive_dual_cutoff.py
+++ b/test/neighbors/bindings/jax/test_naive_dual_cutoff.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -26,6 +28,8 @@ from nvalchemiops.jax.neighbors import naive_neighbor_list_dual_cutoff
 from .conftest import create_simple_cubic_system_jax, requires_gpu
 
 pytestmark = requires_gpu
+
+dual_module = import_module("nvalchemiops.jax.neighbors.naive_dual_cutoff")
 
 
 class TestNaiveDualCutoffCorrectness:
@@ -403,3 +407,48 @@ class TestNaiveDualCutoffSelectiveRebuildFlags:
 
         assert jnp.all(nn1b == nn1_ref), "nn1 should match full rebuild when flag=True"
         assert jnp.all(nn2b == nn2_ref), "nn2 should match full rebuild when flag=True"
+
+
+class TestRegistrationLaziness:
+    """Regression tests for lazy direct dual-cutoff naive registry construction."""
+
+    @staticmethod
+    def _direct_registrations():
+        """Return every direct dual-cutoff lazy registration."""
+        return tuple(dual_module._DIRECT_NAIVE_DUAL_KERNELS.values())
+
+    @pytest.fixture(autouse=True)
+    def _restore_direct_caches(self):
+        """Restore process-global direct caches after each laziness test."""
+        snapshots = [
+            (registration, dict(registration._cache))
+            for registration in self._direct_registrations()
+        ]
+        try:
+            yield
+        finally:
+            for registration, cache in snapshots:
+                registration._cache.clear()
+                registration._cache.update(cache)
+
+    def _clear_direct_caches(self) -> None:
+        """Clear lazy direct dual-cutoff wrapper caches before each check."""
+        for registration in self._direct_registrations():
+            registration._cache.clear()
+
+    def test_direct_no_pbc_caches_one_wrapper(self) -> None:
+        """Direct scalar no-PBC should register exactly one dtype wrapper."""
+        self._clear_direct_caches()
+        positions = jnp.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]], dtype=jnp.float32)
+        naive_neighbor_list_dual_cutoff(
+            positions,
+            0.75,
+            1.0,
+            max_neighbors1=4,
+            max_neighbors2=4,
+        )
+
+        assert len(dual_module._DIRECT_NAIVE_DUAL_KERNELS[("none", False)]._cache) == 1
+        for key, registration in dual_module._DIRECT_NAIVE_DUAL_KERNELS.items():
+            if key != ("none", False):
+                assert len(registration._cache) == 0

--- a/test/neighbors/bindings/jax/test_registration.py
+++ b/test/neighbors/bindings/jax/test_registration.py
@@ -1322,3 +1322,47 @@ class TestClusterTileJaxRegistration:
             getattr(preload, preload_name)(spec)
 
         assert side_effects == []
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            _registration._ClusterTileBuildJaxSpec(False, True, False),
+            _registration._ClusterTileBuildJaxSpec(True, False, True),
+        ],
+    )
+    def test_build_preload_uses_canonical_validation_before_side_effects(
+        self, monkeypatch, spec
+    ) -> None:
+        """Build preload delegates invalid combinations to the shared validator."""
+        preload = importlib.import_module(
+            "nvalchemiops.jax.neighbors._cluster_tile_preload"
+        )
+        validated_specs = []
+        side_effects = []
+
+        def fail_validation(candidate_spec) -> None:
+            validated_specs.append(candidate_spec)
+            raise ValueError("canonical build validation")
+
+        monkeypatch.setattr(
+            preload,
+            "_validate_cluster_tile_build_spec",
+            fail_validation,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            preload,
+            "_current_warp_device_alias",
+            lambda: side_effects.append("device_alias") or "cpu",
+        )
+        monkeypatch.setattr(
+            preload,
+            "_preload_cluster_tile_build_module",
+            lambda *args: side_effects.append("build_module"),
+        )
+
+        with pytest.raises(ValueError, match="canonical build validation"):
+            preload._preload_cluster_tile_build_kernel(spec)
+
+        assert validated_specs == [spec]
+        assert side_effects == []

--- a/test/neighbors/bindings/jax/test_registration.py
+++ b/test/neighbors/bindings/jax/test_registration.py
@@ -17,48 +17,15 @@
 
 from __future__ import annotations
 
+import functools
 import importlib
-import importlib.util
 
 import jax.numpy as jnp
 import pytest
 import warp as wp
 from warp.jax_experimental import GraphMode
 
-from nvalchemiops.jax.neighbors import _registration
-
-_batch_cell_list = importlib.import_module("nvalchemiops.jax.neighbors.batch_cell_list")
-_cell_list = importlib.import_module("nvalchemiops.jax.neighbors.cell_list")
-
-
-def _clear_jax_registration_caches() -> None:
-    """Clear registration caches that mocked tests can populate."""
-    _registration._get_cell_list_build_jax_kernel.cache_clear()
-    _registration._get_cell_list_query_jax_kernel.cache_clear()
-    _registration._get_naive_jax_kernel.cache_clear()
-    _registration._get_cluster_tile_build_jax_callable.cache_clear()
-    _registration._get_cluster_tile_query_jax_callable.cache_clear()
-    _cell_list._get_jax_cell_list_pair_outputs_kernel.cache_clear()
-    _batch_cell_list._get_jax_batch_cell_list_pair_outputs_kernel.cache_clear()
-
-    for registrations in (
-        _cell_list._CELL_LIST_BUILD_REGISTRATIONS,
-        _cell_list._CELL_LIST_QUERY_REGISTRATIONS,
-        _batch_cell_list._BATCH_CELL_LIST_BUILD_REGISTRATIONS,
-        _batch_cell_list._BATCH_CELL_LIST_QUERY_REGISTRATIONS,
-    ):
-        for registration in registrations.values():
-            registration._cache.clear()
-
-
-@pytest.fixture(autouse=True)
-def _clear_jax_registration_caches_after_each_test():
-    """Isolate cached registrations from temporary mocks, even on failures."""
-    _clear_jax_registration_caches()
-    try:
-        yield
-    finally:
-        _clear_jax_registration_caches()
+from nvalchemiops.jax.neighbors import _cluster_tile_preload, _registration
 
 
 class TestRegistrationHelpers:
@@ -67,7 +34,7 @@ class TestRegistrationHelpers:
     def test_register_jax_kernel_preserves_output_order_and_disables_backward(
         self, monkeypatch
     ) -> None:
-        """Register kernels with the schema's output count and order."""
+        """Register kernels with the output tuple's count and order."""
         calls = []
 
         def fake_jax_kernel(kernel, **kwargs):
@@ -78,11 +45,9 @@ class TestRegistrationHelpers:
             return "registered-kernel"
 
         monkeypatch.setattr(_registration, "jax_kernel", fake_jax_kernel)
-        schema = _registration._JaxOutputSchema(
-            ("neighbor_matrix", "num_neighbors", "neighbor_shifts")
-        )
+        outputs = ("neighbor_matrix", "num_neighbors", "neighbor_shifts")
 
-        result = _registration._register_jax_kernel("warp-kernel", schema)
+        result = _registration._register_jax_kernel("warp-kernel", outputs)
 
         assert result == "registered-kernel"
         assert calls == [
@@ -99,12 +64,30 @@ class TestRegistrationHelpers:
                 },
             )
         ]
-        assert schema.in_out_argnames == (
+        assert outputs == (
             "neighbor_matrix",
             "num_neighbors",
             "neighbor_shifts",
         )
-        assert schema.num_outputs == 3
+
+    def test_register_jax_kernel_list_mutation_does_not_affect_source_tuple(
+        self, monkeypatch
+    ) -> None:
+        """Pass a fresh list to jax_kernel without mutating the source tuple."""
+        calls = []
+
+        def fake_jax_kernel(kernel, **kwargs):
+            calls.append(list(kwargs["in_out_argnames"]))
+            kwargs["in_out_argnames"].append("mutated")
+            return "registered-kernel"
+
+        monkeypatch.setattr(_registration, "jax_kernel", fake_jax_kernel)
+        outputs = ("neighbor_matrix", "num_neighbors")
+
+        _registration._register_jax_kernel("warp-kernel", outputs)
+
+        assert outputs == ("neighbor_matrix", "num_neighbors")
+        assert calls == [["neighbor_matrix", "num_neighbors"]]
 
     def test_register_jax_callable_uses_explicit_graph_mode(self, monkeypatch) -> None:
         """Register callables with the requested graph mode and output order."""
@@ -121,11 +104,11 @@ class TestRegistrationHelpers:
             return "registered-callable"
 
         monkeypatch.setattr(_registration, "jax_callable", fake_jax_callable)
-        schema = _registration._JaxOutputSchema(("sorted_positions", "neighbor_matrix"))
+        outputs = ("sorted_positions", "neighbor_matrix")
 
         result = _registration._register_jax_callable(
             "warp-callable",
-            schema,
+            outputs,
             graph_mode=GraphMode.NONE,
         )
 
@@ -140,42 +123,54 @@ class TestRegistrationHelpers:
                 },
             )
         ]
-        assert schema.in_out_argnames == ("sorted_positions", "neighbor_matrix")
+        assert outputs == ("sorted_positions", "neighbor_matrix")
 
 
-class TestLazyDtypeRegistrations:
-    """Test lazy dtype-specific wrapper registration."""
+class TestLazyJaxKernel:
+    """Test lazy dtype-specific direct kernel registration."""
 
-    def test_constructs_and_caches_dtype_registration(self) -> None:
+    def test_constructs_and_caches_dtype_registration(self, monkeypatch) -> None:
         """Construct each supported dtype once and cache by normalized dtype."""
         built_dtypes = []
+        registration_calls = []
 
-        def factory(wp_dtype):
+        def build(wp_dtype):
             built_dtypes.append(wp_dtype)
-            return "jax:kernel-float32"
+            return "warp-kernel", ("out_a", "out_b")
 
-        registrations = _registration._LazyDtypeRegistrations(
-            factory,
+        def fake_register(kernel, outputs):
+            registration_calls.append((kernel, outputs))
+            return "jax-kernel"
+
+        monkeypatch.setattr(_registration, "_register_jax_kernel", fake_register)
+        registrations = _registration._LazyJaxKernel(
+            build,
             {jnp.float32: wp.float32},
         )
 
         first = registrations[jnp.float32]
         second = registrations[jnp.dtype("float32")]
 
-        assert first == "jax:kernel-float32"
+        assert first == "jax-kernel"
         assert second is first
         assert built_dtypes == [wp.float32]
+        assert registration_calls == [("warp-kernel", ("out_a", "out_b"))]
 
-    def test_supports_float64_and_dtype_membership(self) -> None:
+    def test_supports_float64_and_dtype_membership(self, monkeypatch) -> None:
         """Recognize supported dtypes and convert float64 before construction."""
         built_dtypes = []
 
-        def factory(wp_dtype):
+        def build(wp_dtype):
             built_dtypes.append(wp_dtype)
-            return wp_dtype
+            return wp_dtype, ("out",)
 
-        registrations = _registration._LazyDtypeRegistrations(
-            factory,
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_kernel",
+            lambda kernel, outputs: kernel,
+        )
+        registrations = _registration._LazyJaxKernel(
+            build,
             {jnp.float32: wp.float32, jnp.float64: wp.float64},
         )
 
@@ -185,13 +180,18 @@ class TestLazyDtypeRegistrations:
         assert registrations[jnp.float64] == wp.float64
         assert built_dtypes == [wp.float64]
 
-    def test_float32_only_mapping_rejects_unsupported_dtype_before_factory(
+    def test_float32_only_mapping_rejects_unsupported_dtype_before_build(
         self,
     ) -> None:
-        """Raise KeyError before the factory for an undeclared dtype."""
+        """Raise KeyError before build for an undeclared dtype."""
         built_dtypes = []
-        registrations = _registration._LazyDtypeRegistrations(
-            lambda wp_dtype: built_dtypes.append(wp_dtype),
+
+        def build(wp_dtype):
+            built_dtypes.append(wp_dtype)
+            return "warp", ("out",)
+
+        registrations = _registration._LazyJaxKernel(
+            build,
             {jnp.float32: wp.float32},
         )
 
@@ -206,8 +206,8 @@ class TestLazyDtypeRegistrations:
     def test_copies_caller_supplied_dtype_map(self) -> None:
         """Preserve the declared mappings after the caller mutates its map."""
         dtype_map = {jnp.float32: wp.float32}
-        registrations = _registration._LazyDtypeRegistrations(
-            lambda wp_dtype: wp_dtype,
+        registrations = _registration._LazyJaxKernel(
+            lambda wp_dtype: ("warp", ("out",)),
             dtype_map,
         )
         dtype_map[jnp.float64] = wp.float64
@@ -217,131 +217,120 @@ class TestLazyDtypeRegistrations:
         with pytest.raises(KeyError):
             registrations[jnp.float64]
 
-    def test_cells_per_system_reuses_a_dtype_independent_registration(
-        self, monkeypatch
-    ) -> None:
-        """Share the batch cells-per-system wrapper across floating dtypes."""
-        binding = importlib.import_module("nvalchemiops.jax.neighbors.batch_cell_list")
-        registrations = []
-        try:
-            with monkeypatch.context() as scoped_monkeypatch:
-                scoped_monkeypatch.setattr(
-                    _registration,
-                    "_get_cell_list_build_jax_kernel",
-                    lambda spec: registrations.append(spec) or object(),
-                )
-                binding = importlib.reload(binding)
-                cells_per_system = binding._BATCH_CELL_LIST_BUILD_REGISTRATIONS[
-                    "cells_per_system"
-                ]
-
-                assert cells_per_system[jnp.float32] is cells_per_system[jnp.float64]
-                assert registrations == [
-                    _registration._CellListBuildJaxSpec(
-                        "cells_per_system",
-                        wp.float32,
-                        True,
-                    ),
-                ]
-        finally:
-            importlib.reload(binding)
-
-
-class TestJaxOutputSchema:
-    """Test immutable registration output schemas."""
-
-    def test_schema_is_frozen(self) -> None:
-        """Reject mutation of a frozen output schema."""
-        schema = _registration._JaxOutputSchema(("neighbor_matrix", "num_neighbors"))
-
-        with pytest.raises(AttributeError):
-            schema.in_out_argnames = ("replacement",)
-
-    @pytest.mark.parametrize(
-        "spec_type, args",
-        [
-            (
-                _registration._CellListQueryJaxSpec,
-                (wp.float32, False, True, False, False, False, False, None, "sorted"),
-            ),
-            (
-                _registration._ClusterTileQueryJaxSpec,
-                (False, "matrix", False, False, False, False, False, False, None),
-            ),
-        ],
-    )
-    def test_boolean_heavy_query_specs_require_keyword_arguments(
-        self,
-        spec_type,
-        args,
-    ) -> None:
-        """Reject positional values for multi-axis query specializations."""
-        with pytest.raises(TypeError):
-            spec_type(*args)
-
-
-class TestNaiveJaxKernelRegistration:
-    """Test lazy registration of direct naive JAX kernels."""
-
-    @staticmethod
-    def _module():
-        """Import the direct naive registration module under test."""
-        assert (
-            importlib.util.find_spec("nvalchemiops.jax.neighbors._registration")
-            is not None
+    def test_forwards_exact_output_tuple_to_register(self, monkeypatch) -> None:
+        """Pass the build callback's output tuple unchanged to registration."""
+        registration_calls = []
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_kernel",
+            lambda kernel, outputs: registration_calls.append(outputs) or "jax",
         )
-        return _registration
+        registrations = _registration._LazyJaxKernel(
+            lambda wp_dtype: ("warp", ("neighbor_matrix", "num_neighbors")),
+            {jnp.float32: wp.float32},
+        )
 
-    @staticmethod
-    def _spec(module, **kwargs):
-        """Build a valid single-cutoff geometry registration spec."""
-        defaults = {
-            "operation": "single_cutoff",
-            "wp_dtype": wp.float32,
-            "batched": False,
-            "pbc_mode": "none",
-            "selective": False,
-            "partial": False,
-            "half_fill": False,
-            "return_vectors": True,
-            "return_distances": True,
-            "pair_fn": None,
-        }
-        defaults.update(kwargs)
-        return module._NaiveJaxKernelSpec(**defaults)
+        assert registrations[jnp.float32] == "jax"
+        assert registration_calls == [("neighbor_matrix", "num_neighbors")]
 
-    def test_registers_exact_single_pbc_pair_schema_and_getter_kwargs(
+    def test_constant_cache_key_reuses_one_wrapper_across_dtypes(
         self, monkeypatch
     ) -> None:
-        """Construct single-cutoff pair kernels with the complete ABI schema."""
-        module = self._module()
-        module._get_naive_jax_kernel.cache_clear()
+        """Share one registered wrapper when cache_key is dtype-independent."""
+        built_dtypes = []
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_kernel",
+            lambda kernel, outputs: object(),
+        )
+        registrations = _registration._LazyJaxKernel(
+            lambda wp_dtype: (built_dtypes.append(wp_dtype) or "warp", ("out",)),
+            {jnp.float32: wp.float32, jnp.float64: wp.float64},
+            cache_key=lambda wp_dtype: "cells_per_system",
+        )
+
+        assert registrations[jnp.float32] is registrations[jnp.float64]
+        assert built_dtypes == [wp.float32]
+
+
+class TestNaiveRegistrationFactory:
+    """Test lazy naive direct-kernel factory registrations."""
+
+    def test_single_cutoff_no_pbc_topology(self, monkeypatch) -> None:
+        """Register single-cutoff no-PBC topology with exact getter kwargs."""
         getter_calls = []
         registration_calls = []
+        monkeypatch.setattr(
+            _registration,
+            "get_naive_neighbor_matrix_kernel",
+            lambda wp_dtype, **kwargs: getter_calls.append((wp_dtype, kwargs))
+            or "warp",
+        )
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_kernel",
+            lambda kernel, outputs: registration_calls.append((kernel, outputs))
+            or "jax",
+        )
+        registrations = _registration._lazy_naive_kernel(
+            operation="single_cutoff",
+            batched=False,
+            pbc_mode="none",
+            selective=True,
+            half_fill=True,
+        )
 
-        def fake_getter(wp_dtype, **kwargs):
-            getter_calls.append((wp_dtype, kwargs))
-            return "warp-kernel"
+        assert registrations[jnp.float32] == "jax"
+        assert getter_calls == [
+            (
+                wp.float32,
+                {
+                    "pbc_mode": "none",
+                    "batched": False,
+                    "selective": True,
+                    "partial": False,
+                    "half_fill": True,
+                    "return_vectors": False,
+                    "return_distances": False,
+                    "pair_fn": None,
+                },
+            )
+        ]
+        assert registration_calls == [
+            ("warp", ("neighbor_matrix1", "num_neighbors1")),
+        ]
 
-        def fake_register(kernel, schema):
-            registration_calls.append((kernel, schema))
-            return "jax-kernel"
-
-        monkeypatch.setattr(module, "get_naive_neighbor_matrix_kernel", fake_getter)
-        monkeypatch.setattr(module, "_register_jax_kernel", fake_register)
-        spec = self._spec(
-            module,
+    def test_single_cutoff_pbc_geometry_and_pair_fn(self, monkeypatch) -> None:
+        """Register PBC geometry and pair outputs with exact ABI order."""
+        getter_calls = []
+        registration_calls = []
+        pair_fn = object()
+        monkeypatch.setattr(
+            _registration,
+            "get_naive_neighbor_matrix_kernel",
+            lambda wp_dtype, **kwargs: getter_calls.append((wp_dtype, kwargs))
+            or "warp",
+        )
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_kernel",
+            lambda kernel, outputs: registration_calls.append((kernel, outputs))
+            or "jax",
+        )
+        registrations = _registration._lazy_naive_kernel(
+            operation="single_cutoff",
             batched=True,
             pbc_mode="wrap_on_entry",
             partial=True,
             half_fill=True,
-            pair_fn="pair-fn",
+            geometry=True,
+            pair_fn=pair_fn,
         )
 
-        assert module._get_naive_jax_kernel(spec) == "jax-kernel"
+        assert registrations[jnp.float64] == "jax"
         assert getter_calls == [
             (
-                wp.float32,
+                wp.float64,
                 {
                     "pbc_mode": "wrap_on_entry",
                     "batched": True,
@@ -350,396 +339,163 @@ class TestNaiveJaxKernelRegistration:
                     "half_fill": True,
                     "return_vectors": True,
                     "return_distances": True,
-                    "pair_fn": "pair-fn",
+                    "pair_fn": pair_fn,
                 },
             )
         ]
         assert registration_calls == [
             (
-                "warp-kernel",
-                _registration._JaxOutputSchema(
-                    (
-                        "neighbor_matrix1",
-                        "neighbor_matrix_shifts1",
-                        "num_neighbors1",
-                        "neighbor_vectors",
-                        "neighbor_distances",
-                        "pair_energies",
-                        "pair_forces",
-                    )
+                "warp",
+                (
+                    "neighbor_matrix1",
+                    "neighbor_matrix_shifts1",
+                    "num_neighbors1",
+                    "neighbor_vectors",
+                    "neighbor_distances",
+                    "pair_energies",
+                    "pair_forces",
                 ),
             )
         ]
 
-    def test_registers_exact_dual_schema_and_ignores_half_fill(
-        self, monkeypatch
-    ) -> None:
-        """Preserve the dual getter's public half-fill compatibility behavior."""
-        module = self._module()
-        module._get_naive_jax_kernel.cache_clear()
+    def test_dual_cutoff_pbc(self, monkeypatch) -> None:
+        """Register dual-cutoff PBC with the dual getter and ABI."""
         getter_calls = []
         registration_calls = []
-
-        def fake_getter(wp_dtype, **kwargs):
-            getter_calls.append((wp_dtype, kwargs))
-            return "dual-warp-kernel"
-
-        def fake_register(kernel, schema):
-            registration_calls.append((kernel, schema))
-            return "dual-jax-kernel"
-
         monkeypatch.setattr(
-            module,
+            _registration,
             "get_naive_neighbor_matrix_dual_cutoff_kernel",
-            fake_getter,
+            lambda wp_dtype, **kwargs: getter_calls.append((wp_dtype, kwargs))
+            or "warp",
         )
-        monkeypatch.setattr(module, "_register_jax_kernel", fake_register)
-        spec = self._spec(
-            module,
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_kernel",
+            lambda kernel, outputs: registration_calls.append((kernel, outputs))
+            or "jax",
+        )
+        registrations = _registration._lazy_naive_kernel(
             operation="dual_cutoff",
-            wp_dtype=wp.float64,
+            batched=False,
             pbc_mode="prewrapped",
-            return_vectors=False,
-            return_distances=False,
+            selective=True,
         )
 
-        assert module._get_naive_jax_kernel(spec) == "dual-jax-kernel"
+        assert registrations[jnp.float32] == "jax"
         assert getter_calls == [
             (
-                wp.float64,
+                wp.float32,
                 {
                     "pbc_mode": "prewrapped",
                     "batched": False,
-                    "selective": False,
+                    "selective": True,
                 },
             )
         ]
         assert registration_calls == [
             (
-                "dual-warp-kernel",
-                _registration._JaxOutputSchema(
-                    (
-                        "neighbor_matrix1",
-                        "neighbor_matrix_shifts1",
-                        "num_neighbors1",
-                        "neighbor_matrix2",
-                        "neighbor_matrix_shifts2",
-                        "num_neighbors2",
-                    )
+                "warp",
+                (
+                    "neighbor_matrix1",
+                    "neighbor_matrix_shifts1",
+                    "num_neighbors1",
+                    "neighbor_matrix2",
+                    "neighbor_matrix_shifts2",
+                    "num_neighbors2",
                 ),
             )
         ]
 
-    def test_caches_equal_specs_and_separates_pair_function_identities(
-        self, monkeypatch
-    ) -> None:
-        """Cache immutable equivalent specs while preserving pair function identity."""
-        module = self._module()
-        module._get_naive_jax_kernel.cache_clear()
-        getter_calls = []
-
-        def fake_getter(wp_dtype, **kwargs):
-            getter_calls.append((wp_dtype, kwargs))
-            return object()
-
-        monkeypatch.setattr(module, "get_naive_neighbor_matrix_kernel", fake_getter)
-        monkeypatch.setattr(
-            module, "_register_jax_kernel", lambda kernel, schema: object()
-        )
-        pair_fn_one = object()
-        pair_fn_two = object()
-        first = self._spec(module, pair_fn=pair_fn_one)
-        equal_first = self._spec(module, pair_fn=pair_fn_one)
-        second = self._spec(module, pair_fn=pair_fn_two)
-
-        assert module._get_naive_jax_kernel(first) is module._get_naive_jax_kernel(
-            equal_first
-        )
-        assert module._get_naive_jax_kernel(first) is not module._get_naive_jax_kernel(
-            second
-        )
-        assert len(getter_calls) == 2
-
     @pytest.mark.parametrize(
-        "changes",
+        "kwargs",
         [
-            {"return_vectors": True, "return_distances": False},
-            {"pair_fn": object(), "return_vectors": False, "return_distances": False},
+            {"operation": "invalid"},
+            {"pair_fn": object(), "geometry": False},
             {
                 "operation": "dual_cutoff",
-                "return_vectors": True,
-                "return_distances": True,
+                "geometry": True,
             },
             {
                 "operation": "dual_cutoff",
                 "partial": True,
-                "return_vectors": False,
-                "return_distances": False,
             },
             {
                 "operation": "dual_cutoff",
                 "half_fill": True,
-                "return_vectors": False,
-                "return_distances": False,
             },
+            {"partial": True, "geometry": False},
+            {"partial": True, "selective": True, "geometry": True},
             {"pbc_mode": "invalid"},
         ],
     )
-    def test_rejects_invalid_specs_before_getter_or_registration(
-        self, monkeypatch, changes
+    def test_rejects_invalid_options_before_side_effects(
+        self, monkeypatch, kwargs
     ) -> None:
-        """Reject unsupported direct registrations without constructing side effects."""
-        module = self._module()
-        module._get_naive_jax_kernel.cache_clear()
+        """Reject unsupported naive options without getter or registration."""
         getter_calls = []
         registration_calls = []
         monkeypatch.setattr(
-            module,
+            _registration,
             "get_naive_neighbor_matrix_kernel",
             lambda *args, **kwargs: getter_calls.append((args, kwargs)),
         )
         monkeypatch.setattr(
-            module,
+            _registration,
+            "get_naive_neighbor_matrix_dual_cutoff_kernel",
+            lambda *args, **kwargs: getter_calls.append((args, kwargs)),
+        )
+        monkeypatch.setattr(
+            _registration,
             "_register_jax_kernel",
             lambda *args, **kwargs: registration_calls.append((args, kwargs)),
         )
+        defaults = {
+            "operation": "single_cutoff",
+            "batched": False,
+            "pbc_mode": "none",
+        }
+        defaults.update(kwargs)
+        registrations = _registration._lazy_naive_kernel(**defaults)
 
         with pytest.raises(ValueError):
-            module._get_naive_jax_kernel(self._spec(module, **changes))
+            registrations[jnp.float32]
 
         assert getter_calls == []
         assert registration_calls == []
 
 
-class TestNaiveBindingRegistrations:
-    """Test lazy registry wiring in the naive JAX bindings."""
-
-    @staticmethod
-    def _import_binding(module_name: str):
-        """Import one naive JAX binding module."""
-        return importlib.import_module(f"nvalchemiops.jax.neighbors.{module_name}")
-
-    @pytest.mark.parametrize(
-        ("module_name", "batched"),
-        [
-            ("batch_naive", True),
-            ("naive_dual_cutoff", False),
-            ("batch_naive_dual_cutoff", True),
-        ],
-    )
-    def test_import_does_not_construct_direct_wrappers(
-        self, monkeypatch, module_name, batched
-    ) -> None:
-        """Delay direct registrations until a dtype lookup requests one."""
-        calls = []
-
-        def fake_getter(spec):
-            calls.append(spec)
-            return "lazy-jax-kernel"
-
-        module = self._import_binding(module_name)
-        try:
-            with monkeypatch.context() as scoped_monkeypatch:
-                scoped_monkeypatch.setattr(
-                    _registration,
-                    "_get_naive_jax_kernel",
-                    fake_getter,
-                )
-                module = importlib.reload(module)
-
-                assert calls == []
-                registrations = (
-                    module._DIRECT_BATCH_NAIVE_KERNELS
-                    if module_name == "batch_naive"
-                    else module._DIRECT_NAIVE_DUAL_KERNELS
-                    if module_name == "naive_dual_cutoff"
-                    else module._DIRECT_BATCH_NAIVE_DUAL_KERNELS
-                )
-                key = (
-                    ("prewrapped", True, False)
-                    if module_name == "batch_naive"
-                    else ("prewrapped", True)
-                )
-                assert registrations[key][jnp.float64] == "lazy-jax-kernel"
-                assert calls == [
-                    _registration._NaiveJaxKernelSpec(
-                        operation=(
-                            "dual_cutoff"
-                            if "dual_cutoff" in module_name
-                            else "single_cutoff"
-                        ),
-                        wp_dtype=wp.float64,
-                        batched=batched,
-                        pbc_mode="prewrapped",
-                        selective=True,
-                        partial=False,
-                        half_fill=False,
-                        return_vectors=False,
-                        return_distances=False,
-                        pair_fn=None,
-                    )
-                ]
-        finally:
-            importlib.reload(module)
-
-    @pytest.mark.parametrize(
-        ("module_name", "batched"),
-        [
-            ("naive_dual_cutoff", False),
-            ("batch_naive_dual_cutoff", True),
-        ],
-    )
-    def test_dual_binding_lookup_uses_exact_hard_coded_spec(
-        self, monkeypatch, module_name, batched
-    ) -> None:
-        """Use direct dual-cutoff specs without forwarding public half_fill."""
-        calls = []
-
-        def fake_getter(spec):
-            calls.append(spec)
-            return "dual-jax-kernel"
-
-        with monkeypatch.context() as scoped_monkeypatch:
-            scoped_monkeypatch.setattr(
-                _registration,
-                "_get_naive_jax_kernel",
-                fake_getter,
-            )
-            module = importlib.reload(self._import_binding(module_name))
-            registrations = (
-                module._DIRECT_NAIVE_DUAL_KERNELS
-                if module_name == "naive_dual_cutoff"
-                else module._DIRECT_BATCH_NAIVE_DUAL_KERNELS
-            )
-
-            assert (
-                registrations[("wrap_on_entry", False)][jnp.float32]
-                == "dual-jax-kernel"
-            )
-            assert calls == [
-                _registration._NaiveJaxKernelSpec(
-                    operation="dual_cutoff",
-                    wp_dtype=wp.float32,
-                    batched=batched,
-                    pbc_mode="wrap_on_entry",
-                    selective=False,
-                    partial=False,
-                    half_fill=False,
-                    return_vectors=False,
-                    return_distances=False,
-                    pair_fn=None,
-                )
-            ]
-        importlib.reload(module)
-
-
-class TestCellListJaxKernelRegistration:
-    """Test lazy registration of direct cell-list JAX kernels."""
-
-    @staticmethod
-    def _module():
-        """Import the direct cell-list registration module under test."""
-        assert (
-            importlib.util.find_spec("nvalchemiops.jax.neighbors._registration")
-            is not None
-        )
-        return _registration
-
-    def test_mocked_build_registration_does_not_leak_to_real_binding_lookup(
-        self, monkeypatch
-    ) -> None:
-        """Do not reuse a mocked build wrapper after its patch is restored."""
-        module = self._module()
-        spec = module._CellListBuildJaxSpec("construct_bin_size", wp.float32, False)
-
-        try:
-            with monkeypatch.context() as scoped_monkeypatch:
-                scoped_monkeypatch.setattr(
-                    module,
-                    "get_build_cell_list_kernel",
-                    lambda *args, **kwargs: "fake-warp-kernel",
-                )
-                scoped_monkeypatch.setattr(
-                    module,
-                    "_register_jax_kernel",
-                    lambda *args, **kwargs: "fake-jax-kernel",
-                )
-                assert module._get_cell_list_build_jax_kernel(spec) == "fake-jax-kernel"
-        finally:
-            _clear_jax_registration_caches()
-
-        assert (
-            _cell_list._CELL_LIST_BUILD_REGISTRATIONS["construct_bin_size"][jnp.float32]
-            != "fake-jax-kernel"
-        )
-
-    @pytest.mark.parametrize(
-        ("module_name", "registry_name", "batched"),
-        [
-            ("cell_list", "_CELL_LIST_BUILD_REGISTRATIONS", False),
-            ("batch_cell_list", "_BATCH_CELL_LIST_BUILD_REGISTRATIONS", True),
-        ],
-    )
-    def test_cell_list_binding_import_defers_direct_registration(
-        self, monkeypatch, module_name, registry_name, batched
-    ) -> None:
-        """Construct direct cell-list wrappers only when their dtype is used."""
-        calls = []
-        module = importlib.import_module(f"nvalchemiops.jax.neighbors.{module_name}")
-        try:
-            with monkeypatch.context() as scoped_monkeypatch:
-                scoped_monkeypatch.setattr(
-                    _registration,
-                    "_get_cell_list_build_jax_kernel",
-                    lambda spec: calls.append(spec) or "lazy-jax-kernel",
-                )
-                module = importlib.reload(module)
-
-                assert calls == []
-                assert (
-                    getattr(module, registry_name)["construct_bin_size"][jnp.float32]
-                    == "lazy-jax-kernel"
-                )
-                assert calls == [
-                    _registration._CellListBuildJaxSpec(
-                        "construct_bin_size",
-                        wp.float32,
-                        batched,
-                    )
-                ]
-        finally:
-            importlib.reload(module)
+class TestCellListRegistrationFactory:
+    """Test lazy cell-list direct-kernel factory registrations."""
 
     def test_registers_each_build_stage_with_exact_abi(self, monkeypatch) -> None:
-        """Register every supported cell-list build ABI independently."""
-        module = self._module()
-        module._get_cell_list_build_jax_kernel.cache_clear()
+        """Register every supported build stage with exact output tuples."""
         getter_calls = []
-        registrations = []
+        registration_calls = []
         monkeypatch.setattr(
-            module,
+            _registration,
             "get_build_cell_list_kernel",
             lambda *args, **kwargs: getter_calls.append((args, kwargs)) or "warp",
         )
         monkeypatch.setattr(
-            module,
+            _registration,
             "get_cell_list_cells_per_system_kernel",
             lambda: "cells-warp",
         )
         monkeypatch.setattr(
-            module,
+            _registration,
             "get_gather_positions_and_shifts_kernel",
             lambda wp_dtype: "warp",
         )
         monkeypatch.setattr(
-            module,
+            _registration,
             "get_cell_list_gather_kernel",
             lambda wp_dtype: "warp",
         )
         monkeypatch.setattr(
-            module,
+            _registration,
             "_register_jax_kernel",
-            lambda kernel, schema: registrations.append((kernel, schema)) or "jax",
+            lambda kernel, outputs: registration_calls.append((kernel, outputs))
+            or "jax",
         )
 
         expected = {
@@ -765,11 +521,14 @@ class TestCellListJaxKernelRegistration:
             ("cells_per_system", True): ("cells_per_system",),
         }
         for (stage, batched), outputs in expected.items():
-            spec = module._CellListBuildJaxSpec(stage, wp.float32, batched)
-            assert module._get_cell_list_build_jax_kernel(spec) == "jax"
-            assert registrations[-1] == (
+            registrations = _registration._lazy_cell_list_build_kernel(
+                stage=stage,
+                batched=batched,
+            )
+            assert registrations[jnp.float32] == "jax"
+            assert registration_calls[-1] == (
                 "cells-warp" if stage == "cells_per_system" else "warp",
-                _registration._JaxOutputSchema(outputs),
+                outputs,
             )
 
         assert getter_calls == [
@@ -781,37 +540,99 @@ class TestCellListJaxKernelRegistration:
             (("bin_atoms", wp.float32), {"batched": True}),
         ]
 
-    def test_registers_query_getter_flags_and_schema(self, monkeypatch) -> None:
-        """Preserve sorted/direct, partial, geometry, and pair output ABI."""
-        module = self._module()
-        module._get_cell_list_query_jax_kernel.cache_clear()
-        calls = []
-        registered = []
+    def test_gather_stage_routes_unbatched_and_batched_getters(
+        self, monkeypatch
+    ) -> None:
+        """Route gather builds to the unbatched and batched gather getters."""
+        unbatched_calls = []
+        batched_calls = []
         monkeypatch.setattr(
-            module,
-            "get_query_cell_list_kernel",
-            lambda *args, **kwargs: calls.append((args, kwargs)) or "warp",
+            _registration,
+            "get_gather_positions_and_shifts_kernel",
+            lambda wp_dtype: unbatched_calls.append(wp_dtype) or "unbatched-warp",
         )
         monkeypatch.setattr(
-            module,
+            _registration,
+            "get_cell_list_gather_kernel",
+            lambda wp_dtype: batched_calls.append(wp_dtype) or "batched-warp",
+        )
+        monkeypatch.setattr(
+            _registration,
             "_register_jax_kernel",
-            lambda kernel, schema: registered.append((kernel, schema)) or "jax",
+            lambda kernel, outputs: "jax",
+        )
+
+        unbatched = _registration._lazy_cell_list_build_kernel(
+            stage="gather",
+            batched=False,
+        )
+        batched = _registration._lazy_cell_list_build_kernel(
+            stage="gather",
+            batched=True,
+        )
+
+        assert unbatched[jnp.float32] == "jax"
+        assert batched[jnp.float64] == "jax"
+        assert unbatched_calls == [wp.float32]
+        assert batched_calls == [wp.float64]
+
+    def test_cells_per_system_reuses_dtype_independent_wrapper(
+        self, monkeypatch
+    ) -> None:
+        """Share one cells-per-system wrapper across floating dtypes."""
+        getter_calls = []
+        monkeypatch.setattr(
+            _registration,
+            "get_cell_list_cells_per_system_kernel",
+            lambda: getter_calls.append("called") or "cells-warp",
+        )
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_kernel",
+            lambda kernel, outputs: object(),
+        )
+        registrations = _registration._lazy_cell_list_build_kernel(
+            stage="cells_per_system",
+            batched=True,
+        )
+
+        assert registrations[jnp.float32] is registrations[jnp.float64]
+        assert getter_calls == ["called"]
+
+    def test_registers_unbatched_sorted_and_direct_queries(self, monkeypatch) -> None:
+        """Register unbatched sorted and direct query paths with exact kwargs."""
+        getter_calls = []
+        registration_calls = []
+        monkeypatch.setattr(
+            _registration,
+            "get_query_cell_list_kernel",
+            lambda *args, **kwargs: getter_calls.append((args, kwargs)) or "warp",
+        )
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_kernel",
+            lambda kernel, outputs: registration_calls.append((kernel, outputs))
+            or "jax",
         )
         pair_fn = object()
-        spec = module._CellListQueryJaxSpec(
-            wp_dtype=wp.float64,
+        sorted_regs = _registration._lazy_cell_list_query_kernel(
             batched=False,
             selective=True,
             partial=True,
             half_fill=True,
-            return_vectors=True,
-            return_distances=True,
+            geometry=True,
             pair_fn=pair_fn,
             atom_centric_path="sorted",
         )
+        direct_regs = _registration._lazy_cell_list_query_kernel(
+            batched=False,
+            selective=False,
+            atom_centric_path="direct",
+        )
 
-        assert module._get_cell_list_query_jax_kernel(spec) == "jax"
-        assert calls == [
+        assert sorted_regs[jnp.float64] == "jax"
+        assert direct_regs[jnp.float32] == "jax"
+        assert getter_calls == [
             (
                 (wp.float64,),
                 {
@@ -825,163 +646,496 @@ class TestCellListJaxKernelRegistration:
                     "pair_fn": pair_fn,
                     "atom_centric_path": "sorted",
                 },
-            )
+            ),
+            (
+                (wp.float32,),
+                {
+                    "strategy": "atom_centric",
+                    "batched": False,
+                    "selective": False,
+                    "partial": False,
+                    "half_fill": False,
+                    "return_vectors": False,
+                    "return_distances": False,
+                    "pair_fn": None,
+                    "atom_centric_path": "direct",
+                },
+            ),
         ]
-        assert registered == [
+        assert registration_calls == [
             (
                 "warp",
-                _registration._JaxOutputSchema(
-                    (
-                        "neighbor_matrix",
-                        "neighbor_matrix_shifts",
-                        "num_neighbors",
-                        "neighbor_vectors",
-                        "neighbor_distances",
-                        "pair_energies",
-                        "pair_forces",
-                    )
+                (
+                    "neighbor_matrix",
+                    "neighbor_matrix_shifts",
+                    "num_neighbors",
+                    "neighbor_vectors",
+                    "neighbor_distances",
+                    "pair_energies",
+                    "pair_forces",
+                ),
+            ),
+            (
+                "warp",
+                (
+                    "neighbor_matrix",
+                    "neighbor_matrix_shifts",
+                    "num_neighbors",
+                ),
+            ),
+        ]
+
+    def test_registers_batched_sorted_query(self, monkeypatch) -> None:
+        """Register batched sorted queries with topology-only ABI."""
+        getter_calls = []
+        registration_calls = []
+        monkeypatch.setattr(
+            _registration,
+            "get_query_cell_list_kernel",
+            lambda *args, **kwargs: getter_calls.append((args, kwargs)) or "warp",
+        )
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_kernel",
+            lambda kernel, outputs: registration_calls.append((kernel, outputs))
+            or "jax",
+        )
+        registrations = _registration._lazy_cell_list_query_kernel(
+            batched=True,
+            selective=True,
+            half_fill=True,
+        )
+
+        assert registrations[jnp.float32] == "jax"
+        assert getter_calls == [
+            (
+                (wp.float32,),
+                {
+                    "strategy": "atom_centric",
+                    "batched": True,
+                    "selective": True,
+                    "partial": False,
+                    "half_fill": True,
+                    "return_vectors": False,
+                    "return_distances": False,
+                    "pair_fn": None,
+                    "atom_centric_path": "sorted",
+                },
+            )
+        ]
+        assert registration_calls == [
+            (
+                "warp",
+                (
+                    "neighbor_matrix",
+                    "neighbor_matrix_shifts",
+                    "num_neighbors",
                 ),
             )
         ]
 
-    def test_cache_axes_and_invalid_specs_have_no_side_effects(
-        self, monkeypatch
+    @pytest.mark.parametrize(
+        "factory_name, kwargs",
+        [
+            (
+                "_lazy_cell_list_build_kernel",
+                {"stage": "cells_per_system", "batched": False},
+            ),
+            (
+                "_lazy_cell_list_build_kernel",
+                {"stage": "invalid", "batched": False},
+            ),
+            (
+                "_lazy_cell_list_query_kernel",
+                {"batched": True, "atom_centric_path": "direct"},
+            ),
+            (
+                "_lazy_cell_list_query_kernel",
+                {"batched": False, "geometry": False, "pair_fn": object()},
+            ),
+        ],
+    )
+    def test_rejects_invalid_options_before_side_effects(
+        self, monkeypatch, factory_name, kwargs
     ) -> None:
-        """Cache equivalent specs and reject unsupported combinations early."""
-        module = self._module()
-        module._get_cell_list_query_jax_kernel.cache_clear()
+        """Reject unsupported cell-list options without getter or registration."""
+        factory = getattr(_registration, factory_name)
         getter_calls = []
+        registration_calls = []
         monkeypatch.setattr(
-            module,
+            _registration,
+            "get_build_cell_list_kernel",
+            lambda *args, **kwargs: getter_calls.append((args, kwargs)),
+        )
+        monkeypatch.setattr(
+            _registration,
             "get_query_cell_list_kernel",
-            lambda *args, **kwargs: getter_calls.append((args, kwargs)) or object(),
+            lambda *args, **kwargs: getter_calls.append((args, kwargs)),
         )
-        monkeypatch.setattr(module, "_register_jax_kernel", lambda *args: object())
-        valid = module._CellListQueryJaxSpec(
-            wp_dtype=wp.float32,
-            batched=False,
-            selective=True,
-            partial=False,
-            half_fill=False,
-            return_vectors=False,
-            return_distances=False,
-            pair_fn=None,
-            atom_centric_path="direct",
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_kernel",
+            lambda *args, **kwargs: registration_calls.append((args, kwargs)),
         )
-        assert module._get_cell_list_query_jax_kernel(
-            valid
-        ) is module._get_cell_list_query_jax_kernel(valid)
-        assert len(getter_calls) == 1
-        for spec in (
-            module._CellListBuildJaxSpec("estimate_sizes", wp.float32, False),
-            module._CellListQueryJaxSpec(
-                wp_dtype=wp.float32,
-                batched=True,
-                selective=True,
-                partial=False,
-                half_fill=False,
-                return_vectors=False,
-                return_distances=False,
-                pair_fn=None,
-                atom_centric_path="direct",
-            ),
-            module._CellListQueryJaxSpec(
-                wp_dtype=wp.float32,
-                batched=False,
-                selective=True,
-                partial=False,
-                half_fill=False,
-                return_vectors=True,
-                return_distances=False,
-                pair_fn=None,
-                atom_centric_path="sorted",
-            ),
-            module._CellListQueryJaxSpec(
-                wp_dtype=wp.float32,
-                batched=False,
-                selective=True,
-                partial=False,
-                half_fill=False,
-                return_vectors=False,
-                return_distances=False,
-                pair_fn=object(),
-                atom_centric_path="sorted",
-            ),
-        ):
-            with pytest.raises(ValueError):
-                (
-                    module._get_cell_list_build_jax_kernel(spec)
-                    if isinstance(spec, module._CellListBuildJaxSpec)
-                    else module._get_cell_list_query_jax_kernel(spec)
-                )
-        assert len(getter_calls) == 1
+        registrations = factory(**kwargs)
+
+        with pytest.raises(ValueError):
+            registrations[jnp.float32]
+
+        assert getter_calls == []
+        assert registration_calls == []
 
 
-class TestClusterTileJaxRegistration:
-    """Test shared cluster-tile JAX callback registrations."""
+class TestClusterTileSemanticMaps:
+    """Test cluster-tile graph registration semantic maps."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_pair_registration_cache(self, monkeypatch):
+        """Keep mocked pair registrations out of the production cache."""
+        binding = self._binding("cluster_tile")
+        original = binding._get_jax_cluster_tile_pair_fn_registration
+        monkeypatch.setattr(
+            binding,
+            "_get_jax_cluster_tile_pair_fn_registration",
+            functools.cache(original.__wrapped__),
+        )
+        yield
 
     @staticmethod
-    def _query_spec(**kwargs):
-        """Build a valid single-system matrix query registration spec."""
-        defaults = {
-            "batched": False,
-            "output_format": "matrix",
-            "tile_segmented": False,
-            "coo_segmented": False,
-            "selective": False,
-            "dual_cutoff": False,
-            "return_vectors": False,
-            "return_distances": False,
-            "pair_fn": None,
-        }
-        defaults.update(kwargs)
-        return _registration._ClusterTileQueryJaxSpec(**defaults)
+    def _binding(module_name: str):
+        return importlib.import_module(f"nvalchemiops.jax.neighbors.{module_name}")
 
-    def test_registers_exact_build_schemas(self, monkeypatch) -> None:
-        """Build registrations retain each callback's ordered in-place ABI."""
-        _registration._get_cluster_tile_build_jax_callable.cache_clear()
+    @pytest.mark.parametrize(
+        ("module_name", "builds_name", "queries_name"),
+        [
+            ("cluster_tile", "_CLUSTER_TILE_BUILDS", "_CLUSTER_TILE_QUERIES"),
+            (
+                "batch_cluster_tile",
+                "_BATCH_CLUSTER_TILE_BUILDS",
+                "_BATCH_CLUSTER_TILE_QUERIES",
+            ),
+        ],
+    )
+    def test_binding_maps_contain_only_graph_registrations(
+        self, module_name, builds_name, queries_name
+    ) -> None:
+        """Expose only bundled callback/preload graph registrations."""
+        binding = self._binding(module_name)
+        builds = getattr(binding, builds_name)
+        queries = getattr(binding, queries_name)
+
+        assert set(builds) == {"full", "selective"}
+        assert set(queries) == {
+            "matrix",
+            "matrix_selective",
+            "matrix_dual",
+            "matrix_dual_selective",
+            "matrix_geometry",
+            "coo",
+            "coo_segmented",
+        }
+        for registration in (*builds.values(), *queries.values()):
+            assert isinstance(registration, _registration._GraphRegistration)
+            assert callable(registration.callable)
+            assert callable(registration.preload)
+
+    def test_pair_fn_helper_caches_complete_bundles_by_identity(
+        self, monkeypatch
+    ) -> None:
+        """Distinct pair_fn identities cache separate graph bundles."""
+        binding = self._binding("cluster_tile")
+        preload_calls = []
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_callable",
+            lambda *args, **kwargs: object(),
+        )
+        monkeypatch.setattr(
+            _registration,
+            "_preload_cluster_tile_query_kernel",
+            lambda **kwargs: preload_calls.append(kwargs),
+        )
+        pair_one, pair_two = object(), object()
+
+        first = binding._get_jax_cluster_tile_pair_fn_registration(pair_one)
+        second = binding._get_jax_cluster_tile_pair_fn_registration(pair_one)
+        third = binding._get_jax_cluster_tile_pair_fn_registration(pair_two)
+
+        assert first is second
+        assert third is not first
+        first.preload()
+        assert preload_calls[-1]["pair_fn"] is pair_one
+
+    @staticmethod
+    def _mock_registration_map(keys, preload_calls, callable_calls):
+        """Build a map of lightweight graph registrations for dispatch tests."""
+
+        def make_registration(key):
+            if key == "full":
+
+                def build_callable(*args):
+                    callable_calls.append(key)
+                    return args[5:14]
+
+            elif key == "selective":
+
+                def build_callable(*args):
+                    callable_calls.append(key)
+                    return args[5:14]
+
+            elif key in {"coo", "coo_segmented"}:
+
+                def build_callable(*args, key=key):
+                    callable_calls.append(key)
+                    if key == "coo_segmented":
+                        return args[10], args[12], args[13], args[14]
+                    return args[9], args[10], args[11]
+
+            else:
+
+                def build_callable(*args, key=key):
+                    callable_calls.append(key)
+                    if "dual" in key:
+                        return tuple(jnp.zeros(1, dtype=jnp.int32) for _ in range(6))
+                    if key == "matrix_geometry":
+                        return tuple(jnp.zeros(1, dtype=jnp.float32) for _ in range(5))
+                    return tuple(jnp.zeros(1, dtype=jnp.int32) for _ in range(3))
+
+            return _registration._GraphRegistration(
+                callable=build_callable,
+                preload=lambda *args, key=key, **kwargs: preload_calls.append(key),
+            )
+
+        return {key: make_registration(key) for key in keys}
+
+    def test_build_dispatch_uses_matching_bundle(self, monkeypatch) -> None:
+        """Build dispatch preloads and calls the selected bundle only."""
+        binding = self._binding("cluster_tile")
+        preload_calls = []
+        callable_calls = []
+        original_sort = binding._morton_sort_and_gather
+        original_builds = binding._CLUSTER_TILE_BUILDS
+        with monkeypatch.context() as scoped:
+            scoped.setattr(
+                binding,
+                "_morton_sort_and_gather",
+                lambda *args, **kwargs: (
+                    jnp.zeros(1, jnp.int32),
+                    jnp.zeros(1, jnp.int32),
+                    jnp.zeros(1, jnp.float32),
+                    jnp.zeros(1, jnp.float32),
+                    jnp.zeros(1, jnp.float32),
+                ),
+            )
+            scoped.setattr(
+                binding,
+                "_CLUSTER_TILE_BUILDS",
+                self._mock_registration_map(
+                    ("full", "selective"),
+                    preload_calls,
+                    callable_calls,
+                ),
+            )
+
+            positions = jnp.zeros((1, 3), dtype=jnp.float32)
+            cell = jnp.eye(3, dtype=jnp.float32)
+            binding.build_cluster_tile_list(positions, 1.0, cell)
+            binding.build_cluster_tile_list(
+                positions,
+                1.0,
+                cell,
+                rebuild_flags=jnp.ones(1, dtype=jnp.bool_),
+            )
+
+            assert preload_calls == ["full", "selective"]
+            assert callable_calls == ["full", "selective"]
+        assert binding._morton_sort_and_gather is original_sort
+        assert binding._CLUSTER_TILE_BUILDS is original_builds
+
+    def test_matrix_dispatch_uses_matching_bundle(self, monkeypatch) -> None:
+        """Matrix dispatch selects one bundled registration by precedence."""
+        binding = self._binding("cluster_tile")
+        preload_calls = []
+        callable_calls = []
+        original_queries = binding._CLUSTER_TILE_QUERIES
+        with monkeypatch.context() as scoped:
+            scoped.setattr(
+                binding,
+                "_CLUSTER_TILE_QUERIES",
+                self._mock_registration_map(
+                    (
+                        "matrix",
+                        "matrix_selective",
+                        "matrix_dual",
+                        "matrix_dual_selective",
+                        "matrix_geometry",
+                        "coo",
+                        "coo_segmented",
+                    ),
+                    preload_calls,
+                    callable_calls,
+                ),
+            )
+
+            args = (
+                jnp.zeros(1, jnp.int32),
+                jnp.zeros(1, jnp.float32),
+                jnp.zeros(1, jnp.float32),
+                jnp.zeros(1, jnp.float32),
+                jnp.zeros(1, jnp.int32),
+                jnp.zeros(1, jnp.int32),
+                jnp.zeros(1, jnp.int32),
+                jnp.eye(3, dtype=jnp.float32),
+            )
+            binding.query_cluster_tile(*args, 1.0, 1, 4, cutoff2=2.0)
+            binding.query_cluster_tile(
+                *args,
+                1.0,
+                1,
+                4,
+                rebuild_flags=jnp.ones(1, dtype=jnp.bool_),
+            )
+            binding.query_cluster_tile(
+                *args,
+                1.0,
+                1,
+                4,
+                return_vectors=True,
+                return_distances=True,
+            )
+
+            assert preload_calls == [
+                "matrix_dual",
+                "matrix_selective",
+                "matrix_geometry",
+            ]
+            assert callable_calls == [
+                "matrix_dual",
+                "matrix_selective",
+                "matrix_geometry",
+            ]
+        assert binding._CLUSTER_TILE_QUERIES is original_queries
+
+    def test_matrix_dispatch_preloads_the_executing_array_device(
+        self, monkeypatch
+    ) -> None:
+        """Matrix dispatch forwards its executing array to the preload bundle."""
+        binding = self._binding("cluster_tile")
+        device_sources = []
+        registration = _registration._GraphRegistration(
+            callable=lambda *args: tuple(
+                jnp.zeros(1, dtype=jnp.int32) for _ in range(3)
+            ),
+            preload=lambda **kwargs: device_sources.append(kwargs["device_source"]),
+        )
+        original_queries = binding._CLUSTER_TILE_QUERIES
+        with monkeypatch.context() as scoped:
+            scoped.setattr(binding, "_CLUSTER_TILE_QUERIES", {"matrix": registration})
+            args = (
+                jnp.zeros(1, jnp.int32),
+                jnp.zeros(1, jnp.float32),
+                jnp.zeros(1, jnp.float32),
+                jnp.zeros(1, jnp.float32),
+                jnp.zeros(1, jnp.int32),
+                jnp.zeros(1, jnp.int32),
+                jnp.zeros(1, jnp.int32),
+                jnp.eye(3, dtype=jnp.float32),
+            )
+            binding.query_cluster_tile(*args, 1.0, 1, 4)
+
+            assert device_sources == [args[1]]
+        assert binding._CLUSTER_TILE_QUERIES is original_queries
+
+    def test_coo_dispatch_uses_buffer_segmentation(self, monkeypatch) -> None:
+        """COO dispatch keys off paired buffers, not rebuild flags alone."""
+        binding = self._binding("cluster_tile")
+        preload_calls = []
+        callable_calls = []
+        original_queries = binding._CLUSTER_TILE_QUERIES
+        with monkeypatch.context() as scoped:
+            scoped.setattr(
+                binding,
+                "_CLUSTER_TILE_QUERIES",
+                self._mock_registration_map(
+                    ("coo", "coo_segmented"),
+                    preload_calls,
+                    callable_calls,
+                ),
+            )
+
+            common = (
+                jnp.zeros(1, jnp.int32),
+                jnp.zeros(1, jnp.float32),
+                jnp.zeros(1, jnp.float32),
+                jnp.zeros(1, jnp.float32),
+                jnp.zeros(1, jnp.int32),
+                jnp.zeros(1, jnp.int32),
+                jnp.zeros(1, jnp.int32),
+                jnp.eye(3, dtype=jnp.float32),
+            )
+            binding.query_cluster_tile_coo(*common, 1.0, 1, 8)
+            binding.query_cluster_tile_coo(
+                *common,
+                1.0,
+                1,
+                8,
+                pair_offsets=jnp.array([0, 0], dtype=jnp.int32),
+                pair_counts=jnp.zeros(1, dtype=jnp.int32),
+            )
+
+            assert preload_calls == ["coo", "coo_segmented"]
+            assert callable_calls == ["coo", "coo_segmented"]
+        assert binding._CLUSTER_TILE_QUERIES is original_queries
+
+
+class TestGraphRegistrationFactories:
+    """Test cluster-tile graph registration bundle factories."""
+
+    def test_registration_reuses_preload_option_validators(self) -> None:
+        """Registration factories share the preload module's canonical guards."""
+        assert (
+            _registration._validate_cluster_tile_build_options
+            is _cluster_tile_preload._validate_cluster_tile_build_options
+        )
+        assert (
+            _registration._validate_cluster_tile_matrix_options
+            is _cluster_tile_preload._validate_cluster_tile_matrix_options
+        )
+        assert (
+            _registration._validate_cluster_tile_coo_options
+            is _cluster_tile_preload._validate_cluster_tile_coo_options
+        )
+
+    def test_build_registration_uses_exact_abi_and_warp_graph_mode(
+        self, monkeypatch
+    ) -> None:
+        """Build factories register callbacks with the fixed output ABI."""
         calls = []
         monkeypatch.setattr(
             _registration,
             "_register_jax_callable",
-            lambda callback, schema, *, graph_mode: calls.append(
-                (callback, schema, graph_mode)
+            lambda callback, outputs, *, graph_mode: calls.append(
+                (callback, outputs, graph_mode)
             )
             or "jax",
         )
+        monkeypatch.setattr(
+            _registration,
+            "_preload_cluster_tile_build_kernel",
+            lambda: None,
+        )
 
-        cases = [
+        registration = _registration._cluster_tile_build_registration(
+            "build-callback",
+            batched=True,
+            segmented=True,
+            selective=True,
+        )
+
+        assert registration.callable == "jax"
+        assert calls == [
             (
-                _registration._ClusterTileBuildJaxSpec(False, False, False),
-                (
-                    "group_ctr_x",
-                    "group_ctr_y",
-                    "group_ctr_z",
-                    "group_ext_x",
-                    "group_ext_y",
-                    "group_ext_z",
-                    "num_tiles",
-                    "tile_row_group",
-                    "tile_col_group",
-                ),
-            ),
-            (
-                _registration._ClusterTileBuildJaxSpec(True, False, False),
-                (
-                    "group_ctr_x",
-                    "group_ctr_y",
-                    "group_ctr_z",
-                    "group_ext_x",
-                    "group_ext_y",
-                    "group_ext_z",
-                    "num_tiles",
-                    "tile_row_group",
-                    "tile_col_group",
-                    "tile_system",
-                ),
-            ),
-            (
-                _registration._ClusterTileBuildJaxSpec(True, True, True),
+                "build-callback",
                 (
                     "group_ctr_x",
                     "group_ctr_y",
@@ -995,51 +1149,46 @@ class TestClusterTileJaxRegistration:
                     "tile_col_group",
                     "tile_system",
                 ),
-            ),
-        ]
-        for index, (spec, expected) in enumerate(cases):
-            assert (
-                _registration._get_cluster_tile_build_jax_callable(spec, index) == "jax"
-            )
-            assert calls[-1] == (
-                index,
-                _registration._JaxOutputSchema(expected),
                 GraphMode.WARP,
             )
+        ]
 
-    def test_registers_exact_query_schemas_and_preserves_pair_fn_cache_axis(
+    def test_matrix_registration_uses_exact_abi_and_warp_graph_mode(
         self, monkeypatch
     ) -> None:
-        """Query schemas follow matrix/COO ABI and distinct pair functions cache apart."""
-        _registration._get_cluster_tile_query_jax_callable.cache_clear()
+        """Matrix factories preserve dual, geometry, and pair output ordering."""
         calls = []
         monkeypatch.setattr(
             _registration,
             "_register_jax_callable",
-            lambda callback, schema, *, graph_mode: calls.append(
-                (callback, schema, graph_mode)
+            lambda callback, outputs, *, graph_mode: calls.append(
+                (callback, outputs, graph_mode)
             )
-            or object(),
+            or "jax",
         )
-        pair_one, pair_two = object(), object()
-        matrix = self._query_spec(
+        monkeypatch.setattr(
+            _registration,
+            "_preload_cluster_tile_query_kernel",
+            lambda **kwargs: None,
+        )
+        pair_fn = object()
+
+        dual = _registration._cluster_tile_matrix_registration(
+            "dual-callback",
+            batched=False,
             dual_cutoff=True,
         )
-        geometry_pair = self._query_spec(
-            return_vectors=True,
-            return_distances=True,
-            pair_fn=pair_one,
-        )
-        segmented_coo = self._query_spec(
-            batched=True,
-            output_format="coo",
-            tile_segmented=True,
-            coo_segmented=True,
-            selective=True,
+        geometry_pair = _registration._cluster_tile_matrix_registration(
+            "pair-callback",
+            batched=False,
+            geometry=True,
+            pair_fn=pair_fn,
         )
 
-        assert _registration._get_cluster_tile_query_jax_callable(matrix, "matrix")
-        assert calls[-1][1] == _registration._JaxOutputSchema(
+        assert dual.callable == "jax"
+        assert geometry_pair.callable == "jax"
+        assert calls[0] == (
+            "dual-callback",
             (
                 "neighbor_matrix",
                 "num_neighbors",
@@ -1047,405 +1196,528 @@ class TestClusterTileJaxRegistration:
                 "neighbor_matrix2",
                 "num_neighbors2",
                 "neighbor_matrix_shifts2",
-            )
+            ),
+            GraphMode.WARP,
         )
-        first = _registration._get_cluster_tile_query_jax_callable(
-            geometry_pair, "pair-one"
+        assert calls[1] == (
+            "pair-callback",
+            (
+                "neighbor_matrix",
+                "num_neighbors",
+                "neighbor_matrix_shifts",
+                "neighbor_vectors",
+                "neighbor_distances",
+                "pair_energies",
+                "pair_forces",
+            ),
+            GraphMode.WARP,
         )
-        assert first is _registration._get_cluster_tile_query_jax_callable(
-            geometry_pair, "pair-one"
-        )
-        assert (
-            _registration._get_cluster_tile_query_jax_callable(
-                self._query_spec(
-                    return_vectors=True,
-                    return_distances=True,
-                    pair_fn=pair_two,
-                ),
-                "pair-two",
-            )
-            is not first
-        )
-        assert _registration._get_cluster_tile_query_jax_callable(segmented_coo, "coo")
-        assert calls[-1][1] == _registration._JaxOutputSchema(
-            ("pair_counter", "pair_counts", "coo_list", "coo_shifts")
-        )
-        assert all(call[2] is GraphMode.WARP for call in calls)
 
-    @pytest.mark.parametrize(
-        "spec",
-        [
-            _registration._ClusterTileBuildJaxSpec(False, True, False),
-            _registration._ClusterTileBuildJaxSpec(True, False, True),
-            _registration._ClusterTileQueryJaxSpec(
-                batched=False,
-                output_format="matrix",
-                tile_segmented=True,
-                coo_segmented=False,
-                selective=False,
-                dual_cutoff=False,
-                return_vectors=False,
-                return_distances=False,
-                pair_fn=None,
-            ),
-            _registration._ClusterTileQueryJaxSpec(
-                batched=False,
-                output_format="coo",
-                tile_segmented=False,
-                coo_segmented=False,
-                selective=False,
-                dual_cutoff=True,
-                return_vectors=False,
-                return_distances=False,
-                pair_fn=None,
-            ),
-            _registration._ClusterTileQueryJaxSpec(
-                batched=False,
-                output_format="coo",
-                tile_segmented=False,
-                coo_segmented=False,
-                selective=False,
-                dual_cutoff=False,
-                return_vectors=True,
-                return_distances=True,
-                pair_fn=None,
-            ),
-            _registration._ClusterTileQueryJaxSpec(
-                batched=False,
-                output_format="matrix",
-                tile_segmented=False,
-                coo_segmented=False,
-                selective=False,
-                dual_cutoff=True,
-                return_vectors=True,
-                return_distances=True,
-                pair_fn=None,
-            ),
-        ],
-    )
-    def test_rejects_invalid_cluster_tile_specs_before_registration(
-        self, monkeypatch, spec
+    def test_coo_registration_uses_exact_abi_and_warp_graph_mode(
+        self, monkeypatch
     ) -> None:
-        """Unsupported combinations do not construct callback registrations."""
-        _registration._get_cluster_tile_build_jax_callable.cache_clear()
-        _registration._get_cluster_tile_query_jax_callable.cache_clear()
+        """COO factories preserve compact and segmented output ordering."""
         calls = []
         monkeypatch.setattr(
             _registration,
             "_register_jax_callable",
-            lambda *args, **kwargs: calls.append((args, kwargs)),
+            lambda callback, outputs, *, graph_mode: calls.append(
+                (callback, outputs, graph_mode)
+            )
+            or "jax",
+        )
+        monkeypatch.setattr(
+            _registration,
+            "_preload_cluster_tile_coo_kernel",
+            lambda **kwargs: None,
         )
 
-        with pytest.raises(ValueError):
-            if isinstance(spec, _registration._ClusterTileBuildJaxSpec):
-                _registration._get_cluster_tile_build_jax_callable(spec, "callback")
-            else:
-                _registration._get_cluster_tile_query_jax_callable(spec, "callback")
-        assert calls == []
-
-    def test_preload_forwards_the_same_query_spec_object(self, monkeypatch) -> None:
-        """Query preload keeps the immutable registration spec object intact."""
-        preload = importlib.import_module(
-            "nvalchemiops.jax.neighbors._cluster_tile_preload"
+        compact = _registration._cluster_tile_coo_registration(
+            "compact-callback",
+            batched=False,
         )
-        matrix_spec = self._query_spec(pair_fn=object())
-        coo_spec = self._query_spec(
+        segmented = _registration._cluster_tile_coo_registration(
+            "segmented-callback",
             batched=True,
-            output_format="coo",
             tile_segmented=True,
             coo_segmented=True,
             selective=True,
         )
-        matrix_calls = []
-        coo_calls = []
-        monkeypatch.setattr(preload, "_current_warp_device_alias", lambda: "cuda:0")
+
+        assert compact.callable == "jax"
+        assert segmented.callable == "jax"
+        assert calls[0] == (
+            "compact-callback",
+            ("pair_counter", "coo_list", "coo_shifts"),
+            GraphMode.WARP,
+        )
+        assert calls[1] == (
+            "segmented-callback",
+            ("pair_counter", "pair_counts", "coo_list", "coo_shifts"),
+            GraphMode.WARP,
+        )
+
+    def test_preload_closures_forward_exact_matrix_options(self, monkeypatch) -> None:
+        """Matrix bundles preload with the same validated primitive options."""
+        preload_calls = []
         monkeypatch.setattr(
-            preload,
-            "_preload_cluster_tile_query_kernel_cached",
-            lambda device_alias, spec: matrix_calls.append((device_alias, spec)),
+            _registration,
+            "_register_jax_callable",
+            lambda *args, **kwargs: "jax",
         )
         monkeypatch.setattr(
-            preload,
-            "_preload_cluster_tile_coo_kernel_cached",
-            lambda device_alias, spec: coo_calls.append((device_alias, spec)),
+            _registration,
+            "_preload_cluster_tile_query_kernel",
+            lambda **kwargs: preload_calls.append(kwargs),
+        )
+        pair_fn = object()
+
+        registration = _registration._cluster_tile_matrix_registration(
+            "matrix-callback",
+            batched=True,
+            tile_segmented=True,
+            selective=False,
+            dual_cutoff=False,
+            geometry=True,
+            pair_fn=pair_fn,
+        )
+        registration.preload()
+
+        assert preload_calls == [
+            {
+                "batched": True,
+                "tile_segmented": True,
+                "selective": False,
+                "dual_cutoff": False,
+                "geometry": True,
+                "pair_fn": pair_fn,
+            }
+        ]
+
+    def test_preload_closures_forward_exact_coo_options(self, monkeypatch) -> None:
+        """COO bundles preload with the same validated primitive options."""
+        preload_calls = []
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_callable",
+            lambda *args, **kwargs: "jax",
+        )
+        monkeypatch.setattr(
+            _registration,
+            "_preload_cluster_tile_coo_kernel",
+            lambda **kwargs: preload_calls.append(kwargs),
         )
 
-        preload._preload_cluster_tile_query_kernel(matrix_spec)
-        preload._preload_cluster_tile_coo_kernel(coo_spec)
-
-        assert matrix_calls == [("cuda:0", matrix_spec)]
-        assert matrix_calls[0][1] is matrix_spec
-        assert coo_calls == [("cuda:0", coo_spec)]
-        assert coo_calls[0][1] is coo_spec
-
-    def test_single_build_registration_and_preload_share_specs(
-        self, monkeypatch
-    ) -> None:
-        """Use each single-system build spec object for registration and preload."""
-        binding = importlib.import_module("nvalchemiops.jax.neighbors.cluster_tile")
-        registrations = []
-        preloads = []
-        try:
-            with monkeypatch.context() as scoped_monkeypatch:
-                scoped_monkeypatch.setattr(
-                    _registration,
-                    "_get_cluster_tile_build_jax_callable",
-                    lambda spec, callback: registrations.append(spec) or callback,
-                )
-                binding = importlib.reload(binding)
-                scoped_monkeypatch.setattr(
-                    binding,
-                    "_preload_cluster_tile_build_kernel",
-                    lambda spec: preloads.append(spec),
-                )
-                scoped_monkeypatch.setattr(
-                    binding,
-                    "_jax_build_cluster_tile_list",
-                    lambda *args: args[5:14],
-                )
-                scoped_monkeypatch.setattr(
-                    binding,
-                    "_jax_build_cluster_tile_list_selective",
-                    lambda *args: args[5:14],
-                )
-
-                positions = jnp.zeros((1, 3), dtype=jnp.float32)
-                cell = jnp.eye(3, dtype=jnp.float32)
-                binding.build_cluster_tile_list(positions, 1.0, cell)
-                binding.build_cluster_tile_list(
-                    positions,
-                    1.0,
-                    cell,
-                    rebuild_flags=jnp.ones(1, dtype=jnp.bool_),
-                )
-
-                assert registrations == [
-                    binding._CLUSTER_TILE_BUILD_SPEC,
-                    binding._CLUSTER_TILE_BUILD_SELECTIVE_SPEC,
-                ]
-                assert preloads == registrations
-                assert preloads[0] is registrations[0]
-                assert preloads[1] is registrations[1]
-        finally:
-            importlib.reload(binding)
-
-    def test_batch_build_registration_and_preload_share_specs(
-        self, monkeypatch
-    ) -> None:
-        """Use each batched build spec object for registration and preload."""
-        binding = importlib.import_module(
-            "nvalchemiops.jax.neighbors.batch_cluster_tile"
+        registration = _registration._cluster_tile_coo_registration(
+            "coo-callback",
+            batched=True,
+            tile_segmented=True,
+            coo_segmented=True,
+            selective=True,
         )
-        registrations = []
-        preloads = []
-        try:
-            with monkeypatch.context() as scoped_monkeypatch:
-                scoped_monkeypatch.setattr(
-                    _registration,
-                    "_get_cluster_tile_build_jax_callable",
-                    lambda spec, callback: registrations.append(spec) or callback,
-                )
-                binding = importlib.reload(binding)
-                scoped_monkeypatch.setattr(
-                    binding,
-                    "_preload_cluster_tile_build_kernel",
-                    lambda spec: preloads.append(spec),
-                )
-                scoped_monkeypatch.setattr(
-                    binding,
-                    "_jax_batch_build_cluster_tile_list",
-                    lambda *args: args[7:17],
-                )
-                scoped_monkeypatch.setattr(
-                    binding,
-                    "_jax_batch_build_cluster_tile_list_selective",
-                    lambda *args: (*args[7:14], args[15], *args[17:20]),
-                )
+        registration.preload()
 
-                positions = jnp.zeros((1, 3), dtype=jnp.float32)
-                cell_batch = jnp.eye(3, dtype=jnp.float32)[jnp.newaxis, :, :]
-                batch_ptr = jnp.array([0, 1], dtype=jnp.int32)
-                binding.batch_build_cluster_tile_list(
-                    positions,
-                    1.0,
-                    cell_batch,
-                    batch_ptr,
-                )
-                binding.batch_build_cluster_tile_list(
-                    positions,
-                    1.0,
-                    cell_batch,
-                    batch_ptr,
-                    rebuild_flags=jnp.ones(1, dtype=jnp.bool_),
-                    tile_offsets=jnp.array([0, 1], dtype=jnp.int32),
-                    tile_counts=jnp.zeros(1, dtype=jnp.int32),
-                )
+        assert preload_calls == [
+            {
+                "batched": True,
+                "tile_segmented": True,
+                "coo_segmented": True,
+                "selective": True,
+            }
+        ]
 
-                assert registrations == [
-                    binding._BATCH_CLUSTER_TILE_BUILD_SPEC,
-                    binding._BATCH_CLUSTER_TILE_BUILD_SELECTIVE_SPEC,
-                ]
-                assert preloads == registrations
-                assert preloads[0] is registrations[0]
-                assert preloads[1] is registrations[1]
-        finally:
-            importlib.reload(binding)
+    def test_build_preload_closure_is_no_arg(self, monkeypatch) -> None:
+        """Build bundles expose a no-argument preload closure."""
+        preload_calls = []
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_callable",
+            lambda *args, **kwargs: "jax",
+        )
+        monkeypatch.setattr(
+            _registration,
+            "_preload_cluster_tile_build_kernel",
+            lambda: preload_calls.append("called"),
+        )
+
+        registration = _registration._cluster_tile_build_registration(
+            "build-callback",
+            batched=False,
+            segmented=False,
+            selective=False,
+        )
+        registration.preload()
+
+        assert preload_calls == ["called"]
 
     @pytest.mark.parametrize(
-        ("preload_name", "spec"),
+        "factory_name, kwargs",
         [
             (
-                "_preload_cluster_tile_query_kernel",
-                _registration._ClusterTileQueryJaxSpec(
-                    batched=False,
-                    output_format="coo",
-                    tile_segmented=False,
-                    coo_segmented=False,
-                    selective=False,
-                    dual_cutoff=False,
-                    return_vectors=False,
-                    return_distances=False,
-                    pair_fn=None,
-                ),
+                "_cluster_tile_build_registration",
+                {
+                    "callback": "callback",
+                    "batched": False,
+                    "segmented": True,
+                    "selective": False,
+                },
             ),
             (
-                "_preload_cluster_tile_query_kernel",
-                _registration._ClusterTileQueryJaxSpec(
-                    batched=False,
-                    output_format="matrix",
-                    tile_segmented=False,
-                    coo_segmented=True,
-                    selective=False,
-                    dual_cutoff=False,
-                    return_vectors=False,
-                    return_distances=False,
-                    pair_fn=None,
-                ),
+                "_cluster_tile_build_registration",
+                {
+                    "callback": "callback",
+                    "batched": True,
+                    "segmented": False,
+                    "selective": True,
+                },
             ),
             (
-                "_preload_cluster_tile_query_kernel",
-                _registration._ClusterTileQueryJaxSpec(
-                    batched=False,
-                    output_format="matrix",
-                    tile_segmented=True,
-                    coo_segmented=False,
-                    selective=False,
-                    dual_cutoff=False,
-                    return_vectors=False,
-                    return_distances=False,
-                    pair_fn=None,
-                ),
+                "_cluster_tile_matrix_registration",
+                {
+                    "callback": "callback",
+                    "batched": False,
+                    "tile_segmented": True,
+                },
             ),
             (
-                "_preload_cluster_tile_query_kernel",
-                _registration._ClusterTileQueryJaxSpec(
-                    batched=False,
-                    output_format="matrix",
-                    tile_segmented=False,
-                    coo_segmented=False,
-                    selective=False,
-                    dual_cutoff=False,
-                    return_vectors=True,
-                    return_distances=False,
-                    pair_fn=None,
-                ),
+                "_cluster_tile_matrix_registration",
+                {
+                    "callback": "callback",
+                    "batched": False,
+                    "geometry": True,
+                    "selective": True,
+                },
             ),
             (
-                "_preload_cluster_tile_query_kernel",
-                _registration._ClusterTileQueryJaxSpec(
-                    batched=False,
-                    output_format="matrix",
-                    tile_segmented=False,
-                    coo_segmented=False,
-                    selective=True,
-                    dual_cutoff=True,
-                    return_vectors=True,
-                    return_distances=True,
-                    pair_fn=None,
-                ),
+                "_cluster_tile_matrix_registration",
+                {
+                    "callback": "callback",
+                    "batched": False,
+                    "dual_cutoff": True,
+                    "geometry": True,
+                },
             ),
             (
-                "_preload_cluster_tile_coo_kernel",
-                _registration._ClusterTileQueryJaxSpec(
-                    batched=False,
-                    output_format="matrix",
-                    tile_segmented=False,
-                    coo_segmented=False,
-                    selective=False,
-                    dual_cutoff=False,
-                    return_vectors=False,
-                    return_distances=False,
-                    pair_fn=None,
-                ),
+                "_cluster_tile_coo_registration",
+                {
+                    "callback": "callback",
+                    "batched": False,
+                    "tile_segmented": True,
+                },
             ),
             (
-                "_preload_cluster_tile_coo_kernel",
-                _registration._ClusterTileQueryJaxSpec(
-                    batched=False,
-                    output_format="coo",
-                    tile_segmented=False,
-                    coo_segmented=False,
-                    selective=False,
-                    dual_cutoff=True,
-                    return_vectors=False,
-                    return_distances=False,
-                    pair_fn=None,
-                ),
-            ),
-            (
-                "_preload_cluster_tile_coo_kernel",
-                _registration._ClusterTileQueryJaxSpec(
-                    batched=False,
-                    output_format="coo",
-                    tile_segmented=False,
-                    coo_segmented=False,
-                    selective=False,
-                    dual_cutoff=False,
-                    return_vectors=True,
-                    return_distances=True,
-                    pair_fn=None,
-                ),
-            ),
-            (
-                "_preload_cluster_tile_coo_kernel",
-                _registration._ClusterTileQueryJaxSpec(
-                    batched=True,
-                    output_format="coo",
-                    tile_segmented=True,
-                    coo_segmented=True,
-                    selective=False,
-                    dual_cutoff=False,
-                    return_vectors=False,
-                    return_distances=False,
-                    pair_fn=None,
-                ),
-            ),
-            (
-                "_preload_cluster_tile_coo_kernel",
-                _registration._ClusterTileQueryJaxSpec(
-                    batched=True,
-                    output_format="coo",
-                    tile_segmented=True,
-                    coo_segmented=False,
-                    selective=True,
-                    dual_cutoff=False,
-                    return_vectors=False,
-                    return_distances=False,
-                    pair_fn=None,
-                ),
+                "_cluster_tile_coo_registration",
+                {
+                    "callback": "callback",
+                    "batched": True,
+                    "tile_segmented": True,
+                    "coo_segmented": True,
+                    "selective": False,
+                },
             ),
         ],
     )
-    def test_preload_rejects_invalid_query_specs_before_side_effects(
-        self, monkeypatch, preload_name, spec
+    def test_rejects_invalid_factory_options_before_side_effects(
+        self, monkeypatch, factory_name, kwargs
     ) -> None:
-        """Invalid preload specs cannot select a device or construct kernels."""
-        preload = importlib.import_module(
+        """Invalid graph bundles do not register callables or preload kernels."""
+        callable_calls = []
+        preload_calls = []
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_callable",
+            lambda *args, **kwargs: callable_calls.append((args, kwargs)),
+        )
+        monkeypatch.setattr(
+            _registration,
+            "_preload_cluster_tile_build_kernel",
+            lambda: preload_calls.append("build"),
+        )
+        monkeypatch.setattr(
+            _registration,
+            "_preload_cluster_tile_query_kernel",
+            lambda **kwargs: preload_calls.append(kwargs),
+        )
+        monkeypatch.setattr(
+            _registration,
+            "_preload_cluster_tile_coo_kernel",
+            lambda **kwargs: preload_calls.append(kwargs),
+        )
+
+        with pytest.raises(ValueError):
+            getattr(_registration, factory_name)(**kwargs)
+
+        assert callable_calls == []
+        assert preload_calls == []
+
+
+class TestClusterTilePreload:
+    """Test spec-free cluster-tile preload entry points."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_preload_caches(self, monkeypatch):
+        """Keep mocked preload entries out of production preload caches."""
+        preload = self._preload_module()
+        for cache_name in (
+            "_preload_cluster_tile_query_kernel_cached",
+            "_preload_cluster_tile_coo_kernel_cached",
+        ):
+            original = getattr(preload, cache_name)
+            monkeypatch.setattr(
+                preload, cache_name, functools.cache(original.__wrapped__)
+            )
+        yield
+
+    @staticmethod
+    def _preload_module():
+        """Import the cluster-tile preload module under test."""
+        return importlib.import_module(
             "nvalchemiops.jax.neighbors._cluster_tile_preload"
         )
+
+    @staticmethod
+    def _stub_module_loads(preload, monkeypatch) -> None:
+        """Avoid sentinel allocation and Warp module loading in routing tests."""
+        monkeypatch.setattr(preload, "empty_sentinel", lambda *args: None)
+        monkeypatch.setattr(preload, "_load_kernel_modules", lambda *args: None)
+
+    def test_matrix_preload_uses_unbatched_getter(self, monkeypatch) -> None:
+        """Unbatched matrix preload constructs the single-system getter."""
+        preload = self._preload_module()
+        getter_calls = []
+        monkeypatch.setattr(preload, "_current_warp_device_alias", lambda: "cuda:0")
+        monkeypatch.setattr(
+            preload,
+            "get_query_cluster_tile_kernel",
+            lambda **kwargs: getter_calls.append(kwargs) or object(),
+        )
+        monkeypatch.setattr(
+            preload,
+            "get_batch_query_cluster_tile_kernel",
+            lambda **kwargs: getter_calls.append(kwargs) or object(),
+        )
+        self._stub_module_loads(preload, monkeypatch)
+
+        preload._preload_cluster_tile_query_kernel(
+            batched=False,
+            tile_segmented=False,
+            selective=False,
+            dual_cutoff=False,
+            geometry=False,
+            pair_fn=None,
+        )
+
+        assert len(getter_calls) == 1
+        assert getter_calls[0] == {
+            "tile_segmented": False,
+            "selective": False,
+            "dual_cutoff": False,
+            "return_vectors": False,
+            "return_distances": False,
+            "pair_fn": None,
+        }
+
+    def test_matrix_preload_uses_supplied_execution_device(self, monkeypatch) -> None:
+        """Matrix preload targets the device selected by the executing array."""
+        preload = self._preload_module()
+        jax_device = object()
+        device_aliases = []
+
+        class DeviceSource:
+            """Minimal JAX-array double with one selected execution device."""
+
+            def devices(self):
+                return {jax_device}
+
+        monkeypatch.setattr(
+            preload.wp,
+            "device_from_jax",
+            lambda device: "cuda:1" if device is jax_device else "unexpected",
+        )
+        monkeypatch.setattr(
+            preload,
+            "get_query_cluster_tile_kernel",
+            lambda **kwargs: object(),
+        )
+        monkeypatch.setattr(
+            preload.wp,
+            "get_device",
+            lambda alias: device_aliases.append(alias) or object(),
+        )
+        self._stub_module_loads(preload, monkeypatch)
+
+        preload._preload_cluster_tile_query_kernel(
+            batched=False,
+            device_source=DeviceSource(),
+        )
+
+        assert device_aliases == ["cuda:1"]
+
+    def test_matrix_preload_uses_batched_getter(self, monkeypatch) -> None:
+        """Batched matrix preload constructs the batch getter."""
+        preload = self._preload_module()
+        getter_calls = []
+        monkeypatch.setattr(preload, "_current_warp_device_alias", lambda: "cuda:0")
+        monkeypatch.setattr(
+            preload,
+            "get_query_cluster_tile_kernel",
+            lambda **kwargs: getter_calls.append("unbatched") or object(),
+        )
+        monkeypatch.setattr(
+            preload,
+            "get_batch_query_cluster_tile_kernel",
+            lambda **kwargs: getter_calls.append(kwargs) or object(),
+        )
+        self._stub_module_loads(preload, monkeypatch)
+
+        preload._preload_cluster_tile_query_kernel(
+            batched=True,
+            tile_segmented=True,
+            selective=True,
+            dual_cutoff=True,
+            geometry=False,
+            pair_fn=None,
+        )
+
+        assert len(getter_calls) == 1
+        assert getter_calls[0] == {
+            "tile_segmented": True,
+            "selective": True,
+            "dual_cutoff": True,
+            "return_vectors": False,
+            "return_distances": False,
+            "pair_fn": None,
+        }
+
+    def test_coo_preload_uses_matching_getter_and_segmented_build_module(
+        self, monkeypatch
+    ) -> None:
+        """Segmented COO preload loads build modules before the COO getter."""
+        preload = self._preload_module()
         side_effects = []
-        preload._preload_cluster_tile_query_kernel_cached.cache_clear()
-        preload._preload_cluster_tile_coo_kernel_cached.cache_clear()
+        monkeypatch.setattr(preload, "_current_warp_device_alias", lambda: "cuda:0")
+        monkeypatch.setattr(
+            preload,
+            "_preload_cluster_tile_build_module",
+            lambda device_alias: side_effects.append(("build", device_alias)),
+        )
+        monkeypatch.setattr(
+            preload,
+            "get_query_cluster_tile_coo_kernel",
+            lambda **kwargs: side_effects.append(("getter", kwargs)) or object(),
+        )
+        monkeypatch.setattr(
+            preload,
+            "get_batch_query_cluster_tile_coo_kernel",
+            lambda **kwargs: side_effects.append(("batch_getter", kwargs)) or object(),
+        )
+        self._stub_module_loads(preload, monkeypatch)
+
+        preload._preload_cluster_tile_coo_kernel(
+            batched=True,
+            tile_segmented=True,
+            coo_segmented=True,
+            selective=True,
+        )
+
+        assert side_effects[0] == ("build", "cuda:0")
+        assert side_effects[1] == (
+            "batch_getter",
+            {
+                "tile_segmented": True,
+                "coo_segmented": True,
+                "selective": True,
+            },
+        )
+
+    def test_compact_coo_preload_uses_unbatched_getter(self, monkeypatch) -> None:
+        """Compact COO preload constructs the single-system COO getter."""
+        preload = self._preload_module()
+        getter_calls = []
+        monkeypatch.setattr(preload, "_current_warp_device_alias", lambda: "cuda:0")
+        monkeypatch.setattr(
+            preload,
+            "get_query_cluster_tile_coo_kernel",
+            lambda **kwargs: getter_calls.append(kwargs) or object(),
+        )
+        monkeypatch.setattr(
+            preload,
+            "get_batch_query_cluster_tile_coo_kernel",
+            lambda **kwargs: getter_calls.append(kwargs) or object(),
+        )
+        self._stub_module_loads(preload, monkeypatch)
+
+        preload._preload_cluster_tile_coo_kernel(
+            batched=False,
+            tile_segmented=False,
+            coo_segmented=False,
+            selective=False,
+        )
+
+        assert len(getter_calls) == 1
+        assert getter_calls[0] == {
+            "tile_segmented": False,
+            "coo_segmented": False,
+            "selective": False,
+        }
+
+    def test_build_preload_accepts_no_arguments(self, monkeypatch) -> None:
+        """Build preload loads the shared module without option arguments."""
+        preload = self._preload_module()
+        module_calls = []
+        monkeypatch.setattr(
+            preload,
+            "_preload_cluster_tile_build_module",
+            lambda device_alias: module_calls.append(device_alias),
+        )
+        monkeypatch.setattr(preload, "_current_warp_device_alias", lambda: "cuda:0")
+
+        preload._preload_cluster_tile_build_kernel()
+
+        assert module_calls == ["cuda:0"]
+
+    @pytest.mark.parametrize(
+        "preload_name, kwargs",
+        [
+            (
+                "_preload_cluster_tile_query_kernel",
+                {
+                    "batched": False,
+                    "tile_segmented": True,
+                },
+            ),
+            (
+                "_preload_cluster_tile_query_kernel",
+                {
+                    "batched": False,
+                    "geometry": True,
+                    "selective": True,
+                },
+            ),
+            (
+                "_preload_cluster_tile_coo_kernel",
+                {
+                    "batched": False,
+                    "tile_segmented": True,
+                },
+            ),
+            (
+                "_preload_cluster_tile_coo_kernel",
+                {
+                    "batched": True,
+                    "tile_segmented": True,
+                    "coo_segmented": True,
+                    "selective": False,
+                },
+            ),
+        ],
+    )
+    def test_rejects_invalid_keyword_options_before_side_effects(
+        self, monkeypatch, preload_name, kwargs
+    ) -> None:
+        """Invalid preload keyword options do not touch device or getters."""
+        preload = self._preload_module()
+        side_effects = []
         monkeypatch.setattr(
             preload,
             "_current_warp_device_alias",
@@ -1493,50 +1765,6 @@ class TestClusterTileJaxRegistration:
         )
 
         with pytest.raises(ValueError):
-            getattr(preload, preload_name)(spec)
+            getattr(preload, preload_name)(**kwargs)
 
-        assert side_effects == []
-
-    @pytest.mark.parametrize(
-        "spec",
-        [
-            _registration._ClusterTileBuildJaxSpec(False, True, False),
-            _registration._ClusterTileBuildJaxSpec(True, False, True),
-        ],
-    )
-    def test_build_preload_uses_canonical_validation_before_side_effects(
-        self, monkeypatch, spec
-    ) -> None:
-        """Build preload delegates invalid combinations to the shared validator."""
-        preload = importlib.import_module(
-            "nvalchemiops.jax.neighbors._cluster_tile_preload"
-        )
-        validated_specs = []
-        side_effects = []
-
-        def fail_validation(candidate_spec) -> None:
-            validated_specs.append(candidate_spec)
-            raise ValueError("canonical build validation")
-
-        monkeypatch.setattr(
-            preload,
-            "_validate_cluster_tile_build_spec",
-            fail_validation,
-            raising=False,
-        )
-        monkeypatch.setattr(
-            preload,
-            "_current_warp_device_alias",
-            lambda: side_effects.append("device_alias") or "cpu",
-        )
-        monkeypatch.setattr(
-            preload,
-            "_preload_cluster_tile_build_module",
-            lambda *args: side_effects.append("build_module"),
-        )
-
-        with pytest.raises(ValueError, match="canonical build validation"):
-            preload._preload_cluster_tile_build_kernel(spec)
-
-        assert validated_specs == [spec]
         assert side_effects == []

--- a/test/neighbors/bindings/jax/test_registration.py
+++ b/test/neighbors/bindings/jax/test_registration.py
@@ -1,0 +1,1324 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for common lazy JAX registration primitives."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+
+import jax.numpy as jnp
+import pytest
+import warp as wp
+from warp.jax_experimental import GraphMode
+
+from nvalchemiops.jax.neighbors import _registration
+
+_batch_cell_list = importlib.import_module("nvalchemiops.jax.neighbors.batch_cell_list")
+_cell_list = importlib.import_module("nvalchemiops.jax.neighbors.cell_list")
+
+
+def _clear_jax_registration_caches() -> None:
+    """Clear registration caches that mocked tests can populate."""
+    _registration._get_cell_list_build_jax_kernel.cache_clear()
+    _registration._get_cell_list_query_jax_kernel.cache_clear()
+    _registration._get_naive_jax_kernel.cache_clear()
+    _registration._get_cluster_tile_build_jax_callable.cache_clear()
+    _registration._get_cluster_tile_query_jax_callable.cache_clear()
+    _cell_list._get_jax_cell_list_pair_outputs_kernel.cache_clear()
+    _batch_cell_list._get_jax_batch_cell_list_pair_outputs_kernel.cache_clear()
+
+    for registrations in (
+        _cell_list._CELL_LIST_BUILD_REGISTRATIONS,
+        _cell_list._CELL_LIST_QUERY_REGISTRATIONS,
+        _batch_cell_list._BATCH_CELL_LIST_BUILD_REGISTRATIONS,
+        _batch_cell_list._BATCH_CELL_LIST_QUERY_REGISTRATIONS,
+    ):
+        for registration in registrations.values():
+            registration._cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_jax_registration_caches_after_each_test():
+    """Isolate cached registrations from temporary mocks, even on failures."""
+    _clear_jax_registration_caches()
+    try:
+        yield
+    finally:
+        _clear_jax_registration_caches()
+
+
+class TestRegistrationHelpers:
+    """Test the direct Warp/JAX registration adapters."""
+
+    def test_register_jax_kernel_preserves_output_order_and_disables_backward(
+        self, monkeypatch
+    ) -> None:
+        """Register kernels with the schema's output count and order."""
+        calls = []
+
+        def fake_jax_kernel(kernel, **kwargs):
+            calls.append(
+                (kernel, {**kwargs, "in_out_argnames": list(kwargs["in_out_argnames"])})
+            )
+            kwargs["in_out_argnames"].pop()
+            return "registered-kernel"
+
+        monkeypatch.setattr(_registration, "jax_kernel", fake_jax_kernel)
+        schema = _registration._JaxOutputSchema(
+            ("neighbor_matrix", "num_neighbors", "neighbor_shifts")
+        )
+
+        result = _registration._register_jax_kernel("warp-kernel", schema)
+
+        assert result == "registered-kernel"
+        assert calls == [
+            (
+                "warp-kernel",
+                {
+                    "num_outputs": 3,
+                    "in_out_argnames": [
+                        "neighbor_matrix",
+                        "num_neighbors",
+                        "neighbor_shifts",
+                    ],
+                    "enable_backward": False,
+                },
+            )
+        ]
+        assert schema.in_out_argnames == (
+            "neighbor_matrix",
+            "num_neighbors",
+            "neighbor_shifts",
+        )
+        assert schema.num_outputs == 3
+
+    def test_register_jax_callable_uses_explicit_graph_mode(self, monkeypatch) -> None:
+        """Register callables with the requested graph mode and output order."""
+        calls = []
+
+        def fake_jax_callable(callable_obj, **kwargs):
+            calls.append(
+                (
+                    callable_obj,
+                    {**kwargs, "in_out_argnames": list(kwargs["in_out_argnames"])},
+                )
+            )
+            kwargs["in_out_argnames"].pop()
+            return "registered-callable"
+
+        monkeypatch.setattr(_registration, "jax_callable", fake_jax_callable)
+        schema = _registration._JaxOutputSchema(("sorted_positions", "neighbor_matrix"))
+
+        result = _registration._register_jax_callable(
+            "warp-callable",
+            schema,
+            graph_mode=GraphMode.NONE,
+        )
+
+        assert result == "registered-callable"
+        assert calls == [
+            (
+                "warp-callable",
+                {
+                    "num_outputs": 2,
+                    "in_out_argnames": ["sorted_positions", "neighbor_matrix"],
+                    "graph_mode": GraphMode.NONE,
+                },
+            )
+        ]
+        assert schema.in_out_argnames == ("sorted_positions", "neighbor_matrix")
+
+
+class TestLazyDtypeRegistrations:
+    """Test lazy dtype-specific wrapper registration."""
+
+    def test_constructs_and_caches_dtype_registration(self) -> None:
+        """Construct each supported dtype once and cache by normalized dtype."""
+        built_dtypes = []
+
+        def factory(wp_dtype):
+            built_dtypes.append(wp_dtype)
+            return "jax:kernel-float32"
+
+        registrations = _registration._LazyDtypeRegistrations(
+            factory,
+            {jnp.float32: wp.float32},
+        )
+
+        first = registrations[jnp.float32]
+        second = registrations[jnp.dtype("float32")]
+
+        assert first == "jax:kernel-float32"
+        assert second is first
+        assert built_dtypes == [wp.float32]
+
+    def test_supports_float64_and_dtype_membership(self) -> None:
+        """Recognize supported dtypes and convert float64 before construction."""
+        built_dtypes = []
+
+        def factory(wp_dtype):
+            built_dtypes.append(wp_dtype)
+            return wp_dtype
+
+        registrations = _registration._LazyDtypeRegistrations(
+            factory,
+            {jnp.float32: wp.float32, jnp.float64: wp.float64},
+        )
+
+        assert jnp.float32 in registrations
+        assert jnp.dtype("float64") in registrations
+        assert jnp.int32 not in registrations
+        assert registrations[jnp.float64] == wp.float64
+        assert built_dtypes == [wp.float64]
+
+    def test_float32_only_mapping_rejects_unsupported_dtype_before_factory(
+        self,
+    ) -> None:
+        """Raise KeyError before the factory for an undeclared dtype."""
+        built_dtypes = []
+        registrations = _registration._LazyDtypeRegistrations(
+            lambda wp_dtype: built_dtypes.append(wp_dtype),
+            {jnp.float32: wp.float32},
+        )
+
+        assert jnp.float32 in registrations
+        assert jnp.float64 not in registrations
+
+        with pytest.raises(KeyError):
+            registrations[jnp.float64]
+
+        assert built_dtypes == []
+
+    def test_copies_caller_supplied_dtype_map(self) -> None:
+        """Preserve the declared mappings after the caller mutates its map."""
+        dtype_map = {jnp.float32: wp.float32}
+        registrations = _registration._LazyDtypeRegistrations(
+            lambda wp_dtype: wp_dtype,
+            dtype_map,
+        )
+        dtype_map[jnp.float64] = wp.float64
+
+        assert jnp.float64 not in registrations
+
+        with pytest.raises(KeyError):
+            registrations[jnp.float64]
+
+    def test_cells_per_system_reuses_a_dtype_independent_registration(
+        self, monkeypatch
+    ) -> None:
+        """Share the batch cells-per-system wrapper across floating dtypes."""
+        binding = importlib.import_module("nvalchemiops.jax.neighbors.batch_cell_list")
+        registrations = []
+        try:
+            with monkeypatch.context() as scoped_monkeypatch:
+                scoped_monkeypatch.setattr(
+                    _registration,
+                    "_get_cell_list_build_jax_kernel",
+                    lambda spec: registrations.append(spec) or object(),
+                )
+                binding = importlib.reload(binding)
+                cells_per_system = binding._BATCH_CELL_LIST_BUILD_REGISTRATIONS[
+                    "cells_per_system"
+                ]
+
+                assert cells_per_system[jnp.float32] is cells_per_system[jnp.float64]
+                assert registrations == [
+                    _registration._CellListBuildJaxSpec(
+                        "cells_per_system",
+                        wp.float32,
+                        True,
+                    ),
+                ]
+        finally:
+            importlib.reload(binding)
+
+
+class TestJaxOutputSchema:
+    """Test immutable registration output schemas."""
+
+    def test_schema_is_frozen(self) -> None:
+        """Reject mutation of a frozen output schema."""
+        schema = _registration._JaxOutputSchema(("neighbor_matrix", "num_neighbors"))
+
+        with pytest.raises(AttributeError):
+            schema.in_out_argnames = ("replacement",)
+
+
+class TestNaiveJaxKernelRegistration:
+    """Test lazy registration of direct naive JAX kernels."""
+
+    @staticmethod
+    def _module():
+        """Import the direct naive registration module under test."""
+        assert (
+            importlib.util.find_spec("nvalchemiops.jax.neighbors._registration")
+            is not None
+        )
+        return _registration
+
+    @staticmethod
+    def _spec(module, **kwargs):
+        """Build a valid single-cutoff geometry registration spec."""
+        defaults = {
+            "operation": "single_cutoff",
+            "wp_dtype": wp.float32,
+            "batched": False,
+            "pbc_mode": "none",
+            "selective": False,
+            "partial": False,
+            "half_fill": False,
+            "return_vectors": True,
+            "return_distances": True,
+            "pair_fn": None,
+        }
+        defaults.update(kwargs)
+        return module._NaiveJaxKernelSpec(**defaults)
+
+    def test_registers_exact_single_pbc_pair_schema_and_getter_kwargs(
+        self, monkeypatch
+    ) -> None:
+        """Construct single-cutoff pair kernels with the complete ABI schema."""
+        module = self._module()
+        module._get_naive_jax_kernel.cache_clear()
+        getter_calls = []
+        registration_calls = []
+
+        def fake_getter(wp_dtype, **kwargs):
+            getter_calls.append((wp_dtype, kwargs))
+            return "warp-kernel"
+
+        def fake_register(kernel, schema):
+            registration_calls.append((kernel, schema))
+            return "jax-kernel"
+
+        monkeypatch.setattr(module, "get_naive_neighbor_matrix_kernel", fake_getter)
+        monkeypatch.setattr(module, "_register_jax_kernel", fake_register)
+        spec = self._spec(
+            module,
+            batched=True,
+            pbc_mode="wrap_on_entry",
+            partial=True,
+            half_fill=True,
+            pair_fn="pair-fn",
+        )
+
+        assert module._get_naive_jax_kernel(spec) == "jax-kernel"
+        assert getter_calls == [
+            (
+                wp.float32,
+                {
+                    "pbc_mode": "wrap_on_entry",
+                    "batched": True,
+                    "selective": False,
+                    "partial": True,
+                    "half_fill": True,
+                    "return_vectors": True,
+                    "return_distances": True,
+                    "pair_fn": "pair-fn",
+                },
+            )
+        ]
+        assert registration_calls == [
+            (
+                "warp-kernel",
+                _registration._JaxOutputSchema(
+                    (
+                        "neighbor_matrix1",
+                        "neighbor_matrix_shifts1",
+                        "num_neighbors1",
+                        "neighbor_vectors",
+                        "neighbor_distances",
+                        "pair_energies",
+                        "pair_forces",
+                    )
+                ),
+            )
+        ]
+
+    def test_registers_exact_dual_schema_and_ignores_half_fill(
+        self, monkeypatch
+    ) -> None:
+        """Preserve the dual getter's public half-fill compatibility behavior."""
+        module = self._module()
+        module._get_naive_jax_kernel.cache_clear()
+        getter_calls = []
+        registration_calls = []
+
+        def fake_getter(wp_dtype, **kwargs):
+            getter_calls.append((wp_dtype, kwargs))
+            return "dual-warp-kernel"
+
+        def fake_register(kernel, schema):
+            registration_calls.append((kernel, schema))
+            return "dual-jax-kernel"
+
+        monkeypatch.setattr(
+            module,
+            "get_naive_neighbor_matrix_dual_cutoff_kernel",
+            fake_getter,
+        )
+        monkeypatch.setattr(module, "_register_jax_kernel", fake_register)
+        spec = self._spec(
+            module,
+            operation="dual_cutoff",
+            wp_dtype=wp.float64,
+            pbc_mode="prewrapped",
+            return_vectors=False,
+            return_distances=False,
+        )
+
+        assert module._get_naive_jax_kernel(spec) == "dual-jax-kernel"
+        assert getter_calls == [
+            (
+                wp.float64,
+                {
+                    "pbc_mode": "prewrapped",
+                    "batched": False,
+                    "selective": False,
+                },
+            )
+        ]
+        assert registration_calls == [
+            (
+                "dual-warp-kernel",
+                _registration._JaxOutputSchema(
+                    (
+                        "neighbor_matrix1",
+                        "neighbor_matrix_shifts1",
+                        "num_neighbors1",
+                        "neighbor_matrix2",
+                        "neighbor_matrix_shifts2",
+                        "num_neighbors2",
+                    )
+                ),
+            )
+        ]
+
+    def test_caches_equal_specs_and_separates_pair_function_identities(
+        self, monkeypatch
+    ) -> None:
+        """Cache immutable equivalent specs while preserving pair function identity."""
+        module = self._module()
+        module._get_naive_jax_kernel.cache_clear()
+        getter_calls = []
+
+        def fake_getter(wp_dtype, **kwargs):
+            getter_calls.append((wp_dtype, kwargs))
+            return object()
+
+        monkeypatch.setattr(module, "get_naive_neighbor_matrix_kernel", fake_getter)
+        monkeypatch.setattr(
+            module, "_register_jax_kernel", lambda kernel, schema: object()
+        )
+        pair_fn_one = object()
+        pair_fn_two = object()
+        first = self._spec(module, pair_fn=pair_fn_one)
+        equal_first = self._spec(module, pair_fn=pair_fn_one)
+        second = self._spec(module, pair_fn=pair_fn_two)
+
+        assert module._get_naive_jax_kernel(first) is module._get_naive_jax_kernel(
+            equal_first
+        )
+        assert module._get_naive_jax_kernel(first) is not module._get_naive_jax_kernel(
+            second
+        )
+        assert len(getter_calls) == 2
+
+    @pytest.mark.parametrize(
+        "changes",
+        [
+            {"return_vectors": True, "return_distances": False},
+            {"pair_fn": object(), "return_vectors": False, "return_distances": False},
+            {
+                "operation": "dual_cutoff",
+                "return_vectors": True,
+                "return_distances": True,
+            },
+            {
+                "operation": "dual_cutoff",
+                "partial": True,
+                "return_vectors": False,
+                "return_distances": False,
+            },
+            {
+                "operation": "dual_cutoff",
+                "half_fill": True,
+                "return_vectors": False,
+                "return_distances": False,
+            },
+            {"pbc_mode": "invalid"},
+        ],
+    )
+    def test_rejects_invalid_specs_before_getter_or_registration(
+        self, monkeypatch, changes
+    ) -> None:
+        """Reject unsupported direct registrations without constructing side effects."""
+        module = self._module()
+        module._get_naive_jax_kernel.cache_clear()
+        getter_calls = []
+        registration_calls = []
+        monkeypatch.setattr(
+            module,
+            "get_naive_neighbor_matrix_kernel",
+            lambda *args, **kwargs: getter_calls.append((args, kwargs)),
+        )
+        monkeypatch.setattr(
+            module,
+            "_register_jax_kernel",
+            lambda *args, **kwargs: registration_calls.append((args, kwargs)),
+        )
+
+        with pytest.raises(ValueError):
+            module._get_naive_jax_kernel(self._spec(module, **changes))
+
+        assert getter_calls == []
+        assert registration_calls == []
+
+
+class TestNaiveBindingRegistrations:
+    """Test lazy registry wiring in the naive JAX bindings."""
+
+    @staticmethod
+    def _import_binding(module_name: str):
+        """Import one naive JAX binding module."""
+        return importlib.import_module(f"nvalchemiops.jax.neighbors.{module_name}")
+
+    @pytest.mark.parametrize(
+        ("module_name", "batched"),
+        [
+            ("batch_naive", True),
+            ("naive_dual_cutoff", False),
+            ("batch_naive_dual_cutoff", True),
+        ],
+    )
+    def test_import_does_not_construct_direct_wrappers(
+        self, monkeypatch, module_name, batched
+    ) -> None:
+        """Delay direct registrations until a dtype lookup requests one."""
+        calls = []
+
+        def fake_getter(spec):
+            calls.append(spec)
+            return "lazy-jax-kernel"
+
+        module = self._import_binding(module_name)
+        try:
+            with monkeypatch.context() as scoped_monkeypatch:
+                scoped_monkeypatch.setattr(
+                    _registration,
+                    "_get_naive_jax_kernel",
+                    fake_getter,
+                )
+                module = importlib.reload(module)
+
+                assert calls == []
+                registrations = (
+                    module._DIRECT_BATCH_NAIVE_KERNELS
+                    if module_name == "batch_naive"
+                    else module._DIRECT_NAIVE_DUAL_KERNELS
+                    if module_name == "naive_dual_cutoff"
+                    else module._DIRECT_BATCH_NAIVE_DUAL_KERNELS
+                )
+                key = (
+                    ("prewrapped", True, False)
+                    if module_name == "batch_naive"
+                    else ("prewrapped", True)
+                )
+                assert registrations[key][jnp.float64] == "lazy-jax-kernel"
+                assert calls == [
+                    _registration._NaiveJaxKernelSpec(
+                        operation=(
+                            "dual_cutoff"
+                            if "dual_cutoff" in module_name
+                            else "single_cutoff"
+                        ),
+                        wp_dtype=wp.float64,
+                        batched=batched,
+                        pbc_mode="prewrapped",
+                        selective=True,
+                        partial=False,
+                        half_fill=False,
+                        return_vectors=False,
+                        return_distances=False,
+                        pair_fn=None,
+                    )
+                ]
+        finally:
+            importlib.reload(module)
+
+    @pytest.mark.parametrize(
+        ("module_name", "batched"),
+        [
+            ("naive_dual_cutoff", False),
+            ("batch_naive_dual_cutoff", True),
+        ],
+    )
+    def test_dual_binding_lookup_uses_exact_hard_coded_spec(
+        self, monkeypatch, module_name, batched
+    ) -> None:
+        """Use direct dual-cutoff specs without forwarding public half_fill."""
+        calls = []
+
+        def fake_getter(spec):
+            calls.append(spec)
+            return "dual-jax-kernel"
+
+        with monkeypatch.context() as scoped_monkeypatch:
+            scoped_monkeypatch.setattr(
+                _registration,
+                "_get_naive_jax_kernel",
+                fake_getter,
+            )
+            module = importlib.reload(self._import_binding(module_name))
+            registrations = (
+                module._DIRECT_NAIVE_DUAL_KERNELS
+                if module_name == "naive_dual_cutoff"
+                else module._DIRECT_BATCH_NAIVE_DUAL_KERNELS
+            )
+
+            assert (
+                registrations[("wrap_on_entry", False)][jnp.float32]
+                == "dual-jax-kernel"
+            )
+            assert calls == [
+                _registration._NaiveJaxKernelSpec(
+                    operation="dual_cutoff",
+                    wp_dtype=wp.float32,
+                    batched=batched,
+                    pbc_mode="wrap_on_entry",
+                    selective=False,
+                    partial=False,
+                    half_fill=False,
+                    return_vectors=False,
+                    return_distances=False,
+                    pair_fn=None,
+                )
+            ]
+        importlib.reload(module)
+
+
+class TestCellListJaxKernelRegistration:
+    """Test lazy registration of direct cell-list JAX kernels."""
+
+    @staticmethod
+    def _module():
+        """Import the direct cell-list registration module under test."""
+        assert (
+            importlib.util.find_spec("nvalchemiops.jax.neighbors._registration")
+            is not None
+        )
+        return _registration
+
+    def test_mocked_build_registration_does_not_leak_to_real_binding_lookup(
+        self, monkeypatch
+    ) -> None:
+        """Do not reuse a mocked build wrapper after its patch is restored."""
+        module = self._module()
+        spec = module._CellListBuildJaxSpec("construct_bin_size", wp.float32, False)
+
+        try:
+            with monkeypatch.context() as scoped_monkeypatch:
+                scoped_monkeypatch.setattr(
+                    module,
+                    "get_build_cell_list_kernel",
+                    lambda *args, **kwargs: "fake-warp-kernel",
+                )
+                scoped_monkeypatch.setattr(
+                    module,
+                    "_register_jax_kernel",
+                    lambda *args, **kwargs: "fake-jax-kernel",
+                )
+                assert module._get_cell_list_build_jax_kernel(spec) == "fake-jax-kernel"
+        finally:
+            _clear_jax_registration_caches()
+
+        assert (
+            _cell_list._CELL_LIST_BUILD_REGISTRATIONS["construct_bin_size"][jnp.float32]
+            != "fake-jax-kernel"
+        )
+
+    @pytest.mark.parametrize(
+        ("module_name", "registry_name", "batched"),
+        [
+            ("cell_list", "_CELL_LIST_BUILD_REGISTRATIONS", False),
+            ("batch_cell_list", "_BATCH_CELL_LIST_BUILD_REGISTRATIONS", True),
+        ],
+    )
+    def test_cell_list_binding_import_defers_direct_registration(
+        self, monkeypatch, module_name, registry_name, batched
+    ) -> None:
+        """Construct direct cell-list wrappers only when their dtype is used."""
+        calls = []
+        module = importlib.import_module(f"nvalchemiops.jax.neighbors.{module_name}")
+        try:
+            with monkeypatch.context() as scoped_monkeypatch:
+                scoped_monkeypatch.setattr(
+                    _registration,
+                    "_get_cell_list_build_jax_kernel",
+                    lambda spec: calls.append(spec) or "lazy-jax-kernel",
+                )
+                module = importlib.reload(module)
+
+                assert calls == []
+                assert (
+                    getattr(module, registry_name)["construct_bin_size"][jnp.float32]
+                    == "lazy-jax-kernel"
+                )
+                assert calls == [
+                    _registration._CellListBuildJaxSpec(
+                        "construct_bin_size",
+                        wp.float32,
+                        batched,
+                    )
+                ]
+        finally:
+            importlib.reload(module)
+
+    def test_registers_each_build_stage_with_exact_abi(self, monkeypatch) -> None:
+        """Register every supported cell-list build ABI independently."""
+        module = self._module()
+        module._get_cell_list_build_jax_kernel.cache_clear()
+        getter_calls = []
+        registrations = []
+        monkeypatch.setattr(
+            module,
+            "get_build_cell_list_kernel",
+            lambda *args, **kwargs: getter_calls.append((args, kwargs)) or "warp",
+        )
+        monkeypatch.setattr(
+            module,
+            "get_cell_list_cells_per_system_kernel",
+            lambda: "cells-warp",
+        )
+        monkeypatch.setattr(
+            module,
+            "get_gather_positions_and_shifts_kernel",
+            lambda wp_dtype: "warp",
+        )
+        monkeypatch.setattr(
+            module,
+            "get_cell_list_gather_kernel",
+            lambda wp_dtype: "warp",
+        )
+        monkeypatch.setattr(
+            module,
+            "_register_jax_kernel",
+            lambda kernel, schema: registrations.append((kernel, schema)) or "jax",
+        )
+
+        expected = {
+            ("construct_bin_size", False): ("cells_per_dimension_single",),
+            ("construct_bin_size", True): ("cells_per_dimension_batch",),
+            ("count_atoms", False): (
+                "atoms_per_cell_count",
+                "atom_periodic_shifts",
+            ),
+            ("count_atoms", True): ("atoms_per_cell_count", "atom_periodic_shifts"),
+            ("bin_atoms", False): (
+                "atom_to_cell_mapping",
+                "atoms_per_cell_count",
+                "cell_atom_list",
+            ),
+            ("bin_atoms", True): (
+                "atom_to_cell_mapping",
+                "atoms_per_cell_count",
+                "cell_atom_list",
+            ),
+            ("gather", False): ("dst_pos", "dst_shifts"),
+            ("gather", True): ("sorted_positions", "sorted_shifts"),
+            ("cells_per_system", True): ("cells_per_system",),
+        }
+        for (stage, batched), outputs in expected.items():
+            spec = module._CellListBuildJaxSpec(stage, wp.float32, batched)
+            assert module._get_cell_list_build_jax_kernel(spec) == "jax"
+            assert registrations[-1] == (
+                "cells-warp" if stage == "cells_per_system" else "warp",
+                _registration._JaxOutputSchema(outputs),
+            )
+
+        assert getter_calls == [
+            (("construct_bin_size", wp.float32), {"batched": False}),
+            (("construct_bin_size", wp.float32), {"batched": True}),
+            (("count_atoms", wp.float32), {"batched": False}),
+            (("count_atoms", wp.float32), {"batched": True}),
+            (("bin_atoms", wp.float32), {"batched": False}),
+            (("bin_atoms", wp.float32), {"batched": True}),
+        ]
+
+    def test_registers_query_getter_flags_and_schema(self, monkeypatch) -> None:
+        """Preserve sorted/direct, partial, geometry, and pair output ABI."""
+        module = self._module()
+        module._get_cell_list_query_jax_kernel.cache_clear()
+        calls = []
+        registered = []
+        monkeypatch.setattr(
+            module,
+            "get_query_cell_list_kernel",
+            lambda *args, **kwargs: calls.append((args, kwargs)) or "warp",
+        )
+        monkeypatch.setattr(
+            module,
+            "_register_jax_kernel",
+            lambda kernel, schema: registered.append((kernel, schema)) or "jax",
+        )
+        pair_fn = object()
+        spec = module._CellListQueryJaxSpec(
+            wp.float64, False, True, True, True, True, True, pair_fn, "sorted"
+        )
+
+        assert module._get_cell_list_query_jax_kernel(spec) == "jax"
+        assert calls == [
+            (
+                (wp.float64,),
+                {
+                    "strategy": "atom_centric",
+                    "batched": False,
+                    "selective": True,
+                    "partial": True,
+                    "half_fill": True,
+                    "return_vectors": True,
+                    "return_distances": True,
+                    "pair_fn": pair_fn,
+                    "atom_centric_path": "sorted",
+                },
+            )
+        ]
+        assert registered == [
+            (
+                "warp",
+                _registration._JaxOutputSchema(
+                    (
+                        "neighbor_matrix",
+                        "neighbor_matrix_shifts",
+                        "num_neighbors",
+                        "neighbor_vectors",
+                        "neighbor_distances",
+                        "pair_energies",
+                        "pair_forces",
+                    )
+                ),
+            )
+        ]
+
+    def test_cache_axes_and_invalid_specs_have_no_side_effects(
+        self, monkeypatch
+    ) -> None:
+        """Cache equivalent specs and reject unsupported combinations early."""
+        module = self._module()
+        module._get_cell_list_query_jax_kernel.cache_clear()
+        getter_calls = []
+        monkeypatch.setattr(
+            module,
+            "get_query_cell_list_kernel",
+            lambda *args, **kwargs: getter_calls.append((args, kwargs)) or object(),
+        )
+        monkeypatch.setattr(module, "_register_jax_kernel", lambda *args: object())
+        valid = module._CellListQueryJaxSpec(
+            wp.float32, False, True, False, False, False, False, None, "direct"
+        )
+        assert module._get_cell_list_query_jax_kernel(
+            valid
+        ) is module._get_cell_list_query_jax_kernel(valid)
+        assert len(getter_calls) == 1
+        for spec in (
+            module._CellListBuildJaxSpec("estimate_sizes", wp.float32, False),
+            module._CellListQueryJaxSpec(
+                wp.float32, True, True, False, False, False, False, None, "direct"
+            ),
+            module._CellListQueryJaxSpec(
+                wp.float32, False, True, False, False, True, False, None, "sorted"
+            ),
+            module._CellListQueryJaxSpec(
+                wp.float32, False, True, False, False, False, False, object(), "sorted"
+            ),
+        ):
+            with pytest.raises(ValueError):
+                (
+                    module._get_cell_list_build_jax_kernel(spec)
+                    if isinstance(spec, module._CellListBuildJaxSpec)
+                    else module._get_cell_list_query_jax_kernel(spec)
+                )
+        assert len(getter_calls) == 1
+
+
+class TestClusterTileJaxRegistration:
+    """Test shared cluster-tile JAX callback registrations."""
+
+    @staticmethod
+    def _query_spec(**kwargs):
+        """Build a valid single-system matrix query registration spec."""
+        defaults = {
+            "batched": False,
+            "output_format": "matrix",
+            "tile_segmented": False,
+            "coo_segmented": False,
+            "selective": False,
+            "dual_cutoff": False,
+            "return_vectors": False,
+            "return_distances": False,
+            "pair_fn": None,
+        }
+        defaults.update(kwargs)
+        return _registration._ClusterTileQueryJaxSpec(**defaults)
+
+    def test_registers_exact_build_schemas(self, monkeypatch) -> None:
+        """Build registrations retain each callback's ordered in-place ABI."""
+        _registration._get_cluster_tile_build_jax_callable.cache_clear()
+        calls = []
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_callable",
+            lambda callback, schema, *, graph_mode: calls.append(
+                (callback, schema, graph_mode)
+            )
+            or "jax",
+        )
+
+        cases = [
+            (
+                _registration._ClusterTileBuildJaxSpec(False, False, False),
+                (
+                    "group_ctr_x",
+                    "group_ctr_y",
+                    "group_ctr_z",
+                    "group_ext_x",
+                    "group_ext_y",
+                    "group_ext_z",
+                    "num_tiles",
+                    "tile_row_group",
+                    "tile_col_group",
+                ),
+            ),
+            (
+                _registration._ClusterTileBuildJaxSpec(True, False, False),
+                (
+                    "group_ctr_x",
+                    "group_ctr_y",
+                    "group_ctr_z",
+                    "group_ext_x",
+                    "group_ext_y",
+                    "group_ext_z",
+                    "num_tiles",
+                    "tile_row_group",
+                    "tile_col_group",
+                    "tile_system",
+                ),
+            ),
+            (
+                _registration._ClusterTileBuildJaxSpec(True, True, True),
+                (
+                    "group_ctr_x",
+                    "group_ctr_y",
+                    "group_ctr_z",
+                    "group_ext_x",
+                    "group_ext_y",
+                    "group_ext_z",
+                    "num_tiles",
+                    "tile_counts",
+                    "tile_row_group",
+                    "tile_col_group",
+                    "tile_system",
+                ),
+            ),
+        ]
+        for index, (spec, expected) in enumerate(cases):
+            assert (
+                _registration._get_cluster_tile_build_jax_callable(spec, index) == "jax"
+            )
+            assert calls[-1] == (
+                index,
+                _registration._JaxOutputSchema(expected),
+                GraphMode.WARP,
+            )
+
+    def test_registers_exact_query_schemas_and_preserves_pair_fn_cache_axis(
+        self, monkeypatch
+    ) -> None:
+        """Query schemas follow matrix/COO ABI and distinct pair functions cache apart."""
+        _registration._get_cluster_tile_query_jax_callable.cache_clear()
+        calls = []
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_callable",
+            lambda callback, schema, *, graph_mode: calls.append(
+                (callback, schema, graph_mode)
+            )
+            or object(),
+        )
+        pair_one, pair_two = object(), object()
+        matrix = self._query_spec(
+            dual_cutoff=True,
+        )
+        geometry_pair = self._query_spec(
+            return_vectors=True,
+            return_distances=True,
+            pair_fn=pair_one,
+        )
+        segmented_coo = self._query_spec(
+            batched=True,
+            output_format="coo",
+            tile_segmented=True,
+            coo_segmented=True,
+            selective=True,
+        )
+
+        assert _registration._get_cluster_tile_query_jax_callable(matrix, "matrix")
+        assert calls[-1][1] == _registration._JaxOutputSchema(
+            (
+                "neighbor_matrix",
+                "num_neighbors",
+                "neighbor_matrix_shifts",
+                "neighbor_matrix2",
+                "num_neighbors2",
+                "neighbor_matrix_shifts2",
+            )
+        )
+        first = _registration._get_cluster_tile_query_jax_callable(
+            geometry_pair, "pair-one"
+        )
+        assert first is _registration._get_cluster_tile_query_jax_callable(
+            geometry_pair, "pair-one"
+        )
+        assert (
+            _registration._get_cluster_tile_query_jax_callable(
+                self._query_spec(
+                    return_vectors=True,
+                    return_distances=True,
+                    pair_fn=pair_two,
+                ),
+                "pair-two",
+            )
+            is not first
+        )
+        assert _registration._get_cluster_tile_query_jax_callable(segmented_coo, "coo")
+        assert calls[-1][1] == _registration._JaxOutputSchema(
+            ("pair_counter", "pair_counts", "coo_list", "coo_shifts")
+        )
+        assert all(call[2] is GraphMode.WARP for call in calls)
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            _registration._ClusterTileBuildJaxSpec(False, True, False),
+            _registration._ClusterTileBuildJaxSpec(True, False, True),
+            _registration._ClusterTileQueryJaxSpec(
+                False, "matrix", True, False, False, False, False, False, None
+            ),
+            _registration._ClusterTileQueryJaxSpec(
+                False, "coo", False, False, False, True, False, False, None
+            ),
+            _registration._ClusterTileQueryJaxSpec(
+                False, "coo", False, False, False, False, True, True, None
+            ),
+            _registration._ClusterTileQueryJaxSpec(
+                False, "matrix", False, False, False, True, True, True, None
+            ),
+        ],
+    )
+    def test_rejects_invalid_cluster_tile_specs_before_registration(
+        self, monkeypatch, spec
+    ) -> None:
+        """Unsupported combinations do not construct callback registrations."""
+        _registration._get_cluster_tile_build_jax_callable.cache_clear()
+        _registration._get_cluster_tile_query_jax_callable.cache_clear()
+        calls = []
+        monkeypatch.setattr(
+            _registration,
+            "_register_jax_callable",
+            lambda *args, **kwargs: calls.append((args, kwargs)),
+        )
+
+        with pytest.raises(ValueError):
+            if isinstance(spec, _registration._ClusterTileBuildJaxSpec):
+                _registration._get_cluster_tile_build_jax_callable(spec, "callback")
+            else:
+                _registration._get_cluster_tile_query_jax_callable(spec, "callback")
+        assert calls == []
+
+    def test_preload_forwards_the_same_query_spec_object(self, monkeypatch) -> None:
+        """Query preload keeps the immutable registration spec object intact."""
+        preload = importlib.import_module(
+            "nvalchemiops.jax.neighbors._cluster_tile_preload"
+        )
+        matrix_spec = self._query_spec(pair_fn=object())
+        coo_spec = self._query_spec(
+            batched=True,
+            output_format="coo",
+            tile_segmented=True,
+            coo_segmented=True,
+            selective=True,
+        )
+        matrix_calls = []
+        coo_calls = []
+        monkeypatch.setattr(preload, "_current_warp_device_alias", lambda: "cuda:0")
+        monkeypatch.setattr(
+            preload,
+            "_preload_cluster_tile_query_kernel_cached",
+            lambda device_alias, spec: matrix_calls.append((device_alias, spec)),
+        )
+        monkeypatch.setattr(
+            preload,
+            "_preload_cluster_tile_coo_kernel_cached",
+            lambda device_alias, spec: coo_calls.append((device_alias, spec)),
+        )
+
+        preload._preload_cluster_tile_query_kernel(matrix_spec)
+        preload._preload_cluster_tile_coo_kernel(coo_spec)
+
+        assert matrix_calls == [("cuda:0", matrix_spec)]
+        assert matrix_calls[0][1] is matrix_spec
+        assert coo_calls == [("cuda:0", coo_spec)]
+        assert coo_calls[0][1] is coo_spec
+
+    def test_single_build_registration_and_preload_share_specs(
+        self, monkeypatch
+    ) -> None:
+        """Use each single-system build spec object for registration and preload."""
+        binding = importlib.import_module("nvalchemiops.jax.neighbors.cluster_tile")
+        registrations = []
+        preloads = []
+        try:
+            with monkeypatch.context() as scoped_monkeypatch:
+                scoped_monkeypatch.setattr(
+                    _registration,
+                    "_get_cluster_tile_build_jax_callable",
+                    lambda spec, callback: registrations.append(spec) or callback,
+                )
+                binding = importlib.reload(binding)
+                scoped_monkeypatch.setattr(
+                    binding,
+                    "_preload_cluster_tile_build_kernel",
+                    lambda spec: preloads.append(spec),
+                )
+                scoped_monkeypatch.setattr(
+                    binding,
+                    "_jax_build_cluster_tile_list",
+                    lambda *args: args[5:14],
+                )
+                scoped_monkeypatch.setattr(
+                    binding,
+                    "_jax_build_cluster_tile_list_selective",
+                    lambda *args: args[5:14],
+                )
+
+                positions = jnp.zeros((1, 3), dtype=jnp.float32)
+                cell = jnp.eye(3, dtype=jnp.float32)
+                binding.build_cluster_tile_list(positions, 1.0, cell)
+                binding.build_cluster_tile_list(
+                    positions,
+                    1.0,
+                    cell,
+                    rebuild_flags=jnp.ones(1, dtype=jnp.bool_),
+                )
+
+                assert registrations == [
+                    binding._CLUSTER_TILE_BUILD_SPEC,
+                    binding._CLUSTER_TILE_BUILD_SELECTIVE_SPEC,
+                ]
+                assert preloads == registrations
+                assert preloads[0] is registrations[0]
+                assert preloads[1] is registrations[1]
+        finally:
+            importlib.reload(binding)
+
+    def test_batch_build_registration_and_preload_share_specs(
+        self, monkeypatch
+    ) -> None:
+        """Use each batched build spec object for registration and preload."""
+        binding = importlib.import_module(
+            "nvalchemiops.jax.neighbors.batch_cluster_tile"
+        )
+        registrations = []
+        preloads = []
+        try:
+            with monkeypatch.context() as scoped_monkeypatch:
+                scoped_monkeypatch.setattr(
+                    _registration,
+                    "_get_cluster_tile_build_jax_callable",
+                    lambda spec, callback: registrations.append(spec) or callback,
+                )
+                binding = importlib.reload(binding)
+                scoped_monkeypatch.setattr(
+                    binding,
+                    "_preload_cluster_tile_build_kernel",
+                    lambda spec: preloads.append(spec),
+                )
+                scoped_monkeypatch.setattr(
+                    binding,
+                    "_jax_batch_build_cluster_tile_list",
+                    lambda *args: args[7:17],
+                )
+                scoped_monkeypatch.setattr(
+                    binding,
+                    "_jax_batch_build_cluster_tile_list_selective",
+                    lambda *args: (*args[7:14], args[15], *args[17:20]),
+                )
+
+                positions = jnp.zeros((1, 3), dtype=jnp.float32)
+                cell_batch = jnp.eye(3, dtype=jnp.float32)[jnp.newaxis, :, :]
+                batch_ptr = jnp.array([0, 1], dtype=jnp.int32)
+                binding.batch_build_cluster_tile_list(
+                    positions,
+                    1.0,
+                    cell_batch,
+                    batch_ptr,
+                )
+                binding.batch_build_cluster_tile_list(
+                    positions,
+                    1.0,
+                    cell_batch,
+                    batch_ptr,
+                    rebuild_flags=jnp.ones(1, dtype=jnp.bool_),
+                    tile_offsets=jnp.array([0, 1], dtype=jnp.int32),
+                    tile_counts=jnp.zeros(1, dtype=jnp.int32),
+                )
+
+                assert registrations == [
+                    binding._BATCH_CLUSTER_TILE_BUILD_SPEC,
+                    binding._BATCH_CLUSTER_TILE_BUILD_SELECTIVE_SPEC,
+                ]
+                assert preloads == registrations
+                assert preloads[0] is registrations[0]
+                assert preloads[1] is registrations[1]
+        finally:
+            importlib.reload(binding)
+
+    @pytest.mark.parametrize(
+        ("preload_name", "spec"),
+        [
+            (
+                "_preload_cluster_tile_query_kernel",
+                _registration._ClusterTileQueryJaxSpec(
+                    False, "coo", False, False, False, False, False, False, None
+                ),
+            ),
+            (
+                "_preload_cluster_tile_query_kernel",
+                _registration._ClusterTileQueryJaxSpec(
+                    False, "matrix", False, True, False, False, False, False, None
+                ),
+            ),
+            (
+                "_preload_cluster_tile_query_kernel",
+                _registration._ClusterTileQueryJaxSpec(
+                    False, "matrix", True, False, False, False, False, False, None
+                ),
+            ),
+            (
+                "_preload_cluster_tile_query_kernel",
+                _registration._ClusterTileQueryJaxSpec(
+                    False, "matrix", False, False, False, False, True, False, None
+                ),
+            ),
+            (
+                "_preload_cluster_tile_query_kernel",
+                _registration._ClusterTileQueryJaxSpec(
+                    False, "matrix", False, False, True, True, True, True, None
+                ),
+            ),
+            (
+                "_preload_cluster_tile_coo_kernel",
+                _registration._ClusterTileQueryJaxSpec(
+                    False, "matrix", False, False, False, False, False, False, None
+                ),
+            ),
+            (
+                "_preload_cluster_tile_coo_kernel",
+                _registration._ClusterTileQueryJaxSpec(
+                    False, "coo", False, False, False, True, False, False, None
+                ),
+            ),
+            (
+                "_preload_cluster_tile_coo_kernel",
+                _registration._ClusterTileQueryJaxSpec(
+                    False, "coo", False, False, False, False, True, True, None
+                ),
+            ),
+            (
+                "_preload_cluster_tile_coo_kernel",
+                _registration._ClusterTileQueryJaxSpec(
+                    True, "coo", True, True, False, False, False, False, None
+                ),
+            ),
+            (
+                "_preload_cluster_tile_coo_kernel",
+                _registration._ClusterTileQueryJaxSpec(
+                    True, "coo", True, False, True, False, False, False, None
+                ),
+            ),
+        ],
+    )
+    def test_preload_rejects_invalid_query_specs_before_side_effects(
+        self, monkeypatch, preload_name, spec
+    ) -> None:
+        """Invalid preload specs cannot select a device or construct kernels."""
+        preload = importlib.import_module(
+            "nvalchemiops.jax.neighbors._cluster_tile_preload"
+        )
+        side_effects = []
+        preload._preload_cluster_tile_query_kernel_cached.cache_clear()
+        preload._preload_cluster_tile_coo_kernel_cached.cache_clear()
+        monkeypatch.setattr(
+            preload,
+            "_current_warp_device_alias",
+            lambda: side_effects.append("device_alias") or "cpu",
+        )
+        monkeypatch.setattr(
+            preload,
+            "get_query_cluster_tile_kernel",
+            lambda **kwargs: side_effects.append("matrix_getter"),
+        )
+        monkeypatch.setattr(
+            preload,
+            "get_batch_query_cluster_tile_kernel",
+            lambda **kwargs: side_effects.append("batch_matrix_getter"),
+        )
+        monkeypatch.setattr(
+            preload,
+            "get_query_cluster_tile_coo_kernel",
+            lambda **kwargs: side_effects.append("coo_getter"),
+        )
+        monkeypatch.setattr(
+            preload,
+            "get_batch_query_cluster_tile_coo_kernel",
+            lambda **kwargs: side_effects.append("batch_coo_getter"),
+        )
+        monkeypatch.setattr(
+            preload,
+            "_preload_cluster_tile_build_module",
+            lambda *args: side_effects.append("build_module"),
+        )
+        monkeypatch.setattr(
+            preload.wp,
+            "get_device",
+            lambda *args: side_effects.append("get_device"),
+        )
+        monkeypatch.setattr(
+            preload,
+            "empty_sentinel",
+            lambda *args: side_effects.append("sentinel"),
+        )
+        monkeypatch.setattr(
+            preload,
+            "_load_kernel_modules",
+            lambda *args: side_effects.append("module_load"),
+        )
+
+        with pytest.raises(ValueError):
+            getattr(preload, preload_name)(spec)
+
+        assert side_effects == []

--- a/test/neighbors/bindings/jax/test_registration.py
+++ b/test/neighbors/bindings/jax/test_registration.py
@@ -257,6 +257,28 @@ class TestJaxOutputSchema:
         with pytest.raises(AttributeError):
             schema.in_out_argnames = ("replacement",)
 
+    @pytest.mark.parametrize(
+        "spec_type, args",
+        [
+            (
+                _registration._CellListQueryJaxSpec,
+                (wp.float32, False, True, False, False, False, False, None, "sorted"),
+            ),
+            (
+                _registration._ClusterTileQueryJaxSpec,
+                (False, "matrix", False, False, False, False, False, False, None),
+            ),
+        ],
+    )
+    def test_boolean_heavy_query_specs_require_keyword_arguments(
+        self,
+        spec_type,
+        args,
+    ) -> None:
+        """Reject positional values for multi-axis query specializations."""
+        with pytest.raises(TypeError):
+            spec_type(*args)
+
 
 class TestNaiveJaxKernelRegistration:
     """Test lazy registration of direct naive JAX kernels."""
@@ -777,7 +799,15 @@ class TestCellListJaxKernelRegistration:
         )
         pair_fn = object()
         spec = module._CellListQueryJaxSpec(
-            wp.float64, False, True, True, True, True, True, pair_fn, "sorted"
+            wp_dtype=wp.float64,
+            batched=False,
+            selective=True,
+            partial=True,
+            half_fill=True,
+            return_vectors=True,
+            return_distances=True,
+            pair_fn=pair_fn,
+            atom_centric_path="sorted",
         )
 
         assert module._get_cell_list_query_jax_kernel(spec) == "jax"
@@ -828,7 +858,15 @@ class TestCellListJaxKernelRegistration:
         )
         monkeypatch.setattr(module, "_register_jax_kernel", lambda *args: object())
         valid = module._CellListQueryJaxSpec(
-            wp.float32, False, True, False, False, False, False, None, "direct"
+            wp_dtype=wp.float32,
+            batched=False,
+            selective=True,
+            partial=False,
+            half_fill=False,
+            return_vectors=False,
+            return_distances=False,
+            pair_fn=None,
+            atom_centric_path="direct",
         )
         assert module._get_cell_list_query_jax_kernel(
             valid
@@ -837,13 +875,37 @@ class TestCellListJaxKernelRegistration:
         for spec in (
             module._CellListBuildJaxSpec("estimate_sizes", wp.float32, False),
             module._CellListQueryJaxSpec(
-                wp.float32, True, True, False, False, False, False, None, "direct"
+                wp_dtype=wp.float32,
+                batched=True,
+                selective=True,
+                partial=False,
+                half_fill=False,
+                return_vectors=False,
+                return_distances=False,
+                pair_fn=None,
+                atom_centric_path="direct",
             ),
             module._CellListQueryJaxSpec(
-                wp.float32, False, True, False, False, True, False, None, "sorted"
+                wp_dtype=wp.float32,
+                batched=False,
+                selective=True,
+                partial=False,
+                half_fill=False,
+                return_vectors=True,
+                return_distances=False,
+                pair_fn=None,
+                atom_centric_path="sorted",
             ),
             module._CellListQueryJaxSpec(
-                wp.float32, False, True, False, False, False, False, object(), "sorted"
+                wp_dtype=wp.float32,
+                batched=False,
+                selective=True,
+                partial=False,
+                half_fill=False,
+                return_vectors=False,
+                return_distances=False,
+                pair_fn=object(),
+                atom_centric_path="sorted",
             ),
         ):
             with pytest.raises(ValueError):
@@ -1016,16 +1078,48 @@ class TestClusterTileJaxRegistration:
             _registration._ClusterTileBuildJaxSpec(False, True, False),
             _registration._ClusterTileBuildJaxSpec(True, False, True),
             _registration._ClusterTileQueryJaxSpec(
-                False, "matrix", True, False, False, False, False, False, None
+                batched=False,
+                output_format="matrix",
+                tile_segmented=True,
+                coo_segmented=False,
+                selective=False,
+                dual_cutoff=False,
+                return_vectors=False,
+                return_distances=False,
+                pair_fn=None,
             ),
             _registration._ClusterTileQueryJaxSpec(
-                False, "coo", False, False, False, True, False, False, None
+                batched=False,
+                output_format="coo",
+                tile_segmented=False,
+                coo_segmented=False,
+                selective=False,
+                dual_cutoff=True,
+                return_vectors=False,
+                return_distances=False,
+                pair_fn=None,
             ),
             _registration._ClusterTileQueryJaxSpec(
-                False, "coo", False, False, False, False, True, True, None
+                batched=False,
+                output_format="coo",
+                tile_segmented=False,
+                coo_segmented=False,
+                selective=False,
+                dual_cutoff=False,
+                return_vectors=True,
+                return_distances=True,
+                pair_fn=None,
             ),
             _registration._ClusterTileQueryJaxSpec(
-                False, "matrix", False, False, False, True, True, True, None
+                batched=False,
+                output_format="matrix",
+                tile_segmented=False,
+                coo_segmented=False,
+                selective=False,
+                dual_cutoff=True,
+                return_vectors=True,
+                return_distances=True,
+                pair_fn=None,
             ),
         ],
     )
@@ -1203,61 +1297,141 @@ class TestClusterTileJaxRegistration:
             (
                 "_preload_cluster_tile_query_kernel",
                 _registration._ClusterTileQueryJaxSpec(
-                    False, "coo", False, False, False, False, False, False, None
+                    batched=False,
+                    output_format="coo",
+                    tile_segmented=False,
+                    coo_segmented=False,
+                    selective=False,
+                    dual_cutoff=False,
+                    return_vectors=False,
+                    return_distances=False,
+                    pair_fn=None,
                 ),
             ),
             (
                 "_preload_cluster_tile_query_kernel",
                 _registration._ClusterTileQueryJaxSpec(
-                    False, "matrix", False, True, False, False, False, False, None
+                    batched=False,
+                    output_format="matrix",
+                    tile_segmented=False,
+                    coo_segmented=True,
+                    selective=False,
+                    dual_cutoff=False,
+                    return_vectors=False,
+                    return_distances=False,
+                    pair_fn=None,
                 ),
             ),
             (
                 "_preload_cluster_tile_query_kernel",
                 _registration._ClusterTileQueryJaxSpec(
-                    False, "matrix", True, False, False, False, False, False, None
+                    batched=False,
+                    output_format="matrix",
+                    tile_segmented=True,
+                    coo_segmented=False,
+                    selective=False,
+                    dual_cutoff=False,
+                    return_vectors=False,
+                    return_distances=False,
+                    pair_fn=None,
                 ),
             ),
             (
                 "_preload_cluster_tile_query_kernel",
                 _registration._ClusterTileQueryJaxSpec(
-                    False, "matrix", False, False, False, False, True, False, None
+                    batched=False,
+                    output_format="matrix",
+                    tile_segmented=False,
+                    coo_segmented=False,
+                    selective=False,
+                    dual_cutoff=False,
+                    return_vectors=True,
+                    return_distances=False,
+                    pair_fn=None,
                 ),
             ),
             (
                 "_preload_cluster_tile_query_kernel",
                 _registration._ClusterTileQueryJaxSpec(
-                    False, "matrix", False, False, True, True, True, True, None
+                    batched=False,
+                    output_format="matrix",
+                    tile_segmented=False,
+                    coo_segmented=False,
+                    selective=True,
+                    dual_cutoff=True,
+                    return_vectors=True,
+                    return_distances=True,
+                    pair_fn=None,
                 ),
             ),
             (
                 "_preload_cluster_tile_coo_kernel",
                 _registration._ClusterTileQueryJaxSpec(
-                    False, "matrix", False, False, False, False, False, False, None
+                    batched=False,
+                    output_format="matrix",
+                    tile_segmented=False,
+                    coo_segmented=False,
+                    selective=False,
+                    dual_cutoff=False,
+                    return_vectors=False,
+                    return_distances=False,
+                    pair_fn=None,
                 ),
             ),
             (
                 "_preload_cluster_tile_coo_kernel",
                 _registration._ClusterTileQueryJaxSpec(
-                    False, "coo", False, False, False, True, False, False, None
+                    batched=False,
+                    output_format="coo",
+                    tile_segmented=False,
+                    coo_segmented=False,
+                    selective=False,
+                    dual_cutoff=True,
+                    return_vectors=False,
+                    return_distances=False,
+                    pair_fn=None,
                 ),
             ),
             (
                 "_preload_cluster_tile_coo_kernel",
                 _registration._ClusterTileQueryJaxSpec(
-                    False, "coo", False, False, False, False, True, True, None
+                    batched=False,
+                    output_format="coo",
+                    tile_segmented=False,
+                    coo_segmented=False,
+                    selective=False,
+                    dual_cutoff=False,
+                    return_vectors=True,
+                    return_distances=True,
+                    pair_fn=None,
                 ),
             ),
             (
                 "_preload_cluster_tile_coo_kernel",
                 _registration._ClusterTileQueryJaxSpec(
-                    True, "coo", True, True, False, False, False, False, None
+                    batched=True,
+                    output_format="coo",
+                    tile_segmented=True,
+                    coo_segmented=True,
+                    selective=False,
+                    dual_cutoff=False,
+                    return_vectors=False,
+                    return_distances=False,
+                    pair_fn=None,
                 ),
             ),
             (
                 "_preload_cluster_tile_coo_kernel",
                 _registration._ClusterTileQueryJaxSpec(
-                    True, "coo", True, False, True, False, False, False, None
+                    batched=True,
+                    output_format="coo",
+                    tile_segmented=True,
+                    coo_segmented=False,
+                    selective=True,
+                    dual_cutoff=False,
+                    return_vectors=False,
+                    return_distances=False,
+                    pair_fn=None,
                 ),
             ),
         ],


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Consolidate JAX neighbor-list registration behind private, schema-aware lazy registries.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- Add private immutable registration specifications and schema-aware lazy wrapper construction for naive, cell-list, and cluster-tile JAX neighbor bindings.
- Preserve existing direct-kernel and callback execution paths, output ABI ordering, JAX gradient reconstruction, and cluster-tile graph preload behavior.
- Add registration, cache, preload, graph-capture, and wrapper-isolation regression coverage.

## Testing

- [x] Unit tests pass locally (`make pytest`) — Not run.
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

Cold-import benchmarks for the eight JAX neighbor modules improved by ~45% versus the clean baseline. 

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
