### PR TITLE
fix(electrostatics): avoid per-system backward recomputation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Monopole Torch and JAX Ewald, PME, and slab entry points accept keyword-only
+  `energy_reduction="atom" | "system"` (default `"atom"`). `"atom"` returns
+  per-atom energies `(N,)`; `"system"` returns per-system totals `(B,)`.
+  Direct-output fields (forces, charge gradients, virials) keep their existing
+  shapes. Torch eager atom mode may synchronize once per participating component
+  when a materialized uniform cotangent is proven by value inspection; system
+  mode is structurally sync-free for arbitrary `(B,)` loss weights. JAX adds
+  API/layout parity only; underlying Warp kernels remain atom-buffer-oriented.
+
 ## 0.4.0 - 2026-07-13
 
 ### Added

--- a/docs/modules/jax/electrostatics.rst
+++ b/docs/modules/jax/electrostatics.rst
@@ -26,7 +26,12 @@ accepted for cell-differentiated calls as static metadata that is assumed to
 correspond to the current ``cell``; cache-generation derivatives are not
 recovered. Energy-returning Ewald, PME, and slab paths support atom-weighted
 losses such as ``(weights * energies).sum()`` for positions, charges, and
-supported cell derivatives. JAX PME supports first-order cell/strain gradients,
+supported cell derivatives. Monopole entry points provide the keyword-only
+``energy_reduction`` option. The default, ``"atom"``, returns one energy per
+atom with shape ``(N,)``. Set it to ``"system"`` to sum energies within each
+system and return shape ``(B,)``. Other requested outputs keep their existing
+shapes.
+JAX PME supports first-order cell/strain gradients,
 but PME cell/strain HVPs, including full PME with ``slab_correction=True``, are
 explicitly unsupported until a native transposable PME cell-HVP path is
 implemented and tested.

--- a/docs/modules/torch/electrostatics.rst
+++ b/docs/modules/torch/electrostatics.rst
@@ -15,7 +15,16 @@ neighbor topology are treated as constants. Cell-derived caches such as
 correspond to the current ``cell``; their cache-generation derivatives are not
 recovered. Energy-returning Ewald, PME, and slab paths support atom-weighted
 losses such as ``(weights * energies).sum()`` for positions, charges, and
-supported cell derivatives.
+supported cell derivatives. Monopole entry points provide the keyword-only
+``energy_reduction`` option. The default, ``"atom"``, returns one energy per
+atom with shape ``(N,)``. Set it to ``"system"`` to sum energies within each
+system and return shape ``(B,)``. Other requested outputs, including forces,
+charge gradients, and virials, keep their existing shapes.
+
+In eager atom mode, recognizing a materialized uniform output gradient may
+require reading its value, which synchronizes CUDA once. System mode avoids
+this check: per-system output gradients go directly to the cached backward.
+Internally, the Warp kernels continue to use per-atom energy buffers.
 Point-charge Ewald/PME inputs support ``float32`` and ``float64``. Keep all
 floating inputs and precomputed metadata in a call on a consistent dtype.
 

--- a/docs/userguide/about/intro.md
+++ b/docs/userguide/about/intro.md
@@ -366,7 +366,9 @@ energies = ewald_summation(
 forces = -torch.autograd.grad(energies.sum(), positions)[0]
 ```
 
-Returns per-atom energies; sum by system using `batch_idx`.
+Returns per-atom energies by default (`energy_reduction="atom"`). For
+per-system totals with shape `(num_systems,)`, pass
+`energy_reduction="system"` instead of reducing with `batch_idx`.
 :::
 
 ::::

--- a/docs/userguide/about/migration.md
+++ b/docs/userguide/about/migration.md
@@ -6,7 +6,7 @@
 
 This guide lists user-visible migrations by release.
 
-## v0.4.0: Electrostatics
+## Unreleased
 
 ### Energy Output Layout (`energy_reduction`)
 
@@ -54,6 +54,8 @@ or CUDA graph capture, only metadata-proven atom cotangents use the fast path;
 system mode is the guaranteed sync-free layout. JAX adds API/layout parity
 only; underlying Warp kernels remain atom-buffer-oriented.
 
+## v0.4.0: Electrostatics
+
 ### Energy-Derivative Training
 
 For full Ewald/PME APIs, prefer deriving training quantities from the returned
@@ -78,13 +80,12 @@ This support is exposed through standard autograd on scalar losses; the
 electrostatics APIs do not expose public Hessian or Jacobian tensors/functions.
 
 JAX full Ewald/PME supports first-order energy derivatives for positions,
-charges, and row-vector displacement virials using the same energy-cotangent
-reducer as Torch (per-atom by default, or per-system with
-`energy_reduction="system"`). Higher-order JAX support is limited to tested
-position and charge scalar losses. JAX PME stress/cell/strain, alpha, and
-precomputed-metadata higher-order paths are unsupported until implemented and
-tested. JAX direct-output flags remain functional for compatibility in v0.4.0
-but are deprecated for differentiable training.
+charges, and row-vector displacement virials using the same per-system
+energy-cotangent reducer as Torch. Higher-order JAX support is limited to
+tested position and charge scalar losses. JAX PME stress/cell/strain, alpha,
+and precomputed-metadata higher-order paths are unsupported until implemented
+and tested. JAX direct-output flags remain functional for compatibility in
+v0.4.0 but are deprecated for differentiable training.
 
 ### Precomputed Electrostatics Metadata
 

--- a/docs/userguide/about/migration.md
+++ b/docs/userguide/about/migration.md
@@ -8,6 +8,52 @@ This guide lists user-visible migrations by release.
 
 ## v0.4.0: Electrostatics
 
+### Energy Output Layout (`energy_reduction`)
+
+Monopole Torch and JAX Ewald, PME, and slab entry points accept keyword-only
+`energy_reduction="atom" | "system"` (default `"atom"`).
+
+| Mode | Energy shape | Typical use |
+|------|--------------|-------------|
+| `"atom"` (default) | `(N,)` per-atom | Weighted atom losses, existing `E.sum()` recipes |
+| `"system"` | `(B,)` per-system | Batched per-system losses without manual `scatter_add` |
+
+Direct-output fields are unchanged: forces remain `(N, 3)`, charge gradients
+remain `(N,)`, and virials remain `(B, 3, 3)`.
+
+For batched per-system losses, prefer `energy_reduction="system"` over
+manually reducing per-atom energies with `scatter_add` or `segment_sum`:
+
+```python
+# Torch: per-system energy and forces from one call.
+energy = particle_mesh_ewald(
+    positions, charges, cell,
+    batch_idx=batch_idx,
+    energy_reduction="system",
+    neighbor_list=nl, neighbor_ptr=nl_ptr, neighbor_shifts=shifts,
+)  # (B,)
+forces = -torch.autograd.grad(energy.sum(), positions)[0]
+```
+
+```python
+# JAX: same layout under jit when energy_reduction is static.
+energy = particle_mesh_ewald(
+    positions, charges, cell,
+    batch_idx=batch_idx,
+    energy_reduction="system",
+    neighbor_list=nl, neighbor_ptr=nl_ptr, neighbor_shifts=shifts,
+)  # (B,)
+```
+
+On Torch CUDA, eager atom mode may synchronize once per participating component
+when a materialized uniform cotangent must be proven by value inspection (for
+example `grad_outputs=torch.ones_like(energy)` on a contiguous per-atom
+energy). System mode is structurally sync-free: arbitrary `(B,)` cotangents
+reach the cached backward without inspecting atom values. Under `torch.compile`
+or CUDA graph capture, only metadata-proven atom cotangents use the fast path;
+system mode is the guaranteed sync-free layout. JAX adds API/layout parity
+only; underlying Warp kernels remain atom-buffer-oriented.
+
 ### Energy-Derivative Training
 
 For full Ewald/PME APIs, prefer deriving training quantities from the returned
@@ -32,8 +78,9 @@ This support is exposed through standard autograd on scalar losses; the
 electrostatics APIs do not expose public Hessian or Jacobian tensors/functions.
 
 JAX full Ewald/PME supports first-order energy derivatives for positions,
-charges, and row-vector displacement virials using the same per-system
-energy-cotangent reducer as Torch. Higher-order JAX support is limited to tested
+charges, and row-vector displacement virials using the same energy-cotangent
+reducer as Torch (per-atom by default, or per-system with
+`energy_reduction="system"`). Higher-order JAX support is limited to tested
 position and charge scalar losses. JAX PME stress/cell/strain, alpha, and
 precomputed-metadata higher-order paths are unsupported until implemented and
 tested. JAX direct-output flags remain functional for compatibility in v0.4.0

--- a/docs/userguide/components/electrostatics.md
+++ b/docs/userguide/components/electrostatics.md
@@ -57,7 +57,11 @@ All methods support:
 ```{important}
 For MLIP training with the full Ewald/PME APIs, call the function without
 direct-output flags and derive forces, stress, and charge gradients from the
-returned energy tensor. The full-api flags `compute_forces`,
+returned energy tensor. The default `energy_reduction="atom"` returns per-atom
+energies `(N,)`; pass `energy_reduction="system"` for per-system totals `(B,)`
+in batched per-system losses. Direct-output fields (forces, charge gradients,
+virials) keep their existing shapes regardless of the energy layout. The
+full-api flags `compute_forces`,
 `compute_charge_gradients`, `compute_virial`, and `hybrid_forces` are deprecated
 and emit `DeprecationWarning`; component APIs such as `ewald_real_space`,
 `ewald_reciprocal_space`, and `pme_reciprocal_space` keep direct outputs as
@@ -414,9 +418,11 @@ E_{\text{background}} = \frac{\pi}{2\alpha^2 V} Q_{\text{total}}^2
 
 ### Usage Examples
 
-The full Ewald API returns per-atom energy by default. Derive training forces
-from that energy; direct-output flags are legacy compatibility outputs and emit
-`DeprecationWarning`. Snippets in this section that still request
+The full Ewald API returns per-atom energy by default (`energy_reduction="atom"`).
+Pass `energy_reduction="system"` for per-system totals `(B,)` in batched
+workflows. Derive training forces from the returned energy; direct-output flags
+are legacy compatibility outputs and emit `DeprecationWarning`. Snippets in
+this section that still request
 `compute_forces=True`, `compute_charge_gradients=True`, or `compute_virial=True`
 show the legacy direct-output tuple contract.
 
@@ -1984,8 +1990,10 @@ energies, forces = ewald_summation(
     max_atoms_per_system=max_atoms_per_system,
 )
 
-# energies: (total_atoms,) - per-atom energies
-# Sum per system:
+# energies: (total_atoms,) - per-atom energies (default energy_reduction="atom")
+# For per-system totals (B,), pass energy_reduction="system" instead:
+# energies = ewald_summation(..., batch_idx=batch_idx, energy_reduction="system")
+# Sum per system (atom mode only):
 energy_per_system = torch.zeros(3, device=positions.device)
 energy_per_system.scatter_add_(0, batch_idx.long(), energies)
 ```
@@ -2045,8 +2053,10 @@ energies, forces = ewald_summation(
     compute_forces=True,
 )
 
-# energies: (total_atoms,) - per-atom energies
-# Sum per system using segment_sum:
+# energies: (total_atoms,) - per-atom energies (default energy_reduction="atom")
+# For per-system totals (B,), pass energy_reduction="system" instead:
+# energies = ewald_summation(..., batch_idx=batch_idx, energy_reduction="system")
+# Sum per system (atom mode only):
 energy_per_system = jax.ops.segment_sum(energies, batch_idx, num_segments=3)
 ```
 
@@ -2190,10 +2200,15 @@ explicitly:
 
 ```python
 charges.requires_grad_(True)
-energies = ewald_summation(...)
-energy_per_system = torch.zeros(3, device=positions.device)
-# scatter add based on the system index mapping
-energy_per_system.scatter_add_(0, batch_idx.long(), energies)
+# Atom mode (default): reduce manually, or use system mode directly:
+energies = ewald_summation(
+    ..., batch_idx=batch_idx, energy_reduction="system",
+)
+energy_per_system = energies  # already (B,)
+# Atom-mode alternative:
+# energies = ewald_summation(..., batch_idx=batch_idx)
+# energy_per_system = torch.zeros(3, device=positions.device)
+# energy_per_system.scatter_add_(0, batch_idx.long(), energies)
 # now compute the derivatives
 (charge_gradients,) = torch.autograd.grad(
   outputs=[energy_per_system],
@@ -2217,11 +2232,10 @@ def batch_energy_fn(charges):
         positions, charges, cell, alpha=0.3, k_cutoff=8.0,
         neighbor_list=nl, neighbor_ptr=nl_ptr, neighbor_shifts=shifts,
         batch_idx=batch_idx,
+        energy_reduction="system",  # (B,) without manual segment_sum
         compute_forces=False,
     )
-    # Sum per system using segment_sum
-    energy_per_system = jax.ops.segment_sum(energies, batch_idx, num_segments=3)
-    return jnp.sum(energy_per_system)
+    return jnp.sum(energies)
 
 charge_gradients = jax.grad(batch_energy_fn)(charges)
 ```
@@ -2582,7 +2596,10 @@ of the full
 {func}`~nvalchemiops.torch.interactions.electrostatics.particle_mesh_ewald`
 APIs, with matching first-order support on the full JAX Ewald/PME APIs**.
 Forces, virial/stress, and charge gradients are derivatives of that energy.
-With no direct-output flags set, the call returns the per-atom energy tensor only.
+With no direct-output flags set, the call returns the per-atom energy tensor
+only (`energy_reduction="atom"`, the default). Pass `energy_reduction="system"`
+for per-system totals `(B,)`; direct-output fields (forces, charge gradients,
+virials) keep their existing shapes regardless of the energy layout.
 
 Only `positions`, `charges`, and `cell` are differentiable inputs in this
 contract. Setup values such as `alpha`, cutoffs, accuracy, mesh spacing or
@@ -2618,6 +2635,53 @@ Second-order support means differentiating scalar losses through these energy
 paths with Torch/JAX autograd. Electrostatics does not expose public Hessian or
 Jacobian tensors/functions.
 
+(energy-reduction)=
+
+### Energy Output Layout (`energy_reduction`)
+
+Monopole Torch and JAX Ewald, PME, and slab entry points accept keyword-only
+`energy_reduction="atom" | "system"` (default `"atom"`).
+
+| Mode | Energy shape | Typical use |
+|------|--------------|-------------|
+| `"atom"` (default) | `(N,)` per-atom | Weighted atom losses, `E.sum()` force/stress recipes |
+| `"system"` | `(B,)` per-system | Batched per-system losses, sync-free Torch CUDA routing |
+
+`B` follows the normalized cell batch shape. A single `(3, 3)` cell yields
+`B == 1` and system-mode energy shape `(1,)`, never a scalar. In direct-output
+tuples, only the first energy field changes shape; forces remain `(N, 3)`,
+charge gradients remain `(N,)`, and virials remain `(B, 3, 3)`.
+
+Composite Ewald/PME calls apply the same layout to every energy component
+(real, reciprocal, correction, and optional slab) before combining. Hybrid and
+direct-output internals remain atom-major; reduction occurs only at the public
+boundary. Underlying Warp kernels and custom ops continue to use atom-buffer
+layouts.
+
+For batched per-system losses, prefer `energy_reduction="system"` over manually
+reducing per-atom energies:
+
+```python
+energy = particle_mesh_ewald(
+    positions, charges, cell,
+    batch_idx=batch_idx,
+    energy_reduction="system",
+    neighbor_list=nl, neighbor_ptr=nl_ptr, neighbor_shifts=shifts,
+)  # (B,)
+loss = (weights * energy).sum()
+```
+
+On Torch CUDA, eager atom mode may synchronize once per participating terminal
+component when a materialized uniform cotangent must be proven by value
+inspection (for example `grad_outputs=torch.ones_like(energy)` on a contiguous
+per-atom energy tensor). System mode is structurally sync-free: arbitrary
+`(B,)` cotangents reach the cached backward without inspecting atom values.
+Under `torch.compile` or CUDA graph capture, only metadata-proven atom
+cotangents use the fast cached path; system mode is the guaranteed sync-free
+layout. JAX adds API/layout parity only; it does not change the Torch cotangent
+routing behavior or broaden JAX support for arbitrary non-uniform per-atom
+output cotangents.
+
 (sync-free-electrostatics)=
 
 ### Sync-Free Electrostatics Calls
@@ -2629,6 +2693,9 @@ user-side logging never synchronize internally. The guidance below applies to
 energy-returning autograd paths unless stated otherwise; deprecated full-API
 direct-output flags and component direct outputs are compatibility or
 MD/inference paths, not the primary differentiable sync-free contract.
+For batched per-system losses on Torch CUDA, prefer
+`energy_reduction="system"` so arbitrary `(B,)` cotangents reach the cached
+backward without atom-value inspection.
 
 For Torch batched Ewald reciprocal calls, pass a host-known
 `max_atoms_per_system` upper bound to `ewald_reciprocal_space` or
@@ -2735,13 +2802,17 @@ positions = positions.detach().requires_grad_(True)
 energy = particle_mesh_ewald(
     positions, charges, cell,
     neighbor_list=nl, neighbor_ptr=nl_ptr, neighbor_shifts=shifts,
-)  # returns the per-atom energy tensor only
+)  # returns the per-atom energy tensor only (energy_reduction="atom")
+
+# Batched per-system layout:
+# energy = particle_mesh_ewald(..., batch_idx=batch_idx, energy_reduction="system")
 
 forces = -torch.autograd.grad(energy.sum(), positions)[0]  # (N, 3)
 ```
 
-`energy.sum()` is the scalar total energy whose derivative is the full force for
-the graph that produced `energy`.
+`energy.sum()` (atom mode) or `(weights * energy).sum()` (system mode) is the
+scalar total energy whose derivative is the full force for the graph that
+produced `energy`.
 
 ### Force-Loss Training
 
@@ -2888,10 +2959,11 @@ deprecated flags remain available for compatibility in v0.4.0 but emit a
 
 | Deprecated flag | Replacement |
 |-----------------|-------------|
-| `compute_forces=True` | `forces = -torch.autograd.grad(E.sum(), positions)[0]` |
+| `compute_forces=True` | `forces = -torch.autograd.grad(E.sum(), positions)[0]` (atom mode) or `grad((weights * E).sum(), positions)` (system mode) |
 | `compute_virial=True` | `grad_u = torch.autograd.grad(E.sum(), displacement)[0]` with the row-vector displacement recipe; `virial = -grad_u`, `stress = grad_u / V` |
-| `compute_charge_gradients=True` | `dEdq = torch.autograd.grad(E.sum(), charges)[0]` |
+| `compute_charge_gradients=True` | `dEdq = torch.autograd.grad(E.sum(), charges)[0]` (atom mode) or `grad((weights * E).sum(), charges)` (system mode) |
 | `hybrid_forces=True` | Keep `charges = charge_model(positions)` in the graph; derive the force from energy (full `q(R)` force) |
+| Manual `scatter_add` / `segment_sum` on atom energy | `energy_reduction="system"` on the monopole Ewald/PME/slab APIs |
 
 ```{note}
 These deprecations apply to the **full** APIs only. `ewald_real_space`,
@@ -2902,7 +2974,8 @@ the differentiable training contract.
 
 ```{note}
 JAX full Ewald/PME follows the same first-order energy-derivative contract
-for positions, charges, and row-vector displacement virials. Higher-order JAX
+for positions, charges, and row-vector displacement virials, with matching
+`energy_reduction` output layouts. Higher-order JAX
 support is limited to tested position and charge scalar losses; PME reciprocal
 terms use the native PME mesh HVP path. JAX PME stress/cell/strain, alpha, and
 precomputed-metadata higher-order paths are

--- a/examples/electrostatics/11_pme_energy_derivative_training.py
+++ b/examples/electrostatics/11_pme_energy_derivative_training.py
@@ -28,6 +28,13 @@ deprecated and emit a ``DeprecationWarning``. They remain available for
 compatibility in v0.4.0, so this example also checks that the autograd results
 match the legacy direct outputs, which is the migration check.
 
+Monopole Ewald/PME/slab entry points accept ``energy_reduction="atom"`` (default)
+or ``"system"``. Atom mode returns per-atom energies ``(N,)``; system mode
+returns per-system totals ``(B,)`` for batched per-system losses. Direct-output
+fields (forces, charge gradients, virials) keep their existing shapes. On Torch
+CUDA, eager atom mode may synchronize when proving a materialized uniform
+cotangent; ``energy_reduction="system"`` is structurally sync-free.
+
 In this example you will learn:
 
 - Forces from energy autograd: ``F = -grad(E.sum(), positions)``
@@ -36,6 +43,7 @@ In this example you will learn:
   ``dE/dq . dq/dR`` charge-model chain-rule term
 - Strain-first virial/stress and stress-loss training
 - Charge gradients from energy autograd: ``dE/dq = grad(E.sum(), charges)``
+- ``energy_reduction="system"`` for batched per-system energy layout ``(B,)``
 
 .. important::
     This script is intended as an API demonstration. Do not use this script
@@ -135,7 +143,7 @@ pme_kwargs = dict(
 
 positions_f = positions.detach().requires_grad_(True)
 energy = particle_mesh_ewald(positions_f, charges, cell, **pme_kwargs)
-print(f"\nenergy shape: {tuple(energy.shape)}  (per-atom)")
+print(f"\nenergy shape: {tuple(energy.shape)}  (per-atom, energy_reduction='atom')")
 
 forces = -torch.autograd.grad(energy.sum(), positions_f)[0]
 print(f"forces shape: {tuple(forces.shape)}")
@@ -365,6 +373,8 @@ if cg_diff >= 1e-6:
 # 5. **Combined E + F + stress loss** -- take forces and virial from a single
 #    ``torch.autograd.grad(E.sum(), (positions, strain), create_graph=True)`` call,
 #    not two separate calls, so the reciprocal double-backward runs once.
+# 6. **Batched per-system layout** -- pass ``energy_reduction="system"`` to get
+#    ``(B,)`` energies for per-system losses without manual ``scatter_add``.
 #
 # Each autograd result matched the corresponding (deprecated) direct kernel
 # output, confirming the migration is numerically exact.

--- a/nvalchemiops/interactions/electrostatics/ewald_real_factory.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_real_factory.py
@@ -70,7 +70,7 @@ Equivalently, ``d Phi / d cell`` is the outer product of ``n`` and
 """
 
 from functools import lru_cache
-from typing import Any
+from typing import Any, Literal
 
 import warp as wp
 
@@ -182,6 +182,7 @@ def _ewald_real_module_name(
     order: str = "forward",
     tiled: bool = False,
     cell_literal: bool = False,
+    energy_layout: Literal["atom", "system"] = "atom",
 ) -> str:
     """Deterministic Warp ``module=`` name for one ``ewald_real`` specialization.
 
@@ -198,6 +199,8 @@ def _ewald_real_module_name(
         parts.append("tiled" if order == "forward" else f"{order}_tiled")
     if cell_literal:
         parts.append("cellliteral")
+    if energy_layout == "system":
+        parts.append("systemenergy")
     suffix = "_".join(parts) if parts else None
     return _make_specialization_module_name(
         "ewald_real",
@@ -221,6 +224,7 @@ def _name_and_document(
     order: str,
     tiled: bool = False,
     cell_literal: bool = False,
+    energy_layout: Literal["atom", "system"] = "atom",
 ) -> None:
     """Give a generated ``ewald_real`` kernel a descriptive name + spec docstring."""
     features = [
@@ -231,6 +235,7 @@ def _name_and_document(
         neighbor_input,
         "" if order == "forward" else order,
         "tiled" if tiled else "",
+        "systemenergy" if energy_layout == "system" else "",
     ]
     _name_and_document_kernel(
         kernel,
@@ -243,6 +248,7 @@ def _name_and_document(
             ("deriv_state", deriv_state.name),
             ("cell_grad", bool(cell_grad)),
             ("order", order),
+            ("energy_layout", energy_layout),
         ],
     )
 
@@ -635,6 +641,7 @@ def _validate_axes(
     order: str,
     tiled: bool = False,
     cell_literal: bool = False,
+    energy_layout: Literal["atom", "system"] = "atom",
 ) -> None:
     """Raise for unsupported / invalid component-axis combinations.
 
@@ -656,6 +663,16 @@ def _validate_axes(
         order=order,
         component="ewald_real",
     )
+    if energy_layout not in {"atom", "system"}:
+        raise NotImplementedError(
+            "ewald_real factory supports energy_layout in ('atom', 'system'); "
+            f"got {energy_layout!r}"
+        )
+    if energy_layout == "system" and order != "forward":
+        raise NotImplementedError(
+            "ewald_real system energy_layout is only implemented for "
+            f"order='forward'; got order={order!r}"
+        )
     if neighbor_input not in ("list", "matrix"):
         raise NotImplementedError(
             f"ewald_real factory supports neighbor_input in ('list', 'matrix'); "
@@ -712,6 +729,7 @@ def make_ewald_real_kernel(
     order: str = "forward",
     tiled: bool = False,
     cell_literal: bool = False,
+    energy_layout: Literal["atom", "system"] = "atom",
 ) -> wp.Kernel:
     """Return a cached, specialized ``ewald_real`` Warp kernel.
 
@@ -774,23 +792,29 @@ def make_ewald_real_kernel(
         order,
         tiled,
         cell_literal,
+        energy_layout,
     )
 
     if order == "forward":
         if tiled:
             if cell_literal:
                 return _make_forward_kernel_tiled_cell_literal(
-                    wp_dtype, batched, neighbor_input, deriv_state, cell_grad
+                    wp_dtype,
+                    batched,
+                    neighbor_input,
+                    deriv_state,
+                    cell_grad,
+                    energy_layout,
                 )
             return _make_forward_kernel_tiled(
-                wp_dtype, batched, neighbor_input, deriv_state, cell_grad
+                wp_dtype, batched, neighbor_input, deriv_state, cell_grad, energy_layout
             )
         if cell_literal:
             return _make_forward_kernel_cell_literal(
-                wp_dtype, batched, neighbor_input, deriv_state, cell_grad
+                wp_dtype, batched, neighbor_input, deriv_state, cell_grad, energy_layout
             )
         return _make_forward_kernel(
-            wp_dtype, batched, neighbor_input, deriv_state, cell_grad
+            wp_dtype, batched, neighbor_input, deriv_state, cell_grad, energy_layout
         )
     if order == "backward":
         return _make_backward_kernel(
@@ -815,6 +839,7 @@ def get_ewald_real_kernel(
     order: str = "forward",
     tiled: bool = False,
     cell_literal: bool = False,
+    energy_layout: Literal["atom", "system"] = "atom",
     component: str = "ewald_real",
 ) -> wp.Kernel:
     """Return a cached ``ewald_real`` kernel, validating dtype + component.
@@ -869,6 +894,7 @@ def get_ewald_real_kernel(
         order=order,
         tiled=tiled,
         cell_literal=cell_literal,
+        energy_layout=energy_layout,
     )
 
 
@@ -881,6 +907,7 @@ def _make_forward_kernel(
     neighbor_input: str,
     deriv_state: _DerivState,
     cell_grad: bool,
+    energy_layout: Literal["atom", "system"],
 ) -> wp.Kernel:
     """Build the forward kernel: energy (+forces +charge-grad +virial)."""
     info = _DTYPE_INFO[wp_dtype]
@@ -892,8 +919,11 @@ def _make_forward_kernel(
     HAS_FORCE = deriv_state in {_DerivState.E_F, _DerivState.E_F_dQ}
     HAS_CHARGE = deriv_state in {_DerivState.E_dQ, _DerivState.E_F_dQ}
     CELL_GRAD = bool(cell_grad)
+    SYSTEM_ENERGY = energy_layout == "system"
 
-    module_name = _ewald_real_module_name(wp_dtype, BATCHED, neighbor_input, "forward")
+    module_name = _ewald_real_module_name(
+        wp_dtype, BATCHED, neighbor_input, "forward", energy_layout=energy_layout
+    )
     accumulate_pair = _make_forward_pair_fn(
         wp_dtype, deriv_state=deriv_state, cell_grad=cell_grad
     )
@@ -992,7 +1022,10 @@ def _make_forward_kernel(
                     charge_gradients,
                 )
 
-        wp.atomic_add(pair_energies, atom_i, energy_acc)
+        if SYSTEM_ENERGY:
+            wp.atomic_add(pair_energies, isys, energy_acc)
+        else:
+            wp.atomic_add(pair_energies, atom_i, energy_acc)
         if HAS_FORCE:
             wp.atomic_add(atomic_forces, atom_i, force_i_acc)
             if CELL_GRAD:
@@ -1009,6 +1042,7 @@ def _make_forward_kernel(
         deriv_state=deriv_state,
         cell_grad=cell_grad,
         order="forward",
+        energy_layout=energy_layout,
     )
     return _ewald_real
 
@@ -1022,6 +1056,7 @@ def _make_forward_kernel_cell_literal(
     neighbor_input: str,
     deriv_state: _DerivState,
     cell_grad: bool,
+    energy_layout: Literal["atom", "system"],
 ) -> wp.Kernel:
     """Build the CSR/list forward kernel that also emits literal ``dE/dcell``.
 
@@ -1037,9 +1072,15 @@ def _make_forward_kernel_cell_literal(
     HAS_FORCE = deriv_state in {_DerivState.E_F, _DerivState.E_F_dQ}
     HAS_CHARGE = deriv_state in {_DerivState.E_dQ, _DerivState.E_F_dQ}
     CELL_GRAD = bool(cell_grad)
+    SYSTEM_ENERGY = energy_layout == "system"
 
     module_name = _ewald_real_module_name(
-        wp_dtype, BATCHED, neighbor_input, "forward", cell_literal=True
+        wp_dtype,
+        BATCHED,
+        neighbor_input,
+        "forward",
+        cell_literal=True,
+        energy_layout=energy_layout,
     )
     accumulate_pair = _make_forward_pair_fn(
         wp_dtype, deriv_state=deriv_state, cell_grad=cell_grad, cell_literal=True
@@ -1114,7 +1155,10 @@ def _make_forward_kernel_cell_literal(
                 charge_gradients,
             )
 
-        wp.atomic_add(pair_energies, atom_i, energy_acc)
+        if SYSTEM_ENERGY:
+            wp.atomic_add(pair_energies, isys, energy_acc)
+        else:
+            wp.atomic_add(pair_energies, atom_i, energy_acc)
         if HAS_FORCE:
             wp.atomic_add(atomic_forces, atom_i, force_i_acc)
             wp.atomic_add(dedcell_atom, atom_i, dedcell_acc)
@@ -1133,6 +1177,7 @@ def _make_forward_kernel_cell_literal(
         cell_grad=cell_grad,
         order="forward",
         cell_literal=True,
+        energy_layout=energy_layout,
     )
     return _ewald_real_cell_literal
 
@@ -1146,6 +1191,7 @@ def _make_forward_kernel_tiled(
     neighbor_input: str,
     deriv_state: _DerivState,
     cell_grad: bool,
+    energy_layout: Literal["atom", "system"],
 ) -> wp.Kernel:
     """Build the cooperative-block forward kernel for the neighbor-matrix layout.
 
@@ -1172,9 +1218,15 @@ def _make_forward_kernel_tiled(
     HAS_FORCE = deriv_state in {_DerivState.E_F, _DerivState.E_F_dQ}
     HAS_CHARGE = deriv_state in {_DerivState.E_dQ, _DerivState.E_F_dQ}
     CELL_GRAD = bool(cell_grad)
+    SYSTEM_ENERGY = energy_layout == "system"
 
     module_name = _ewald_real_module_name(
-        wp_dtype, BATCHED, neighbor_input, "forward", tiled=True
+        wp_dtype,
+        BATCHED,
+        neighbor_input,
+        "forward",
+        tiled=True,
+        energy_layout=energy_layout,
     )
     accumulate_pair = _make_forward_pair_fn(
         wp_dtype, deriv_state=deriv_state, cell_grad=cell_grad
@@ -1255,7 +1307,10 @@ def _make_forward_kernel_tiled(
             cg_sum = wp.tile_sum(wp.tile(cg_i_acc))
 
         if lane == 0:
-            wp.tile_atomic_add(pair_energies, energy_sum, offset=(atom_i,))
+            if SYSTEM_ENERGY:
+                wp.tile_atomic_add(pair_energies, energy_sum, offset=(isys,))
+            else:
+                wp.tile_atomic_add(pair_energies, energy_sum, offset=(atom_i,))
             if HAS_FORCE:
                 wp.tile_atomic_add(atomic_forces, force_sum, offset=(atom_i,))
                 if CELL_GRAD:
@@ -1275,6 +1330,7 @@ def _make_forward_kernel_tiled(
         cell_grad=cell_grad,
         order="forward",
         tiled=True,
+        energy_layout=energy_layout,
     )
     return _ewald_real_tiled
 
@@ -1288,6 +1344,7 @@ def _make_forward_kernel_tiled_cell_literal(
     neighbor_input: str,
     deriv_state: _DerivState,
     cell_grad: bool,
+    energy_layout: Literal["atom", "system"],
 ) -> wp.Kernel:
     """Cooperative-block forward kernel that also emits the literal ``dE/dcell``.
 
@@ -1309,9 +1366,16 @@ def _make_forward_kernel_tiled_cell_literal(
     HAS_FORCE = deriv_state in {_DerivState.E_F, _DerivState.E_F_dQ}
     HAS_CHARGE = deriv_state in {_DerivState.E_dQ, _DerivState.E_F_dQ}
     CELL_GRAD = bool(cell_grad)
+    SYSTEM_ENERGY = energy_layout == "system"
 
     module_name = _ewald_real_module_name(
-        wp_dtype, BATCHED, neighbor_input, "forward", tiled=True, cell_literal=True
+        wp_dtype,
+        BATCHED,
+        neighbor_input,
+        "forward",
+        tiled=True,
+        cell_literal=True,
+        energy_layout=energy_layout,
     )
     accumulate_pair = _make_forward_pair_fn(
         wp_dtype, deriv_state=deriv_state, cell_grad=cell_grad, cell_literal=True
@@ -1399,7 +1463,10 @@ def _make_forward_kernel_tiled_cell_literal(
             cg_sum = wp.tile_sum(wp.tile(cg_i_acc))
 
         if lane == 0:
-            wp.tile_atomic_add(pair_energies, energy_sum, offset=(atom_i,))
+            if SYSTEM_ENERGY:
+                wp.tile_atomic_add(pair_energies, energy_sum, offset=(isys,))
+            else:
+                wp.tile_atomic_add(pair_energies, energy_sum, offset=(atom_i,))
             if HAS_FORCE:
                 wp.tile_atomic_add(atomic_forces, force_sum, offset=(atom_i,))
                 # Per-atom mat33d write: one owner per atom_i, so plain atomic_add
@@ -1423,6 +1490,7 @@ def _make_forward_kernel_tiled_cell_literal(
         order="forward",
         tiled=True,
         cell_literal=True,
+        energy_layout=energy_layout,
     )
     return _ewald_real_tiled_cell_literal
 

--- a/nvalchemiops/jax/interactions/electrostatics/_utils.py
+++ b/nvalchemiops/jax/interactions/electrostatics/_utils.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import jax
 import jax.numpy as jnp
 
@@ -53,7 +55,7 @@ def _prepare_cell(cell: jax.Array) -> tuple[jax.Array, int]:
 _ENERGY_REDUCTIONS = ("atom", "system")
 
 
-def _validate_energy_reduction(energy_reduction: str) -> None:
+def _validate_energy_reduction(energy_reduction: Literal["atom", "system"]) -> None:
     """Validate the public ``energy_reduction`` keyword-only option.
 
     Parameters
@@ -129,7 +131,7 @@ def _distribute_system_values(
 
 def _apply_energy_reduction(
     result: jax.Array | tuple[jax.Array, ...],
-    energy_reduction: str,
+    energy_reduction: Literal["atom", "system"],
     batch_idx: jax.Array | None,
     cell: jax.Array,
 ) -> jax.Array | tuple[jax.Array, ...]:

--- a/nvalchemiops/jax/interactions/electrostatics/_utils.py
+++ b/nvalchemiops/jax/interactions/electrostatics/_utils.py
@@ -50,6 +50,125 @@ def _prepare_cell(cell: jax.Array) -> tuple[jax.Array, int]:
     return cell, cell.shape[0]
 
 
+_ENERGY_REDUCTIONS = ("atom", "system")
+
+
+def _validate_energy_reduction(energy_reduction: str) -> None:
+    """Validate the public ``energy_reduction`` keyword-only option.
+
+    Parameters
+    ----------
+    energy_reduction : str
+        Requested public energy layout. Must be a static Python string so
+        that branching on it under ``jax.jit`` stays static (pass it via
+        ``static_argnames`` when jitting).
+
+    Raises
+    ------
+    ValueError
+        If ``energy_reduction`` is not one of ``"atom"`` or ``"system"``.
+    """
+    if energy_reduction not in _ENERGY_REDUCTIONS:
+        raise ValueError(
+            f"energy_reduction must be one of {_ENERGY_REDUCTIONS}, "
+            f"got {energy_reduction!r}"
+        )
+
+
+def _system_sum_from_atoms(
+    values: jax.Array,
+    batch_idx: jax.Array | None,
+    num_systems: int,
+) -> jax.Array:
+    """Sum per-atom scalar values into one scalar per system.
+
+    Uses a differentiable scatter-add so gradients flow back to ``values``
+    unchanged; this is a uniform per-atom sum and does not weight atoms.
+    """
+    if batch_idx is None:
+        return values.sum(keepdims=True)
+    return (
+        jnp.zeros((num_systems,), dtype=values.dtype)
+        .at[batch_idx.astype(jnp.int32)]
+        .add(values)
+    )
+
+
+def _per_system_atom_counts(
+    batch_idx: jax.Array | None,
+    num_systems: int,
+    num_atoms: int,
+) -> jax.Array:
+    """Return per-system atom counts as float64."""
+    if batch_idx is None:
+        return jnp.full((num_systems,), float(num_atoms), dtype=jnp.float64)
+    return (
+        jnp.zeros((num_systems,), dtype=jnp.float64)
+        .at[batch_idx.astype(jnp.int32)]
+        .add(jnp.ones((num_atoms,), dtype=jnp.float64))
+    )
+
+
+def _distribute_system_values(
+    system_values: jax.Array,
+    batch_idx: jax.Array | None,
+    num_atoms: int,
+) -> jax.Array:
+    """Distribute per-system values uniformly over each system's atoms."""
+    if batch_idx is None:
+        if num_atoms == 0:
+            return jnp.zeros((0,), dtype=system_values.dtype)
+        return jnp.full(
+            (num_atoms,), system_values[0] / num_atoms, dtype=system_values.dtype
+        )
+
+    bidx = batch_idx.astype(jnp.int32)
+    counts = _per_system_atom_counts(batch_idx, system_values.shape[0], num_atoms)
+    return (system_values / jnp.maximum(counts, 1.0))[bidx]
+
+
+def _apply_energy_reduction(
+    result: jax.Array | tuple[jax.Array, ...],
+    energy_reduction: str,
+    batch_idx: jax.Array | None,
+    cell: jax.Array,
+) -> jax.Array | tuple[jax.Array, ...]:
+    """Apply the public ``energy_reduction`` layout to an atom-layout result.
+
+    Called at the public wrapper boundary after existing custom-JVP,
+    direct-output, or hybrid atom-layout operations have produced ``result``.
+    Only the energy field changes: additional tuple entries (forces, charge
+    gradients, virial) pass through unchanged. ``"system"`` reduction is a
+    plain differentiable scatter-sum over atoms (uniform weights); it does
+    not support nonuniform per-atom weighting.
+
+    Parameters
+    ----------
+    result : jax.Array or tuple[jax.Array, ...]
+        Atom-layout energy array, or a tuple whose first entry is the
+        atom-layout energy array.
+    energy_reduction : str
+        Either ``"atom"`` (identity) or ``"system"`` (scatter-sum by
+        ``batch_idx`` into shape ``(B,)``, or ``(1,)`` for a single system).
+    batch_idx : jax.Array or None, shape (N,)
+        System index per atom, or ``None`` for a single system.
+    cell : jax.Array, shape (3, 3) or (B, 3, 3)
+        Unit cell matrices, used only to infer the number of systems.
+
+    Returns
+    -------
+    jax.Array or tuple[jax.Array, ...]
+        ``result`` with its energy field reduced to the requested layout.
+    """
+    if energy_reduction == "atom":
+        return result
+    num_systems = 1 if cell.ndim == 2 else cell.shape[0]
+    if isinstance(result, tuple):
+        energies, *rest = result
+        return (_system_sum_from_atoms(energies, batch_idx, num_systems), *rest)
+    return _system_sum_from_atoms(result, batch_idx, num_systems)
+
+
 def _build_electrostatic_result(
     energies: jax.Array,
     forces: jax.Array | None,

--- a/nvalchemiops/jax/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/jax/interactions/electrostatics/ewald.py
@@ -62,11 +62,15 @@ from nvalchemiops.jax.interactions.electrostatics._lazy_jax_kernels import (
     _make_jax_kernel_factory,
 )
 from nvalchemiops.jax.interactions.electrostatics._utils import (
+    _apply_energy_reduction,
     _build_electrostatic_result,
     _component_direct_output_deprecation_msg,
     _direct_output_deprecation_msg,
+    _distribute_system_values,
     _normalize_dtype,
     _prepare_cell,
+    _system_sum_from_atoms,
+    _validate_energy_reduction,
 )
 from nvalchemiops.jax.interactions.electrostatics.k_vectors import (
     generate_k_vectors_ewald_summation,
@@ -869,6 +873,8 @@ def ewald_real_space(
     compute_forces: bool = False,
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
+    *,
+    energy_reduction: str = "atom",
 ) -> jax.Array | tuple[jax.Array, ...]:
     """Compute real-space Ewald energy and optional direct derivative outputs.
 
@@ -916,11 +922,21 @@ def ewald_real_space(
         .. deprecated:: 0.4.0
             Deprecated. Return explicit virial tensor. Raises
             ``DeprecationWarning`` when True.
+    energy_reduction : {"atom", "system"}, keyword-only, default="atom"
+        Public energy layout. ``"atom"`` returns per-atom energies of shape
+        (N,) (default, unchanged behavior). ``"system"`` returns per-system
+        energies of shape (B,) (or (1,) for a single system), computed as a
+        differentiable, uniform scatter-sum of the per-atom energies; it does
+        not support nonuniform per-atom weighting. Only the energy field of
+        the return value changes; forces, charge gradients, and the virial
+        keep their existing atom/system layouts.
 
     Returns
     -------
-    jax.Array, shape (N,)
-        Per-atom real-space Ewald energy when no derivative flags are set.
+    jax.Array, shape (N,) or (B,)
+        Real-space Ewald energy when no derivative flags are set: per-atom
+        when ``energy_reduction="atom"``, per-system when
+        ``energy_reduction="system"``.
     tuple[jax.Array, ...]
         ``(energies, forces)`` when ``compute_forces=True``;
         ``(energies, forces, charge_gradients)`` when
@@ -932,6 +948,7 @@ def ewald_real_space(
     :func:`nvalchemiops.jax.interactions.electrostatics.ewald.ewald_reciprocal_space` : Reciprocal-space Ewald contribution.
     :func:`nvalchemiops.jax.interactions.electrostatics.ewald.ewald_summation` : Complete Ewald summation combining both components.
     """
+    _validate_energy_reduction(energy_reduction)
     component_deprecated_flags = tuple(
         name
         for name, enabled in (
@@ -950,7 +967,7 @@ def ewald_real_space(
         )
 
     if compute_forces or compute_charge_gradients or compute_virial:
-        return _ewald_real_space_impl(
+        result = _ewald_real_space_impl(
             positions=positions,
             charges=charges,
             cell=cell,
@@ -966,11 +983,12 @@ def ewald_real_space(
             compute_charge_gradients=compute_charge_gradients,
             compute_virial=compute_virial,
         )
+        return _apply_energy_reduction(result, energy_reduction, batch_idx, cell)
 
     if mask_value is None:
         mask_value = positions.shape[0]
     use_matrix = neighbor_matrix is not None and neighbor_matrix_shifts is not None
-    return _ewald_real_space_energy_jvp(
+    result = _ewald_real_space_energy_jvp(
         positions,
         charges,
         cell,
@@ -984,6 +1002,7 @@ def ewald_real_space(
         mask_value,
         use_matrix,
     )
+    return _apply_energy_reduction(result, energy_reduction, batch_idx, cell)
 
 
 def _ewald_reciprocal_space_impl(
@@ -1401,6 +1420,8 @@ def ewald_reciprocal_space(
     compute_forces: bool = False,
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
+    *,
+    energy_reduction: str = "atom",
 ) -> jax.Array | tuple[jax.Array, ...]:
     """Compute reciprocal-space Ewald energy and optional direct outputs.
 
@@ -1441,12 +1462,22 @@ def ewald_reciprocal_space(
     compute_virial : bool, default=False
         Deprecated. Return explicit virial tensor. Raises
         ``DeprecationWarning`` when True.
+    energy_reduction : {"atom", "system"}, keyword-only, default="atom"
+        Public energy layout. ``"atom"`` returns per-atom energies of shape
+        (N,) (default, unchanged behavior). ``"system"`` returns per-system
+        energies of shape (B,) (or (1,) for a single system), computed as a
+        differentiable, uniform scatter-sum of the per-atom energies; it does
+        not support nonuniform per-atom weighting. Only the energy field of
+        the return value changes; forces, charge gradients, and the virial
+        keep their existing atom/system layouts.
 
     Returns
     -------
-    jax.Array, shape (N,)
-        Per-atom reciprocal-space Ewald energy (with self and background
-        corrections) when no derivative flags are set.
+    jax.Array, shape (N,) or (B,)
+        Reciprocal-space Ewald energy (with self and background corrections)
+        when no derivative flags are set: per-atom when
+        ``energy_reduction="atom"``, per-system when
+        ``energy_reduction="system"``.
     tuple[jax.Array, ...]
         ``(energies, forces)`` when ``compute_forces=True``;
         ``(energies, forces, charge_gradients)`` when
@@ -1459,6 +1490,7 @@ def ewald_reciprocal_space(
     :func:`nvalchemiops.jax.interactions.electrostatics.ewald.ewald_summation` : Complete Ewald summation combining both components.
     :func:`nvalchemiops.jax.interactions.electrostatics.k_vectors.generate_k_vectors_ewald_summation` : Generates ``k_vectors`` from a cell and cutoff.
     """
+    _validate_energy_reduction(energy_reduction)
     component_deprecated_flags = tuple(
         name
         for name, enabled in (
@@ -1479,7 +1511,7 @@ def ewald_reciprocal_space(
     k_vectors = jax.lax.stop_gradient(k_vectors)
 
     if compute_forces or compute_charge_gradients or compute_virial:
-        return _ewald_reciprocal_space_impl(
+        result = _ewald_reciprocal_space_impl(
             positions=positions,
             charges=charges,
             cell=cell,
@@ -1491,8 +1523,9 @@ def ewald_reciprocal_space(
             compute_charge_gradients=compute_charge_gradients,
             compute_virial=compute_virial,
         )
+        return _apply_energy_reduction(result, energy_reduction, batch_idx, cell)
 
-    return _ewald_reciprocal_space_energy_jvp(
+    result = _ewald_reciprocal_space_energy_jvp(
         positions,
         charges,
         cell,
@@ -1501,6 +1534,7 @@ def ewald_reciprocal_space(
         batch_idx,
         max_atoms_per_system,
     )
+    return _apply_energy_reduction(result, energy_reduction, batch_idx, cell)
 
 
 def _tangent_or_zeros(tangent, primal: jax.Array, dtype=None) -> jax.Array:
@@ -1558,55 +1592,6 @@ def _kvector_tangent_from_cell(
     if k_vectors.ndim == 2:
         return tangent[0]
     return tangent
-
-
-def _per_system_atom_counts(
-    batch_idx: jax.Array | None,
-    num_systems: int,
-    num_atoms: int,
-) -> jax.Array:
-    """Return per-system atom counts as float64 for tangent redistribution."""
-    if batch_idx is None:
-        return jnp.full((num_systems,), float(num_atoms), dtype=jnp.float64)
-    bidx = batch_idx.astype(jnp.int32)
-    return (
-        jnp.zeros((num_systems,), dtype=jnp.float64)
-        .at[bidx]
-        .add(jnp.ones((num_atoms,), dtype=jnp.float64))
-    )
-
-
-def _system_sum_from_atoms(
-    values: jax.Array,
-    batch_idx: jax.Array | None,
-    num_systems: int,
-) -> jax.Array:
-    """Sum per-atom scalar values into one scalar per system."""
-    if batch_idx is None:
-        return values.sum(keepdims=True)
-    return (
-        jnp.zeros((num_systems,), dtype=values.dtype)
-        .at[batch_idx.astype(jnp.int32)]
-        .add(values)
-    )
-
-
-def _distribute_system_values(
-    system_values: jax.Array,
-    batch_idx: jax.Array | None,
-    num_atoms: int,
-) -> jax.Array:
-    """Distribute per-system values uniformly over each system's atoms."""
-    if batch_idx is None:
-        if num_atoms == 0:
-            return jnp.zeros((0,), dtype=system_values.dtype)
-        return jnp.full(
-            (num_atoms,), system_values[0] / num_atoms, dtype=system_values.dtype
-        )
-
-    bidx = batch_idx.astype(jnp.int32)
-    counts = _per_system_atom_counts(batch_idx, system_values.shape[0], num_atoms)
-    return (system_values / jnp.maximum(counts, 1.0))[bidx]
 
 
 def _real_space_energy_reference(
@@ -3075,6 +3060,7 @@ def ewald_summation(
     slab_correction: bool = False,
     *,
     miller_bounds: tuple[int, int, int] | None = None,
+    energy_reduction: str = "atom",
 ) -> jax.Array | tuple[jax.Array, ...]:
     """Compute complete Ewald summation.
 
@@ -3125,13 +3111,22 @@ def ewald_summation(
         Per-system periodic boundary conditions for slab correction.
     slab_correction : bool, default=False
         If True, add the Yeh-Berkowitz/Ballenegger slab correction.
+    energy_reduction : {"atom", "system"}, keyword-only, default="atom"
+        Public energy layout. ``"atom"`` returns per-atom energies of shape
+        (N,) (default, unchanged behavior). ``"system"`` returns per-system
+        energies of shape (B,) (or (1,) for a single system), computed as a
+        differentiable, uniform scatter-sum of the per-atom energies; it does
+        not support nonuniform per-atom weighting. Only the energy field of
+        the return value changes; forces, charge gradients, and the virial
+        keep their existing atom/system layouts.
 
     Returns
     -------
-    jax.Array, shape (N,)
-        Per-atom total Ewald energy when no deprecated direct-output flags are
-        set. Gradients flow through positions, charges, and cell via the
-        registered custom-JVP rules.
+    jax.Array, shape (N,) or (B,)
+        Total Ewald energy when no deprecated direct-output flags are set:
+        per-atom when ``energy_reduction="atom"``, per-system when
+        ``energy_reduction="system"``. Gradients flow through positions,
+        charges, and cell via the registered custom-JVP rules.
     tuple[jax.Array, ...]
         When any deprecated flag is True: ``(energies,)`` extended by the
         requested outputs in order — forces of shape (N, 3),
@@ -3146,6 +3141,7 @@ def ewald_summation(
     :func:`nvalchemiops.jax.interactions.electrostatics.parameters.estimate_ewald_parameters` : Automatic alpha and k-cutoff estimation.
     :func:`nvalchemiops.jax.interactions.electrostatics.k_vectors.generate_k_vectors_ewald_summation` : Generates k-vectors from cell and cutoff.
     """
+    _validate_energy_reduction(energy_reduction)
     if compute_forces or compute_virial or compute_charge_gradients or hybrid_forces:
         warnings.warn(
             _direct_output_deprecation_msg("ewald_summation"),
@@ -3197,10 +3193,11 @@ def ewald_summation(
             pbc_prepared,
             batch_idx=batch_idx,
         )
-        return base_energy + slab_energy
+        result = base_energy + slab_energy
+        return _apply_energy_reduction(result, energy_reduction, batch_idx, cell_3d)
 
     if compute_forces or compute_charge_gradients or compute_virial or hybrid_forces:
-        return _ewald_summation_impl(
+        result = _ewald_summation_impl(
             positions=positions,
             charges=charges,
             cell=cell,
@@ -3224,6 +3221,7 @@ def ewald_summation(
             pbc=pbc,
             slab_correction=slab_correction,
         )
+        return _apply_energy_reduction(result, energy_reduction, batch_idx, cell)
 
     generated_k_vectors = k_vectors is None
     alpha_resolved, k_vectors_resolved = _resolve_ewald_summation_parameters(
@@ -3243,7 +3241,7 @@ def ewald_summation(
     if mask_value is None:
         mask_value = positions.shape[0]
 
-    return _ewald_summation_energy_jvp(
+    result = _ewald_summation_energy_jvp(
         positions,
         charges,
         cell,
@@ -3259,3 +3257,4 @@ def ewald_summation(
         max_atoms_per_system,
         mask_value,
     )
+    return _apply_energy_reduction(result, energy_reduction, batch_idx, cell)

--- a/nvalchemiops/jax/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/jax/interactions/electrostatics/ewald.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import functools
 import math
 import warnings
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -874,7 +875,7 @@ def ewald_real_space(
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
     *,
-    energy_reduction: str = "atom",
+    energy_reduction: Literal["atom", "system"] = "atom",
 ) -> jax.Array | tuple[jax.Array, ...]:
     """Compute real-space Ewald energy and optional direct derivative outputs.
 
@@ -1421,7 +1422,7 @@ def ewald_reciprocal_space(
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
     *,
-    energy_reduction: str = "atom",
+    energy_reduction: Literal["atom", "system"] = "atom",
 ) -> jax.Array | tuple[jax.Array, ...]:
     """Compute reciprocal-space Ewald energy and optional direct outputs.
 
@@ -3060,7 +3061,7 @@ def ewald_summation(
     slab_correction: bool = False,
     *,
     miller_bounds: tuple[int, int, int] | None = None,
-    energy_reduction: str = "atom",
+    energy_reduction: Literal["atom", "system"] = "atom",
 ) -> jax.Array | tuple[jax.Array, ...]:
     """Compute complete Ewald summation.
 

--- a/nvalchemiops/jax/interactions/electrostatics/pme.py
+++ b/nvalchemiops/jax/interactions/electrostatics/pme.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import functools
 import math
 import warnings
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -2598,7 +2599,7 @@ def pme_reciprocal_space(
     compute_virial: bool = False,
     hybrid_forces: bool = False,
     *,
-    energy_reduction: str = "atom",
+    energy_reduction: Literal["atom", "system"] = "atom",
     cell_inv_t: jax.Array | None = None,
     volume: jax.Array | None = None,
     moduli_x: jax.Array | None = None,
@@ -3190,7 +3191,7 @@ def particle_mesh_ewald(
     pbc: jax.Array | None = None,
     slab_correction: bool = False,
     *,
-    energy_reduction: str = "atom",
+    energy_reduction: Literal["atom", "system"] = "atom",
     cell_inv_t: jax.Array | None = None,
     volume: jax.Array | None = None,
     moduli_x: jax.Array | None = None,

--- a/nvalchemiops/jax/interactions/electrostatics/pme.py
+++ b/nvalchemiops/jax/interactions/electrostatics/pme.py
@@ -65,11 +65,14 @@ from nvalchemiops.jax.interactions.electrostatics._lazy_jax_kernels import (
     _make_jax_kernels,
 )
 from nvalchemiops.jax.interactions.electrostatics._utils import (
+    _apply_energy_reduction,
     _build_electrostatic_result,
     _component_direct_output_deprecation_msg,
     _direct_output_deprecation_msg,
     _normalize_dtype,
     _prepare_cell,
+    _system_sum_from_atoms,
+    _validate_energy_reduction,
 )
 from nvalchemiops.jax.interactions.electrostatics.ewald import (
     ewald_real_space,
@@ -1861,53 +1864,6 @@ def _unsupported_pme_cell_hvp_primal_jvp(
     )
 
 
-def _system_sum_from_atoms(
-    values: jax.Array,
-    batch_idx: jax.Array | None,
-    num_systems: int,
-) -> jax.Array:
-    """Sum per-atom scalar values into one scalar per system."""
-    if batch_idx is None:
-        return values.sum(keepdims=True)
-    return (
-        jnp.zeros((num_systems,), dtype=values.dtype)
-        .at[batch_idx.astype(jnp.int32)]
-        .add(values)
-    )
-
-
-def _per_system_atom_counts(
-    batch_idx: jax.Array | None,
-    num_systems: int,
-    num_atoms: int,
-) -> jax.Array:
-    """Return per-system atom counts as float64 for tangent redistribution."""
-    if batch_idx is None:
-        return jnp.full((num_systems,), float(num_atoms), dtype=jnp.float64)
-    return (
-        jnp.zeros((num_systems,), dtype=jnp.float64)
-        .at[batch_idx.astype(jnp.int32)]
-        .add(jnp.ones((num_atoms,), dtype=jnp.float64))
-    )
-
-
-def _distribute_system_values(
-    system_values: jax.Array,
-    batch_idx: jax.Array | None,
-    num_atoms: int,
-) -> jax.Array:
-    """Distribute per-system values uniformly over each system's atoms."""
-    if batch_idx is None:
-        if num_atoms == 0:
-            return jnp.zeros((0,), dtype=system_values.dtype)
-        return jnp.full(
-            (num_atoms,), system_values[0] / num_atoms, dtype=system_values.dtype
-        )
-
-    counts = _per_system_atom_counts(batch_idx, system_values.shape[0], num_atoms)
-    return (system_values / jnp.maximum(counts, 1.0))[batch_idx.astype(jnp.int32)]
-
-
 def _cell_tangent_system_values(
     grad_cell: jax.Array,
     tangent_cell,
@@ -2642,6 +2598,7 @@ def pme_reciprocal_space(
     compute_virial: bool = False,
     hybrid_forces: bool = False,
     *,
+    energy_reduction: str = "atom",
     cell_inv_t: jax.Array | None = None,
     volume: jax.Array | None = None,
     moduli_x: jax.Array | None = None,
@@ -2693,6 +2650,14 @@ def pme_reciprocal_space(
         are deprecated for differentiable training.
     hybrid_forces : bool, default=False
         Deprecated charge-gradient injection mode for compatibility.
+    energy_reduction : {"atom", "system"}, keyword-only, default="atom"
+        Public energy layout. ``"atom"`` returns per-atom energies of shape
+        (N,) (default, unchanged behavior). ``"system"`` returns per-system
+        energies of shape (B,) (or (1,) for a single system), computed as a
+        differentiable, uniform scatter-sum of the per-atom energies; it does
+        not support nonuniform per-atom weighting. Only the energy field of
+        the return value changes; forces, charge gradients, and the virial
+        keep their existing atom/system layouts.
     cell_inv_t, volume, moduli_x, moduli_y, moduli_z : jax.Array or None
         Optional precomputed PME intermediates. These are setup constants for
         JAX and are not differentiable inputs. Cell-derived metadata such as
@@ -2702,8 +2667,9 @@ def pme_reciprocal_space(
 
     Returns
     -------
-    energies : jax.Array, shape (N,)
-        Per-atom reciprocal-space energies.
+    energies : jax.Array, shape (N,) or (B,)
+        Reciprocal-space energies: per-atom when ``energy_reduction="atom"``,
+        per-system when ``energy_reduction="system"``.
     forces : jax.Array, shape (N, 3), optional
         Per-atom forces. Only present when ``compute_forces=True``.
     charge_gradients : jax.Array, shape (N,), optional
@@ -2725,6 +2691,7 @@ def pme_reciprocal_space(
     losses. Stress/cell/strain HVPs, alpha HVPs, and precomputed-metadata HVPs
     are unsupported until explicitly implemented and tested.
     """
+    _validate_energy_reduction(energy_reduction)
     _require_explicit_mesh_dimensions_in_tracing(
         mesh_dimensions=mesh_dimensions,
         cell=cell,
@@ -2750,7 +2717,7 @@ def pme_reciprocal_space(
         )
 
     if compute_forces or compute_charge_gradients or compute_virial or hybrid_forces:
-        return _pme_reciprocal_space_impl(
+        result = _pme_reciprocal_space_impl(
             positions=positions,
             charges=charges,
             cell=cell,
@@ -2771,10 +2738,11 @@ def pme_reciprocal_space(
             compute_virial=compute_virial,
             hybrid_forces=hybrid_forces,
         )
+        return _apply_energy_reduction(result, energy_reduction, batch_idx, cell)
     if mesh_dimensions is None and mesh_spacing is not None:
         mesh_dimensions = mesh_spacing_to_dimensions(cell, mesh_spacing)
         mesh_spacing = None
-    return _pme_reciprocal_energy_jvp(
+    result = _pme_reciprocal_energy_jvp(
         positions,
         charges,
         cell,
@@ -2791,6 +2759,7 @@ def pme_reciprocal_space(
         moduli_y,
         moduli_z,
     )
+    return _apply_energy_reduction(result, energy_reduction, batch_idx, cell)
 
 
 def _particle_mesh_ewald_impl(
@@ -3221,6 +3190,7 @@ def particle_mesh_ewald(
     pbc: jax.Array | None = None,
     slab_correction: bool = False,
     *,
+    energy_reduction: str = "atom",
     cell_inv_t: jax.Array | None = None,
     volume: jax.Array | None = None,
     moduli_x: jax.Array | None = None,
@@ -3281,6 +3251,14 @@ def particle_mesh_ewald(
         Per-system periodic boundary conditions for slab correction.
     slab_correction : bool, default=False
         If True, add the Yeh-Berkowitz/Ballenegger slab correction.
+    energy_reduction : {"atom", "system"}, keyword-only, default="atom"
+        Public energy layout. ``"atom"`` returns per-atom energies of shape
+        (N,) (default, unchanged behavior). ``"system"`` returns per-system
+        energies of shape (B,) (or (1,) for a single system), computed as a
+        differentiable, uniform scatter-sum of the per-atom energies; it does
+        not support nonuniform per-atom weighting. Only the energy field of
+        the return value changes; forces, charge gradients, and the virial
+        keep their existing atom/system layouts.
     volume, cell_inv_t, moduli_x, moduli_y, moduli_z : jax.Array or None
         Optional precomputed PME intermediates. Cell-derived values supplied
         while differentiating with respect to ``cell`` are treated as static
@@ -3288,8 +3266,10 @@ def particle_mesh_ewald(
 
     Returns
     -------
-    energies : jax.Array, shape (N,)
-        Per-atom total electrostatic energies (real + reciprocal + slab).
+    energies : jax.Array, shape (N,) or (B,)
+        Total electrostatic energies (real + reciprocal + slab): per-atom
+        when ``energy_reduction="atom"``, per-system when
+        ``energy_reduction="system"``.
     forces : jax.Array, shape (N, 3), optional
         Per-atom forces. Only present when ``compute_forces=True`` (deprecated).
     charge_gradients : jax.Array, shape (N,), optional
@@ -3307,6 +3287,7 @@ def particle_mesh_ewald(
     setup values. If ``alpha`` would otherwise be estimated from traced inputs,
     precompute it outside the transformation and pass it explicitly.
     """
+    _validate_energy_reduction(energy_reduction)
     if compute_forces or compute_virial or compute_charge_gradients or hybrid_forces:
         warnings.warn(
             _direct_output_deprecation_msg("particle_mesh_ewald"),
@@ -3315,7 +3296,7 @@ def particle_mesh_ewald(
         )
 
     if compute_forces or compute_charge_gradients or compute_virial or hybrid_forces:
-        return _particle_mesh_ewald_impl(
+        result = _particle_mesh_ewald_impl(
             positions=positions,
             charges=charges,
             cell=cell,
@@ -3345,6 +3326,7 @@ def particle_mesh_ewald(
             moduli_y=moduli_y,
             moduli_z=moduli_z,
         )
+        return _apply_energy_reduction(result, energy_reduction, batch_idx, cell)
 
     cell_3d, alpha_arr, mesh_dims = _resolve_particle_mesh_ewald_parameters(
         positions=positions,
@@ -3362,7 +3344,7 @@ def particle_mesh_ewald(
     # Energy-only path: call the impl directly so the full energy is the sum of
     # real-space and reciprocal terms. Component custom derivative rules provide
     # energy gradients and reverse-mode position/charge higher-order losses.
-    return _particle_mesh_ewald_impl(
+    result = _particle_mesh_ewald_impl(
         positions=positions,
         charges=charges,
         cell=cell_3d,
@@ -3391,3 +3373,4 @@ def particle_mesh_ewald(
         moduli_y=moduli_y,
         moduli_z=moduli_z,
     )
+    return _apply_energy_reduction(result, energy_reduction, batch_idx, cell_3d)

--- a/nvalchemiops/jax/interactions/electrostatics/slab.py
+++ b/nvalchemiops/jax/interactions/electrostatics/slab.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import jax
 import jax.numpy as jnp
 from jax.interpreters import ad as jax_ad
@@ -1013,7 +1015,7 @@ def compute_slab_correction(
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
     *,
-    energy_reduction: str = "atom",
+    energy_reduction: Literal["atom", "system"] = "atom",
 ) -> jax.Array | tuple[jax.Array, ...]:
     """Yeh-Berkowitz/Ballenegger slab correction for 2D periodic systems.
 

--- a/nvalchemiops/jax/interactions/electrostatics/slab.py
+++ b/nvalchemiops/jax/interactions/electrostatics/slab.py
@@ -43,9 +43,11 @@ from nvalchemiops.jax.interactions.electrostatics._lazy_jax_kernels import (
     _make_jax_kernels,
 )
 from nvalchemiops.jax.interactions.electrostatics._utils import (
+    _apply_energy_reduction,
     _build_electrostatic_result,
     _normalize_dtype,
     _prepare_cell,
+    _validate_energy_reduction,
 )
 
 __all__ = ["compute_slab_correction"]
@@ -289,53 +291,6 @@ def _precompute_slab_geometry(
         slab_height_sq,
         launch_dims=(num_systems,),
     )
-
-
-def _system_sum_from_atoms(
-    values: jax.Array,
-    batch_idx: jax.Array | None,
-    num_systems: int,
-) -> jax.Array:
-    """Sum atom values by system."""
-    if batch_idx is None:
-        return values.sum(keepdims=True)
-    return (
-        jnp.zeros((num_systems,), dtype=values.dtype)
-        .at[batch_idx.astype(jnp.int32)]
-        .add(values)
-    )
-
-
-def _per_system_atom_counts(
-    batch_idx: jax.Array | None,
-    num_systems: int,
-    num_atoms: int,
-) -> jax.Array:
-    """Return atom counts per system as float64."""
-    if batch_idx is None:
-        return jnp.full((num_systems,), float(num_atoms), dtype=jnp.float64)
-    return (
-        jnp.zeros((num_systems,), dtype=jnp.float64)
-        .at[batch_idx.astype(jnp.int32)]
-        .add(jnp.ones((num_atoms,), dtype=jnp.float64))
-    )
-
-
-def _distribute_system_values(
-    system_values: jax.Array,
-    batch_idx: jax.Array | None,
-    num_atoms: int,
-) -> jax.Array:
-    """Distribute per-system values uniformly to atoms."""
-    if batch_idx is None:
-        if num_atoms == 0:
-            return jnp.zeros((0,), dtype=system_values.dtype)
-        return jnp.full(
-            (num_atoms,), system_values[0] / num_atoms, dtype=system_values.dtype
-        )
-    bidx = batch_idx.astype(jnp.int32)
-    counts = _per_system_atom_counts(batch_idx, system_values.shape[0], num_atoms)
-    return (system_values / jnp.maximum(counts, 1.0))[bidx]
 
 
 def _slab_correction_energy_kernel_value(
@@ -763,7 +718,7 @@ def _slab_correction_energy_autodiff(
     return _slab_correction_energy_jvp(positions, charges, cell, pbc, batch_idx)
 
 
-def compute_slab_correction(
+def _compute_slab_correction_impl(
     positions: jax.Array,
     charges: jax.Array,
     cell: jax.Array,
@@ -773,48 +728,10 @@ def compute_slab_correction(
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
 ) -> jax.Array | tuple[jax.Array, ...]:
-    """Yeh-Berkowitz/Ballenegger slab correction for 2D periodic systems.
+    """Compute the atom-layout slab correction result.
 
-    Returns the standalone slab correction contribution for JAX electrostatics
-    APIs. The caller can add the returned energy, force, charge-gradient, and
-    virial terms to 3D-periodic Ewald or PME component outputs. Energy-only
-    calls use explicit Warp-backed derivative paths; direct-output flags remain
-    forward compatibility paths.
-
-    Parameters
-    ----------
-    positions : jax.Array, shape (N, 3)
-        Atomic coordinates.
-    charges : jax.Array, shape (N,)
-        Atomic charges.
-    cell : jax.Array, shape (3, 3) or (B, 3, 3)
-        Unit cell matrices.
-    pbc : jax.Array, shape (3,) or (B, 3), dtype=bool
-        Per-system periodic boundary conditions. True marks periodic directions
-        and False marks the non-periodic slab direction. Systems whose pbc row
-        is not slab-like contribute zero. A shape (3,) array is accepted only
-        for single-system calls.
-    batch_idx : jax.Array, shape (N,), dtype=int32, optional
-        System index for each atom. Defaults to all zeros for a single system.
-        When provided, atoms must be grouped by system: ``batch_idx`` must be
-        contiguous, nondecreasing, and use system IDs ``0..B-1``.
-    compute_forces : bool, default=False
-        If True, return per-atom slab forces.
-    compute_charge_gradients : bool, default=False
-        If True, return per-atom slab charge gradients dE_slab/dq_i.
-    compute_virial : bool, default=False
-        If True, return per-system slab virial tensors.
-
-    Returns
-    -------
-    energies : jax.Array, shape (N,)
-        Per-atom slab correction energy.
-    forces : jax.Array, shape (N, 3), optional
-        Per-atom slab force.
-    charge_gradients : jax.Array, shape (N,), optional
-        Per-atom slab charge gradient.
-    virial : jax.Array, shape (B, 3, 3), optional
-        Per-system slab virial tensor.
+    Implementation for :func:`compute_slab_correction`. The public wrapper
+    applies the ``energy_reduction`` layout after this function returns.
     """
     dtype = _normalize_dtype(positions.dtype)
     positions_cast = positions.astype(dtype)
@@ -1084,3 +1001,81 @@ def compute_slab_correction(
         )
 
     return energy_out
+
+
+def compute_slab_correction(
+    positions: jax.Array,
+    charges: jax.Array,
+    cell: jax.Array,
+    pbc: jax.Array,
+    batch_idx: jax.Array | None = None,
+    compute_forces: bool = False,
+    compute_charge_gradients: bool = False,
+    compute_virial: bool = False,
+    *,
+    energy_reduction: str = "atom",
+) -> jax.Array | tuple[jax.Array, ...]:
+    """Yeh-Berkowitz/Ballenegger slab correction for 2D periodic systems.
+
+    Returns the standalone slab correction contribution for JAX electrostatics
+    APIs. The caller can add the returned energy, force, charge-gradient, and
+    virial terms to 3D-periodic Ewald or PME component outputs. Energy-only
+    calls use explicit Warp-backed derivative paths; direct-output flags remain
+    forward compatibility paths.
+
+    Parameters
+    ----------
+    positions : jax.Array, shape (N, 3)
+        Atomic coordinates.
+    charges : jax.Array, shape (N,)
+        Atomic charges.
+    cell : jax.Array, shape (3, 3) or (B, 3, 3)
+        Unit cell matrices.
+    pbc : jax.Array, shape (3,) or (B, 3), dtype=bool
+        Per-system periodic boundary conditions. True marks periodic directions
+        and False marks the non-periodic slab direction. Systems whose pbc row
+        is not slab-like contribute zero. A shape (3,) array is accepted only
+        for single-system calls.
+    batch_idx : jax.Array, shape (N,), dtype=int32, optional
+        System index for each atom. Defaults to all zeros for a single system.
+        When provided, atoms must be grouped by system: ``batch_idx`` must be
+        contiguous, nondecreasing, and use system IDs ``0..B-1``.
+    compute_forces : bool, default=False
+        If True, return per-atom slab forces.
+    compute_charge_gradients : bool, default=False
+        If True, return per-atom slab charge gradients dE_slab/dq_i.
+    compute_virial : bool, default=False
+        If True, return per-system slab virial tensors.
+    energy_reduction : {"atom", "system"}, keyword-only, default="atom"
+        Public energy layout. ``"atom"`` returns per-atom energies of shape
+        (N,) (default, unchanged behavior). ``"system"`` returns per-system
+        energies of shape (B,) (or (1,) for a single system), computed as a
+        differentiable, uniform scatter-sum of the per-atom energies; it does
+        not support nonuniform per-atom weighting. Only the energy field of
+        the return value changes; forces, charge gradients, and the virial
+        keep their existing atom/system layouts.
+
+    Returns
+    -------
+    energies : jax.Array, shape (N,) or (B,)
+        Slab correction energy: per-atom when ``energy_reduction="atom"``,
+        per-system when ``energy_reduction="system"``.
+    forces : jax.Array, shape (N, 3), optional
+        Per-atom slab force.
+    charge_gradients : jax.Array, shape (N,), optional
+        Per-atom slab charge gradient.
+    virial : jax.Array, shape (B, 3, 3), optional
+        Per-system slab virial tensor.
+    """
+    _validate_energy_reduction(energy_reduction)
+    result = _compute_slab_correction_impl(
+        positions,
+        charges,
+        cell,
+        pbc,
+        batch_idx,
+        compute_forces,
+        compute_charge_gradients,
+        compute_virial,
+    )
+    return _apply_energy_reduction(result, energy_reduction, batch_idx, cell)

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_real_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_real_chain.py
@@ -53,18 +53,23 @@ from nvalchemiops.torch._warp_op_helpers import (
 )
 from nvalchemiops.torch.interactions.electrostatics._util import (
     _is_per_system_uniform_cotangent,
+    _system_cotangent_to_atoms,
 )
 from nvalchemiops.torch.types import get_wp_dtype, get_wp_mat_dtype, get_wp_vec_dtype
 
 __all__ = [
     "ewald_real_energy_single",
     "ewald_real_energy_batch",
+    "ewald_real_system_energy_batch",
+    "ewald_real_system_energy_single",
     "register_ewald_real_ops",
     "real_space_cell_connect",
 ]
 
 _REAL_SINGLE: dict[str, object] | None = None
 _REAL_BATCH: dict[str, object] | None = None
+_REAL_SYSTEM_SINGLE: dict[str, object] | None = None
+_REAL_SYSTEM_BATCH: dict[str, object] | None = None
 _LITERAL_CELL_GRAD: dict[str, object] | None = None
 _EWALD_REAL_OPS_REGISTERED = False
 
@@ -259,6 +264,7 @@ def _forward_impl(
     need_charge,
     need_cell,
     need_virial,
+    energy_layout="atom",
 ):
     """Fused forward: energy + detached derivative caches / direct virial.
 
@@ -286,7 +292,12 @@ def _forward_impl(
     # position/charge gradients are also active.
     use_cell_literal = bool(need_cell)
 
-    energies = torch.zeros(num_atoms, device=positions.device, dtype=torch.float64)
+    num_systems = cell.shape[0]
+    energies = torch.zeros(
+        num_atoms if energy_layout == "atom" else num_systems,
+        device=positions.device,
+        dtype=torch.float64,
+    )
     # Caches: dE/dR (= -force) per atom, dE/dq per atom, literal dE/dcell per atom
     # (N,3,3). Zero-size when not needed so the op output arity stays static.
     dEdR = torch.zeros(
@@ -302,7 +313,6 @@ def _forward_impl(
         device=positions.device,
         dtype=torch.float64,
     )
-    num_systems = cell.shape[0]
     virial = torch.zeros(
         num_systems if need_virial else 0,
         3,
@@ -343,6 +353,7 @@ def _forward_impl(
         order="forward",
         tiled=use_matrix,
         cell_literal=use_cell_literal,
+        energy_layout=energy_layout,
     )
     wp_batch = _wp(batch_idx, wp.int32) if batched else sentinels["batch_id"]
     # The forward kernel writes the physical force F only for force-bearing
@@ -413,6 +424,7 @@ def _backward_impl(
     need_pos,
     need_charge,
     need_cell,
+    energy_layout="atom",
 ):
     """First backward = cheap scale of the detached forward caches (no pair loop).
 
@@ -446,8 +458,10 @@ def _backward_impl(
     # Recompute the exact weighted VJP from the differentiable Torch pair energy. The
     # uniform path (the common training case, e.g. energy.sum()) keeps the fast scale.
     any_need = need_pos or need_charge or need_cell
-    if any_need and not _cotangent_per_system_uniform(
-        grad_energy_atom, batch_idx, num_systems
+    if (
+        energy_layout == "atom"
+        and any_need
+        and not _cotangent_per_system_uniform(grad_energy_atom, batch_idx, num_systems)
     ):
         edge_i, edge_j, unit_shifts = _neighbor_edges(
             use_matrix,
@@ -500,9 +514,12 @@ def _backward_impl(
     if scale_positions or scale_charges:
         device = wp.device_from_torch(positions.device)
         wp_vec = get_wp_vec_dtype(input_dtype)
-        grad_energy = _per_system_cotangent(
-            grad_energy_atom, batch_idx, num_systems, num_atoms
-        )
+        if energy_layout == "system":
+            grad_energy = grad_energy_atom.reshape(-1).to(torch.float64)
+        else:
+            grad_energy = _per_system_cotangent(
+                grad_energy_atom, batch_idx, num_systems, num_atoms
+            )
         sentinels = alloc_ewald_real_sentinels(get_wp_dtype(input_dtype), device)
         wp_batch = (
             _wp(batch_idx, wp.int32) if batch_idx is not None else sentinels["batch_id"]
@@ -553,6 +570,7 @@ def _double_backward_impl(
     need_pos,
     need_charge,
     need_cell,
+    energy_layout="atom",
 ):
     # ``dEdR_cache`` / ``dEdq_cache`` (the backward op's leading cache inputs) and
     # ``need_pos`` / ``need_charge`` are accepted for positional alignment but NOT
@@ -583,12 +601,20 @@ def _double_backward_impl(
     )
 
     if num_atoms == 0 or _is_empty(use_matrix, idx_j, neighbor_matrix):
-        gge = _distribute_to_atoms(grad_grad_energy, batch_idx, num_systems, num_atoms)
+        if energy_layout == "system":
+            gge = grad_grad_energy
+        else:
+            gge = _distribute_to_atoms(
+                grad_grad_energy, batch_idx, num_systems, num_atoms
+            )
         return gge, grad_positions, grad_charges, grad_cell
 
-    grad_energy = _per_system_cotangent(
-        grad_energy_atom, batch_idx, num_systems, num_atoms
-    )
+    if energy_layout == "system":
+        grad_energy = grad_energy_atom.reshape(-1).to(torch.float64)
+    else:
+        grad_energy = _per_system_cotangent(
+            grad_energy_atom, batch_idx, num_systems, num_atoms
+        )
 
     sentinels = alloc_ewald_real_sentinels(wp_scalar, device)
     nbr = _neighbor_args(
@@ -642,7 +668,10 @@ def _double_backward_impl(
             )
         else:
             wp.launch(kernel, dim=[num_atoms], inputs=launch_inputs, device=device)
-    gge = _distribute_to_atoms(grad_grad_energy, batch_idx, num_systems, num_atoms)
+    if energy_layout == "system":
+        gge = grad_grad_energy
+    else:
+        gge = _distribute_to_atoms(grad_grad_energy, batch_idx, num_systems, num_atoms)
     return gge, grad_positions, grad_charges, grad_cell
 
 
@@ -913,6 +942,269 @@ def _real_double_backward_batch(
     )
 
 
+def _real_forward_system_single(
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    alpha: torch.Tensor,
+    idx_j: torch.Tensor,
+    neighbor_ptr: torch.Tensor,
+    neighbor_shifts: torch.Tensor,
+    neighbor_matrix: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor,
+    mask_value: int,
+    use_matrix: bool,
+    need_pos: bool,
+    need_charge: bool,
+    need_cell: bool,
+    need_virial: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    return _forward_impl(
+        positions,
+        charges,
+        cell,
+        alpha,
+        None,
+        idx_j,
+        neighbor_ptr,
+        neighbor_shifts,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        mask_value,
+        use_matrix,
+        need_pos,
+        need_charge,
+        need_cell,
+        need_virial,
+        "system",
+    )
+
+
+def _real_forward_system_batch(
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    alpha: torch.Tensor,
+    batch_idx: torch.Tensor,
+    idx_j: torch.Tensor,
+    neighbor_ptr: torch.Tensor,
+    neighbor_shifts: torch.Tensor,
+    neighbor_matrix: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor,
+    mask_value: int,
+    use_matrix: bool,
+    need_pos: bool,
+    need_charge: bool,
+    need_cell: bool,
+    need_virial: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    return _forward_impl(
+        positions,
+        charges,
+        cell,
+        alpha,
+        batch_idx,
+        idx_j,
+        neighbor_ptr,
+        neighbor_shifts,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        mask_value,
+        use_matrix,
+        need_pos,
+        need_charge,
+        need_cell,
+        need_virial,
+        "system",
+    )
+
+
+def _real_backward_system_single(
+    dEdR_cache: torch.Tensor,
+    dEdq_cache: torch.Tensor,
+    grad_energy: torch.Tensor,
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    alpha: torch.Tensor,
+    idx_j: torch.Tensor,
+    neighbor_ptr: torch.Tensor,
+    neighbor_shifts: torch.Tensor,
+    neighbor_matrix: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor,
+    mask_value: int,
+    use_matrix: bool,
+    need_pos: bool,
+    need_charge: bool,
+    need_cell: bool,
+    need_virial: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return _backward_impl(
+        dEdR_cache,
+        dEdq_cache,
+        grad_energy,
+        positions,
+        charges,
+        cell,
+        alpha,
+        None,
+        idx_j,
+        neighbor_ptr,
+        neighbor_shifts,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        mask_value,
+        use_matrix,
+        need_pos,
+        need_charge,
+        need_cell,
+        "system",
+    )
+
+
+def _real_backward_system_batch(
+    dEdR_cache: torch.Tensor,
+    dEdq_cache: torch.Tensor,
+    grad_energy: torch.Tensor,
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    alpha: torch.Tensor,
+    batch_idx: torch.Tensor,
+    idx_j: torch.Tensor,
+    neighbor_ptr: torch.Tensor,
+    neighbor_shifts: torch.Tensor,
+    neighbor_matrix: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor,
+    mask_value: int,
+    use_matrix: bool,
+    need_pos: bool,
+    need_charge: bool,
+    need_cell: bool,
+    need_virial: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return _backward_impl(
+        dEdR_cache,
+        dEdq_cache,
+        grad_energy,
+        positions,
+        charges,
+        cell,
+        alpha,
+        batch_idx,
+        idx_j,
+        neighbor_ptr,
+        neighbor_shifts,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        mask_value,
+        use_matrix,
+        need_pos,
+        need_charge,
+        need_cell,
+        "system",
+    )
+
+
+def _real_double_backward_system_single(
+    v_pos: torch.Tensor,
+    v_charge: torch.Tensor,
+    v_cell_zero: torch.Tensor,
+    dEdR_cache: torch.Tensor,
+    dEdq_cache: torch.Tensor,
+    grad_energy: torch.Tensor,
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    alpha: torch.Tensor,
+    idx_j: torch.Tensor,
+    neighbor_ptr: torch.Tensor,
+    neighbor_shifts: torch.Tensor,
+    neighbor_matrix: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor,
+    mask_value: int,
+    use_matrix: bool,
+    need_pos: bool,
+    need_charge: bool,
+    need_cell: bool,
+    need_virial: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    return _double_backward_impl(
+        v_pos,
+        v_charge,
+        v_cell_zero,
+        dEdR_cache,
+        dEdq_cache,
+        grad_energy,
+        positions,
+        charges,
+        cell,
+        alpha,
+        None,
+        idx_j,
+        neighbor_ptr,
+        neighbor_shifts,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        mask_value,
+        use_matrix,
+        need_pos,
+        need_charge,
+        need_cell,
+        "system",
+    )
+
+
+def _real_double_backward_system_batch(
+    v_pos: torch.Tensor,
+    v_charge: torch.Tensor,
+    v_cell_zero: torch.Tensor,
+    dEdR_cache: torch.Tensor,
+    dEdq_cache: torch.Tensor,
+    grad_energy: torch.Tensor,
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    alpha: torch.Tensor,
+    batch_idx: torch.Tensor,
+    idx_j: torch.Tensor,
+    neighbor_ptr: torch.Tensor,
+    neighbor_shifts: torch.Tensor,
+    neighbor_matrix: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor,
+    mask_value: int,
+    use_matrix: bool,
+    need_pos: bool,
+    need_charge: bool,
+    need_cell: bool,
+    need_virial: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    return _double_backward_impl(
+        v_pos,
+        v_charge,
+        v_cell_zero,
+        dEdR_cache,
+        dEdq_cache,
+        grad_energy,
+        positions,
+        charges,
+        cell,
+        alpha,
+        batch_idx,
+        idx_j,
+        neighbor_ptr,
+        neighbor_shifts,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        mask_value,
+        use_matrix,
+        need_pos,
+        need_charge,
+        need_cell,
+        "system",
+    )
+
+
 # ===========================================================================
 # Register the chains
 # ===========================================================================
@@ -965,6 +1257,19 @@ def _real_forward_fake(positions, *args):
     return energy, dEdR, dEdq, dedcell, virial
 
 
+def _real_system_forward_fake(positions, *args):
+    """System-energy forward fake with atom-major derivative caches."""
+    _energy, dEdR, dEdq, dedcell, virial = _real_forward_fake(positions, *args)
+    cell = args[1]
+    return (
+        positions.new_empty(cell.shape[0], dtype=torch.float64),
+        dEdR,
+        dEdq,
+        dedcell,
+        virial,
+    )
+
+
 def _real_backward_fake(dEdR_cache, dEdq_cache, grad_energy, positions, charges, *args):
     """Backward fake: ``(grad_positions, grad_charges, zero grad_cell)``."""
     n = positions.shape[0]
@@ -998,9 +1303,33 @@ def _real_double_backward_fake(
     )
 
 
+def _real_system_double_backward_fake(
+    v_pos,
+    v_charge,
+    v_cell_zero,
+    dEdR_cache,
+    dEdq_cache,
+    grad_energy,
+    positions,
+    charges,
+    *args,
+):
+    """System-energy double-backward fake preserving the system energy layout."""
+    _ = v_pos, v_charge, v_cell_zero, dEdR_cache, dEdq_cache, charges
+    cell = args[0]
+    n = positions.shape[0]
+    return (
+        grad_energy.new_empty(grad_energy.shape),
+        positions.new_empty(n, 3, dtype=positions.dtype),
+        positions.new_empty(n, dtype=torch.float64),
+        cell.new_empty(cell.shape),
+    )
+
+
 def register_ewald_real_ops() -> None:
     """Register the Ewald real-space Torch custom-op chain once."""
-    global _EWALD_REAL_OPS_REGISTERED, _LITERAL_CELL_GRAD, _REAL_BATCH, _REAL_SINGLE
+    global _EWALD_REAL_OPS_REGISTERED, _LITERAL_CELL_GRAD
+    global _REAL_BATCH, _REAL_SINGLE, _REAL_SYSTEM_BATCH, _REAL_SYSTEM_SINGLE
     if _EWALD_REAL_OPS_REGISTERED:
         return
 
@@ -1047,6 +1376,45 @@ def register_ewald_real_ops() -> None:
         batch_match=True,
     )
 
+    _REAL_SYSTEM_SINGLE = register_warp_op_chain(
+        name="nvalchemiops::ewald_real_system_energy_single",
+        forward=_real_forward_system_single,
+        backward=_real_backward_system_single,
+        double_backward=_real_double_backward_system_single,
+        forward_fake=_real_system_forward_fake,
+        backward_fake=_real_backward_fake,
+        double_backward_fake=_real_system_double_backward_fake,
+        forward_return_arity=5,
+        propagate_outputs=(0,),
+        save_forward_outputs=(1, 2),
+        diff_input_positions=(0, 1, 2),
+        n_forward_inputs=15,
+        backward_return_arity=3,
+        second_order_diff_positions=(2, 3, 4, 5),
+        n_backward_inputs=18,
+        double_backward_return_arity=4,
+    )
+
+    _REAL_SYSTEM_BATCH = register_warp_op_chain(
+        name="nvalchemiops::ewald_real_system_energy_batch",
+        forward=_real_forward_system_batch,
+        backward=_real_backward_system_batch,
+        double_backward=_real_double_backward_system_batch,
+        forward_fake=_real_system_forward_fake,
+        backward_fake=_real_backward_fake,
+        double_backward_fake=_real_system_double_backward_fake,
+        forward_return_arity=5,
+        propagate_outputs=(0,),
+        save_forward_outputs=(1, 2),
+        diff_input_positions=(0, 1, 2),
+        n_forward_inputs=16,
+        backward_return_arity=3,
+        second_order_diff_positions=(2, 3, 4, 5),
+        n_backward_inputs=19,
+        double_backward_return_arity=4,
+        batch_match=True,
+    )
+
     _LITERAL_CELL_GRAD = register_warp_op_chain(
         name="nvalchemiops::ewald_real_literal_cell_grad",
         forward=_literal_cell_grad_forward,
@@ -1076,6 +1444,22 @@ def ewald_real_energy_batch(*args, **kwargs):
     if _REAL_BATCH is None:
         raise RuntimeError("Ewald real batched op registration failed")
     return _REAL_BATCH["forward"](*args, **kwargs)
+
+
+def ewald_real_system_energy_single(*args, **kwargs):
+    """Call the registered single-system real-space system-energy op."""
+    register_ewald_real_ops()
+    if _REAL_SYSTEM_SINGLE is None:
+        raise RuntimeError("Ewald real system single-op registration failed")
+    return _REAL_SYSTEM_SINGLE["forward"](*args, **kwargs)
+
+
+def ewald_real_system_energy_batch(*args, **kwargs):
+    """Call the registered batched real-space system-energy op."""
+    register_ewald_real_ops()
+    if _REAL_SYSTEM_BATCH is None:
+        raise RuntimeError("Ewald real system batch-op registration failed")
+    return _REAL_SYSTEM_BATCH["forward"](*args, **kwargs)
 
 
 # ===========================================================================
@@ -1919,10 +2303,10 @@ class _RealCellGrad(torch.autograd.Function):
         neighbor_matrix,
         neighbor_matrix_shifts,
         mask_value,
+        energy_layout,
     ):
-        return torch.zeros(
-            positions.shape[0], dtype=torch.float64, device=positions.device
-        )
+        num_energy = positions.shape[0] if energy_layout == "atom" else cell.shape[0]
+        return torch.zeros(num_energy, dtype=torch.float64, device=positions.device)
 
     @staticmethod
     def setup_context(ctx, inputs, output):
@@ -1939,6 +2323,7 @@ class _RealCellGrad(torch.autograd.Function):
             neighbor_matrix,
             neighbor_matrix_shifts,
             mask_value,
+            energy_layout,
         ) = inputs
         ctx.save_for_backward(
             positions,
@@ -1954,9 +2339,10 @@ class _RealCellGrad(torch.autograd.Function):
         )
         ctx.batch_idx = batch_idx
         ctx.mask_value = mask_value
+        ctx.energy_layout = energy_layout
 
     @staticmethod
-    def backward(ctx, grad_energy_atom):
+    def backward(ctx, grad_energy):
         (
             positions,
             charges,
@@ -1970,6 +2356,12 @@ class _RealCellGrad(torch.autograd.Function):
             neighbor_matrix_shifts,
         ) = ctx.saved_tensors
         num_atoms = positions.shape[0]
+        if ctx.energy_layout == "system":
+            grad_energy_atom = _system_cotangent_to_atoms(
+                grad_energy, ctx.batch_idx, num_atoms
+            )
+        else:
+            grad_energy_atom = grad_energy
         if torch.is_grad_enabled():
             # Path 3: stress-loss double-backward. dE/dcell must stay differentiable
             # so the dE/dR dcell / dE/dq dcell / dE/dcell^2 cross terms flow. Use
@@ -2093,6 +2485,7 @@ class _RealCellGrad(torch.autograd.Function):
             None,
             None,
             None,
+            None,
         )
 
 
@@ -2110,6 +2503,7 @@ def real_space_cell_connect(
     neighbor_matrix: torch.Tensor,
     neighbor_matrix_shifts: torch.Tensor,
     mask_value: int,
+    energy_layout: str = "atom",
 ) -> torch.Tensor:
     """Add the value-zero cell-gradient connector to the kernel ``energy``.
 
@@ -2135,4 +2529,5 @@ def real_space_cell_connect(
         neighbor_matrix,
         neighbor_matrix_shifts,
         mask_value,
+        energy_layout,
     )

--- a/nvalchemiops/torch/interactions/electrostatics/_slab_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_slab_chain.py
@@ -24,13 +24,15 @@ import warp as wp
 
 from nvalchemiops.torch._warp_op_helpers import register_warp_op_chain
 from nvalchemiops.torch.interactions.electrostatics._util import (
-    _is_sync_free_uniform_cotangent,
+    _is_per_system_uniform_cotangent,
+    _reduce_atom_energy,
 )
 from nvalchemiops.torch.types import get_wp_dtype, get_wp_mat_dtype, get_wp_vec_dtype
 
 __all__ = ["register_slab_ops", "slab_correction_energy"]
 
 _SLAB_CHAIN: dict[str, object] | None = None
+_SLAB_SYSTEM_CHAIN: dict[str, object] | None = None
 _SLAB_OPS_REGISTERED = False
 
 
@@ -70,23 +72,7 @@ def _cotangent_per_system_uniform(
     num_systems: int,
 ) -> bool:
     """Whether the per-atom energy cotangent is constant within each system."""
-    if _is_sync_free_uniform_cotangent(grad_energy_atom):
-        return True
-    g = grad_energy_atom.reshape(-1)
-    if g.numel() == 0:
-        return True
-    if g.numel() == 1 or g.numel() == num_systems:
-        return True
-    if g.numel() != batch_idx.numel():
-        return False
-    if g.is_cuda:
-        return False
-    idx = batch_idx.to(device=g.device, dtype=torch.long)
-    g64 = g.to(torch.float64)
-    sys_max = torch.full(
-        (num_systems,), float("-inf"), dtype=torch.float64, device=g.device
-    ).scatter_reduce(0, idx, g64, reduce="amax", include_self=False)
-    return bool(torch.all(g64 == sys_max.index_select(0, idx)).item())
+    return _is_per_system_uniform_cotangent(grad_energy_atom, batch_idx, num_systems)
 
 
 def _distribute_system_values(
@@ -391,12 +377,13 @@ def _slab_weighted_double_backward_values(
     return grad_grad_energy, grad_positions, grad_charges, grad_cell
 
 
-def _slab_forward_launch(
+def _slab_forward_layout(
     positions: torch.Tensor,
     charges: torch.Tensor,
     cell: torch.Tensor,
     pbc: torch.Tensor,
     batch_idx: torch.Tensor,
+    system_energy: bool,
 ) -> torch.Tensor:
     from nvalchemiops.interactions.electrostatics.slab_kernels import (
         _launch_slab_correction,
@@ -405,7 +392,11 @@ def _slab_forward_launch(
     num_atoms = positions.shape[0]
     energies = torch.zeros(num_atoms, device=positions.device, dtype=torch.float64)
     if num_atoms == 0:
-        return energies
+        return (
+            _reduce_atom_energy(energies, batch_idx, cell.shape[0])
+            if system_energy
+            else energies
+        )
 
     mz, mz2, qtotal = _run_moments(positions, charges, cell, pbc, batch_idx)
     slab_axis, slab_normal, slab_volume, slab_height_sq = _run_geometry(
@@ -434,17 +425,29 @@ def _slab_forward_launch(
             wp_dtype=wp_dtype,
             device=device,
         )
+    if system_energy:
+        return _reduce_atom_energy(energies, batch_idx, cell.shape[0])
     return energies
 
 
-def _slab_backward_launch(
+def _slab_backward_layout(
     grad_energy: torch.Tensor,
     positions: torch.Tensor,
     charges: torch.Tensor,
     cell: torch.Tensor,
     pbc: torch.Tensor,
     batch_idx: torch.Tensor,
+    system_energy: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if system_energy:
+        return _slab_backward_values(
+            positions,
+            charges,
+            cell,
+            pbc,
+            batch_idx,
+            grad_energy.reshape(-1).to(torch.float64),
+        )
     if not _cotangent_per_system_uniform(grad_energy, batch_idx, cell.shape[0]):
         return _slab_weighted_backward_values(
             positions,
@@ -458,7 +461,7 @@ def _slab_backward_launch(
     return _slab_backward_values(positions, charges, cell, pbc, batch_idx, grad_system)
 
 
-def _slab_double_backward_launch(
+def _slab_double_backward_layout(
     h_pos: torch.Tensor,
     h_charge: torch.Tensor,
     h_cell: torch.Tensor,
@@ -468,8 +471,11 @@ def _slab_double_backward_launch(
     cell: torch.Tensor,
     pbc: torch.Tensor,
     batch_idx: torch.Tensor,
+    system_energy: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    if not _cotangent_per_system_uniform(grad_energy, batch_idx, cell.shape[0]):
+    if not system_energy and not _cotangent_per_system_uniform(
+        grad_energy, batch_idx, cell.shape[0]
+    ):
         return _slab_weighted_double_backward_values(
             h_pos,
             h_charge,
@@ -484,7 +490,11 @@ def _slab_double_backward_launch(
 
     num_atoms = positions.shape[0]
     num_systems = cell.shape[0]
-    grad_system = _per_system_cotangent(grad_energy, batch_idx, num_systems)
+    grad_system = (
+        grad_energy.reshape(-1).to(torch.float64)
+        if system_energy
+        else _per_system_cotangent(grad_energy, batch_idx, num_systems)
+    )
     ones_system = torch.ones(num_systems, device=positions.device, dtype=torch.float64)
 
     base_pos, base_q, base_cell = _slab_backward_values(
@@ -502,7 +512,11 @@ def _slab_double_backward_launch(
     system_dot = system_dot + (
         base_cell.to(torch.float64) * h_cell.to(torch.float64)
     ).sum(dim=(1, 2))
-    grad_grad_energy = _distribute_system_values(system_dot, batch_idx, num_atoms)
+    grad_grad_energy = (
+        system_dot
+        if system_energy
+        else _distribute_system_values(system_dot, batch_idx, num_atoms)
+    )
 
     grad_positions = torch.zeros_like(positions)
     grad_charges = torch.zeros(num_atoms, device=positions.device, dtype=torch.float64)
@@ -566,26 +580,29 @@ def _slab_double_backward_launch(
     return grad_grad_energy, grad_positions, grad_charges, grad_cell
 
 
-def _slab_forward_fake(
+def _slab_forward_fake_layout(
     positions: torch.Tensor,
     charges: torch.Tensor,
     cell: torch.Tensor,
     pbc: torch.Tensor,
     batch_idx: torch.Tensor,
+    system_energy: bool,
 ) -> torch.Tensor:
-    del charges, cell, pbc, batch_idx
-    return torch.empty(positions.shape[0], device=positions.device, dtype=torch.float64)
+    del charges, pbc, batch_idx
+    size = cell.shape[0] if system_energy else positions.shape[0]
+    return torch.empty(size, device=positions.device, dtype=torch.float64)
 
 
-def _slab_backward_fake(
+def _slab_backward_fake_layout(
     grad_energy: torch.Tensor,
     positions: torch.Tensor,
     charges: torch.Tensor,
     cell: torch.Tensor,
     pbc: torch.Tensor,
     batch_idx: torch.Tensor,
+    system_energy: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    del grad_energy, charges, pbc, batch_idx
+    del grad_energy, charges, pbc, batch_idx, system_energy
     return (
         torch.empty_like(positions),
         torch.empty(positions.shape[0], device=positions.device, dtype=torch.float64),
@@ -593,7 +610,83 @@ def _slab_backward_fake(
     )
 
 
-def _slab_double_backward_fake(
+def _slab_double_backward_fake_layout(
+    h_pos: torch.Tensor,
+    h_charge: torch.Tensor,
+    h_cell: torch.Tensor,
+    grad_energy: torch.Tensor,
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    pbc: torch.Tensor,
+    batch_idx: torch.Tensor,
+    system_energy: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    del h_pos, h_charge, h_cell, grad_energy, charges, pbc, batch_idx
+    energy_size = cell.shape[0] if system_energy else positions.shape[0]
+    return (
+        torch.empty(energy_size, device=positions.device, dtype=torch.float64),
+        torch.empty_like(positions),
+        torch.empty(positions.shape[0], device=positions.device, dtype=torch.float64),
+        torch.empty_like(cell),
+    )
+
+
+def _slab_forward_launch(
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    pbc: torch.Tensor,
+    batch_idx: torch.Tensor,
+) -> torch.Tensor:
+    """Run the established atom-major five-input forward op."""
+    return _slab_forward_layout(
+        positions, charges, cell, pbc, batch_idx, system_energy=False
+    )
+
+
+def _slab_system_forward_launch(
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    pbc: torch.Tensor,
+    batch_idx: torch.Tensor,
+) -> torch.Tensor:
+    """Run the internal system-major five-input forward op."""
+    return _slab_forward_layout(
+        positions, charges, cell, pbc, batch_idx, system_energy=True
+    )
+
+
+def _slab_backward_launch(
+    grad_energy: torch.Tensor,
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    pbc: torch.Tensor,
+    batch_idx: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run the established atom-major backward op."""
+    return _slab_backward_layout(
+        grad_energy, positions, charges, cell, pbc, batch_idx, system_energy=False
+    )
+
+
+def _slab_system_backward_launch(
+    grad_energy: torch.Tensor,
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    pbc: torch.Tensor,
+    batch_idx: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run the internal system-major backward op."""
+    return _slab_backward_layout(
+        grad_energy, positions, charges, cell, pbc, batch_idx, system_energy=True
+    )
+
+
+def _slab_double_backward_launch(
     h_pos: torch.Tensor,
     h_charge: torch.Tensor,
     h_cell: torch.Tensor,
@@ -604,18 +697,130 @@ def _slab_double_backward_fake(
     pbc: torch.Tensor,
     batch_idx: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    del h_pos, h_charge, h_cell, grad_energy, charges, pbc, batch_idx
-    return (
-        torch.empty(positions.shape[0], device=positions.device, dtype=torch.float64),
-        torch.empty_like(positions),
-        torch.empty(positions.shape[0], device=positions.device, dtype=torch.float64),
-        torch.empty_like(cell),
+    """Run the established atom-major double-backward op."""
+    return _slab_double_backward_layout(
+        h_pos,
+        h_charge,
+        h_cell,
+        grad_energy,
+        positions,
+        charges,
+        cell,
+        pbc,
+        batch_idx,
+        system_energy=False,
+    )
+
+
+def _slab_system_double_backward_launch(
+    h_pos: torch.Tensor,
+    h_charge: torch.Tensor,
+    h_cell: torch.Tensor,
+    grad_energy: torch.Tensor,
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    pbc: torch.Tensor,
+    batch_idx: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run the internal system-major double-backward op."""
+    return _slab_double_backward_layout(
+        h_pos,
+        h_charge,
+        h_cell,
+        grad_energy,
+        positions,
+        charges,
+        cell,
+        pbc,
+        batch_idx,
+        system_energy=True,
+    )
+
+
+def _slab_forward_fake(positions, charges, cell, pbc, batch_idx):
+    """Fake atom-major forward output."""
+    return _slab_forward_fake_layout(
+        positions, charges, cell, pbc, batch_idx, system_energy=False
+    )
+
+
+def _slab_system_forward_fake(positions, charges, cell, pbc, batch_idx):
+    """Fake system-major forward output."""
+    return _slab_forward_fake_layout(
+        positions, charges, cell, pbc, batch_idx, system_energy=True
+    )
+
+
+def _slab_backward_fake(grad_energy, positions, charges, cell, pbc, batch_idx):
+    """Fake atom-major backward outputs."""
+    return _slab_backward_fake_layout(
+        grad_energy, positions, charges, cell, pbc, batch_idx, system_energy=False
+    )
+
+
+def _slab_system_backward_fake(grad_energy, positions, charges, cell, pbc, batch_idx):
+    """Fake system-major backward outputs."""
+    return _slab_backward_fake_layout(
+        grad_energy, positions, charges, cell, pbc, batch_idx, system_energy=True
+    )
+
+
+def _slab_double_backward_fake(
+    h_pos,
+    h_charge,
+    h_cell,
+    grad_energy,
+    positions,
+    charges,
+    cell,
+    pbc,
+    batch_idx,
+):
+    """Fake atom-major double-backward outputs."""
+    return _slab_double_backward_fake_layout(
+        h_pos,
+        h_charge,
+        h_cell,
+        grad_energy,
+        positions,
+        charges,
+        cell,
+        pbc,
+        batch_idx,
+        system_energy=False,
+    )
+
+
+def _slab_system_double_backward_fake(
+    h_pos,
+    h_charge,
+    h_cell,
+    grad_energy,
+    positions,
+    charges,
+    cell,
+    pbc,
+    batch_idx,
+):
+    """Fake system-major double-backward outputs."""
+    return _slab_double_backward_fake_layout(
+        h_pos,
+        h_charge,
+        h_cell,
+        grad_energy,
+        positions,
+        charges,
+        cell,
+        pbc,
+        batch_idx,
+        system_energy=True,
     )
 
 
 def register_slab_ops() -> None:
     """Register the slab-correction Torch custom-op chain once."""
-    global _SLAB_CHAIN, _SLAB_OPS_REGISTERED
+    global _SLAB_CHAIN, _SLAB_OPS_REGISTERED, _SLAB_SYSTEM_CHAIN
     if _SLAB_OPS_REGISTERED:
         return
 
@@ -633,12 +838,34 @@ def register_slab_ops() -> None:
         double_backward_fake=_slab_double_backward_fake,
         double_backward_return_arity=4,
     )
+    _SLAB_SYSTEM_CHAIN = register_warp_op_chain(
+        name="nvalchemiops::slab_correction_system_energy",
+        forward=_slab_system_forward_launch,
+        backward=_slab_system_backward_launch,
+        double_backward=_slab_system_double_backward_launch,
+        diff_input_positions=(0, 1, 2),
+        n_forward_inputs=5,
+        second_order_diff_positions=(0, 1, 2, 3),
+        n_backward_inputs=6,
+        forward_fake=_slab_system_forward_fake,
+        backward_fake=_slab_system_backward_fake,
+        double_backward_fake=_slab_system_double_backward_fake,
+        double_backward_return_arity=4,
+    )
     _SLAB_OPS_REGISTERED = True
 
 
-def slab_correction_energy(*args, **kwargs):
-    """Call the registered slab-correction energy op."""
+def slab_correction_energy(
+    positions,
+    charges,
+    cell,
+    pbc,
+    batch_idx,
+    system_energy=False,
+):
+    """Call the atom- or system-layout registered slab facade."""
     register_slab_ops()
-    if _SLAB_CHAIN is None:
+    chain = _SLAB_SYSTEM_CHAIN if system_energy else _SLAB_CHAIN
+    if chain is None:
         raise RuntimeError("Slab correction op registration failed")
-    return _SLAB_CHAIN["forward"](*args, **kwargs)
+    return chain["forward"](positions, charges, cell, pbc, batch_idx)

--- a/nvalchemiops/torch/interactions/electrostatics/_util.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_util.py
@@ -30,6 +30,8 @@ __all__ = [
     "_InjectCachedEvalGrad",
     "_InjectCachedEvalGradWithFallback",
     "_InjectChargeGrad",
+    "_reduce_atom_energy",
+    "_validate_energy_reduction",
     "_build_electrostatic_result",
     "_combine_electrostatic_outputs",
     "_compiled_direct_output_deprecation_signal",
@@ -37,6 +39,46 @@ __all__ = [
     "_sum_charge_gradients",
     "_unpack_electrostatic_outputs",
 ]
+
+
+def _validate_energy_reduction(energy_reduction: str) -> str:
+    """Validate and return the public electrostatics energy layout."""
+    if energy_reduction not in {"atom", "system"}:
+        raise ValueError(
+            "energy_reduction must be either 'atom' or 'system', "
+            f"got {energy_reduction!r}"
+        )
+    return energy_reduction
+
+
+def _reduce_atom_energy(
+    energy: torch.Tensor,
+    batch_idx: torch.Tensor | None,
+    num_systems: int,
+) -> torch.Tensor:
+    """Sum an atom-major energy tensor into an explicit system-major layout."""
+    flat = energy.reshape(-1)
+    result = flat.new_zeros((num_systems,))
+    if flat.numel() == 0 or num_systems == 0:
+        return result
+    if batch_idx is None:
+        result[0] = flat.sum()
+        return result
+    return result.index_add(0, batch_idx.to(device=flat.device, dtype=torch.long), flat)
+
+
+def _system_cotangent_to_atoms(
+    grad_system: torch.Tensor,
+    batch_idx: torch.Tensor | None,
+    num_atoms: int,
+) -> torch.Tensor:
+    """Broadcast an explicit system cotangent to atom-major layout."""
+    grad = grad_system.reshape(-1)
+    if num_atoms == 0:
+        return grad.new_zeros((0,))
+    if batch_idx is None:
+        return grad[0].expand(num_atoms)
+    return grad.index_select(0, batch_idx.to(device=grad.device, dtype=torch.long))
 
 
 def _sum_charge_gradients(
@@ -275,39 +317,6 @@ def _component_direct_output_deprecation_msg(fn: str, flags: tuple[str, ...]) ->
     )
 
 
-def _num_atoms_from_state(
-    pos_grad_state: torch.Tensor | None,
-    charge_grad_state: torch.Tensor | None,
-    batch_idx: torch.Tensor | None,
-) -> int:
-    """Infer the atom count for per-atom cotangent broadcasting."""
-    if charge_grad_state is not None:
-        return int(charge_grad_state.shape[0])
-    if pos_grad_state is not None:
-        return int(pos_grad_state.shape[0])
-    if batch_idx is not None:
-        return int(batch_idx.shape[0])
-    return 0
-
-
-def _num_systems_from_state(
-    grad_energy: torch.Tensor,
-    cell_grad_state: torch.Tensor | None,
-    batch_idx: torch.Tensor | None,
-    num_atoms: int,
-) -> int:
-    """Infer the system count for per-system cotangent reduction."""
-    if cell_grad_state is not None:
-        return int(cell_grad_state.shape[0])
-    if batch_idx is None:
-        return 1
-    if grad_energy.numel() != num_atoms:
-        return int(grad_energy.numel())
-    if batch_idx.numel() == 0:
-        return 0
-    return int(batch_idx.max().item()) + 1
-
-
 def _energy_cotangents(
     grad_energy: torch.Tensor,
     batch_idx: torch.Tensor | None,
@@ -355,7 +364,9 @@ def _is_uniform_cotangent(grad_energy: torch.Tensor) -> bool:
     if _is_sync_free_uniform_cotangent(grad_energy):
         return True
     grad = grad_energy.reshape(-1)
-    if grad.is_cuda:
+    if grad.numel() == 0:
+        return True
+    if not _can_inspect_cotangent_values(grad):
         return False
     return bool(torch.all(grad == grad[0]).item())
 
@@ -368,6 +379,18 @@ def _is_sync_free_uniform_cotangent(grad_energy: torch.Tensor) -> bool:
         size <= 1 or stride == 0
         for size, stride in zip(grad_energy.shape, grad_energy.stride(), strict=True)
     )
+
+
+def _can_inspect_cotangent_values(grad_energy: torch.Tensor) -> bool:
+    """Whether eager code may perform an exact device-value uniformity check."""
+    if not grad_energy.is_cuda:
+        return True
+    if torch.compiler.is_compiling():
+        return False
+    try:
+        return not torch.cuda.is_current_stream_capturing()
+    except RuntimeError:
+        return False
 
 
 def _is_per_system_uniform_cotangent(
@@ -384,7 +407,7 @@ def _is_per_system_uniform_cotangent(
         return True
     if grad.numel() == 1 or grad.numel() == num_systems:
         return True
-    if grad.is_cuda:
+    if not _can_inspect_cotangent_values(grad):
         return False
     if batch_idx is None:
         return bool(torch.all(grad == grad[0]).item())
@@ -424,48 +447,69 @@ class _InjectCachedEvalGrad(torch.autograd.Function):
         charge_grad_state,
         cell_grad_state,
         batch_idx,
+        energy_reduction="atom",
+        num_systems=None,
     ):
-        """Return energy unchanged."""
+        """Return energy in the requested public layout."""
+        if energy_reduction == "system":
+            count = int(cell.shape[0]) if num_systems is None else int(num_systems)
+            return _reduce_atom_energy(energy, batch_idx, count)
         return energy
 
     @staticmethod
     def setup_context(ctx, inputs, output):
         """Save detached direct-derivative caches for the eval branch."""
+        base_inputs = inputs[:8]
         (
             _energy,
-            _positions,
+            positions,
             _charges,
             cell,
             pos_grad_state,
             charge_grad_state,
             cell_grad_state,
             batch_idx,
-        ) = inputs
+        ) = base_inputs
         ctx.save_for_backward(pos_grad_state, charge_grad_state, cell_grad_state)
         ctx.batch_idx = batch_idx
-        ctx.num_systems = int(cell.shape[0]) if cell.dim() == 3 else 1
+        ctx.num_atoms = int(positions.shape[0])
+        ctx.energy_reduction = inputs[8] if len(inputs) > 8 else "atom"
+        ctx.num_systems = (
+            int(inputs[9])
+            if len(inputs) > 9 and inputs[9] is not None
+            else (int(cell.shape[0]) if cell.dim() == 3 else 1)
+        )
+        ctx.num_inputs = len(inputs)
 
     @staticmethod
     def backward(ctx, grad_energy):
         """Use cached derivatives for uniform eval, else pass to eager energy."""
         pos_grad_state, charge_grad_state, cell_grad_state = ctx.saved_tensors
+        num_atoms = ctx.num_atoms
 
-        if torch.is_grad_enabled() or not _is_uniform_cotangent(grad_energy):
-            return grad_energy, None, None, None, None, None, None, None
+        if ctx.energy_reduction == "system":
+            grad_system = grad_energy.reshape(-1)
+            atom_grad = _system_cotangent_to_atoms(
+                grad_system, ctx.batch_idx, num_atoms
+            )
+            if torch.is_grad_enabled():
+                result = (atom_grad, None, None, None, None, None, None, None)
+                return result + (None,) * (ctx.num_inputs - len(result))
+        elif torch.is_grad_enabled() or not _is_per_system_uniform_cotangent(
+            grad_energy, ctx.batch_idx, ctx.num_systems
+        ):
+            result = (grad_energy, None, None, None, None, None, None, None)
+            return result + (None,) * (ctx.num_inputs - len(result))
 
-        num_atoms = _num_atoms_from_state(
-            pos_grad_state, charge_grad_state, ctx.batch_idx
-        )
-        if grad_energy.numel() != 0 and _is_sync_free_uniform_cotangent(grad_energy):
+        if ctx.energy_reduction == "system":
+            pass
+        elif grad_energy.numel() != 0 and _is_sync_free_uniform_cotangent(grad_energy):
             scale = grad_energy.reshape(-1)[0]
             atom_grad = scale.expand(num_atoms)
             grad_system = scale.expand(ctx.num_systems)
         else:
-            num_systems = _num_systems_from_state(
-                grad_energy, cell_grad_state, ctx.batch_idx, num_atoms
-            )
             grad_system, atom_grad = _energy_cotangents(
-                grad_energy, ctx.batch_idx, num_atoms, num_systems
+                grad_energy, ctx.batch_idx, num_atoms, ctx.num_systems
             )
 
         grad_positions = None
@@ -480,7 +524,17 @@ class _InjectCachedEvalGrad(torch.autograd.Function):
         if cell_grad_state is not None:
             grad_cell = cell_grad_state * grad_system.view(-1, 1, 1)
 
-        return None, grad_positions, grad_charges, grad_cell, None, None, None, None
+        result = (
+            None,
+            grad_positions,
+            grad_charges,
+            grad_cell,
+            None,
+            None,
+            None,
+            None,
+        )
+        return result + (None,) * (ctx.num_inputs - len(result))
 
 
 class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
@@ -503,13 +557,21 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
         cell_grad_state,
         batch_idx,
         fallback_fn,
+        energy_reduction="atom",
+        num_systems=None,
+        force_fallback=False,
+        fallback_returns_system=False,
     ):
-        """Return energy unchanged."""
+        """Return energy in the requested public layout."""
+        if energy_reduction == "system":
+            count = int(cell.shape[0]) if num_systems is None else int(num_systems)
+            return _reduce_atom_energy(energy, batch_idx, count)
         return energy
 
     @staticmethod
     def setup_context(ctx, inputs, output):
         """Save inputs, caches, and the fallback callable."""
+        base_inputs = inputs[:9]
         (
             _energy,
             positions,
@@ -520,7 +582,7 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
             cell_grad_state,
             batch_idx,
             fallback_fn,
-        ) = inputs
+        ) = base_inputs
         ctx.save_for_backward(
             positions,
             charges,
@@ -531,7 +593,16 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
         )
         ctx.batch_idx = batch_idx
         ctx.fallback_fn = fallback_fn
-        ctx.num_systems = int(cell.shape[0]) if cell.dim() == 3 else 1
+        ctx.num_atoms = int(positions.shape[0])
+        ctx.energy_reduction = inputs[9] if len(inputs) > 9 else "atom"
+        ctx.num_systems = (
+            int(inputs[10])
+            if len(inputs) > 10 and inputs[10] is not None
+            else (int(cell.shape[0]) if cell.dim() == 3 else 1)
+        )
+        ctx.force_fallback = bool(inputs[11]) if len(inputs) > 11 else False
+        ctx.fallback_returns_system = bool(inputs[12]) if len(inputs) > 12 else False
+        ctx.num_inputs = len(inputs)
 
     @staticmethod
     def backward(ctx, grad_energy):
@@ -545,8 +616,28 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
             charge_grad_state,
             cell_grad_state,
         ) = ctx.saved_tensors
+        num_atoms = ctx.num_atoms
 
-        if create_graph or not _is_uniform_cotangent(grad_energy):
+        def _pad(result):
+            return result + (None,) * (ctx.num_inputs - len(result))
+
+        def _public_fallback_energy(recomputed):
+            if ctx.energy_reduction == "system" and not ctx.fallback_returns_system:
+                return _reduce_atom_energy(recomputed, ctx.batch_idx, ctx.num_systems)
+            return recomputed
+
+        if ctx.energy_reduction == "system":
+            grad_system = grad_energy.reshape(-1)
+            atom_grad = _system_cotangent_to_atoms(
+                grad_system, ctx.batch_idx, num_atoms
+            )
+            use_fallback = create_graph or ctx.force_fallback
+        else:
+            use_fallback = create_graph or not _is_per_system_uniform_cotangent(
+                grad_energy, ctx.batch_idx, ctx.num_systems
+            )
+
+        if use_fallback:
             # q(R) routing:
             # - create_graph: return connected position/cell/alpha gradients only; do not
             #   also return grad_charges from the same connected recompute.
@@ -564,7 +655,9 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
                             diff_inputs.append(tensor)
                             diff_names.append(name)
                     with torch.enable_grad():
-                        recomputed = ctx.fallback_fn(positions, charges, cell)
+                        recomputed = _public_fallback_energy(
+                            ctx.fallback_fn(positions, charges, cell)
+                        )
                         if diff_inputs:
                             diff_grads = torch.autograd.grad(
                                 recomputed,
@@ -576,16 +669,18 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
                             grad_map = dict(zip(diff_names, diff_grads, strict=True))
                         else:
                             grad_map = {}
-                    return (
-                        None,
-                        grad_map.get("positions"),
-                        None,
-                        grad_map.get("cell"),
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
+                    return _pad(
+                        (
+                            None,
+                            grad_map.get("positions"),
+                            None,
+                            grad_map.get("cell"),
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
                     )
 
                 partial_inputs = []
@@ -600,10 +695,12 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
                 with torch.enable_grad():
                     partial_map = {}
                     if partial_inputs:
-                        recomputed_partial = ctx.fallback_fn(
-                            positions,
-                            charges.detach(),
-                            cell,
+                        recomputed_partial = _public_fallback_energy(
+                            ctx.fallback_fn(
+                                positions,
+                                charges.detach(),
+                                cell,
+                            )
                         )
                         partial_grads = torch.autograd.grad(
                             recomputed_partial,
@@ -618,7 +715,9 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
 
                     grad_charges = None
                     if charges.requires_grad:
-                        recomputed_charge = ctx.fallback_fn(positions, charges, cell)
+                        recomputed_charge = _public_fallback_energy(
+                            ctx.fallback_fn(positions, charges, cell)
+                        )
                         (grad_charges,) = torch.autograd.grad(
                             recomputed_charge,
                             charges,
@@ -626,19 +725,23 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
                             allow_unused=True,
                             create_graph=create_graph,
                         )
-                return (
-                    None,
-                    partial_map.get("positions"),
-                    grad_charges,
-                    partial_map.get("cell"),
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
+                return _pad(
+                    (
+                        None,
+                        partial_map.get("positions"),
+                        grad_charges,
+                        partial_map.get("cell"),
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    )
                 )
             with torch.enable_grad():
-                recomputed = ctx.fallback_fn(positions, charges, cell)
+                recomputed = _public_fallback_energy(
+                    ctx.fallback_fn(positions, charges, cell)
+                )
                 diff_inputs = []
                 diff_names = []
                 for name, tensor in (
@@ -660,31 +763,29 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
                         create_graph=create_graph,
                     )
                     grad_map = dict(zip(diff_names, diff_grads, strict=True))
-            return (
-                None,
-                grad_map.get("positions"),
-                grad_map.get("charges"),
-                grad_map.get("cell"),
-                None,
-                None,
-                None,
-                None,
-                None,
+            return _pad(
+                (
+                    None,
+                    grad_map.get("positions"),
+                    grad_map.get("charges"),
+                    grad_map.get("cell"),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
             )
 
-        num_atoms = _num_atoms_from_state(
-            pos_grad_state, charge_grad_state, ctx.batch_idx
-        )
-        if grad_energy.numel() != 0 and _is_sync_free_uniform_cotangent(grad_energy):
+        if ctx.energy_reduction == "system":
+            pass
+        elif grad_energy.numel() != 0 and _is_sync_free_uniform_cotangent(grad_energy):
             scale = grad_energy.reshape(-1)[0]
             atom_grad = scale.expand(num_atoms)
             grad_system = scale.expand(ctx.num_systems)
         else:
-            num_systems = _num_systems_from_state(
-                grad_energy, cell_grad_state, ctx.batch_idx, num_atoms
-            )
             grad_system, atom_grad = _energy_cotangents(
-                grad_energy, ctx.batch_idx, num_atoms, num_systems
+                grad_energy, ctx.batch_idx, num_atoms, ctx.num_systems
             )
 
         grad_positions = None
@@ -699,21 +800,23 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
         if cell_grad_state is not None:
             grad_cell = cell_grad_state * grad_system.view(-1, 1, 1)
 
-        return (
-            None,
-            grad_positions,
-            grad_charges,
-            grad_cell,
-            None,
-            None,
-            None,
-            None,
-            None,
+        return _pad(
+            (
+                None,
+                grad_positions,
+                grad_charges,
+                grad_cell,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
         )
 
 
 class _InjectChargeGrad(torch.autograd.Function):
-    """Backward-compatible 4-argument charge-gradient entry point.
+    """Attach cached charge derivatives with an explicit energy layout.
 
     Uniform/per-system-uniform cotangents keep the historical direct-injection
     path. Non-uniform per-atom cotangents pass through to the input energy graph
@@ -733,16 +836,43 @@ class _InjectChargeGrad(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(energy, charges, charge_grad, batch_idx):
-        """Return energy unchanged."""
+    def forward(
+        energy,
+        charges,
+        charge_grad,
+        batch_idx,
+        energy_reduction="atom",
+        num_systems=None,
+        energy_is_system=False,
+    ):
+        """Return energy in the requested public layout."""
+        if energy_reduction == "system" and not energy_is_system:
+            count = 1 if num_systems is None else int(num_systems)
+            return _reduce_atom_energy(energy, batch_idx, count)
         return energy
 
     @staticmethod
     def setup_context(ctx, inputs, output):
         """Save detached charge-gradient state for backward."""
-        _energy, _charges, charge_grad, batch_idx = inputs
+        _energy, _charges, charge_grad, batch_idx = inputs[:4]
         ctx.save_for_backward(charge_grad)
         ctx.batch_idx = batch_idx
+        ctx.energy_reduction = inputs[4] if len(inputs) > 4 else "atom"
+        if len(inputs) > 5 and inputs[5] is not None:
+            ctx.num_systems = int(inputs[5])
+        elif inputs[5] is None and batch_idx is not None and batch_idx.numel() > 0:
+            # Legacy private 4-argument calls predate the explicit layout contract.
+            ctx.num_systems = int(batch_idx.max().item()) + 1
+        elif batch_idx is not None and _energy.numel() != charge_grad.shape[0]:
+            ctx.num_systems = int(_energy.numel())
+        else:
+            ctx.num_systems = 1
+        ctx.energy_is_system = (
+            bool(inputs[6])
+            if len(inputs) > 6
+            else bool(_energy.numel() != charge_grad.shape[0])
+        )
+        ctx.num_inputs = len(inputs)
 
     @staticmethod
     def backward(ctx, grad_energy):
@@ -750,24 +880,32 @@ class _InjectChargeGrad(torch.autograd.Function):
         (charge_grad_state,) = ctx.saved_tensors
         num_atoms = int(charge_grad_state.shape[0])
 
-        if torch.is_grad_enabled():
-            return grad_energy, None, None, None
+        if ctx.energy_reduction == "system":
+            grad_system = grad_energy.reshape(-1)
+            atom_grad = _system_cotangent_to_atoms(
+                grad_system, ctx.batch_idx, num_atoms
+            )
+            input_grad = grad_system if ctx.energy_is_system else atom_grad
+        else:
+            input_grad = grad_energy
 
-        if grad_energy.numel() != 0 and _is_sync_free_uniform_cotangent(grad_energy):
+        if torch.is_grad_enabled():
+            result = (input_grad, None, None, None)
+            return result + (None,) * (ctx.num_inputs - len(result))
+
+        if ctx.energy_reduction == "system":
+            pass
+        elif grad_energy.numel() != 0 and _is_sync_free_uniform_cotangent(grad_energy):
             atom_grad = grad_energy.reshape(-1)[0].expand(num_atoms)
         else:
-            grad = grad_energy.reshape(-1)
-            if grad.is_cuda and grad.numel() == num_atoms:
-                return grad_energy, None, None, None
-            num_systems = _num_systems_from_state(
-                grad_energy, None, ctx.batch_idx, num_atoms
-            )
             if not _is_per_system_uniform_cotangent(
-                grad_energy, ctx.batch_idx, num_systems
+                grad_energy, ctx.batch_idx, ctx.num_systems
             ):
-                return grad_energy, None, None, None
+                result = (grad_energy, None, None, None)
+                return result + (None,) * (ctx.num_inputs - len(result))
             _grad_system, atom_grad = _energy_cotangents(
-                grad_energy, ctx.batch_idx, num_atoms, num_systems
+                grad_energy, ctx.batch_idx, num_atoms, ctx.num_systems
             )
         grad_charges = charge_grad_state * atom_grad
-        return None, grad_charges, None, None
+        result = (None, grad_charges, None, None)
+        return result + (None,) * (ctx.num_inputs - len(result))

--- a/nvalchemiops/torch/interactions/electrostatics/_util.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_util.py
@@ -23,7 +23,11 @@ This module owns the private autograd connector contracts:
 
 from __future__ import annotations
 
+from typing import Literal
+
 import torch
+
+_CotangentLayout = Literal["atom", "system"]
 
 __all__ = [
     "_has_potentially_geometry_dependent_charges",
@@ -322,40 +326,40 @@ def _energy_cotangents(
     batch_idx: torch.Tensor | None,
     num_atoms: int,
     num_systems: int,
+    layout: _CotangentLayout,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Return per-system and per-atom cotangents for injected derivatives."""
+    """Return explicit per-system and per-atom cotangents for injected derivatives."""
     grad = grad_energy.reshape(-1)
-    if batch_idx is None:
-        if num_systems > 1 and grad.numel() == num_systems:
-            grad_system = grad
-        elif num_systems > 1 and grad.numel() == 1:
-            grad_system = grad.expand(num_systems)
-        elif grad.numel() == num_atoms and num_atoms > 0:
-            grad_system = grad.mean().reshape(1)
-        elif grad.numel() == 0:
-            grad_system = grad.new_zeros((1,))
-        else:
-            grad_system = grad.reshape(-1)[:1]
-        atom_grad = grad_system[0].expand(num_atoms)
-        return grad_system, atom_grad
+    if layout == "atom":
+        if grad.numel() != num_atoms:
+            raise RuntimeError(
+                "Atom-major energy cotangent must have "
+                f"{num_atoms} values, got {grad.numel()}"
+            )
+        atom_grad = grad
+        if batch_idx is None:
+            grad_system = (
+                grad.mean().reshape(1) if num_atoms > 0 else grad.new_zeros((1,))
+            )
+            return grad_system, atom_grad
 
-    bidx = batch_idx
-    if grad.numel() == num_systems:
-        grad_system = grad
-    elif grad.numel() == num_atoms:
+        bidx = batch_idx.to(device=grad.device, dtype=torch.long)
         sums = grad.new_zeros((num_systems,))
         sums = sums.index_add(0, bidx, grad)
         counts = grad.new_zeros((num_systems,))
         counts = counts.index_add(0, bidx, torch.ones_like(grad))
         grad_system = sums / counts.clamp_min(1)
-    elif grad.numel() == 1:
-        grad_system = grad.expand(num_systems)
-    else:
+        return grad_system, atom_grad
+
+    if layout != "system":
+        raise ValueError(f"Unsupported energy cotangent layout {layout!r}")
+    if grad.numel() != num_systems:
         raise RuntimeError(
-            "Energy cotangent must be per-system, per-atom, or scalar for "
-            "_InjectChargeGrad backward"
+            "System-major energy cotangent must have "
+            f"{num_systems} values, got {grad.numel()}"
         )
-    atom_grad = grad_system.index_select(0, bidx)
+    grad_system = grad
+    atom_grad = _system_cotangent_to_atoms(grad_system, batch_idx, num_atoms)
     return grad_system, atom_grad
 
 
@@ -399,13 +403,12 @@ def _is_per_system_uniform_cotangent(
     num_systems: int,
 ) -> bool:
     """Return whether an atom-major cotangent is uniform within each system."""
-    if _is_sync_free_uniform_cotangent(grad_energy):
-        return True
-
     grad = grad_energy.reshape(-1)
     if grad.numel() == 0:
         return True
-    if grad.numel() == 1 or grad.numel() == num_systems:
+    if batch_idx is not None and grad.numel() != batch_idx.numel():
+        return False
+    if _is_sync_free_uniform_cotangent(grad_energy):
         return True
     if not _can_inspect_cotangent_values(grad):
         return False
@@ -488,9 +491,12 @@ class _InjectCachedEvalGrad(torch.autograd.Function):
         num_atoms = ctx.num_atoms
 
         if ctx.energy_reduction == "system":
-            grad_system = grad_energy.reshape(-1)
-            atom_grad = _system_cotangent_to_atoms(
-                grad_system, ctx.batch_idx, num_atoms
+            grad_system, atom_grad = _energy_cotangents(
+                grad_energy,
+                ctx.batch_idx,
+                num_atoms,
+                ctx.num_systems,
+                "system",
             )
             if torch.is_grad_enabled():
                 result = (atom_grad, None, None, None, None, None, None, None)
@@ -503,13 +509,13 @@ class _InjectCachedEvalGrad(torch.autograd.Function):
 
         if ctx.energy_reduction == "system":
             pass
-        elif grad_energy.numel() != 0 and _is_sync_free_uniform_cotangent(grad_energy):
-            scale = grad_energy.reshape(-1)[0]
-            atom_grad = scale.expand(num_atoms)
-            grad_system = scale.expand(ctx.num_systems)
         else:
             grad_system, atom_grad = _energy_cotangents(
-                grad_energy, ctx.batch_idx, num_atoms, ctx.num_systems
+                grad_energy,
+                ctx.batch_idx,
+                num_atoms,
+                ctx.num_systems,
+                "atom",
             )
 
         grad_positions = None
@@ -627,9 +633,12 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
             return recomputed
 
         if ctx.energy_reduction == "system":
-            grad_system = grad_energy.reshape(-1)
-            atom_grad = _system_cotangent_to_atoms(
-                grad_system, ctx.batch_idx, num_atoms
+            grad_system, atom_grad = _energy_cotangents(
+                grad_energy,
+                ctx.batch_idx,
+                num_atoms,
+                ctx.num_systems,
+                "system",
             )
             use_fallback = create_graph or ctx.force_fallback
         else:
@@ -779,13 +788,13 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
 
         if ctx.energy_reduction == "system":
             pass
-        elif grad_energy.numel() != 0 and _is_sync_free_uniform_cotangent(grad_energy):
-            scale = grad_energy.reshape(-1)[0]
-            atom_grad = scale.expand(num_atoms)
-            grad_system = scale.expand(ctx.num_systems)
         else:
             grad_system, atom_grad = _energy_cotangents(
-                grad_energy, ctx.batch_idx, num_atoms, ctx.num_systems
+                grad_energy,
+                ctx.batch_idx,
+                num_atoms,
+                ctx.num_systems,
+                "atom",
             )
 
         grad_positions = None
@@ -858,20 +867,23 @@ class _InjectChargeGrad(torch.autograd.Function):
         ctx.save_for_backward(charge_grad)
         ctx.batch_idx = batch_idx
         ctx.energy_reduction = inputs[4] if len(inputs) > 4 else "atom"
+        ctx.energy_is_system = bool(inputs[6]) if len(inputs) > 6 else False
+        ctx.energy_is_system = ctx.energy_is_system or (
+            _energy.numel() != charge_grad.shape[0]
+        )
+        ctx.output_layout = (
+            "system"
+            if ctx.energy_reduction == "system" or ctx.energy_is_system
+            else "atom"
+        )
         if len(inputs) > 5 and inputs[5] is not None:
             ctx.num_systems = int(inputs[5])
-        elif inputs[5] is None and batch_idx is not None and batch_idx.numel() > 0:
-            # Legacy private 4-argument calls predate the explicit layout contract.
-            ctx.num_systems = int(batch_idx.max().item()) + 1
-        elif batch_idx is not None and _energy.numel() != charge_grad.shape[0]:
+        elif ctx.energy_is_system:
             ctx.num_systems = int(_energy.numel())
+        elif batch_idx is not None and batch_idx.numel() > 0:
+            ctx.num_systems = int(batch_idx.max().item()) + 1
         else:
             ctx.num_systems = 1
-        ctx.energy_is_system = (
-            bool(inputs[6])
-            if len(inputs) > 6
-            else bool(_energy.numel() != charge_grad.shape[0])
-        )
         ctx.num_inputs = len(inputs)
 
     @staticmethod
@@ -880,10 +892,13 @@ class _InjectChargeGrad(torch.autograd.Function):
         (charge_grad_state,) = ctx.saved_tensors
         num_atoms = int(charge_grad_state.shape[0])
 
-        if ctx.energy_reduction == "system":
-            grad_system = grad_energy.reshape(-1)
-            atom_grad = _system_cotangent_to_atoms(
-                grad_system, ctx.batch_idx, num_atoms
+        if ctx.output_layout == "system":
+            grad_system, atom_grad = _energy_cotangents(
+                grad_energy,
+                ctx.batch_idx,
+                num_atoms,
+                ctx.num_systems,
+                "system",
             )
             input_grad = grad_system if ctx.energy_is_system else atom_grad
         else:
@@ -893,10 +908,8 @@ class _InjectChargeGrad(torch.autograd.Function):
             result = (input_grad, None, None, None)
             return result + (None,) * (ctx.num_inputs - len(result))
 
-        if ctx.energy_reduction == "system":
+        if ctx.output_layout == "system":
             pass
-        elif grad_energy.numel() != 0 and _is_sync_free_uniform_cotangent(grad_energy):
-            atom_grad = grad_energy.reshape(-1)[0].expand(num_atoms)
         else:
             if not _is_per_system_uniform_cotangent(
                 grad_energy, ctx.batch_idx, ctx.num_systems
@@ -904,7 +917,11 @@ class _InjectChargeGrad(torch.autograd.Function):
                 result = (grad_energy, None, None, None)
                 return result + (None,) * (ctx.num_inputs - len(result))
             _grad_system, atom_grad = _energy_cotangents(
-                grad_energy, ctx.batch_idx, num_atoms, ctx.num_systems
+                grad_energy,
+                ctx.batch_idx,
+                num_atoms,
+                ctx.num_systems,
+                "atom",
             )
         grad_charges = charge_grad_state * atom_grad
         result = (None, grad_charges, None, None)

--- a/nvalchemiops/torch/interactions/electrostatics/dsf.py
+++ b/nvalchemiops/torch/interactions/electrostatics/dsf.py
@@ -610,7 +610,15 @@ def dsf_coulomb(
         )
 
     if compute_charge_grad:
-        energy = _InjectChargeGrad.apply(energy, charges, charge_grad_out, batch_idx)
+        energy = _InjectChargeGrad.apply(
+            energy,
+            charges,
+            charge_grad_out,
+            batch_idx,
+            "system",
+            num_systems,
+            True,
+        )
 
     # Build return tuple
     if not compute_forces:

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -817,8 +817,9 @@ def ewald_real_space(
 
     Returns
     -------
-    energies : torch.Tensor, shape (N,)
-        Per-atom real-space energy.
+    energies : torch.Tensor, shape (N,) or (B,)
+        Real-space Ewald energy: per-atom when ``energy_reduction="atom"``,
+        per-system when ``energy_reduction="system"``.
     forces : torch.Tensor, shape (N, 3), optional
         Direct component forces (if compute_forces=True).
     charge_gradients : torch.Tensor, shape (N,), optional
@@ -1231,8 +1232,10 @@ def ewald_reciprocal_space(
 
     Returns
     -------
-    energies : torch.Tensor, shape (N,)
-        Per-atom reciprocal-space energy.
+    energies : torch.Tensor, shape (N,) or (B,)
+        Reciprocal-space Ewald energy: per-atom when
+        ``energy_reduction="atom"``, per-system when
+        ``energy_reduction="system"``.
     forces : torch.Tensor, shape (N, 3), optional
         Direct component forces (if compute_forces=True).
     charge_gradients : torch.Tensor, shape (N,), optional
@@ -1686,8 +1689,9 @@ def ewald_summation(
 
     Returns
     -------
-    energies : torch.Tensor, shape (N,)
-        Per-atom total Ewald energy.
+    energies : torch.Tensor, shape (N,) or (B,)
+        Total Ewald energy: per-atom when ``energy_reduction="atom"``,
+        per-system when ``energy_reduction="system"``.
     forces : torch.Tensor, shape (N, 3), optional
         .. deprecated:: 0.4.0
             Deprecated direct forces (if compute_forces=True).

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -98,8 +98,6 @@ from nvalchemiops.torch.interactions.electrostatics._ewald_direct import (
     reciprocal_space_direct,
 )
 from nvalchemiops.torch.interactions.electrostatics._ewald_real_chain import (
-    _neighbor_edges,
-    _real_space_weighted_energy,
     real_space_cell_connect,
 )
 from nvalchemiops.torch.interactions.electrostatics._ewald_recip_chain import (
@@ -329,6 +327,7 @@ def _real_space_energy_outputs(
     want_forces: bool = False,
     want_charge_grad: bool = False,
     want_virial: bool = False,
+    energy_layout: Literal["atom", "system"] = "atom",
 ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
     """Per-atom real-space Ewald energy plus optional deprecated direct outputs.
 
@@ -342,7 +341,11 @@ def _real_space_energy_outputs(
     use_matrix = neighbor_matrix is not None
 
     if num_atoms == 0:
-        energy = torch.zeros(num_atoms, device=device, dtype=torch.float64)
+        energy = torch.zeros(
+            num_atoms if energy_layout == "atom" else cell.shape[0],
+            device=device,
+            dtype=torch.float64,
+        )
         forces = (
             torch.zeros(num_atoms, 3, device=device, dtype=positions.dtype)
             if want_forces
@@ -395,45 +398,51 @@ def _real_space_energy_outputs(
     need_cell = bool(cell.requires_grad)
     ensure_electrostatics_ops_registered()
     if batch_idx is None:
-        energy, dEdR, dEdq, dedcell, direct_virial = (
-            torch.ops.nvalchemiops.ewald_real_energy_single(
-                positions,
-                charges,
-                cell,
-                alpha,
-                idx_j_t,
-                neighbor_ptr_t,
-                neighbor_shifts_t,
-                neighbor_matrix_t,
-                neighbor_matrix_shifts_t,
-                int(mask_value),
-                use_matrix,
-                need_pos,
-                need_charge,
-                need_cell,
-                want_virial,
-            )
+        real_op = (
+            torch.ops.nvalchemiops.ewald_real_energy_single
+            if energy_layout == "atom"
+            else torch.ops.nvalchemiops.ewald_real_system_energy_single
+        )
+        energy, dEdR, dEdq, dedcell, direct_virial = real_op(
+            positions,
+            charges,
+            cell,
+            alpha,
+            idx_j_t,
+            neighbor_ptr_t,
+            neighbor_shifts_t,
+            neighbor_matrix_t,
+            neighbor_matrix_shifts_t,
+            int(mask_value),
+            use_matrix,
+            need_pos,
+            need_charge,
+            need_cell,
+            want_virial,
         )
     else:
-        energy, dEdR, dEdq, dedcell, direct_virial = (
-            torch.ops.nvalchemiops.ewald_real_energy_batch(
-                positions,
-                charges,
-                cell,
-                alpha,
-                batch_idx.to(torch.int32),
-                idx_j_t,
-                neighbor_ptr_t,
-                neighbor_shifts_t,
-                neighbor_matrix_t,
-                neighbor_matrix_shifts_t,
-                int(mask_value),
-                use_matrix,
-                need_pos,
-                need_charge,
-                need_cell,
-                want_virial,
-            )
+        real_op = (
+            torch.ops.nvalchemiops.ewald_real_energy_batch
+            if energy_layout == "atom"
+            else torch.ops.nvalchemiops.ewald_real_system_energy_batch
+        )
+        energy, dEdR, dEdq, dedcell, direct_virial = real_op(
+            positions,
+            charges,
+            cell,
+            alpha,
+            batch_idx.to(torch.int32),
+            idx_j_t,
+            neighbor_ptr_t,
+            neighbor_shifts_t,
+            neighbor_matrix_t,
+            neighbor_matrix_shifts_t,
+            int(mask_value),
+            use_matrix,
+            need_pos,
+            need_charge,
+            need_cell,
+            want_virial,
         )
 
     forces = -dEdR.to(positions.dtype) if want_forces else None
@@ -482,6 +491,7 @@ def _real_space_energy_outputs(
             nm_for_grad,
             nms_for_grad,
             int(mask_value),
+            energy_layout,
         )
     return energy, forces, charge_grads, virial
 
@@ -884,43 +894,6 @@ def ewald_real_space(
 
     idx_j = neighbor_list[1] if neighbor_list is not None else None
 
-    def _system_fallback(p, q, c):
-        use_matrix = neighbor_matrix is not None
-        edge_i, edge_j, unit_shifts = _neighbor_edges(
-            use_matrix,
-            idx_j,
-            neighbor_ptr,
-            neighbor_shifts,
-            neighbor_matrix,
-            neighbor_matrix_shifts,
-            mask_value,
-            p.shape[0],
-            p.device,
-        )
-        cell_3d = c if c.dim() == 3 else c.unsqueeze(0)
-        system_energies = []
-        for system_idx in range(num_systems):
-            if batch_idx is None:
-                atom_weights = torch.ones(
-                    p.shape[0], dtype=torch.float64, device=p.device
-                )
-            else:
-                atom_weights = (batch_idx == system_idx).to(torch.float64)
-            system_energies.append(
-                _real_space_weighted_energy(
-                    p,
-                    q,
-                    cell_3d,
-                    alpha,
-                    edge_i,
-                    edge_j,
-                    unit_shifts,
-                    batch_idx,
-                    atom_weights,
-                )
-            )
-        return torch.stack(system_energies)
-
     # Helper to build the return tuple from raw outputs using match dispatch.
     def _build_result(energies, forces=None, charge_grads=None, virial=None):
         match (
@@ -946,6 +919,51 @@ def ewald_real_space(
                 return energies
 
     want_direct = compute_forces or compute_charge_gradients or compute_virial
+
+    if energy_reduction == "system":
+        system_positions = positions.detach() if hybrid_forces else positions
+        system_cell = cell.detach() if hybrid_forces else cell
+        energies, forces, charge_grads, virial = _real_space_energy_outputs(
+            system_positions,
+            charges,
+            system_cell,
+            alpha,
+            batch_idx=batch_idx,
+            idx_j=idx_j,
+            neighbor_ptr=neighbor_ptr,
+            neighbor_shifts=neighbor_shifts,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            mask_value=mask_value,
+            want_forces=compute_forces,
+            want_charge_grad=compute_charge_gradients or charges.requires_grad,
+            want_virial=compute_virial,
+            energy_layout="system",
+        )
+        if compute_virial and charges.requires_grad and not hybrid_forces:
+
+            def _rs_energy_fn(p, q, c):
+                return _real_space_energy(
+                    p,
+                    q,
+                    c,
+                    alpha,
+                    batch_idx=batch_idx,
+                    idx_j=idx_j,
+                    neighbor_ptr=neighbor_ptr,
+                    neighbor_shifts=neighbor_shifts,
+                    neighbor_matrix=neighbor_matrix,
+                    neighbor_matrix_shifts=neighbor_matrix_shifts,
+                    mask_value=mask_value,
+                )
+
+            virial = _attach_virial_charge_grad(
+                virial, charges, _rs_energy_fn, positions, cell, batch_idx
+            )
+        charge_grads_out = (
+            charge_grads.to(positions.dtype) if charge_grads is not None else None
+        )
+        return _build_result(energies, forces, charge_grads_out, virial)
 
     if hybrid_forces:
         # Positions/cell detached from the graph; charge gradients attached via the
@@ -1077,22 +1095,6 @@ def ewald_real_space(
     )
 
     if not want_direct:
-        if energy_reduction == "system":
-            return _InjectCachedEvalGradWithFallback.apply(
-                energies.detach(),
-                positions,
-                charges,
-                cell,
-                None,
-                None,
-                None,
-                batch_idx,
-                _system_fallback,
-                "system",
-                num_systems,
-                True,
-                True,
-            )
         return energies
 
     # The deprecated direct virial is differentiable w.r.t. charges; re-attach that
@@ -1144,24 +1146,6 @@ def ewald_real_space(
             batch_idx,
             energy_reduction,
             num_systems,
-        )
-    elif energy_reduction == "system" and (
-        positions.requires_grad or charges.requires_grad or cell.requires_grad
-    ):
-        energies = _InjectCachedEvalGradWithFallback.apply(
-            energies.detach(),
-            positions,
-            charges,
-            cell,
-            None,
-            None,
-            None,
-            batch_idx,
-            _system_fallback,
-            "system",
-            num_systems,
-            True,
-            True,
         )
     else:
         energies = _select_energy(energies)

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -86,6 +86,7 @@ Examples
 from __future__ import annotations
 
 import warnings
+from typing import Literal
 
 import torch
 
@@ -97,7 +98,12 @@ from nvalchemiops.torch.interactions.electrostatics._ewald_direct import (
     reciprocal_space_direct,
 )
 from nvalchemiops.torch.interactions.electrostatics._ewald_real_chain import (
+    _neighbor_edges,
+    _real_space_weighted_energy,
     real_space_cell_connect,
+)
+from nvalchemiops.torch.interactions.electrostatics._ewald_recip_chain import (
+    _recip_ksum_energy_torch,
 )
 from nvalchemiops.torch.interactions.electrostatics._registration import (
     ensure_electrostatics_ops_registered,
@@ -113,7 +119,9 @@ from nvalchemiops.torch.interactions.electrostatics._util import (
     _InjectCachedEvalGrad,
     _InjectCachedEvalGradWithFallback,
     _InjectChargeGrad,
+    _reduce_atom_energy,
     _unpack_electrostatic_outputs,
+    _validate_energy_reduction,
 )
 from nvalchemiops.torch.interactions.electrostatics.k_vectors import (
     generate_k_vectors_ewald_summation,
@@ -541,6 +549,37 @@ def _apply_reciprocal_corrections(
     )
 
 
+def _reciprocal_system_energy_torch(
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    k_vectors_2d: torch.Tensor,
+    alpha: torch.Tensor,
+    batch_idx: torch.Tensor | None,
+    num_systems: int,
+) -> torch.Tensor:
+    """Return pure-Torch reciprocal system energies for terminal facades."""
+    cell_3d = cell if cell.dim() == 3 else cell.unsqueeze(0)
+    volume = torch.abs(torch.linalg.det(cell_3d)).to(torch.float64)
+    ksum = _recip_ksum_energy_torch(
+        positions,
+        charges,
+        k_vectors_2d,
+        volume,
+        alpha,
+        batch_idx,
+        num_systems,
+    )
+    energy = _apply_reciprocal_corrections(
+        ksum,
+        charges,
+        volume,
+        alpha,
+        batch_idx,
+    )
+    return _reduce_atom_energy(energy, batch_idx, num_systems)
+
+
 def _reciprocal_space_energy(
     positions: torch.Tensor,
     charges: torch.Tensor,
@@ -550,6 +589,7 @@ def _reciprocal_space_energy(
     *,
     batch_idx: torch.Tensor | None,
     max_atoms_per_system: int | None = None,
+    energy_reduction: Literal["atom", "system"] = "atom",
 ) -> torch.Tensor:
     """Per-atom reciprocal-space Ewald energy, connected to autograd via the chain.
 
@@ -584,16 +624,18 @@ def _reciprocal_space_energy(
         volume = torch.abs(
             torch.det(cell.reshape(3, 3) if cell.dim() == 2 else cell[0])
         ).reshape(1)
-        e_ksum, _, _, _ = torch.ops.nvalchemiops.ewald_recip_energy_single(
-            positions,
-            charges,
-            cell,
-            k_vectors_2d,
-            volume.to(torch.float64),
-            alpha,
-            need_pos,
-            need_charge,
-            need_cell,
+        e_ksum, dEdR, dEdq, _cellgrad_cache = (
+            torch.ops.nvalchemiops.ewald_recip_energy_single(
+                positions,
+                charges,
+                cell,
+                k_vectors_2d,
+                volume.to(torch.float64),
+                alpha,
+                need_pos,
+                need_charge,
+                need_cell,
+            )
         )
     else:
         num_systems = cell.shape[0]
@@ -619,23 +661,79 @@ def _reciprocal_space_energy(
                 raise ValueError(
                     "max_atoms_per_system cannot exceed the total number of atoms"
                 )
-        e_ksum, _, _, _ = torch.ops.nvalchemiops.ewald_recip_energy_batch(
+        e_ksum, dEdR, dEdq, _cellgrad_cache = (
+            torch.ops.nvalchemiops.ewald_recip_energy_batch(
+                positions,
+                charges,
+                cell,
+                k_vectors_2d,
+                volume,
+                alpha,
+                batch_idx.to(torch.int32),
+                atom_start,
+                atom_end,
+                need_pos,
+                need_charge,
+                need_cell,
+                max_atoms_bound,
+            )
+        )
+
+    correction = _apply_reciprocal_corrections(
+        torch.zeros_like(e_ksum), charges, volume, alpha, batch_idx
+    )
+
+    def _system_fallback(p, q, c):
+        return _reciprocal_system_energy_torch(
+            p,
+            q,
+            c,
+            k_vectors_2d,
+            alpha,
+            batch_idx,
+            num_systems,
+        )
+
+    if energy_reduction == "system" and cell.requires_grad:
+        return _InjectCachedEvalGradWithFallback.apply(
+            (e_ksum + correction).detach(),
             positions,
             charges,
             cell,
-            k_vectors_2d,
-            volume,
-            alpha,
-            batch_idx.to(torch.int32),
-            atom_start,
-            atom_end,
-            need_pos,
-            need_charge,
-            need_cell,
-            max_atoms_bound,
+            None,
+            None,
+            None,
+            batch_idx,
+            _system_fallback,
+            "system",
+            num_systems,
+            True,
+            True,
         )
 
-    return _apply_reciprocal_corrections(e_ksum, charges, volume, alpha, batch_idx)
+    if (
+        energy_reduction == "system"
+        and not cell.requires_grad
+        and (positions.requires_grad or charges.requires_grad)
+    ):
+        e_ksum = _InjectCachedEvalGrad.apply(
+            e_ksum,
+            positions,
+            charges,
+            cell,
+            dEdR.detach() if positions.requires_grad else None,
+            dEdq.detach() if charges.requires_grad else None,
+            None,
+            batch_idx,
+            "system",
+            num_systems,
+        )
+        return e_ksum + _reduce_atom_energy(correction, batch_idx, num_systems)
+
+    energies = e_ksum + correction
+    if energy_reduction == "system":
+        return _reduce_atom_energy(energies, batch_idx, num_systems)
+    return energies
 
 
 ###########################################################################################
@@ -659,6 +757,8 @@ def ewald_real_space(
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
     hybrid_forces: bool = False,
+    *,
+    energy_reduction: Literal["atom", "system"] = "atom",
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     r"""Compute real-space Ewald energy and optionally forces, charge gradients, and virial.
 
@@ -712,6 +812,8 @@ def ewald_real_space(
         :math:`\partial E/\partial R|_q` and autograd through the energy
         provides the charge chain-rule term
         :math:`\partial E/\partial q \cdot \mathrm{d}q/\mathrm{d}R`.
+    energy_reduction : {"atom", "system"}, default="atom"
+        Return per-atom energies ``(N,)`` or summed per-system energies ``(B,)``.
 
     Returns
     -------
@@ -740,6 +842,14 @@ def ewald_real_space(
     the forward energy was detached.
 
     """
+    _validate_energy_reduction(energy_reduction)
+    num_systems = int(cell.shape[0]) if cell.dim() == 3 else 1
+
+    def _select_energy(energy):
+        if energy_reduction == "system":
+            return _reduce_atom_energy(energy, batch_idx, num_systems)
+        return energy
+
     component_deprecated_flags = tuple(
         name
         for name, enabled in (
@@ -772,6 +882,43 @@ def ewald_real_space(
         raise ValueError("neighbor_ptr is required when using neighbor_list format")
 
     idx_j = neighbor_list[1] if neighbor_list is not None else None
+
+    def _system_fallback(p, q, c):
+        use_matrix = neighbor_matrix is not None
+        edge_i, edge_j, unit_shifts = _neighbor_edges(
+            use_matrix,
+            idx_j,
+            neighbor_ptr,
+            neighbor_shifts,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            mask_value,
+            p.shape[0],
+            p.device,
+        )
+        cell_3d = c if c.dim() == 3 else c.unsqueeze(0)
+        system_energies = []
+        for system_idx in range(num_systems):
+            if batch_idx is None:
+                atom_weights = torch.ones(
+                    p.shape[0], dtype=torch.float64, device=p.device
+                )
+            else:
+                atom_weights = (batch_idx == system_idx).to(torch.float64)
+            system_energies.append(
+                _real_space_weighted_energy(
+                    p,
+                    q,
+                    cell_3d,
+                    alpha,
+                    edge_i,
+                    edge_j,
+                    unit_shifts,
+                    batch_idx,
+                    atom_weights,
+                )
+            )
+        return torch.stack(system_energies)
 
     # Helper to build the return tuple from raw outputs using match dispatch.
     def _build_result(energies, forces=None, charge_grads=None, virial=None):
@@ -836,7 +983,7 @@ def ewald_real_space(
                 )
 
             energies = _InjectCachedEvalGradWithFallback.apply(
-                energies,
+                energies.detach(),
                 positions,
                 charges,
                 cell,
@@ -845,7 +992,11 @@ def ewald_real_space(
                 None,
                 batch_idx,
                 _fallback,
+                energy_reduction,
+                num_systems,
             )
+        else:
+            energies = _select_energy(energies)
         return _build_result(energies, forces, charge_grads.to(positions.dtype), virial)
 
     if (
@@ -891,7 +1042,7 @@ def ewald_real_space(
             )
 
         energies = _InjectCachedEvalGradWithFallback.apply(
-            energies,
+            energies.detach(),
             positions,
             charges,
             cell,
@@ -900,6 +1051,8 @@ def ewald_real_space(
             None,
             batch_idx,
             _fallback,
+            energy_reduction,
+            num_systems,
         )
         return energies
 
@@ -923,6 +1076,22 @@ def ewald_real_space(
     )
 
     if not want_direct:
+        if energy_reduction == "system":
+            return _InjectCachedEvalGradWithFallback.apply(
+                energies.detach(),
+                positions,
+                charges,
+                cell,
+                None,
+                None,
+                None,
+                batch_idx,
+                _system_fallback,
+                "system",
+                num_systems,
+                True,
+                True,
+            )
         return energies
 
     # The deprecated direct virial is differentiable w.r.t. charges; re-attach that
@@ -956,6 +1125,8 @@ def ewald_real_space(
         not cell.requires_grad
         and (positions.requires_grad or charges.requires_grad)
         and (forces is not None or charge_grads is not None)
+        and (not positions.requires_grad or forces is not None)
+        and (not charges.requires_grad or charge_grads is not None)
     ):
         energies = _InjectCachedEvalGrad.apply(
             energies,
@@ -970,7 +1141,29 @@ def ewald_real_space(
             else None,
             None,
             batch_idx,
+            energy_reduction,
+            num_systems,
         )
+    elif energy_reduction == "system" and (
+        positions.requires_grad or charges.requires_grad or cell.requires_grad
+    ):
+        energies = _InjectCachedEvalGradWithFallback.apply(
+            energies.detach(),
+            positions,
+            charges,
+            cell,
+            None,
+            None,
+            None,
+            batch_idx,
+            _system_fallback,
+            "system",
+            num_systems,
+            True,
+            True,
+        )
+    else:
+        energies = _select_energy(energies)
     return _build_result(energies, forces, charge_grads_out, virial)
 
 
@@ -987,6 +1180,7 @@ def ewald_reciprocal_space(
     hybrid_forces: bool = False,
     *,
     max_atoms_per_system: int | None = None,
+    energy_reduction: Literal["atom", "system"] = "atom",
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     r"""Compute reciprocal-space Ewald energy and optionally forces, charge gradients, virial.
 
@@ -1032,6 +1226,8 @@ def ewald_reciprocal_space(
         Overestimates are safe but may launch extra blocks. When omitted, the
         bound is inferred from ``atom_start`` / ``atom_end`` and may
         synchronize on CUDA.
+    energy_reduction : {"atom", "system"}, default="atom"
+        Return per-atom energies ``(N,)`` or summed per-system energies ``(B,)``.
 
     Returns
     -------
@@ -1058,6 +1254,7 @@ def ewald_reciprocal_space(
     losses and higher-order derivatives recompute safe partials or connected
     gradients as needed to avoid double-counting that chain term (issue #115).
     """
+    _validate_energy_reduction(energy_reduction)
     return _ewald_reciprocal_space(
         positions=positions,
         charges=charges,
@@ -1071,6 +1268,7 @@ def ewald_reciprocal_space(
         hybrid_forces=hybrid_forces,
         allow_cell_grad_with_k_vectors=False,
         max_atoms_per_system=max_atoms_per_system,
+        energy_reduction=energy_reduction,
     )
 
 
@@ -1087,8 +1285,10 @@ def _ewald_reciprocal_space(
     hybrid_forces: bool = False,
     allow_cell_grad_with_k_vectors: bool = False,
     max_atoms_per_system: int | None = None,
+    energy_reduction: Literal["atom", "system"] = "atom",
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     """Private reciprocal-space implementation with an internal cell-gradient path."""
+    _validate_energy_reduction(energy_reduction)
     component_deprecated_flags = tuple(
         name
         for name, enabled in (
@@ -1126,6 +1326,13 @@ def _ewald_reciprocal_space(
             k_vectors_2d = k_vectors[:1]
         else:
             k_vectors_2d = k_vectors.unsqueeze(0)
+    num_systems = int(k_vectors_2d.shape[0])
+
+    def _select_energy(energy):
+        if energy_reduction == "system":
+            return _reduce_atom_energy(energy, batch_idx, num_systems)
+        return energy
+
     if not allow_cell_grad_with_k_vectors:
         k_vectors_2d = k_vectors_2d.detach()
 
@@ -1163,7 +1370,6 @@ def _ewald_reciprocal_space(
     # self/background corrections below.
     num_atoms = positions.shape[0]
     if num_atoms == 0:
-        num_systems = k_vectors_2d.shape[0]
         zeros_e = torch.zeros(num_atoms, device=positions.device, dtype=torch.float64)
         zeros_f = torch.zeros(
             num_atoms, 3, device=positions.device, dtype=positions.dtype
@@ -1174,7 +1380,7 @@ def _ewald_reciprocal_space(
         zeros_v = torch.zeros(
             num_systems, 3, 3, device=positions.device, dtype=positions.dtype
         )
-        return _build_result(zeros_e, zeros_f, zeros_cg, zeros_v)
+        return _build_result(_select_energy(zeros_e), zeros_f, zeros_cg, zeros_v)
 
     if hybrid_forces:
         k_vectors_hybrid = k_vectors_2d.detach()
@@ -1223,7 +1429,11 @@ def _ewald_reciprocal_space(
                 None,
                 batch_idx,
                 _fallback,
+                energy_reduction,
+                num_systems,
             )
+        else:
+            energies = _select_energy(energies)
         return _build_result(energies, forces, charge_grads.to(positions.dtype), virial)
 
     differentiable_inputs = (
@@ -1255,7 +1465,7 @@ def _ewald_reciprocal_space(
         charge_grads_out = (
             charge_grads.to(positions.dtype) if charge_grads is not None else None
         )
-        return _build_result(energies, forces, charge_grads_out, virial)
+        return _build_result(_select_energy(energies), forces, charge_grads_out, virial)
 
     energies = _reciprocal_space_energy(
         positions,
@@ -1265,6 +1475,7 @@ def _ewald_reciprocal_space(
         alpha,
         batch_idx=batch_idx,
         max_atoms_per_system=max_atoms_per_system,
+        energy_reduction=energy_reduction if not want_direct else "atom",
     )
 
     if not want_direct:
@@ -1310,7 +1521,35 @@ def _ewald_reciprocal_space(
             k_vectors_2d=k_vectors_2d,
         )
 
-    if (
+    if energy_reduction == "system" and cell.requires_grad:
+
+        def _system_fallback(p, q, c):
+            return _reciprocal_system_energy_torch(
+                p,
+                q,
+                c,
+                k_vectors_2d,
+                alpha,
+                batch_idx,
+                num_systems,
+            )
+
+        energies = _InjectCachedEvalGradWithFallback.apply(
+            energies.detach(),
+            positions,
+            charges,
+            cell,
+            None,
+            None,
+            None,
+            batch_idx,
+            _system_fallback,
+            "system",
+            num_systems,
+            True,
+            True,
+        )
+    elif (
         not cell.requires_grad
         and (positions.requires_grad or charges.requires_grad)
         and (forces is not None or charge_grads is not None)
@@ -1328,7 +1567,11 @@ def _ewald_reciprocal_space(
             else None,
             None,
             batch_idx,
+            energy_reduction,
+            num_systems,
         )
+    else:
+        energies = _select_energy(energies)
 
     charge_grads_out = (
         charge_grads.to(positions.dtype) if charge_grads is not None else None
@@ -1360,6 +1603,7 @@ def ewald_summation(
     *,
     miller_bounds: tuple[int, int, int] | torch.Tensor | None = None,
     max_atoms_per_system: int | None = None,
+    energy_reduction: Literal["atom", "system"] = "atom",
 ) -> tuple[torch.Tensor, ...] | torch.Tensor:
     r"""Complete Ewald summation for long-range electrostatics.
 
@@ -1437,6 +1681,8 @@ def ewald_summation(
         Ballenegger et al. 2009 Eq. 29 non-neutral extension) to the total
         energy and to forces/charge_grads/virial when those are requested.
         Orthorhombic and triclinic slab cells are supported.
+    energy_reduction : {"atom", "system"}, default="atom"
+        Return per-atom energies ``(N,)`` or summed per-system energies ``(B,)``.
 
     Returns
     -------
@@ -1499,6 +1745,7 @@ def ewald_summation(
         ...     compute_forces=True,
         ... )
     """
+    _validate_energy_reduction(energy_reduction)
     if compute_forces or compute_virial or compute_charge_gradients or hybrid_forces:
         if torch.compiler.is_compiling():
             _compiled_direct_output_deprecation_signal("ewald_summation")
@@ -1553,6 +1800,7 @@ def ewald_summation(
             compute_charge_gradients=compute_charge_gradients,
             compute_virial=compute_virial,
             hybrid_forces=hybrid_forces,
+            energy_reduction=energy_reduction,
         )
 
         # Compute reciprocal-space
@@ -1569,6 +1817,7 @@ def ewald_summation(
             hybrid_forces=hybrid_forces,
             allow_cell_grad_with_k_vectors=generated_k_vectors,
             max_atoms_per_system=max_atoms_per_system,
+            energy_reduction=energy_reduction,
         )
         return real, reciprocal
 
@@ -1597,6 +1846,7 @@ def ewald_summation(
                 compute_forces=compute_forces,
                 compute_charge_gradients=True,
                 compute_virial=compute_virial,
+                energy_reduction=energy_reduction,
             )
             slab_energies, slab_forces, slab_charge_grads, slab_virial = (
                 _unpack_electrostatic_outputs(
@@ -1617,9 +1867,16 @@ def ewald_summation(
                     compute_forces=False,
                     compute_charge_gradients=False,
                     compute_virial=False,
+                    energy_reduction=energy_reduction,
                 )
                 slab_energies = _InjectChargeGrad.apply(
-                    slab_energies, charges, slab_charge_grads, batch_idx
+                    slab_energies,
+                    charges,
+                    slab_charge_grads,
+                    batch_idx,
+                    energy_reduction,
+                    num_systems,
+                    energy_reduction == "system",
                 )
 
             slab_result = _build_electrostatic_result(
@@ -1641,6 +1898,7 @@ def ewald_summation(
                 compute_forces=compute_forces,
                 compute_charge_gradients=compute_charge_gradients,
                 compute_virial=compute_virial,
+                energy_reduction=energy_reduction,
             )
 
     return _combine_electrostatic_outputs(

--- a/nvalchemiops/torch/interactions/electrostatics/multipole_ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/multipole_ewald.py
@@ -1964,7 +1964,11 @@ class _AttachRealSpaceCellGradLmax1(torch.autograd.Function):
         if ctx.needs_input_grad[1]:
             batch_idx = batch_idx_saved if ctx.has_batch else None
             grad_system, _ = _energy_cotangents(
-                grad_energy, batch_idx, ctx.num_atoms, ctx.num_systems
+                grad_energy,
+                batch_idx,
+                ctx.num_atoms,
+                ctx.num_systems,
+                "atom",
             )
             if ctx.has_batch:
                 if ctx.l_max == 1:

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -3108,8 +3108,10 @@ def pme_reciprocal_space(
 
     Returns
     -------
-    energies : torch.Tensor, shape (N,)
-        Per-atom reciprocal-space energy (includes self and background corrections).
+    energies : torch.Tensor, shape (N,) or (B,)
+        Reciprocal-space energy, including self and background corrections:
+        per-atom when ``energy_reduction="atom"``, per-system when
+        ``energy_reduction="system"``.
     forces : torch.Tensor, shape (N, 3), optional
         Direct reciprocal-space forces. Only returned if compute_forces=True.
     charge_gradients : torch.Tensor, shape (N,), optional
@@ -3547,8 +3549,9 @@ def particle_mesh_ewald(
 
     Returns
     -------
-    energies : torch.Tensor, shape (N,)
-        Per-atom contribution to total PME energy. Sum gives total energy.
+    energies : torch.Tensor, shape (N,) or (B,)
+        Total PME energy: per-atom when ``energy_reduction="atom"``,
+        per-system when ``energy_reduction="system"``.
     forces : torch.Tensor, shape (N, 3), optional
         .. deprecated:: 0.4.0
             Deprecated direct forces. Only returned if compute_forces=True.

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -2519,20 +2519,13 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
                 None,
             )
 
-        if ctx.energy_reduction == "system":
-            grad_system = grad_energy.reshape(-1)
-        else:
-            grad_system, atom_scale = _energy_cotangents(
-                grad_energy,
-                batch_idx,
-                positions.shape[0],
-                ctx.num_systems,
-            )
-        if ctx.energy_reduction == "system":
-            if batch_idx is None:
-                atom_scale = grad_system[0].expand(positions.shape[0])
-            else:
-                atom_scale = grad_system.index_select(0, batch_idx.to(torch.long))
+        grad_system, atom_scale = _energy_cotangents(
+            grad_energy,
+            batch_idx,
+            positions.shape[0],
+            ctx.num_systems,
+            ctx.energy_reduction,
+        )
         system_scale = grad_system.view(-1, 1, 1)
 
         grad_positions = (

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -166,6 +166,7 @@ References
 import math
 import warnings
 from contextlib import nullcontext
+from typing import Literal
 
 import torch
 import warp as wp
@@ -196,12 +197,15 @@ from nvalchemiops.torch.interactions.electrostatics._util import (
     _component_direct_output_deprecation_msg,
     _detach_setup_tensor,
     _direct_output_deprecation_msg,
+    _energy_cotangents,
     _has_potentially_geometry_dependent_charges,
     _InjectCachedEvalGrad,
     _InjectCachedEvalGradWithFallback,
     _InjectChargeGrad,
-    _is_uniform_cotangent,
+    _is_per_system_uniform_cotangent,
+    _reduce_atom_energy,
     _unpack_electrostatic_outputs,
+    _validate_energy_reduction,
 )
 from nvalchemiops.torch.interactions.electrostatics.ewald import (
     ewald_real_space,
@@ -2136,6 +2140,8 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
         need_pos,
         need_charge,
         need_cell,
+        energy_reduction,
+        num_systems,
     ):
         """Compute energy and direct first-derivative states."""
         need_forces = bool(need_pos) or bool(need_cell)
@@ -2203,6 +2209,10 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
         ctx.need_pos = bool(need_pos)
         ctx.need_charge = bool(need_charge)
         ctx.need_cell = bool(need_cell)
+        ctx.energy_reduction = energy_reduction
+        ctx.num_systems = int(num_systems)
+        if energy_reduction == "system":
+            return _reduce_atom_energy(energies, batch_idx, ctx.num_systems)
         return energies
 
     @staticmethod
@@ -2227,7 +2237,13 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
             cached_dEdcell,
         ) = ctx.saved_tensors
 
-        if create_graph or not _is_uniform_cotangent(grad_energy):
+        use_fallback = create_graph or (
+            ctx.energy_reduction == "atom"
+            and not _is_per_system_uniform_cotangent(
+                grad_energy, batch_idx, ctx.num_systems
+            )
+        )
+        if use_fallback:
             if _has_potentially_geometry_dependent_charges(positions, charges):
                 if create_graph:
                     diff_inputs = []
@@ -2263,6 +2279,10 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
                                 moduli_z=moduli_z,
                             )
                         )
+                        if ctx.energy_reduction == "system":
+                            recomputed = _reduce_atom_energy(
+                                recomputed, batch_idx, ctx.num_systems
+                            )
                         if diff_inputs:
                             diff_grads = torch.autograd.grad(
                                 recomputed,
@@ -2279,6 +2299,8 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
                         None,
                         grad_map.get("cell"),
                         grad_map.get("alpha"),
+                        None,
+                        None,
                         None,
                         None,
                         None,
@@ -2329,6 +2351,10 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
                                 moduli_z=moduli_z,
                             )
                         )
+                        if ctx.energy_reduction == "system":
+                            recomputed_partial = _reduce_atom_energy(
+                                recomputed_partial, batch_idx, ctx.num_systems
+                            )
                         partial_grads = torch.autograd.grad(
                             recomputed_partial,
                             tuple(partial_inputs),
@@ -2363,6 +2389,10 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
                                 moduli_z=moduli_z,
                             )
                         )
+                        if ctx.energy_reduction == "system":
+                            recomputed_charge = _reduce_atom_energy(
+                                recomputed_charge, batch_idx, ctx.num_systems
+                            )
                         (grad_charges,) = torch.autograd.grad(
                             recomputed_charge,
                             charges,
@@ -2375,6 +2405,8 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
                     grad_charges,
                     partial_map.get("cell"),
                     partial_map.get("alpha"),
+                    None,
+                    None,
                     None,
                     None,
                     None,
@@ -2412,6 +2444,10 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
                         moduli_z=moduli_z,
                     )
                 )
+                if ctx.energy_reduction == "system":
+                    recomputed = _reduce_atom_energy(
+                        recomputed, batch_idx, ctx.num_systems
+                    )
                 diff_inputs = []
                 diff_names = []
                 for name, tensor in (
@@ -2453,16 +2489,55 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
                 None,
                 None,
                 None,
+                None,
+                None,
             )
 
-        grad = grad_energy.reshape(-1)
-        atom_scale = grad[0]
-        if batch_idx is None:
-            system_scale = atom_scale
-        else:
-            system_scale = atom_scale
+        if grad_energy.numel() == 0:
+            grad_positions = torch.zeros_like(positions) if ctx.need_pos else None
+            grad_charges = torch.zeros_like(charges) if ctx.need_charge else None
+            grad_cell = torch.zeros_like(cell) if ctx.need_cell else None
+            return (
+                grad_positions,
+                grad_charges,
+                grad_cell,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
 
-        grad_positions = cached_dEdR * atom_scale if ctx.need_pos else None
+        if ctx.energy_reduction == "system":
+            grad_system = grad_energy.reshape(-1)
+        else:
+            grad_system, atom_scale = _energy_cotangents(
+                grad_energy,
+                batch_idx,
+                positions.shape[0],
+                ctx.num_systems,
+            )
+        if ctx.energy_reduction == "system":
+            if batch_idx is None:
+                atom_scale = grad_system[0].expand(positions.shape[0])
+            else:
+                atom_scale = grad_system.index_select(0, batch_idx.to(torch.long))
+        system_scale = grad_system.view(-1, 1, 1)
+
+        grad_positions = (
+            cached_dEdR * atom_scale.unsqueeze(-1) if ctx.need_pos else None
+        )
         grad_charges = cached_dEdq * atom_scale if ctx.need_charge else None
         grad_cell = cached_dEdcell * system_scale if ctx.need_cell else None
 
@@ -2470,6 +2545,8 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
             grad_positions,
             grad_charges,
             grad_cell,
+            None,
+            None,
             None,
             None,
             None,
@@ -2506,6 +2583,8 @@ def _pme_reciprocal_cached_first_grad(
     need_pos: bool,
     need_charge: bool,
     need_cell: bool,
+    energy_reduction: str,
+    num_systems: int,
 ) -> torch.Tensor:
     """Run the private first-order cached PME reciprocal energy path."""
     return _PMEReciprocalCachedFirstGrad.apply(
@@ -2526,6 +2605,8 @@ def _pme_reciprocal_cached_first_grad(
         need_pos,
         need_charge,
         need_cell,
+        energy_reduction,
+        num_systems,
     )
 
 
@@ -2910,6 +2991,8 @@ def _pme_reciprocal_space_impl(
             None,
             batch_idx,
             _fallback,
+            "atom",
+            cell.shape[0] if is_batch else 1,
         )
 
     if return_cell_inv_t:
@@ -2938,6 +3021,7 @@ def pme_reciprocal_space(
     moduli_x: torch.Tensor | None = None,
     moduli_y: torch.Tensor | None = None,
     moduli_z: torch.Tensor | None = None,
+    energy_reduction: Literal["atom", "system"] = "atom",
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     """Compute PME reciprocal-space energy and optionally forces and/or charge gradients.
 
@@ -3026,6 +3110,8 @@ def pme_reciprocal_space(
         charge gradients are attached to the energy via a straight-through
         trick.  Forces and virial are forward-only (not differentiable).
         See :func:`ewald_real_space` for details.
+    energy_reduction : {"atom", "system"}, default="atom"
+        Return per-atom energies ``(N,)`` or summed per-system energies ``(B,)``.
 
     Returns
     -------
@@ -3110,6 +3196,7 @@ def pme_reciprocal_space(
     particle_mesh_ewald : Complete PME calculation (real + reciprocal).
     generate_k_vectors_pme : Generate k-vectors for this function.
     """
+    _validate_energy_reduction(energy_reduction)
     component_deprecated_flags = tuple(
         name
         for name, enabled in (
@@ -3130,6 +3217,12 @@ def pme_reciprocal_space(
 
     ensure_electrostatics_ops_registered()
     cell, num_systems = _prepare_cell(cell)
+
+    def _select_energy(energy):
+        if energy_reduction == "system":
+            return _reduce_atom_energy(energy, batch_idx, num_systems)
+        return energy
+
     alpha_tensor = _detach_setup_tensor(
         _prepare_alpha(alpha, num_systems, torch.float64, positions.device)
     )
@@ -3184,6 +3277,8 @@ def pme_reciprocal_space(
             need_pos=position_grad,
             need_charge=charge_grad,
             need_cell=cell_grad,
+            energy_reduction=energy_reduction,
+            num_systems=num_systems,
         )
 
     # Deprecated direct-output calls still return a differentiable energy. For
@@ -3256,7 +3351,11 @@ def pme_reciprocal_space(
             cached_dEdq,
             cached_dEdcell,
             batch_idx,
+            energy_reduction,
+            num_systems,
         )
+    else:
+        energies = _select_energy(energies)
 
     # Build return tuple based on flags
     match (compute_forces, compute_charge_gradients, compute_virial):
@@ -3313,6 +3412,7 @@ def particle_mesh_ewald(
     moduli_x: torch.Tensor | None = None,
     moduli_y: torch.Tensor | None = None,
     moduli_z: torch.Tensor | None = None,
+    energy_reduction: Literal["atom", "system"] = "atom",
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     """Complete Particle Mesh Ewald (PME) calculation for long-range electrostatics.
 
@@ -3449,6 +3549,8 @@ def particle_mesh_ewald(
         correction to the 3D-periodic PME result. This is only available for
         the full PME interface; use :func:`compute_slab_correction` explicitly
         when manually composing ``ewald_real_space`` and ``pme_reciprocal_space``.
+    energy_reduction : {"atom", "system"}, default="atom"
+        Return per-atom energies ``(N,)`` or summed per-system energies ``(B,)``.
 
     Returns
     -------
@@ -3607,6 +3709,7 @@ def particle_mesh_ewald(
     estimate_pme_parameters : Automatic parameter estimation
     PMEParameters : Container for PME parameters
     """
+    _validate_energy_reduction(energy_reduction)
     if compute_forces or compute_virial or compute_charge_gradients or hybrid_forces:
         if torch.compiler.is_compiling():
             _compiled_direct_output_deprecation_signal("particle_mesh_ewald")
@@ -3806,6 +3909,8 @@ def particle_mesh_ewald(
             cached_dEdcell,
             batch_idx,
             _fallback,
+            energy_reduction,
+            num_systems,
         )
 
     if hybrid_forces and charges.requires_grad and not slab_correction:
@@ -3924,6 +4029,8 @@ def particle_mesh_ewald(
             None,
             batch_idx,
             _fallback,
+            energy_reduction,
+            num_systems,
         )
 
         return _build_electrostatic_result(
@@ -3954,6 +4061,7 @@ def particle_mesh_ewald(
             compute_charge_gradients=compute_charge_gradients,
             compute_virial=compute_virial,
             hybrid_forces=hybrid_forces,
+            energy_reduction=energy_reduction,
         )
 
         # Compute reciprocal-space contribution
@@ -3976,6 +4084,7 @@ def particle_mesh_ewald(
             moduli_y=moduli_y,
             moduli_z=moduli_z,
             hybrid_forces=hybrid_forces,
+            energy_reduction=energy_reduction,
         )
         return rs, rec
 
@@ -4005,6 +4114,7 @@ def particle_mesh_ewald(
                 compute_forces=compute_forces,
                 compute_charge_gradients=True,
                 compute_virial=compute_virial,
+                energy_reduction=energy_reduction,
             )
             slab_energies, slab_forces, slab_charge_grads, slab_virial = (
                 _unpack_electrostatic_outputs(
@@ -4025,9 +4135,16 @@ def particle_mesh_ewald(
                     compute_forces=False,
                     compute_charge_gradients=False,
                     compute_virial=False,
+                    energy_reduction=energy_reduction,
                 )
                 slab_energies = _InjectChargeGrad.apply(
-                    slab_energies, charges, slab_charge_grads, batch_idx
+                    slab_energies,
+                    charges,
+                    slab_charge_grads,
+                    batch_idx,
+                    energy_reduction,
+                    num_systems,
+                    energy_reduction == "system",
                 )
 
             slab_result = _build_electrostatic_result(
@@ -4049,6 +4166,7 @@ def particle_mesh_ewald(
                 compute_forces=compute_forces,
                 compute_charge_gradients=compute_charge_gradients,
                 compute_virial=compute_virial,
+                energy_reduction=energy_reduction,
             )
 
     return _combine_electrostatic_outputs(

--- a/nvalchemiops/torch/interactions/electrostatics/slab.py
+++ b/nvalchemiops/torch/interactions/electrostatics/slab.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import torch
 import warp as wp
 
@@ -37,6 +39,8 @@ from nvalchemiops.torch.interactions.electrostatics._slab_chain import (
 )
 from nvalchemiops.torch.interactions.electrostatics._util import (
     _build_electrostatic_result,
+    _reduce_atom_energy,
+    _validate_energy_reduction,
 )
 from nvalchemiops.torch.types import get_wp_dtype, get_wp_mat_dtype, get_wp_vec_dtype
 
@@ -369,6 +373,8 @@ def compute_slab_correction(
     compute_forces: bool = False,
     compute_charge_gradients: bool = False,
     compute_virial: bool = False,
+    *,
+    energy_reduction: Literal["atom", "system"] = "atom",
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
     """Yeh-Berkowitz slab correction for 2D periodic electrostatics, with the
     Ballenegger et al. (2009) Eq. 29 extension for non-neutral systems.
@@ -417,6 +423,8 @@ def compute_slab_correction(
     compute_virial : bool, default=False
         If True, return per-system virial tensor using the normal-following
         affine strain convention W = E_slab * (I - 2 n n^T).
+    energy_reduction : {"atom", "system"}, default="atom"
+        Return per-atom energies ``(N,)`` or summed per-system energies ``(B,)``.
 
     Returns
     -------
@@ -445,6 +453,7 @@ def compute_slab_correction(
         ...     positions, charges, triclinic_cell, pbc_slab, compute_forces=True
         ... )
     """
+    _validate_energy_reduction(energy_reduction)
     ensure_electrostatics_ops_registered()
     cell, num_systems = _prepare_cell(cell)
     pbc = _prepare_pbc_for_slab(pbc, num_systems, positions.device)
@@ -480,8 +489,15 @@ def compute_slab_correction(
         virial = direct_outputs[out_idx] if compute_virial else None
         if grad_enabled:
             energies = _slab_correction_energy_autograd(
-                positions, charges, cell, pbc, batch_idx
+                positions,
+                charges,
+                cell,
+                pbc,
+                batch_idx,
+                energy_reduction == "system",
             )
+        elif energy_reduction == "system":
+            energies = _reduce_atom_energy(energies, batch_idx, num_systems)
         return _build_electrostatic_result(
             energies,
             forces,
@@ -493,6 +509,16 @@ def compute_slab_correction(
         )
 
     if not grad_enabled:
-        return _run_slab_correction_op(positions, charges, cell, pbc, batch_idx)[0]
+        energies = _run_slab_correction_op(positions, charges, cell, pbc, batch_idx)[0]
+        if energy_reduction == "system":
+            energies = _reduce_atom_energy(energies, batch_idx, num_systems)
+        return energies
 
-    return _slab_correction_energy_autograd(positions, charges, cell, pbc, batch_idx)
+    return _slab_correction_energy_autograd(
+        positions,
+        charges,
+        cell,
+        pbc,
+        batch_idx,
+        energy_reduction == "system",
+    )

--- a/nvalchemiops/torch/interactions/electrostatics/slab.py
+++ b/nvalchemiops/torch/interactions/electrostatics/slab.py
@@ -379,11 +379,12 @@ def compute_slab_correction(
     """Yeh-Berkowitz slab correction for 2D periodic electrostatics, with the
     Ballenegger et al. (2009) Eq. 29 extension for non-neutral systems.
 
-    Returns the slab-correction contribution (per-atom energy and optionally
-    per-atom force, charge gradient, and per-system virial). The caller adds
-    these to the corresponding 3D Ewald/PME quantities; in normal usage the
-    correction is invoked through ``ewald_summation(..., slab_correction=True)``
-    or ``particle_mesh_ewald(..., slab_correction=True)``.
+    Returns the slab-correction contribution (energy in the requested atom/system
+    layout and optionally per-atom force, charge gradient, and per-system virial).
+    The caller adds these to the corresponding 3D Ewald/PME quantities; in normal
+    usage the correction is invoked through
+    ``ewald_summation(..., slab_correction=True)`` or
+    ``particle_mesh_ewald(..., slab_correction=True)``.
 
     Background-charge convention
     ----------------------------
@@ -428,8 +429,9 @@ def compute_slab_correction(
 
     Returns
     -------
-    energies : torch.Tensor, shape (N,), dtype=float64
-        Per-atom slab correction energy.
+    energies : torch.Tensor, shape (N,) or (B,), dtype=float64
+        Slab correction energy: per-atom when ``energy_reduction="atom"``,
+        per-system when ``energy_reduction="system"``.
     forces : torch.Tensor, shape (N, 3), dtype matches positions, optional
         Per-atom slab force (only returned if compute_forces=True).
     charge_grads : torch.Tensor, shape (N,), dtype=float64, optional

--- a/test/interactions/electrostatics/bindings/jax/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/jax/test_ewald.py
@@ -2447,3 +2447,379 @@ class TestEwaldVirialJIT:
         energies, virial = result
         assert virial.shape == (1, 3, 3)
         assert jnp.all(jnp.isfinite(virial))
+
+
+class TestEwaldEnergyReduction:
+    """Tests for the ``energy_reduction`` public atom/system layout option."""
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda positions, charges, cell, nm, nms: ewald_real_space(
+                positions=positions,
+                charges=charges,
+                cell=cell,
+                alpha=0.3,
+                neighbor_matrix=nm,
+                neighbor_matrix_shifts=nms,
+                energy_reduction="bogus",
+            ),
+            lambda positions, charges, cell, nm, nms: ewald_reciprocal_space(
+                positions=positions,
+                charges=charges,
+                cell=cell,
+                k_vectors=generate_k_vectors_ewald_summation(cell, k_cutoff=8.0),
+                alpha=0.3,
+                energy_reduction="bogus",
+            ),
+            lambda positions, charges, cell, nm, nms: ewald_summation(
+                positions=positions,
+                charges=charges,
+                cell=cell,
+                alpha=0.3,
+                k_cutoff=8.0,
+                neighbor_matrix=nm,
+                neighbor_matrix_shifts=nms,
+                energy_reduction="bogus",
+            ),
+        ],
+        ids=["real_space", "reciprocal_space", "summation"],
+    )
+    def test_invalid_energy_reduction_raises(self, device, call):
+        """An unsupported energy_reduction value raises ValueError early."""
+        (
+            positions,
+            charges,
+            cell,
+            neighbor_matrix,
+            _num_neighbors,
+            neighbor_matrix_shifts,
+        ) = create_dipole_system()
+
+        with pytest.raises(ValueError, match="energy_reduction"):
+            call(positions, charges, cell, neighbor_matrix, neighbor_matrix_shifts)
+
+    def test_real_space_system_reduction_single_system_shape_and_value(self, device):
+        """System reduction returns shape (1,) equal to the atom-mode sum."""
+        (
+            positions,
+            charges,
+            cell,
+            neighbor_matrix,
+            _num_neighbors,
+            neighbor_matrix_shifts,
+        ) = create_dipole_system()
+
+        atom_energies = ewald_real_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=0.3,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+        )
+        system_energies = ewald_real_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=0.3,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            energy_reduction="system",
+        )
+
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))
+
+    def test_reciprocal_space_system_reduction_batched_matches_manual_scatter(
+        self, device
+    ):
+        """Batched system reduction matches a manual per-system scatter-sum."""
+        positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [3.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
+                [3.0, 0.0, 0.0],
+            ],
+            dtype=jnp.float64,
+        )
+        charges = jnp.array([1.0, -1.0, 1.0, -1.0], dtype=jnp.float64)
+        cell_single = cubic_cell_jax(10.0, dtype=jnp.float64)
+        cell = jnp.concatenate([cell_single, cell_single], axis=0)
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        alpha = jnp.array([0.3, 0.3])
+        k_vectors = generate_k_vectors_ewald_summation(cell_single, k_cutoff=8.0)
+
+        atom_energies = ewald_reciprocal_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            k_vectors=k_vectors,
+            alpha=alpha,
+            batch_idx=batch_idx,
+        )
+        system_energies = ewald_reciprocal_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            k_vectors=k_vectors,
+            alpha=alpha,
+            batch_idx=batch_idx,
+            energy_reduction="system",
+        )
+
+        expected = (
+            jnp.zeros((2,), dtype=atom_energies.dtype).at[batch_idx].add(atom_energies)
+        )
+        assert system_energies.shape == (2,)
+        assert jnp.allclose(system_energies, expected)
+
+    def test_summation_system_reduction_batched_matches_manual_scatter(self, device):
+        """Full Ewald summation system reduction matches manual scatter-sum."""
+        positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [3.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
+                [3.0, 0.0, 0.0],
+            ],
+            dtype=jnp.float64,
+        )
+        charges = jnp.array([1.0, -1.0, 1.0, -1.0], dtype=jnp.float64)
+        cell_single = cubic_cell_jax(10.0, dtype=jnp.float64)
+        cell = jnp.concatenate([cell_single, cell_single], axis=0)
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 2, 4], dtype=jnp.int32)
+        pbc = jnp.array([[True, True, True], [True, True, True]])
+        neighbor_matrix, _num_neighbors, neighbor_matrix_shifts = batch_cell_list(
+            positions,
+            5.0,
+            cell,
+            pbc,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=32,
+        )
+
+        atom_energies = ewald_summation(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=jnp.array([0.3, 0.3]),
+            k_cutoff=8.0,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            batch_idx=batch_idx,
+        )
+        system_energies = ewald_summation(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=jnp.array([0.3, 0.3]),
+            k_cutoff=8.0,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            batch_idx=batch_idx,
+            energy_reduction="system",
+        )
+
+        expected = (
+            jnp.zeros((2,), dtype=atom_energies.dtype).at[batch_idx].add(atom_energies)
+        )
+        assert system_energies.shape == (2,)
+        assert jnp.allclose(system_energies, expected)
+
+    def test_summation_system_reduction_with_slab_correction(self, device):
+        """System reduction composes with the slab-correction energy path."""
+        positions = jnp.array([[0.0, 0.0, 0.0], [3.0, 0.0, 0.0]], dtype=jnp.float64)
+        charges = jnp.array([1.0, -1.0], dtype=jnp.float64)
+        cell = cubic_cell_jax(10.0, dtype=jnp.float64)
+        pbc = jnp.array([[True, True, False]])
+        neighbor_matrix, _num_neighbors, neighbor_matrix_shifts = cell_list(
+            positions, 5.0, cell, pbc
+        )
+
+        atom_energies = ewald_summation(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            pbc=pbc,
+            slab_correction=True,
+        )
+        system_energies = ewald_summation(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=0.3,
+            k_cutoff=8.0,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            pbc=pbc,
+            slab_correction=True,
+            energy_reduction="system",
+        )
+
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))
+
+    def test_real_space_system_reduction_gradients_match_atom_mode(self, device):
+        """Position gradients are identical whether summed pre- or post-scatter."""
+        (
+            positions,
+            charges,
+            cell,
+            neighbor_matrix,
+            _num_neighbors,
+            neighbor_matrix_shifts,
+        ) = create_dipole_system()
+
+        def atom_loss(pos):
+            return ewald_real_space(
+                positions=pos,
+                charges=charges,
+                cell=cell,
+                alpha=0.3,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+            ).sum()
+
+        def system_loss(pos):
+            return ewald_real_space(
+                positions=pos,
+                charges=charges,
+                cell=cell,
+                alpha=0.3,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+                energy_reduction="system",
+            ).sum()
+
+        grad_atom = jax.grad(atom_loss)(positions)
+        grad_system = jax.grad(system_loss)(positions)
+        assert jnp.allclose(grad_atom, grad_system, rtol=1e-10, atol=1e-12)
+
+    def test_real_space_system_reduction_direct_tuple_only_energy_changes(self, device):
+        """Direct-output tuples keep atom-layout forces; only energy reduces."""
+        (
+            positions,
+            charges,
+            cell,
+            neighbor_matrix,
+            _num_neighbors,
+            neighbor_matrix_shifts,
+        ) = create_dipole_system()
+
+        atom_energies, atom_forces = ewald_real_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=0.3,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            compute_forces=True,
+        )
+        system_energies, system_forces = ewald_real_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=0.3,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            compute_forces=True,
+            energy_reduction="system",
+        )
+
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))
+        assert system_forces.shape == atom_forces.shape
+        assert jnp.allclose(system_forces, atom_forces)
+
+    def test_summation_direct_output_tuple_energy_reduced_others_unchanged(
+        self, device
+    ):
+        """ewald_summation's deprecated direct-output tuple also reduces only energy."""
+        (
+            positions,
+            charges,
+            cell,
+            neighbor_matrix,
+            _num_neighbors,
+            neighbor_matrix_shifts,
+        ) = create_dipole_system()
+
+        with pytest.warns(DeprecationWarning):
+            atom_out = ewald_summation(
+                positions=positions,
+                charges=charges,
+                cell=cell,
+                alpha=0.3,
+                k_cutoff=8.0,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+                compute_forces=True,
+                compute_charge_gradients=True,
+                compute_virial=True,
+            )
+        with pytest.warns(DeprecationWarning):
+            system_out = ewald_summation(
+                positions=positions,
+                charges=charges,
+                cell=cell,
+                alpha=0.3,
+                k_cutoff=8.0,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+                compute_forces=True,
+                compute_charge_gradients=True,
+                compute_virial=True,
+                energy_reduction="system",
+            )
+
+        atom_energies, atom_forces, atom_charge_grads, atom_virial = atom_out
+        system_energies, system_forces, system_charge_grads, system_virial = system_out
+
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))
+        assert jnp.allclose(system_forces, atom_forces)
+        assert jnp.allclose(system_charge_grads, atom_charge_grads)
+        assert jnp.allclose(system_virial, atom_virial)
+
+    def test_real_space_energy_reduction_under_jit(self, device):
+        """energy_reduction is usable as a static string under jax.jit."""
+        (
+            positions,
+            charges,
+            cell,
+            neighbor_matrix,
+            _num_neighbors,
+            neighbor_matrix_shifts,
+        ) = create_dipole_system()
+
+        jitted = jax.jit(
+            lambda pos, chg, cell, nm, nms, reduction: ewald_real_space(
+                positions=pos,
+                charges=chg,
+                cell=cell,
+                alpha=0.3,
+                neighbor_matrix=nm,
+                neighbor_matrix_shifts=nms,
+                energy_reduction=reduction,
+            ),
+            static_argnames=("reduction",),
+        )
+
+        atom_energies = jitted(
+            positions, charges, cell, neighbor_matrix, neighbor_matrix_shifts, "atom"
+        )
+        system_energies = jitted(
+            positions, charges, cell, neighbor_matrix, neighbor_matrix_shifts, "system"
+        )
+
+        assert atom_energies.shape == (2,)
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))

--- a/test/interactions/electrostatics/bindings/jax/test_pme.py
+++ b/test/interactions/electrostatics/bindings/jax/test_pme.py
@@ -3484,5 +3484,302 @@ class TestDirectOutputDeprecation:
         assert jnp.all(jnp.isfinite(energy))
 
 
+class TestPMEEnergyReduction:
+    """Tests for the ``energy_reduction`` public atom/system layout option."""
+
+    mesh_dimensions = (16, 16, 16)
+
+    def test_invalid_energy_reduction_raises_reciprocal(self, device):
+        """pme_reciprocal_space rejects an unsupported energy_reduction value."""
+        positions, charges, cell = create_dipole_system()
+
+        with pytest.raises(ValueError, match="energy_reduction"):
+            pme_reciprocal_space(
+                positions=positions,
+                charges=charges,
+                cell=cell,
+                alpha=jnp.array([0.3]),
+                mesh_dimensions=self.mesh_dimensions,
+                energy_reduction="bogus",
+            )
+
+    def test_invalid_energy_reduction_raises_full(self, device):
+        """particle_mesh_ewald rejects an unsupported energy_reduction value."""
+        positions, charges, cell = create_dipole_system()
+
+        with pytest.raises(ValueError, match="energy_reduction"):
+            particle_mesh_ewald(
+                positions=positions,
+                charges=charges,
+                cell=cell,
+                alpha=0.3,
+                mesh_dimensions=self.mesh_dimensions,
+                energy_reduction="bogus",
+            )
+
+    def test_reciprocal_system_reduction_single_system_shape_and_value(self, device):
+        """System reduction returns shape (1,) equal to the atom-mode sum."""
+        positions, charges, cell = create_simple_system(num_atoms=5)
+
+        atom_energies = pme_reciprocal_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=jnp.array([0.3]),
+            mesh_dimensions=self.mesh_dimensions,
+        )
+        system_energies = pme_reciprocal_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=jnp.array([0.3]),
+            mesh_dimensions=self.mesh_dimensions,
+            energy_reduction="system",
+        )
+
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))
+
+    def test_reciprocal_system_reduction_batched_matches_manual_scatter(self, device):
+        """Batched system reduction matches a manual per-system scatter-sum."""
+        positions = jnp.array(
+            [
+                [1.0, 1.0, 1.0],
+                [3.0, 1.0, 1.0],
+                [5.0, 1.0, 1.0],
+                [1.0, 5.0, 5.0],
+                [3.0, 5.0, 5.0],
+                [5.0, 5.0, 5.0],
+                [7.0, 5.0, 5.0],
+            ],
+            dtype=jnp.float64,
+        )
+        charges = jnp.array([1.0, -1.0, 0.0, 0.5, -0.5, 0.5, -0.5], dtype=jnp.float64)
+        batch_idx = jnp.array([0, 0, 0, 1, 1, 1, 1], dtype=jnp.int32)
+        cells = jnp.stack([jnp.eye(3, dtype=jnp.float64) * 10.0] * 2, axis=0)
+
+        atom_energies = pme_reciprocal_space(
+            positions=positions,
+            charges=charges,
+            cell=cells,
+            alpha=jnp.array([0.3, 0.3]),
+            mesh_dimensions=self.mesh_dimensions,
+            batch_idx=batch_idx,
+        )
+        system_energies = pme_reciprocal_space(
+            positions=positions,
+            charges=charges,
+            cell=cells,
+            alpha=jnp.array([0.3, 0.3]),
+            mesh_dimensions=self.mesh_dimensions,
+            batch_idx=batch_idx,
+            energy_reduction="system",
+        )
+
+        expected = (
+            jnp.zeros((2,), dtype=atom_energies.dtype).at[batch_idx].add(atom_energies)
+        )
+        assert system_energies.shape == (2,)
+        assert jnp.allclose(system_energies, expected)
+
+    def test_full_pme_system_reduction_matches_manual_sum(self, device):
+        """particle_mesh_ewald system reduction matches the atom-mode sum."""
+        positions, charges, cell = create_simple_system(num_atoms=4)
+        pbc = jnp.array([[True, True, True]])
+        neighbor_matrix, _num_neighbors, neighbor_matrix_shifts = cell_list(
+            positions, cutoff=5.0, cell=cell, pbc=pbc
+        )
+
+        atom_energies = particle_mesh_ewald(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=0.3,
+            mesh_dimensions=self.mesh_dimensions,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+        )
+        system_energies = particle_mesh_ewald(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=0.3,
+            mesh_dimensions=self.mesh_dimensions,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            energy_reduction="system",
+        )
+
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))
+
+    def test_full_pme_system_reduction_with_slab_correction(self, device):
+        """System reduction composes with the PME slab-correction energy path."""
+        positions, charges, cell = create_simple_system(num_atoms=4)
+        pbc = jnp.array([[True, True, False]])
+        neighbor_matrix, _num_neighbors, neighbor_matrix_shifts = cell_list(
+            positions, cutoff=5.0, cell=cell, pbc=pbc
+        )
+
+        atom_energies = particle_mesh_ewald(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=0.3,
+            mesh_dimensions=self.mesh_dimensions,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            pbc=pbc,
+            slab_correction=True,
+        )
+        system_energies = particle_mesh_ewald(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=0.3,
+            mesh_dimensions=self.mesh_dimensions,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+            pbc=pbc,
+            slab_correction=True,
+            energy_reduction="system",
+        )
+
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))
+
+    def test_reciprocal_system_reduction_gradients_match_atom_mode(self, device):
+        """Position gradients are identical whether summed pre- or post-scatter."""
+        positions, charges, cell = create_simple_system(num_atoms=5)
+
+        def atom_loss(pos):
+            return pme_reciprocal_space(
+                positions=pos,
+                charges=charges,
+                cell=cell,
+                alpha=jnp.array([0.3]),
+                mesh_dimensions=self.mesh_dimensions,
+            ).sum()
+
+        def system_loss(pos):
+            return pme_reciprocal_space(
+                positions=pos,
+                charges=charges,
+                cell=cell,
+                alpha=jnp.array([0.3]),
+                mesh_dimensions=self.mesh_dimensions,
+                energy_reduction="system",
+            ).sum()
+
+        grad_atom = jax.grad(atom_loss)(positions)
+        grad_system = jax.grad(system_loss)(positions)
+        assert jnp.allclose(grad_atom, grad_system, rtol=1e-10, atol=1e-12)
+
+    def test_reciprocal_direct_tuple_only_energy_changes(self, device):
+        """Direct-output tuples keep atom-layout forces; only energy reduces."""
+        positions, charges, cell = create_dipole_system()
+
+        atom_energies, atom_forces = pme_reciprocal_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=jnp.array([0.3]),
+            mesh_dimensions=self.mesh_dimensions,
+            compute_forces=True,
+        )
+        system_energies, system_forces = pme_reciprocal_space(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=jnp.array([0.3]),
+            mesh_dimensions=self.mesh_dimensions,
+            compute_forces=True,
+            energy_reduction="system",
+        )
+
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))
+        assert jnp.allclose(system_forces, atom_forces)
+
+    def test_full_pme_direct_output_tuple_energy_reduced_others_unchanged(self, device):
+        """particle_mesh_ewald's deprecated direct tuple also reduces only energy."""
+        positions, charges, cell = create_simple_system(num_atoms=4)
+        pbc = jnp.array([[True, True, True]])
+        neighbor_matrix, _num_neighbors, neighbor_matrix_shifts = cell_list(
+            positions, cutoff=5.0, cell=cell, pbc=pbc
+        )
+
+        with pytest.warns(DeprecationWarning):
+            atom_out = particle_mesh_ewald(
+                positions=positions,
+                charges=charges,
+                cell=cell,
+                alpha=0.3,
+                mesh_dimensions=self.mesh_dimensions,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+                compute_forces=True,
+                compute_charge_gradients=True,
+                compute_virial=True,
+            )
+        with pytest.warns(DeprecationWarning):
+            system_out = particle_mesh_ewald(
+                positions=positions,
+                charges=charges,
+                cell=cell,
+                alpha=0.3,
+                mesh_dimensions=self.mesh_dimensions,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+                compute_forces=True,
+                compute_charge_gradients=True,
+                compute_virial=True,
+                energy_reduction="system",
+            )
+
+        atom_energies, atom_forces, atom_charge_grads, atom_virial = atom_out
+        system_energies, system_forces, system_charge_grads, system_virial = system_out
+
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))
+        assert jnp.allclose(system_forces, atom_forces)
+        assert jnp.allclose(system_charge_grads, atom_charge_grads)
+        assert jnp.allclose(system_virial, atom_virial)
+
+    def test_reciprocal_energy_reduction_under_jit(self, device):
+        """energy_reduction is usable as a static string under jax.jit."""
+        positions = jnp.array([[4.0, 5.0, 5.0], [6.0, 5.0, 5.0]], dtype=jnp.float64)
+        charges = jnp.array([1.0, -1.0], dtype=jnp.float64)
+        cell = cubic_cell_jax(10.0)
+        alpha = jnp.array([0.3], dtype=jnp.float64)
+
+        jitted = jax.jit(
+            partial(
+                pme_reciprocal_space,
+                mesh_dimensions=self.mesh_dimensions,
+            ),
+            static_argnames=("energy_reduction",),
+        )
+
+        atom_energies = jitted(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=alpha,
+            energy_reduction="atom",
+        )
+        system_energies = jitted(
+            positions=positions,
+            charges=charges,
+            cell=cell,
+            alpha=alpha,
+            energy_reduction="system",
+        )
+
+        assert atom_energies.shape == (2,)
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/interactions/electrostatics/bindings/jax/test_public_api.py
+++ b/test/interactions/electrostatics/bindings/jax/test_public_api.py
@@ -17,6 +17,7 @@
 
 import inspect
 from pathlib import Path
+from typing import Literal, get_type_hints
 
 import pytest
 
@@ -79,11 +80,11 @@ def test_ewald_miller_bounds_is_keyword_only_after_legacy_slots() -> None:
 )
 def test_monopole_energy_reduction_is_keyword_only(name: str) -> None:
     """Monopole APIs expose the compatible atom/system energy-layout option."""
-    parameter = inspect.signature(getattr(electrostatics, name)).parameters[
-        "energy_reduction"
-    ]
+    function = getattr(electrostatics, name)
+    parameter = inspect.signature(function).parameters["energy_reduction"]
     assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
     assert parameter.default == "atom"
+    assert get_type_hints(function)["energy_reduction"] == Literal["atom", "system"]
 
 
 @pytest.mark.parametrize(

--- a/test/interactions/electrostatics/bindings/jax/test_public_api.py
+++ b/test/interactions/electrostatics/bindings/jax/test_public_api.py
@@ -67,6 +67,26 @@ def test_ewald_miller_bounds_is_keyword_only_after_legacy_slots() -> None:
 
 
 @pytest.mark.parametrize(
+    "name",
+    [
+        "ewald_real_space",
+        "ewald_reciprocal_space",
+        "ewald_summation",
+        "pme_reciprocal_space",
+        "particle_mesh_ewald",
+        "compute_slab_correction",
+    ],
+)
+def test_monopole_energy_reduction_is_keyword_only(name: str) -> None:
+    """Monopole APIs expose the compatible atom/system energy-layout option."""
+    parameter = inspect.signature(getattr(electrostatics, name)).parameters[
+        "energy_reduction"
+    ]
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameter.default == "atom"
+
+
+@pytest.mark.parametrize(
     ("public_name", "private_name"),
     [
         ("pme_green_structure_factor", "_pme_green_structure_factor"),

--- a/test/interactions/electrostatics/bindings/jax/test_slab.py
+++ b/test/interactions/electrostatics/bindings/jax/test_slab.py
@@ -1520,3 +1520,121 @@ class TestJaxPMESlabIntegration:
         _assert_close(slab_outputs[1][3:], jnp.zeros_like(slab_outputs[1][3:]))
         _assert_close(slab_outputs[2][3:], jnp.zeros_like(slab_outputs[2][3:]))
         _assert_close(slab_outputs[3][1], jnp.zeros_like(slab_outputs[3][1]))
+
+
+class TestSlabEnergyReduction:
+    """Tests for the ``energy_reduction`` public atom/system layout option."""
+
+    def test_invalid_energy_reduction_raises(self, device):
+        """compute_slab_correction rejects an unsupported energy_reduction value."""
+        positions, charges, cell, pbc = _make_slab_system()
+
+        with pytest.raises(ValueError, match="energy_reduction"):
+            compute_slab_correction(
+                positions, charges, cell, pbc, energy_reduction="bogus"
+            )
+
+    def test_system_reduction_single_system_shape_and_value(self, device):
+        """System reduction returns shape (1,) equal to the atom-mode sum."""
+        positions, charges, cell, pbc = _make_slab_system()
+
+        atom_energies = compute_slab_correction(positions, charges, cell, pbc)
+        system_energies = compute_slab_correction(
+            positions, charges, cell, pbc, energy_reduction="system"
+        )
+
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))
+
+    def test_system_reduction_batched_matches_manual_scatter(self, device):
+        """Batched system reduction matches a manual per-system scatter-sum."""
+        positions, charges, cell, batch_idx, pbc = _make_batched_system()
+
+        atom_energies = compute_slab_correction(
+            positions, charges, cell, pbc, batch_idx=batch_idx
+        )
+        system_energies = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            batch_idx=batch_idx,
+            energy_reduction="system",
+        )
+
+        expected = (
+            jnp.zeros((2,), dtype=atom_energies.dtype).at[batch_idx].add(atom_energies)
+        )
+        assert system_energies.shape == (2,)
+        assert jnp.allclose(system_energies, expected)
+
+    def test_system_reduction_gradients_match_atom_mode(self, device):
+        """Position gradients are identical whether summed pre- or post-scatter."""
+        positions, charges, cell, pbc = _make_slab_system()
+
+        def atom_loss(pos):
+            return compute_slab_correction(pos, charges, cell, pbc).sum()
+
+        def system_loss(pos):
+            return compute_slab_correction(
+                pos, charges, cell, pbc, energy_reduction="system"
+            ).sum()
+
+        grad_atom = jax.grad(atom_loss)(positions)
+        grad_system = jax.grad(system_loss)(positions)
+        assert jnp.allclose(grad_atom, grad_system, rtol=1e-10, atol=1e-12)
+
+    def test_direct_tuple_only_energy_changes(self, device):
+        """Direct-output tuples keep atom-layout forces; only energy reduces."""
+        positions, charges, cell, pbc = _make_slab_system()
+
+        atom_energies, atom_forces, atom_charge_grads, atom_virial = (
+            compute_slab_correction(
+                positions,
+                charges,
+                cell,
+                pbc,
+                compute_forces=True,
+                compute_charge_gradients=True,
+                compute_virial=True,
+            )
+        )
+        (
+            system_energies,
+            system_forces,
+            system_charge_grads,
+            system_virial,
+        ) = compute_slab_correction(
+            positions,
+            charges,
+            cell,
+            pbc,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+            energy_reduction="system",
+        )
+
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))
+        assert jnp.allclose(system_forces, atom_forces)
+        assert jnp.allclose(system_charge_grads, atom_charge_grads)
+        assert jnp.allclose(system_virial, atom_virial)
+
+    def test_energy_reduction_under_jit(self, device):
+        """energy_reduction is usable as a static string under jax.jit."""
+        positions, charges, cell, pbc = _make_slab_system()
+
+        jitted = jax.jit(
+            lambda pos, chg, cell_in, pbc_in, reduction: compute_slab_correction(
+                pos, chg, cell_in, pbc_in, energy_reduction=reduction
+            ),
+            static_argnames=("reduction",),
+        )
+
+        atom_energies = jitted(positions, charges, cell, pbc, "atom")
+        system_energies = jitted(positions, charges, cell, pbc, "system")
+
+        assert atom_energies.shape == (3,)
+        assert system_energies.shape == (1,)
+        assert jnp.allclose(system_energies, atom_energies.sum(keepdims=True))

--- a/test/interactions/electrostatics/bindings/torch/test_dsf.py
+++ b/test/interactions/electrostatics/bindings/torch/test_dsf.py
@@ -659,6 +659,46 @@ class TestDSFVirial:
 class TestAutograd:
     """Test autograd support for charge gradients."""
 
+    def test_one_atom_per_system_uses_explicit_system_layout(self, device):
+        """Arbitrary system cotangents are not confused with atom layout when N == B."""
+        positions = torch.tensor(
+            [[0.0, 0.0, 0.0], [4.0, 0.0, 0.0]],
+            dtype=torch.float64,
+            device=device,
+        )
+        charges = torch.tensor(
+            [0.8, -0.3], dtype=torch.float64, device=device, requires_grad=True
+        )
+        batch_idx = torch.tensor([0, 1], dtype=torch.int32, device=device)
+        neighbor_matrix = torch.full((2, 1), 2, dtype=torch.int32, device=device)
+        (energy,) = dsf_coulomb(
+            positions,
+            charges,
+            cutoff=6.0,
+            batch_idx=batch_idx,
+            neighbor_matrix=neighbor_matrix,
+            fill_value=2,
+            compute_forces=False,
+            num_systems=2,
+        )
+        weights = torch.tensor([1.7, -0.4], dtype=torch.float64, device=device)
+        (actual,) = torch.autograd.grad(energy, charges, grad_outputs=weights)
+
+        ref = dsf_reference(
+            positions,
+            charges.detach(),
+            cutoff=6.0,
+            alpha=0.2,
+            neighbor_matrix=neighbor_matrix,
+            fill_value=2,
+            batch_idx=batch_idx,
+            num_systems=2,
+            compute_forces=False,
+        )
+        torch.testing.assert_close(
+            actual, ref["charge_grad"] * weights.index_select(0, batch_idx.long())
+        )
+
     def test_energy_differentiable_wrt_charges(self, two_charge_pair):
         """energy.backward() populates charges.grad."""
         positions, charges, nl, ptr = two_charge_pair

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -104,6 +104,276 @@ TIGHT_TOL = 1e-6
 LOOSE_TOL = 1e-4
 
 
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("part", ["real", "reciprocal", "full"])
+def test_system_energy_matches_atom_reduction_and_weighted_gradient(device, part):
+    """System layout preserves values and arbitrary per-system cotangents."""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    dev = torch.device(device)
+    dtype = torch.float64
+    positions = torch.tensor(
+        [
+            [1.0, 2.0, 3.0],
+            [3.0, 2.0, 1.0],
+            [1.5, 2.5, 3.5],
+            [3.5, 2.5, 1.5],
+        ],
+        dtype=dtype,
+        device=dev,
+    )
+    charges = torch.tensor([0.7, -0.7, 0.4, -0.4], dtype=dtype, device=dev)
+    cell = torch.eye(3, dtype=dtype, device=dev).repeat(2, 1, 1) * 8.0
+    batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=dev)
+    neighbor_list = torch.tensor(
+        [[0, 1, 2, 3], [1, 0, 3, 2]], dtype=torch.int32, device=dev
+    )
+    neighbor_ptr = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32, device=dev)
+    shifts = torch.zeros(4, 3, dtype=torch.int32, device=dev)
+    alpha = torch.tensor([0.3, 0.35], dtype=dtype, device=dev)
+    k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=4.0)
+
+    def energy(pos, reduction):
+        common = {
+            "positions": pos,
+            "charges": charges + 0.01 * pos[:, 0],
+            "cell": cell,
+            "batch_idx": batch_idx,
+            "energy_reduction": reduction,
+        }
+        if part == "real":
+            return ewald_real_space(
+                alpha=alpha,
+                neighbor_list=neighbor_list,
+                neighbor_ptr=neighbor_ptr,
+                neighbor_shifts=shifts,
+                **common,
+            )
+        if part == "reciprocal":
+            return ewald_reciprocal_space(
+                k_vectors=k_vectors,
+                alpha=alpha,
+                **common,
+            )
+        return ewald_summation(
+            alpha=alpha,
+            k_vectors=k_vectors,
+            neighbor_list=neighbor_list,
+            neighbor_ptr=neighbor_ptr,
+            neighbor_shifts=shifts,
+            **common,
+        )
+
+    pos_atom = positions.clone().requires_grad_(True)
+    atom_energy = energy(pos_atom, "atom")
+    expected = torch.zeros(2, dtype=atom_energy.dtype, device=dev).index_add(
+        0, batch_idx.long(), atom_energy
+    )
+    pos_system = positions.clone().requires_grad_(True)
+    system_energy = energy(pos_system, "system")
+    weights = torch.tensor([1.7, -0.4], dtype=dtype, device=dev)
+
+    assert system_energy.shape == (2,)
+    torch.testing.assert_close(system_energy, expected)
+    grad_atom = torch.autograd.grad(
+        atom_energy, pos_atom, grad_outputs=weights.index_select(0, batch_idx.long())
+    )[0]
+    grad_system = torch.autograd.grad(system_energy, pos_system, grad_outputs=weights)[
+        0
+    ]
+    torch.testing.assert_close(grad_system, grad_atom, rtol=2e-6, atol=2e-7)
+
+
+@pytest.mark.parametrize("part", ["real", "full"])
+def test_system_qr_cell_backward_bypasses_atom_cotangent_inspection(monkeypatch, part):
+    """System Ewald facades consume (B,) cotangents before atom-major chains."""
+    dtype = torch.float64
+    positions = torch.tensor(
+        [
+            [1.0, 2.0, 3.0],
+            [3.0, 2.0, 1.0],
+            [1.5, 2.5, 3.5],
+            [3.5, 2.5, 1.5],
+        ],
+        dtype=dtype,
+        requires_grad=True,
+    )
+    base_charges = torch.tensor([0.7, -0.7, 0.4, -0.4], dtype=dtype)
+    charges = base_charges + 0.01 * positions[:, 0]
+    cell = (torch.eye(3, dtype=dtype).repeat(2, 1, 1) * 8.0).requires_grad_(True)
+    batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32)
+    neighbor_list = torch.tensor([[0, 1, 2, 3], [1, 0, 3, 2]], dtype=torch.int32)
+    neighbor_ptr = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32)
+    shifts = torch.zeros(4, 3, dtype=torch.int32)
+    alpha = torch.tensor([0.3, 0.35], dtype=dtype)
+    weights = torch.tensor([1.7, -0.4], dtype=dtype)
+
+    ref_positions = positions.detach().clone().requires_grad_(True)
+    ref_cell = cell.detach().clone().requires_grad_(True)
+    ref_common = {
+        "positions": ref_positions,
+        "charges": base_charges + 0.01 * ref_positions[:, 0],
+        "cell": ref_cell,
+        "alpha": alpha,
+        "batch_idx": batch_idx,
+        "neighbor_list": neighbor_list,
+        "neighbor_ptr": neighbor_ptr,
+        "neighbor_shifts": shifts,
+        "energy_reduction": "atom",
+    }
+    if part == "real":
+        ref_energy = ewald_real_space(**ref_common)
+    else:
+        ref_energy = ewald_summation(k_cutoff=4.0, **ref_common)
+    ref_grad_positions, ref_grad_cell = torch.autograd.grad(
+        ref_energy,
+        (ref_positions, ref_cell),
+        grad_outputs=weights.index_select(0, batch_idx.long()),
+        create_graph=True,
+    )
+
+    def _unexpected_atom_check(*_args):
+        raise AssertionError("system cotangent reached atom value inspection")
+
+    monkeypatch.setattr(
+        _ewald_real_chain,
+        "_is_per_system_uniform_cotangent",
+        _unexpected_atom_check,
+    )
+    monkeypatch.setattr(
+        _ewald_recip_chain,
+        "_is_per_system_uniform_cotangent",
+        _unexpected_atom_check,
+    )
+    common = {
+        "positions": positions,
+        "charges": charges,
+        "cell": cell,
+        "alpha": alpha,
+        "batch_idx": batch_idx,
+        "neighbor_list": neighbor_list,
+        "neighbor_ptr": neighbor_ptr,
+        "neighbor_shifts": shifts,
+        "energy_reduction": "system",
+    }
+    if part == "real":
+        energy = ewald_real_space(**common)
+    else:
+        energy = ewald_summation(k_cutoff=4.0, **common)
+
+    grad_positions, grad_cell = torch.autograd.grad(
+        energy, (positions, cell), grad_outputs=weights, create_graph=True
+    )
+    torch.testing.assert_close(grad_positions, ref_grad_positions)
+    torch.testing.assert_close(grad_cell, ref_grad_cell)
+    pos_direction = torch.arange(positions.numel(), dtype=dtype).reshape_as(positions)
+    cell_direction = torch.arange(cell.numel(), dtype=dtype).reshape_as(cell)
+    ref_hvp = torch.autograd.grad(
+        (ref_grad_positions * pos_direction).sum()
+        + (ref_grad_cell * cell_direction).sum(),
+        (ref_positions, ref_cell),
+    )
+    system_hvp = torch.autograd.grad(
+        (grad_positions * pos_direction).sum() + (grad_cell * cell_direction).sum(),
+        (positions, cell),
+    )
+    torch.testing.assert_close(system_hvp[0], ref_hvp[0])
+    torch.testing.assert_close(system_hvp[1], ref_hvp[1])
+
+
+@pytest.mark.parametrize("part", ["reciprocal", "full"])
+def test_system_direct_virial_cell_backward_bypasses_atom_cotangent_inspection(
+    monkeypatch, part
+):
+    """Direct virial tuples retain system cotangents before reciprocal backward."""
+    dtype = torch.float64
+    positions = torch.tensor(
+        [[1.0, 2.0, 3.0], [3.0, 2.0, 1.0], [1.5, 2.5, 3.5], [3.5, 2.5, 1.5]],
+        dtype=dtype,
+    )
+    charges = torch.tensor([0.7, -0.7, 0.4, -0.4], dtype=dtype)
+    cell = (torch.eye(3, dtype=dtype).repeat(2, 1, 1) * 8.0).requires_grad_(True)
+    batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32)
+    alpha = torch.tensor([0.3, 0.35], dtype=dtype)
+    neighbor_list = torch.tensor([[0, 1, 2, 3], [1, 0, 3, 2]], dtype=torch.int32)
+    neighbor_ptr = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32)
+    shifts = torch.zeros(4, 3, dtype=torch.int32)
+    weights = torch.tensor([1.7, -0.4], dtype=dtype)
+
+    ref_cell = cell.detach().clone().requires_grad_(True)
+    with pytest.warns(DeprecationWarning):
+        if part == "reciprocal":
+            ref_energy, _ref_virial = ewald_reciprocal_space(
+                positions,
+                charges,
+                ref_cell,
+                generate_k_vectors_ewald_summation(ref_cell.detach(), k_cutoff=4.0),
+                alpha,
+                batch_idx=batch_idx,
+                compute_virial=True,
+                energy_reduction="atom",
+            )
+        else:
+            ref_energy, _ref_virial = ewald_summation(
+                positions,
+                charges,
+                ref_cell,
+                alpha=alpha,
+                k_cutoff=4.0,
+                batch_idx=batch_idx,
+                neighbor_list=neighbor_list,
+                neighbor_ptr=neighbor_ptr,
+                neighbor_shifts=shifts,
+                compute_virial=True,
+                energy_reduction="atom",
+            )
+    (ref_cell_grad,) = torch.autograd.grad(
+        ref_energy,
+        ref_cell,
+        grad_outputs=weights.index_select(0, batch_idx.long()),
+    )
+
+    def _unexpected_atom_check(*_args):
+        raise AssertionError("system cotangent reached reciprocal atom inspection")
+
+    monkeypatch.setattr(
+        _ewald_recip_chain,
+        "_is_per_system_uniform_cotangent",
+        _unexpected_atom_check,
+    )
+    with pytest.warns(DeprecationWarning):
+        if part == "reciprocal":
+            energy, virial = ewald_reciprocal_space(
+                positions,
+                charges,
+                cell,
+                generate_k_vectors_ewald_summation(cell.detach(), k_cutoff=4.0),
+                alpha,
+                batch_idx=batch_idx,
+                compute_virial=True,
+                energy_reduction="system",
+            )
+        else:
+            energy, virial = ewald_summation(
+                positions,
+                charges,
+                cell,
+                alpha=alpha,
+                k_cutoff=4.0,
+                batch_idx=batch_idx,
+                neighbor_list=neighbor_list,
+                neighbor_ptr=neighbor_ptr,
+                neighbor_shifts=shifts,
+                compute_virial=True,
+                energy_reduction="system",
+            )
+    (cell_grad,) = torch.autograd.grad(energy, cell, grad_outputs=weights)
+
+    assert energy.shape == (2,)
+    assert virial.shape == (2, 3, 3)
+    torch.testing.assert_close(cell_grad, ref_cell_grad)
+
+
 def _torchpme_smearing(alpha: float | torch.Tensor) -> float:
     """Convert Ewald alpha to the scalar smearing parameter torchpme expects."""
     if isinstance(alpha, torch.Tensor):
@@ -7448,7 +7718,7 @@ class TestEwaldMillerBounds:
 
 
 class TestEwaldPerSystemUniformCotangentFastPath:
-    """CUDA cotangent routing stays sync-free for materialized weighted losses."""
+    """CUDA atom mode recognizes exact per-system-uniform materialized weights."""
 
     @staticmethod
     def _batch_inputs(device):
@@ -7481,10 +7751,10 @@ class TestEwaldPerSystemUniformCotangentFastPath:
         )
 
     @pytest.mark.parametrize("device", ["cuda"])
-    def test_real_space_cuda_materialized_per_system_weights_use_fallback(
+    def test_real_space_cuda_materialized_per_system_weights_use_cache(
         self, device, monkeypatch
     ):
-        """Materialized CUDA weights use the exact weighted recompute fallback."""
+        """Materialized CUDA per-system weights avoid weighted recompute."""
         if not torch.cuda.is_available():
             pytest.skip("CUDA not available")
         device = torch.device(device)
@@ -7541,13 +7811,13 @@ class TestEwaldPerSystemUniformCotangentFastPath:
         )
         (actual,) = torch.autograd.grad((atom_weights * energy).sum(), test_pos)
         torch.testing.assert_close(actual, expected, rtol=2e-7, atol=3e-8)
-        assert call_count == 1
+        assert call_count == 0
 
     @pytest.mark.parametrize("device", ["cuda"])
-    def test_recip_cuda_materialized_per_system_weights_use_fallback(
+    def test_recip_cuda_materialized_per_system_weights_use_cache(
         self, device, monkeypatch
     ):
-        """Materialized CUDA reciprocal weights use the exact fallback."""
+        """Materialized CUDA reciprocal weights avoid weighted recompute."""
         if not torch.cuda.is_available():
             pytest.skip("CUDA not available")
         device = torch.device(device)
@@ -7600,7 +7870,7 @@ class TestEwaldPerSystemUniformCotangentFastPath:
         )
         (actual,) = torch.autograd.grad((atom_weights * energy).sum(), test_pos)
         torch.testing.assert_close(actual, expected, rtol=1e-11, atol=1e-12)
-        assert call_count == 1
+        assert call_count == 0
 
 
 class TestEwaldEnergyDerivativeContract:

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -255,9 +255,50 @@ def test_system_energy_matches_atom_reduction_and_weighted_gradient(device, part
     torch.testing.assert_close(grad_system, grad_atom, rtol=2e-6, atol=2e-7)
 
 
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_real_space_system_energy_empty_neighbors_returns_zero_gradients(device):
+    """Fused system output preserves empty-neighbor values and derivatives."""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    dev = torch.device(device)
+    positions = torch.tensor(
+        [[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]],
+        dtype=torch.float64,
+        device=dev,
+        requires_grad=True,
+    )
+    charges = torch.tensor(
+        [0.7, -0.7], dtype=torch.float64, device=dev, requires_grad=True
+    )
+    cell = torch.eye(3, dtype=torch.float64, device=dev).repeat(2, 1, 1) * 8.0
+    cell.requires_grad_(True)
+    batch_idx = torch.tensor([0, 0], dtype=torch.int32, device=dev)
+    neighbor_list = torch.zeros((2, 0), dtype=torch.int32, device=dev)
+    neighbor_ptr = torch.zeros(3, dtype=torch.int32, device=dev)
+    neighbor_shifts = torch.zeros((0, 3), dtype=torch.int32, device=dev)
+
+    energy = ewald_real_space(
+        positions,
+        charges,
+        cell,
+        alpha=torch.tensor([0.3, 0.4], dtype=torch.float64, device=dev),
+        neighbor_list=neighbor_list,
+        neighbor_ptr=neighbor_ptr,
+        neighbor_shifts=neighbor_shifts,
+        batch_idx=batch_idx,
+        energy_reduction="system",
+    )
+    gradients = torch.autograd.grad(energy.sum(), (positions, charges, cell))
+
+    assert energy.shape == (2,)
+    torch.testing.assert_close(energy, torch.zeros_like(energy))
+    for gradient in gradients:
+        torch.testing.assert_close(gradient, torch.zeros_like(gradient))
+
+
 @pytest.mark.parametrize("part", ["real", "full"])
-def test_system_qr_cell_backward_bypasses_atom_cotangent_inspection(monkeypatch, part):
-    """System Ewald facades consume (B,) cotangents before atom-major chains."""
+def test_system_qr_cell_gradients_and_hvp_match_atom_layout(part):
+    """System q(R) cell gradients and HVPs match atom-layout reduction."""
     dtype = torch.float64
     positions = torch.tensor(
         [
@@ -303,19 +344,6 @@ def test_system_qr_cell_backward_bypasses_atom_cotangent_inspection(monkeypatch,
         create_graph=True,
     )
 
-    def _unexpected_atom_check(*_args):
-        raise AssertionError("system cotangent reached atom value inspection")
-
-    monkeypatch.setattr(
-        _ewald_real_chain,
-        "_is_per_system_uniform_cotangent",
-        _unexpected_atom_check,
-    )
-    monkeypatch.setattr(
-        _ewald_recip_chain,
-        "_is_per_system_uniform_cotangent",
-        _unexpected_atom_check,
-    )
     common = {
         "positions": positions,
         "charges": charges,
@@ -7131,6 +7159,62 @@ class TestEwaldTorchCompile:
         torch.testing.assert_close(forces_compiled, forces_eager, rtol=1e-4, atol=1e-4)
         torch.testing.assert_close(grad_compiled, grad_eager, rtol=1e-3, atol=1e-3)
         torch.testing.assert_close(dq_compiled, dq_eager, rtol=1e-3, atol=1e-3)
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="CUDA required for torch.compile"
+    )
+    def test_compiled_real_space_system_energy_weighted_backward(self):
+        """Compiled fused system energies match eager weighted position gradients."""
+        device = torch.device("cuda")
+        dtype = torch.float64
+        positions = torch.tensor(
+            [[1.0, 2.0, 3.0], [3.0, 2.0, 1.0], [1.5, 2.5, 3.5], [3.5, 2.5, 1.5]],
+            dtype=dtype,
+            device=device,
+        )
+        charges = torch.tensor([0.7, -0.7, 0.4, -0.4], dtype=dtype, device=device)
+        cell = torch.eye(3, dtype=dtype, device=device).repeat(2, 1, 1) * 8.0
+        batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=device)
+        neighbor_list = torch.tensor(
+            [[0, 1, 2, 3], [1, 0, 3, 2]], dtype=torch.int32, device=device
+        )
+        neighbor_ptr = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32, device=device)
+        shifts = torch.zeros(4, 3, dtype=torch.int32, device=device)
+        alpha = torch.tensor([0.3, 0.35], dtype=dtype, device=device)
+        weights = torch.tensor([1.7, -0.4], dtype=dtype, device=device)
+
+        def system_energy(pos, q):
+            return ewald_real_space(
+                pos,
+                q,
+                cell,
+                alpha,
+                neighbor_list=neighbor_list,
+                neighbor_ptr=neighbor_ptr,
+                neighbor_shifts=shifts,
+                batch_idx=batch_idx,
+                energy_reduction="system",
+            )
+
+        eager_pos = positions.clone().requires_grad_(True)
+        eager_q = charges.clone().requires_grad_(True)
+        eager_energy = system_energy(eager_pos, eager_q)
+        eager_grad = torch.autograd.grad(
+            eager_energy, (eager_pos, eager_q), grad_outputs=weights
+        )
+
+        compiled_pos = positions.clone().requires_grad_(True)
+        compiled_q = charges.clone().requires_grad_(True)
+        compiled_energy = torch.compile(system_energy, dynamic=True)(
+            compiled_pos, compiled_q
+        )
+        compiled_grad = torch.autograd.grad(
+            compiled_energy, (compiled_pos, compiled_q), grad_outputs=weights
+        )
+
+        torch.testing.assert_close(compiled_energy, eager_energy)
+        torch.testing.assert_close(compiled_grad[0], eager_grad[0])
+        torch.testing.assert_close(compiled_grad[1], eager_grad[1])
 
 
 ###########################################################################################

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -7163,8 +7163,9 @@ class TestEwaldTorchCompile:
     @pytest.mark.skipif(
         not torch.cuda.is_available(), reason="CUDA required for torch.compile"
     )
-    def test_compiled_real_space_system_energy_weighted_backward(self):
-        """Compiled fused system energies match eager weighted position gradients."""
+    @pytest.mark.parametrize("part", ["real", "reciprocal", "full"])
+    def test_compiled_system_energy_weighted_backward(self, part):
+        """Compiled system energies match eager weighted position and charge gradients."""
         device = torch.device("cuda")
         dtype = torch.float64
         positions = torch.tensor(
@@ -7181,19 +7182,38 @@ class TestEwaldTorchCompile:
         neighbor_ptr = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32, device=device)
         shifts = torch.zeros(4, 3, dtype=torch.int32, device=device)
         alpha = torch.tensor([0.3, 0.35], dtype=dtype, device=device)
+        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=4.0)
         weights = torch.tensor([1.7, -0.4], dtype=dtype, device=device)
 
         def system_energy(pos, q):
-            return ewald_real_space(
-                pos,
-                q,
-                cell,
-                alpha,
+            common = {
+                "positions": pos,
+                "charges": q,
+                "cell": cell,
+                "batch_idx": batch_idx,
+                "energy_reduction": "system",
+            }
+            if part == "real":
+                return ewald_real_space(
+                    alpha=alpha,
+                    neighbor_list=neighbor_list,
+                    neighbor_ptr=neighbor_ptr,
+                    neighbor_shifts=shifts,
+                    **common,
+                )
+            if part == "reciprocal":
+                return ewald_reciprocal_space(
+                    k_vectors=k_vectors,
+                    alpha=alpha,
+                    **common,
+                )
+            return ewald_summation(
+                alpha=alpha,
+                k_vectors=k_vectors,
                 neighbor_list=neighbor_list,
                 neighbor_ptr=neighbor_ptr,
                 neighbor_shifts=shifts,
-                batch_idx=batch_idx,
-                energy_reduction="system",
+                **common,
             )
 
         eager_pos = positions.clone().requires_grad_(True)

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -105,6 +105,77 @@ LOOSE_TOL = 1e-4
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_partial_empty_batch_nonuniform_atom_cotangent_uses_fallback(
+    device, monkeypatch
+):
+    """Atom-mode weights remain per-atom when N equals B."""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    dev = torch.device(device)
+    dtype = torch.float64
+    positions = torch.tensor(
+        [[4.0, 5.0, 5.0], [6.0, 5.5, 5.0]],
+        dtype=dtype,
+        device=dev,
+    )
+    charges = torch.tensor([0.8, -0.8], dtype=dtype, device=dev)
+    cell = torch.eye(3, dtype=dtype, device=dev).repeat(2, 1, 1) * 10.0
+    alpha = torch.tensor([0.3, 0.35], dtype=dtype, device=dev)
+    batch_idx = torch.tensor([0, 0], dtype=torch.int32, device=dev)
+    neighbor_list = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32, device=dev)
+    neighbor_ptr = torch.tensor([0, 1, 2], dtype=torch.int32, device=dev)
+    shifts = torch.zeros(2, 3, dtype=torch.int32, device=dev)
+    weights = torch.tensor([1.0, 2.0], dtype=dtype, device=dev)
+
+    def energy(pos, q, alpha_arg):
+        return ewald_real_space(
+            pos,
+            q,
+            cell,
+            alpha_arg,
+            neighbor_list=neighbor_list,
+            neighbor_ptr=neighbor_ptr,
+            neighbor_shifts=shifts,
+            batch_idx=batch_idx,
+        )
+
+    ref_position_grad = finite_difference_jacobian(
+        lambda pos: (weights * energy(pos, charges, alpha)).sum(),
+        positions,
+    )
+    ref_charge_grad = finite_difference_jacobian(
+        lambda q: (weights * energy(positions, q, alpha)).sum(),
+        charges,
+    )
+
+    call_count = 0
+    original = _ewald_real_chain._real_space_weighted_energy
+
+    def _counting_weighted_energy(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        _ewald_real_chain,
+        "_real_space_weighted_energy",
+        _counting_weighted_energy,
+    )
+    test_positions = positions.clone().requires_grad_(True)
+    test_charges = charges.clone().requires_grad_(True)
+    actual = energy(test_positions, test_charges, alpha)
+    position_grad, charge_grad = torch.autograd.grad(
+        actual,
+        (test_positions, test_charges),
+        grad_outputs=weights,
+    )
+
+    assert call_count == 1
+    torch.testing.assert_close(position_grad, ref_position_grad, rtol=1e-5, atol=1e-7)
+    torch.testing.assert_close(charge_grad, ref_charge_grad, rtol=1e-5, atol=1e-7)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("part", ["real", "reciprocal", "full"])
 def test_system_energy_matches_atom_reduction_and_weighted_gradient(device, part):
     """System layout preserves values and arbitrary per-system cotangents."""

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -5009,6 +5009,20 @@ def _pme_contract_batch(device, dtype=torch.float64):
     return positions, charges, cell, batch_idx
 
 
+def _pme_partial_empty_batch(device, dtype=torch.float64):
+    """Two atoms in system zero and an empty system one."""
+    cell_size = 10.0
+    positions = torch.tensor(
+        [[4.0, 5.0, 5.0], [6.0, 5.5, 5.0]],
+        dtype=dtype,
+        device=device,
+    )
+    charges = torch.tensor([0.8, -0.8], dtype=dtype, device=device)
+    cell = torch.eye(3, dtype=dtype, device=device).repeat(2, 1, 1) * cell_size
+    batch_idx = torch.tensor([0, 0], dtype=torch.int32, device=device)
+    return positions, charges, cell, batch_idx
+
+
 def _pme_full_neighbors(positions, cell, device, batch_idx=None, cutoff=5.0):
     if batch_idx is None:
         pbc = torch.tensor([[True, True, True]], device=device)
@@ -5022,7 +5036,7 @@ def _pme_full_neighbors(positions, cell, device, batch_idx=None, cutoff=5.0):
 class TestPMECachedEvalFastPath:
     """Cached first-order eval gradients preserve eager training semantics."""
 
-    def _eager_reciprocal_energy(self, positions, charges, cell):
+    def _eager_reciprocal_energy(self, positions, charges, cell, batch_idx=None):
         """PME reciprocal energy without the cached-eval wrapper."""
         alpha = _prepare_alpha(0.3, cell.shape[0], positions.dtype, positions.device)
         energies, _, _, _ = _pme_reciprocal_space_impl(
@@ -5032,7 +5046,7 @@ class TestPMECachedEvalFastPath:
             alpha,
             _MESH,
             4,
-            None,
+            batch_idx,
             compute_forces=False,
             compute_charge_gradients=False,
             compute_virial=False,
@@ -5078,6 +5092,126 @@ class TestPMECachedEvalFastPath:
         )
 
         torch.testing.assert_close(grad_eval, grad_ref, rtol=1e-5, atol=1e-7)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    @pytest.mark.parametrize("leaf", ["positions", "charges"])
+    @pytest.mark.parametrize(
+        ("weights", "expected_calls"),
+        [
+            ([1.0, 2.0], 2),
+            ([1.0, 1.0], 1),
+        ],
+    )
+    def test_partial_empty_batch_atom_cotangent_routing(
+        self,
+        device,
+        leaf,
+        weights,
+        expected_calls,
+        monkeypatch,
+    ):
+        """Partial-empty batches preserve atom weights and cache uniform ones."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        dev = torch.device(device)
+        positions, charges, cell, batch_idx = _pme_partial_empty_batch(dev)
+        weight_tensor = torch.tensor(weights, dtype=positions.dtype, device=dev)
+
+        ref_positions = positions.clone().requires_grad_(leaf == "positions")
+        ref_charges = charges.clone().requires_grad_(leaf == "charges")
+        reference = self._eager_reciprocal_energy(
+            ref_positions,
+            ref_charges,
+            cell,
+            batch_idx,
+        )
+        (expected,) = torch.autograd.grad(
+            reference,
+            {"positions": ref_positions, "charges": ref_charges}[leaf],
+            grad_outputs=weight_tensor,
+        )
+
+        pme_module = import_module("nvalchemiops.torch.interactions.electrostatics.pme")
+        call_count = 0
+        original_impl = pme_module._pme_reciprocal_space_impl
+
+        def _counting_impl(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return original_impl(*args, **kwargs)
+
+        monkeypatch.setattr(pme_module, "_pme_reciprocal_space_impl", _counting_impl)
+        test_positions = positions.clone().requires_grad_(leaf == "positions")
+        test_charges = charges.clone().requires_grad_(leaf == "charges")
+        energy = pme_reciprocal_space(
+            test_positions,
+            test_charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=_MESH,
+            batch_idx=batch_idx,
+        )
+        (actual,) = torch.autograd.grad(
+            energy,
+            {"positions": test_positions, "charges": test_charges}[leaf],
+            grad_outputs=weight_tensor,
+        )
+
+        assert call_count == expected_calls
+        torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-7)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_partial_empty_batch_system_energy_and_gradients(self, device):
+        """System layout emits an empty-system zero and matches atom gradients."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        dev = torch.device(device)
+        positions, charges, cell, batch_idx = _pme_partial_empty_batch(dev)
+        weights = torch.tensor([1.7, -0.4], dtype=positions.dtype, device=dev)
+
+        atom_positions = positions.clone().requires_grad_(True)
+        atom_charges = charges.clone().requires_grad_(True)
+        atom_energy = pme_reciprocal_space(
+            atom_positions,
+            atom_charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=_MESH,
+            batch_idx=batch_idx,
+        )
+        atom_gradients = torch.autograd.grad(
+            atom_energy,
+            (atom_positions, atom_charges),
+            grad_outputs=weights.index_select(0, batch_idx.long()),
+        )
+
+        system_positions = positions.clone().requires_grad_(True)
+        system_charges = charges.clone().requires_grad_(True)
+        system_energy = pme_reciprocal_space(
+            system_positions,
+            system_charges,
+            cell,
+            alpha=0.3,
+            mesh_dimensions=_MESH,
+            batch_idx=batch_idx,
+            energy_reduction="system",
+        )
+        expected_energy = torch.zeros(2, dtype=atom_energy.dtype, device=dev).index_add(
+            0,
+            batch_idx.long(),
+            atom_energy.detach(),
+        )
+        system_gradients = torch.autograd.grad(
+            system_energy,
+            (system_positions, system_charges),
+            grad_outputs=weights,
+        )
+
+        assert system_energy.shape == (2,)
+        assert system_energy[1].item() == 0.0
+        torch.testing.assert_close(system_energy, expected_energy)
+        torch.testing.assert_close(system_gradients[0], atom_gradients[0])
+        torch.testing.assert_close(system_gradients[1], atom_gradients[1])
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_uniform_sum_uses_cached_first_grad(self, device, monkeypatch):

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -100,6 +100,188 @@ from test.interactions.electrostatics.conftest import (
 ###########################################################################################
 
 
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("part", ["reciprocal", "full"])
+def test_system_energy_matches_atom_reduction_and_weighted_gradient(device, part):
+    """PME system layout retains arbitrary per-system cotangent provenance."""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    dev = torch.device(device)
+    dtype = torch.float64
+    positions = torch.tensor(
+        [
+            [1.0, 2.0, 3.0],
+            [3.0, 2.0, 1.0],
+            [1.5, 2.5, 3.5],
+            [3.5, 2.5, 1.5],
+        ],
+        dtype=dtype,
+        device=dev,
+    )
+    charges = torch.tensor([0.7, -0.7, 0.4, -0.4], dtype=dtype, device=dev)
+    cell = torch.eye(3, dtype=dtype, device=dev).repeat(2, 1, 1) * 8.0
+    batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=dev)
+    neighbor_list = torch.tensor(
+        [[0, 1, 2, 3], [1, 0, 3, 2]], dtype=torch.int32, device=dev
+    )
+    neighbor_ptr = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32, device=dev)
+    shifts = torch.zeros(4, 3, dtype=torch.int32, device=dev)
+
+    def energy(pos, reduction):
+        common = {
+            "positions": pos,
+            "charges": charges + 0.01 * pos[:, 0],
+            "cell": cell,
+            "alpha": torch.tensor([0.3, 0.35], dtype=dtype, device=dev),
+            "mesh_dimensions": (8, 8, 8),
+            "batch_idx": batch_idx,
+            "energy_reduction": reduction,
+        }
+        if part == "reciprocal":
+            return pme_reciprocal_space(**common)
+        return particle_mesh_ewald(
+            neighbor_list=neighbor_list,
+            neighbor_ptr=neighbor_ptr,
+            neighbor_shifts=shifts,
+            **common,
+        )
+
+    pos_atom = positions.clone().requires_grad_(True)
+    atom_energy = energy(pos_atom, "atom")
+    expected = torch.zeros(2, dtype=atom_energy.dtype, device=dev).index_add(
+        0, batch_idx.long(), atom_energy
+    )
+    pos_system = positions.clone().requires_grad_(True)
+    system_energy = energy(pos_system, "system")
+    weights = torch.tensor([1.7, -0.4], dtype=dtype, device=dev)
+
+    assert system_energy.shape == (2,)
+    torch.testing.assert_close(system_energy, expected)
+    grad_atom = torch.autograd.grad(
+        atom_energy,
+        pos_atom,
+        grad_outputs=weights.index_select(0, batch_idx.long()),
+        create_graph=True,
+    )[0]
+    grad_system = torch.autograd.grad(
+        system_energy, pos_system, grad_outputs=weights, create_graph=True
+    )[0]
+    torch.testing.assert_close(grad_system, grad_atom, rtol=2e-6, atol=2e-7)
+    direction = torch.arange(positions.numel(), dtype=dtype, device=dev).reshape_as(
+        positions
+    )
+    hvp_atom = torch.autograd.grad((grad_atom * direction).sum(), pos_atom)[0]
+    hvp_system = torch.autograd.grad((grad_system * direction).sum(), pos_system)[0]
+    torch.testing.assert_close(hvp_system, hvp_atom, rtol=3e-5, atol=3e-7)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_pme_system_cotangent_bypasses_atom_uniformity_check(monkeypatch):
+    """Cached system mode consumes arbitrary (B,) cotangents structurally."""
+    device = torch.device("cuda")
+    positions = torch.tensor(
+        [[1.0, 2.0, 3.0], [3.0, 2.0, 1.0], [1.5, 2.5, 3.5], [3.5, 2.5, 1.5]],
+        dtype=torch.float64,
+        device=device,
+        requires_grad=True,
+    )
+    charges = torch.tensor([0.7, -0.7, 0.4, -0.4], dtype=torch.float64, device=device)
+    cell = torch.eye(3, dtype=torch.float64, device=device).repeat(2, 1, 1) * 8.0
+    batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=device)
+    pme_module = import_module("nvalchemiops.torch.interactions.electrostatics.pme")
+
+    def _unexpected_atom_check(*_args):
+        raise AssertionError("system cotangent reached atom-layout predicate")
+
+    monkeypatch.setattr(
+        pme_module, "_is_per_system_uniform_cotangent", _unexpected_atom_check
+    )
+    energy = pme_reciprocal_space(
+        positions,
+        charges,
+        cell,
+        alpha=torch.tensor([0.3, 0.35], dtype=torch.float64, device=device),
+        mesh_dimensions=(8, 8, 8),
+        batch_idx=batch_idx,
+        energy_reduction="system",
+    )
+    weights = torch.tensor([1.7, -0.4], dtype=torch.float64, device=device)
+    (grad_positions,) = torch.autograd.grad(energy, positions, grad_outputs=weights)
+    assert torch.isfinite(grad_positions).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_pme_atom_materialized_per_system_cotangent_uses_cache(monkeypatch):
+    """Exact eager CUDA checks keep per-system-uniform atom weights cached."""
+    device = torch.device("cuda")
+    positions = torch.tensor(
+        [[1.0, 2.0, 3.0], [3.0, 2.0, 1.0], [1.5, 2.5, 3.5], [3.5, 2.5, 1.5]],
+        dtype=torch.float64,
+        device=device,
+        requires_grad=True,
+    )
+    charges = torch.tensor([0.7, -0.7, 0.4, -0.4], dtype=torch.float64, device=device)
+    cell = torch.eye(3, dtype=torch.float64, device=device).repeat(2, 1, 1) * 8.0
+    batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=device)
+    atom_weights = torch.tensor(
+        [1.7, 1.7, -0.4, -0.4], dtype=torch.float64, device=device
+    )
+    pme_module = import_module("nvalchemiops.torch.interactions.electrostatics.pme")
+    call_count = 0
+    original_impl = pme_module._pme_reciprocal_space_impl
+
+    def _counting_impl(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original_impl(*args, **kwargs)
+
+    monkeypatch.setattr(pme_module, "_pme_reciprocal_space_impl", _counting_impl)
+    energy = pme_reciprocal_space(
+        positions,
+        charges,
+        cell,
+        alpha=torch.tensor([0.3, 0.35], dtype=torch.float64, device=device),
+        mesh_dimensions=(8, 8, 8),
+        batch_idx=batch_idx,
+    )
+    torch.autograd.grad(energy, positions, grad_outputs=atom_weights)
+
+    assert call_count == 1
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_pme_system_direct_virial_create_graph_keeps_atom_cotangent_shape(device):
+    """Cell-only cached state still expands system cotangents to all atoms."""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    dev = torch.device(device)
+    positions = torch.tensor(
+        [[1.0, 2.0, 3.0], [3.0, 2.0, 1.0], [1.5, 2.5, 3.5]],
+        dtype=torch.float64,
+        device=dev,
+    )
+    charges = torch.tensor([0.7, -0.7, 0.0], dtype=torch.float64, device=dev)
+    cell = (torch.eye(3, dtype=torch.float64, device=dev) * 8.0).requires_grad_(True)
+
+    with pytest.warns(DeprecationWarning):
+        energy, _virial = pme_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            alpha=torch.tensor(0.3, dtype=torch.float64, device=dev),
+            mesh_dimensions=(8, 8, 8),
+            compute_virial=True,
+            energy_reduction="system",
+        )
+    weights = torch.tensor([1.7], dtype=torch.float64, device=dev)
+    (cell_grad,) = torch.autograd.grad(
+        energy, cell, grad_outputs=weights, create_graph=True
+    )
+
+    assert cell_grad.shape == cell.shape
+    assert torch.isfinite(cell_grad).all()
+
+
 def _torchpme_smearing(alpha: float | torch.Tensor) -> float:
     """Convert Ewald alpha to the scalar smearing parameter torchpme expects."""
     if isinstance(alpha, torch.Tensor):

--- a/test/interactions/electrostatics/bindings/torch/test_public_api.py
+++ b/test/interactions/electrostatics/bindings/torch/test_public_api.py
@@ -90,6 +90,74 @@ def test_ewald_miller_bounds_is_keyword_only_after_legacy_slots() -> None:
 
 
 @pytest.mark.parametrize(
+    "name",
+    [
+        "ewald_real_space",
+        "ewald_reciprocal_space",
+        "ewald_summation",
+        "pme_reciprocal_space",
+        "particle_mesh_ewald",
+        "compute_slab_correction",
+    ],
+)
+def test_monopole_energy_reduction_is_keyword_only(name: str) -> None:
+    """Monopole APIs expose the compatible atom/system energy-layout option."""
+    parameter = inspect.signature(getattr(electrostatics, name)).parameters[
+        "energy_reduction"
+    ]
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameter.default == "atom"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "ewald_real_space",
+        "ewald_reciprocal_space",
+        "ewald_summation",
+        "pme_reciprocal_space",
+        "particle_mesh_ewald",
+        "compute_slab_correction",
+    ],
+)
+def test_monopole_energy_reduction_rejects_invalid_value_early(name: str) -> None:
+    """Invalid layouts fail before neighbor, mesh, or kernel validation."""
+    positions = torch.zeros((0, 3), dtype=torch.float64)
+    charges = torch.zeros(0, dtype=torch.float64)
+    cell = torch.eye(3, dtype=torch.float64).unsqueeze(0)
+    alpha = torch.tensor([0.3], dtype=torch.float64)
+    pbc = torch.tensor([True, True, False])
+    calls = {
+        "ewald_real_space": lambda: electrostatics.ewald_real_space(
+            positions, charges, cell, alpha, energy_reduction="invalid"
+        ),
+        "ewald_reciprocal_space": lambda: electrostatics.ewald_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            torch.zeros((0, 3), dtype=torch.float64),
+            alpha,
+            energy_reduction="invalid",
+        ),
+        "ewald_summation": lambda: electrostatics.ewald_summation(
+            positions, charges, cell, energy_reduction="invalid"
+        ),
+        "pme_reciprocal_space": lambda: electrostatics.pme_reciprocal_space(
+            positions, charges, cell, alpha, energy_reduction="invalid"
+        ),
+        "particle_mesh_ewald": lambda: electrostatics.particle_mesh_ewald(
+            positions, charges, cell, energy_reduction="invalid"
+        ),
+        "compute_slab_correction": lambda: electrostatics.compute_slab_correction(
+            positions, charges, cell, pbc, energy_reduction="invalid"
+        ),
+    }
+
+    with pytest.raises(ValueError, match="energy_reduction"):
+        calls[name]()
+
+
+@pytest.mark.parametrize(
     ("public_name", "private_name"),
     [
         ("pme_green_structure_factor", "_pme_green_structure_factor"),

--- a/test/interactions/electrostatics/bindings/torch/test_slab.py
+++ b/test/interactions/electrostatics/bindings/torch/test_slab.py
@@ -46,6 +46,7 @@ from nvalchemiops.torch.interactions.electrostatics import (
 from nvalchemiops.torch.interactions.electrostatics import (
     pme_reciprocal_space as _pme_reciprocal_space,
 )
+from nvalchemiops.torch.interactions.electrostatics._slab_chain import register_slab_ops
 from nvalchemiops.torch.interactions.electrostatics.ewald import (
     ewald_summation as _ewald_summation,
 )
@@ -76,6 +77,17 @@ SLAB_CHARGE_GRAD_RTOL = 2e-7
 SLAB_CHARGE_GRAD_ATOL = 5e-8
 PME_SLAB_GRADCHECK_RTOL = 1e-6
 PME_SLAB_GRADCHECK_ATOL = 1e-9
+
+
+def test_slab_registered_energy_schema_keeps_five_inputs():
+    """The established atom-major torch.library op remains schema-compatible."""
+    register_slab_ops()
+
+    assert str(torch.ops.nvalchemiops.slab_correction_energy.default._schema) == (
+        "nvalchemiops::slab_correction_energy("
+        "Tensor positions, Tensor charges, Tensor cell, Tensor pbc, Tensor batch_idx"
+        ") -> Tensor"
+    )
 
 
 def _call_without_direct_output_deprecation(api_name, api, *args, **kwargs):
@@ -159,6 +171,51 @@ def _make_cscl_slab_system(dtype=torch.float64, device="cpu"):
     ).unsqueeze(0)  # (1, 3, 3)
     pbc = torch.tensor([True, True, False], device=device)  # (3,)
     return positions, charges, cell, pbc
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_slab_system_energy_weighted_gradient_and_tuple_layout(device):
+    """Slab facade keeps system cotangents and only reduces tuple energy."""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    pos, charge, cell, _pbc = _make_cscl_slab_system(device=device)
+    positions = torch.cat([pos, pos + torch.tensor([0.2, 0.1, 0.3], device=device)])
+    charges = torch.cat([charge, charge * 0.7])
+    cells = cell.repeat(2, 1, 1)
+    pbc = torch.tensor([[True, True, False], [True, True, False]], device=device)
+    batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=device)
+
+    pos_atom = positions.clone().requires_grad_(True)
+    atom_energy = compute_slab_correction(
+        pos_atom, charges, cells, pbc, batch_idx=batch_idx
+    )
+    pos_system = positions.clone().requires_grad_(True)
+    system_energy, forces = compute_slab_correction(
+        pos_system,
+        charges,
+        cells,
+        pbc,
+        batch_idx=batch_idx,
+        compute_forces=True,
+        energy_reduction="system",
+    )
+    expected = torch.zeros(2, dtype=atom_energy.dtype, device=device).index_add(
+        0, batch_idx.long(), atom_energy
+    )
+    weights = torch.tensor([1.3, -0.6], dtype=torch.float64, device=device)
+
+    assert system_energy.shape == (2,)
+    assert forces.shape == (4, 3)
+    torch.testing.assert_close(system_energy, expected)
+    grad_atom = torch.autograd.grad(
+        atom_energy,
+        pos_atom,
+        grad_outputs=weights.index_select(0, batch_idx.long()),
+    )[0]
+    grad_system = torch.autograd.grad(system_energy, pos_system, grad_outputs=weights)[
+        0
+    ]
+    torch.testing.assert_close(grad_system, grad_atom, rtol=2e-7, atol=2e-8)
 
 
 def _make_triclinic_slab_system(dtype=torch.float64, device="cpu"):

--- a/test/interactions/electrostatics/test_factory_ewald_real.py
+++ b/test/interactions/electrostatics/test_factory_ewald_real.py
@@ -191,7 +191,17 @@ def _alpha_array(num_systems, device, dtype):
     )
 
 
-def _launch_forward(sysd, *, dtype, batched, neighbor_input, device, deriv, cell_grad):
+def _launch_forward(
+    sysd,
+    *,
+    dtype,
+    batched,
+    neighbor_input,
+    device,
+    deriv,
+    cell_grad,
+    energy_layout="atom",
+):
     """Launch a factory forward kernel; return (energies, forces, cg, virial) numpy."""
     if neighbor_input == "list":
         inputs = prepare_csr_inputs(sysd, device, dtype=dtype)
@@ -207,7 +217,9 @@ def _launch_forward(sysd, *, dtype, batched, neighbor_input, device, deriv, cell
         if batched
         else s["batch_id"]
     )
-    energies = wp.zeros(n, dtype=wp.float64, device=device)
+    energies = wp.zeros(
+        n if energy_layout == "atom" else nsys, dtype=wp.float64, device=device
+    )
     forces = wp.zeros(n, dtype=_VEC[dtype], device=device)
     cg = wp.zeros(n, dtype=wp.float64, device=device)
     virial = wp.zeros(nsys, dtype=_MAT[dtype], device=device)
@@ -233,6 +245,7 @@ def _launch_forward(sysd, *, dtype, batched, neighbor_input, device, deriv, cell
         deriv_state=deriv,
         cell_grad=cell_grad,
         order="forward",
+        energy_layout=energy_layout,
     )
     wp.launch(
         kernel,
@@ -601,6 +614,58 @@ class TestForwardDerivativeParity:
             virial=True,
         )
         _assert_forward_parity(v_got, v_ref, dtype)
+
+
+class TestSystemEnergyLayout:
+    """Factory system-layout forward output matches atom-layout reduction."""
+
+    @pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+    @pytest.mark.parametrize("batched,neighbor_input", _GRID, ids=_GRID_IDS)
+    def test_system_energy_matches_atom_layout(
+        self, device, dtype, batched, neighbor_input
+    ):
+        """System layout accumulates each atom-row energy into its system slot."""
+        sysd = _batch_system() if batched else _single_system()
+        atom_energies, *_ = _launch_forward(
+            sysd,
+            dtype=dtype,
+            batched=batched,
+            neighbor_input=neighbor_input,
+            device=device,
+            deriv=_DerivState.E,
+            cell_grad=False,
+        )
+        system_energies, *_ = _launch_forward(
+            sysd,
+            dtype=dtype,
+            batched=batched,
+            neighbor_input=neighbor_input,
+            device=device,
+            deriv=_DerivState.E,
+            cell_grad=False,
+            energy_layout="system",
+        )
+
+        expected = np.zeros(sysd.get("num_systems", 1), dtype=np.float64)
+        if batched:
+            np.add.at(expected, sysd["batch_idx"], atom_energies)
+        else:
+            expected[0] = atom_energies.sum()
+        _assert_forward_parity(system_energies, expected, dtype)
+
+    @pytest.mark.parametrize("order", ["backward", "double_backward"])
+    def test_system_energy_layout_is_forward_only(self, order):
+        """Non-forward factory orders reject the system-output specialization."""
+        with pytest.raises(NotImplementedError, match="energy_layout"):
+            get_ewald_real_kernel(
+                wp.float64,
+                batched=False,
+                neighbor_input="list",
+                deriv_state=_DerivState.E_F,
+                cell_grad=False,
+                order=order,
+                energy_layout="system",
+            )
 
 
 # ==============================================================================

--- a/test/interactions/electrostatics/test_util.py
+++ b/test/interactions/electrostatics/test_util.py
@@ -23,6 +23,8 @@ torch = pytest.importorskip("torch")
 _util = pytest.importorskip("nvalchemiops.torch.interactions.electrostatics._util")
 _InjectChargeGrad = _util._InjectChargeGrad
 _InjectCachedEvalGradWithFallback = _util._InjectCachedEvalGradWithFallback
+_energy_cotangents = _util._energy_cotangents
+_is_per_system_uniform_cotangent = _util._is_per_system_uniform_cotangent
 _is_uniform_cotangent = _util._is_uniform_cotangent
 
 from test.interactions.electrostatics._deriv_check import (  # noqa: E402
@@ -213,6 +215,50 @@ def test_uniform_cotangent_accepts_eager_contiguous_constants(device):
     grad = torch.ones(6, dtype=DT, device=device)
 
     assert _is_uniform_cotangent(grad)
+
+
+@pytest.mark.parametrize("device", _available_devices())
+def test_energy_cotangents_disambiguate_equal_atom_and_system_lengths(device):
+    """Explicit layout distinguishes N == B when one system has no atoms."""
+    batch_idx = torch.tensor([0, 0], dtype=torch.int32, device=device)
+    grad = torch.tensor([1.0, 2.0], dtype=DT, device=device)
+
+    atom_system, atom_grad = _energy_cotangents(
+        grad,
+        batch_idx,
+        num_atoms=2,
+        num_systems=2,
+        layout="atom",
+    )
+    system_system, system_grad = _energy_cotangents(
+        grad,
+        batch_idx,
+        num_atoms=2,
+        num_systems=2,
+        layout="system",
+    )
+
+    torch.testing.assert_close(
+        atom_system,
+        torch.tensor([1.5, 0.0], dtype=DT, device=device),
+    )
+    torch.testing.assert_close(atom_grad, grad)
+    torch.testing.assert_close(system_system, grad)
+    torch.testing.assert_close(
+        system_grad,
+        torch.tensor([1.0, 1.0], dtype=DT, device=device),
+    )
+
+
+@pytest.mark.parametrize("device", _available_devices())
+def test_partial_empty_batch_atom_uniformity(device):
+    """Atom-mode inspection rejects nonuniform weights when N equals B."""
+    batch_idx = torch.tensor([0, 0], dtype=torch.int32, device=device)
+    nonuniform = torch.tensor([1.0, 2.0], dtype=DT, device=device)
+    uniform = torch.tensor([3.0, 3.0], dtype=DT, device=device)
+
+    assert not _is_per_system_uniform_cotangent(nonuniform, batch_idx, 2)
+    assert _is_per_system_uniform_cotangent(uniform, batch_idx, 2)
 
 
 @pytest.mark.parametrize("device", _available_devices())

--- a/test/interactions/electrostatics/test_util.py
+++ b/test/interactions/electrostatics/test_util.py
@@ -208,12 +208,11 @@ def test_uniform_cotangent_accepts_expanded_scalar(device):
 
 
 @pytest.mark.parametrize("device", _available_devices())
-def test_uniform_cotangent_keeps_cuda_contiguous_constants_conservative(device):
-    """Contiguous CUDA constants require value inspection, so stay on fallback."""
+def test_uniform_cotangent_accepts_eager_contiguous_constants(device):
+    """Eager mode checks materialized CPU and CUDA constants exactly."""
     grad = torch.ones(6, dtype=DT, device=device)
 
-    expected = device == "cpu"
-    assert _is_uniform_cotangent(grad) is expected
+    assert _is_uniform_cotangent(grad)
 
 
 @pytest.mark.parametrize("device", _available_devices())
@@ -233,8 +232,8 @@ def test_ewald_uniform_predicates_accept_expanded_scalar(device):
 
 
 @pytest.mark.parametrize("device", _available_devices())
-def test_ewald_uniform_predicates_keep_cuda_per_system_constants_conservative(device):
-    """Non-expanded CUDA constants stay exact by using the weighted fallback."""
+def test_ewald_uniform_predicates_accept_eager_per_system_constants(device):
+    """Eager mode recognizes materialized per-system-uniform cotangents exactly."""
     real_chain = pytest.importorskip(
         "nvalchemiops.torch.interactions.electrostatics._ewald_real_chain"
     )
@@ -244,6 +243,5 @@ def test_ewald_uniform_predicates_keep_cuda_per_system_constants_conservative(de
     grad = torch.tensor([2.0, 2.0, 3.0, 3.0], dtype=DT, device=device)
     batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=device)
 
-    expected = device == "cpu"
-    assert real_chain._cotangent_per_system_uniform(grad, batch_idx, 2) is expected
-    assert recip_chain._cotangent_per_system_uniform(grad, batch_idx, 2) is expected
+    assert real_chain._cotangent_per_system_uniform(grad, batch_idx, 2)
+    assert recip_chain._cotangent_per_system_uniform(grad, batch_idx, 2)

--- a/test/math/test_spline.py
+++ b/test/math/test_spline.py
@@ -923,7 +923,15 @@ def _bspline_via_convolution(u: np.ndarray, order: int, h: float = 1e-4) -> np.n
     box = ((grid >= 0) & (grid < 1)).astype(np.float64)
     spline = box.copy()
     for _ in range(n - 1):
-        spline = np.convolve(spline, box) * h
+        output_size = spline.size + box.size - 1
+        fft_size = 1 << (output_size - 1).bit_length()
+        spline = (
+            np.fft.irfft(
+                np.fft.rfft(spline, fft_size) * np.fft.rfft(box, fft_size),
+                fft_size,
+            )[:output_size]
+            * h
+        )
     out_grid = np.arange(0, len(spline)) * h
     return np.interp(u, out_grid, spline)
 

--- a/test/torch/test_warp_boundary_audit.py
+++ b/test/torch/test_warp_boundary_audit.py
@@ -233,8 +233,9 @@ APPROVED_RAW_WARP_FUNCTIONS = {
     "nvalchemiops/torch/interactions/electrostatics/_slab_chain.py::_run_moments",
     "nvalchemiops/torch/interactions/electrostatics/_slab_chain.py::_scoped_stream",
     "nvalchemiops/torch/interactions/electrostatics/_slab_chain.py::_slab_backward_values",
-    "nvalchemiops/torch/interactions/electrostatics/_slab_chain.py::_slab_double_backward_launch",
-    "nvalchemiops/torch/interactions/electrostatics/_slab_chain.py::_slab_forward_launch",
+    # Shared runtime bodies for the registered atom- and system-layout op chains.
+    "nvalchemiops/torch/interactions/electrostatics/_slab_chain.py::_slab_double_backward_layout",
+    "nvalchemiops/torch/interactions/electrostatics/_slab_chain.py::_slab_forward_layout",
     "nvalchemiops/torch/interactions/electrostatics/_slab_chain.py::_slab_weighted_backward_values",
     "nvalchemiops/torch/interactions/electrostatics/_slab_chain.py::_slab_weighted_double_backward_values",
     "nvalchemiops/torch/interactions/electrostatics/_slab_chain.py::_wp_from_torch",


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Add a first-class per-system energy layout to the monopole Ewald, PME, and slab APIs while preserving the existing per-atom default.

Batched training commonly reduces per-atom energies into one total per system. The existing API required callers to perform that reduction themselves; this change adds a direct `energy_reduction="system"` path and improves backward routing for existing manual reductions. JAX exposes the same energy layout at its public wrapper boundaries.

Previously, a batched per-system loss used a manual reduction:

```python
atom_energy = particle_mesh_ewald(
    positions,
    charges,
    cell,
    batch_idx=batch_idx,
)  # shape: (N,)
system_energy = torch.zeros(
    num_systems, dtype=atom_energy.dtype, device=atom_energy.device
)
system_energy.scatter_add_(0, batch_idx, atom_energy)
loss = (system_weights * system_energy).sum()
```

The new API performs the reduction directly:

```python
system_energy = particle_mesh_ewald(
    positions,
    charges,
    cell,
    batch_idx=batch_idx,
    energy_reduction="system",
)  # shape: (B,)
loss = (system_weights * system_energy).sum()
forces = -torch.autograd.grad(loss, positions)[0]
```

A synchronized CUDA benchmark with 10,000 atoms, float64 inputs, and a `128 x 128 x 128` PME mesh measured the old manual pattern at 356.66 ms before the fix. After the fix, the same pattern takes 12.29 ms, while the new `energy_reduction="system"` path takes 11.99 ms. For comparison, directly summing atom energies takes 12.68 ms after the fix.

The manual reduction produces an all-ones per-atom output gradient stored as a regular tensor. The previous CUDA routing could recognize this uniform gradient only when broadcasting was visible from tensor metadata, so the manual pattern unnecessarily recomputed reciprocal space. Eager mode now checks regular uniform gradients exactly, and the explicit system layout carries per-system gradients directly to the cached PME backward without inspecting per-atom values. Both routes matched the reference force result with maximum absolute differences no larger than `2.91e-11`.

The system layout is important beyond eager-mode convenience. During `torch.compile` or CUDA graph capture, inspecting GPU gradient values is unavailable because it would introduce a graph break or a host synchronization inside capture. Consequently, the eager value check cannot prove that a regular per-atom gradient from a manual reduction is uniform, and that path may fall back to reciprocal-space recomputation. With `energy_reduction="system"`, the backward contract is structural: the output gradient already has shape `(B,)`, so arbitrary per-system loss weights go directly to the cached backward without value inspection. This preserves the fast path in compiled and captured workloads.

The default `energy_reduction="atom"` remains compatible with existing `(N,)` energy outputs. Only the energy field changes layout; forces, charge gradients, and virials retain their established shapes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- Add keyword-only `energy_reduction="atom" | "system"` to the Torch and JAX monopole Ewald, PME, and slab entry points.
- Route Torch system-layout gradients through cached derivative paths without inspecting per-atom values, while retaining exact eager handling for materialized uniform atom cotangents.
- Apply differentiable JAX atom-to-system reductions at public wrapper boundaries without changing derivative-output layouts.
- Preserve atom-major Warp buffers and the established registered slab operator schemas.
- Add API-contract, shape, gradient, higher-order, routing, invalid-input, and direct-output regression coverage.
- Update the changelog, migration guidance, API documentation, and PME training example.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Focused Torch/JAX public-API and cotangent-routing validation passed: 49 tests.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes


> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
