### PR TITLE
fix(electrostatics): compile explicit single-system batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Torch Ewald, PME, and slab backward paths now compile when an explicit
+  single-system batch (`batch_idx=zeros(N)`) is supplied. Reciprocal PME
+  compiled gradients are also correct when a compiled function is reused across
+  mesh sizes.
+
 ## 0.4.0 - 2026-07-13
 
 ### Added

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_direct.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_direct.py
@@ -407,11 +407,14 @@ def _reciprocal_space_direct_op(
             bidx = batch_idx
             alpha_atom = alpha.to(torch.float64).index_select(0, bidx)
             vol = torch.abs(torch.linalg.det(cell.to(torch.float64)))  # (S,)
-            q_over_v = torch.zeros(
-                num_systems, dtype=torch.float64, device=positions.device
-            )
-            q_over_v = q_over_v.index_add(0, bidx, charges64) / vol
-            q_over_v_atom = q_over_v.index_select(0, bidx)
+            if num_systems == 1:
+                q_over_v_atom = (charges64.sum() / vol[0]).expand_as(charges64)
+            else:
+                q_over_v = torch.zeros(
+                    num_systems, dtype=torch.float64, device=positions.device
+                )
+                q_over_v = q_over_v.index_add(0, bidx, charges64) / vol
+                q_over_v_atom = q_over_v.index_select(0, bidx)
         else:
             alpha_atom = alpha.to(torch.float64)[0]
             vol = torch.abs(torch.det(cell[0].to(torch.float64)))
@@ -423,8 +426,13 @@ def _reciprocal_space_direct_op(
     # Virial background correction: W_bg = -E_bg I.
     if want_virial:
         if batched:
-            q_tot = torch.zeros(num_systems, dtype=input_dtype, device=positions.device)
-            q_tot = q_tot.index_add(0, batch_idx, charges.to(input_dtype))
+            if num_systems == 1:
+                q_tot = charges.to(input_dtype).sum().reshape(1)
+            else:
+                q_tot = torch.zeros(
+                    num_systems, dtype=input_dtype, device=positions.device
+                )
+                q_tot = q_tot.index_add(0, batch_idx, charges.to(input_dtype))
             vol = torch.abs(torch.linalg.det(cell)).to(input_dtype)
             alpha_b = alpha.to(input_dtype)
             e_bg = _PI * q_tot**2 / (2.0 * alpha_b**2 * vol)

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_real_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_real_chain.py
@@ -52,7 +52,10 @@ from nvalchemiops.torch._warp_op_helpers import (
     register_warp_op_chain,
 )
 from nvalchemiops.torch.interactions.electrostatics._util import (
+    _distribute_system_mean_cotangent_to_atoms,
     _is_per_system_uniform_cotangent,
+    _mean_atom_values_by_system,
+    _sum_atom_values_by_system,
 )
 from nvalchemiops.torch.types import get_wp_dtype, get_wp_mat_dtype, get_wp_vec_dtype
 
@@ -83,36 +86,20 @@ def _scoped_stream(device: torch.device):
     return wp.ScopedStream(wp.stream_from_torch(torch.cuda.current_stream(device)))
 
 
-def _atom_counts(batch_idx: torch.Tensor, num_systems: int) -> torch.Tensor:
-    """Per-system atom counts (float64)."""
-    counts = torch.zeros(num_systems, dtype=torch.float64, device=batch_idx.device)
-    return counts.index_add(
-        0,
-        batch_idx,
-        torch.ones(batch_idx.shape[0], dtype=torch.float64, device=batch_idx.device),
-    )
-
-
 def _per_system_cotangent(grad_energy_atom, batch_idx, num_systems, num_atoms):
     """Reduce a per-atom energy cotangent ``(N,)`` to per-system ``(S,)`` (mean)."""
     g = grad_energy_atom.reshape(-1).to(torch.float64)
-    if batch_idx is None:
-        if num_atoms == 0:
-            return torch.zeros(1, dtype=torch.float64, device=g.device)
-        return g.mean().reshape(1)
-    sums = torch.zeros(num_systems, dtype=torch.float64, device=g.device)
-    sums = sums.index_add(0, batch_idx, g)
-    return sums / _atom_counts(batch_idx, num_systems).clamp_min(1.0)
+    return _mean_atom_values_by_system(g, batch_idx, num_systems)
 
 
 def _distribute_to_atoms(per_system, batch_idx, num_systems, num_atoms):
     """Distribute a per-system ``dL/d(grad_energy)`` back to per-atom by ``1/count``."""
-    if num_atoms == 0:
-        return torch.zeros(0, dtype=torch.float64, device=per_system.device)
-    if batch_idx is None:
-        return (per_system / float(num_atoms)).expand(num_atoms).clone()
-    counts = _atom_counts(batch_idx, num_systems)
-    return (per_system / counts.clamp_min(1.0)).index_select(0, batch_idx)
+    return _distribute_system_mean_cotangent_to_atoms(
+        per_system,
+        batch_idx,
+        num_systems,
+        num_atoms,
+    )
 
 
 def _cotangent_per_system_uniform(grad_energy_atom, batch_idx, num_systems):
@@ -1201,10 +1188,11 @@ def _real_cell_grad_via_kernel(
         )
     # Weight per-atom blocks by the upstream energy cotangent and reduce per system.
     weighted = grad_energy_atom.to(torch.float64).view(-1, 1, 1) * dedcell_atom
-    grad_cell = torch.zeros(
-        (num_systems, 3, 3), dtype=torch.float64, device=positions.device
+    grad_cell = _sum_atom_values_by_system(
+        weighted,
+        sys_of_atom.to(torch.long),
+        num_systems,
     )
-    grad_cell = grad_cell.index_add(0, sys_of_atom.to(torch.long), weighted)
     return grad_cell.to(cell.dtype)
 
 
@@ -1261,10 +1249,7 @@ def _real_space_dEdcell_analytic(
     # outer(n, dE/dsep)[p, q] = n_p * dE/dsep_q
     contrib = w.view(-1, 1, 1) * n.unsqueeze(2) * d_e_dsep.unsqueeze(1)  # (M, 3, 3)
     contrib = torch.where((r > 1e-8).view(-1, 1, 1), contrib, torch.zeros_like(contrib))
-    grad_cell = torch.zeros(
-        (num_systems, 3, 3), dtype=torch.float64, device=positions.device
-    )
-    grad_cell = grad_cell.index_add(0, sys_of_edge, contrib)
+    grad_cell = _sum_atom_values_by_system(contrib, sys_of_edge, num_systems)
     return grad_cell.to(cell.dtype)
 
 
@@ -1769,23 +1754,14 @@ def _scatter_dedcell_cache(
     dtype: torch.dtype,
 ) -> torch.Tensor:
     """Reduce atom-major literal ``dE/dcell`` cache to per-system cell grads."""
-    num_atoms = dedcell.shape[0]
-    if batch_idx is None:
-        sys_of_atom = torch.zeros(num_atoms, dtype=torch.long, device=dedcell.device)
-    else:
-        sys_of_atom = batch_idx.long()
     weighted = grad_energy_atom.to(torch.float64).view(-1, 1, 1) * dedcell.to(
         torch.float64
     )
-    return (
-        torch.zeros(
-            (num_systems, 3, 3),
-            dtype=torch.float64,
-            device=dedcell.device,
-        )
-        .index_add(0, sys_of_atom, weighted)
-        .to(dtype)
-    )
+    return _sum_atom_values_by_system(
+        weighted,
+        batch_idx,
+        num_systems,
+    ).to(dtype)
 
 
 class _CachedLiteralCellGrad(torch.autograd.Function):

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
@@ -82,7 +82,10 @@ from nvalchemiops.torch._warp_op_helpers import (
     register_warp_op_chain,
 )
 from nvalchemiops.torch.interactions.electrostatics._util import (
+    _broadcast_system_values_to_atoms,
+    _distribute_system_mean_cotangent_to_atoms,
     _is_per_system_uniform_cotangent,
+    _mean_atom_values_by_system,
 )
 from nvalchemiops.torch.types import (
     get_wp_dtype,
@@ -125,34 +128,19 @@ def _scoped_stream(device: torch.device):
     return wp.ScopedStream(wp.stream_from_torch(torch.cuda.current_stream(device)))
 
 
-def _atom_counts(batch_idx: torch.Tensor, num_systems: int) -> torch.Tensor:
-    counts = torch.zeros(num_systems, dtype=torch.float64, device=batch_idx.device)
-    return counts.index_add(
-        0,
-        batch_idx,
-        torch.ones(batch_idx.shape[0], dtype=torch.float64, device=batch_idx.device),
-    )
-
-
 def _per_system_cotangent(grad_energy_atom, batch_idx, num_systems, num_atoms):
     """Reduce a per-atom energy cotangent ``(N,)`` to per-system ``(S,)`` (mean)."""
     g = grad_energy_atom.reshape(-1).to(torch.float64)
-    if batch_idx is None:
-        if num_atoms == 0:
-            return torch.zeros(1, dtype=torch.float64, device=g.device)
-        return g.mean().reshape(1)
-    sums = torch.zeros(num_systems, dtype=torch.float64, device=g.device)
-    sums = sums.index_add(0, batch_idx, g)
-    return sums / _atom_counts(batch_idx, num_systems).clamp_min(1.0)
+    return _mean_atom_values_by_system(g, batch_idx, num_systems)
 
 
 def _distribute_to_atoms(per_system, batch_idx, num_systems, num_atoms):
-    if num_atoms == 0:
-        return torch.zeros(0, dtype=torch.float64, device=per_system.device)
-    if batch_idx is None:
-        return (per_system / float(num_atoms)).expand(num_atoms).clone()
-    counts = _atom_counts(batch_idx, num_systems)
-    return (per_system / counts.clamp_min(1.0)).index_select(0, batch_idx)
+    return _distribute_system_mean_cotangent_to_atoms(
+        per_system,
+        batch_idx,
+        num_systems,
+        num_atoms,
+    )
 
 
 def _cotangent_per_system_uniform(grad_energy_atom, batch_idx, num_systems):
@@ -457,9 +445,12 @@ def _atom_cotangent(grad_energy_atom, batch_idx, num_systems, num_atoms):
     mapped to atoms so the cached-derivative scale reproduces its first-backward value.
     """
     g_sys = _per_system_cotangent(grad_energy_atom, batch_idx, num_systems, num_atoms)
-    if batch_idx is None:
-        return g_sys.expand(num_atoms)
-    return g_sys.index_select(0, batch_idx)
+    return _broadcast_system_values_to_atoms(
+        g_sys,
+        batch_idx,
+        num_systems,
+        num_atoms,
+    )
 
 
 def _forward_impl(

--- a/nvalchemiops/torch/interactions/electrostatics/_slab_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_slab_chain.py
@@ -24,7 +24,10 @@ import warp as wp
 
 from nvalchemiops.torch._warp_op_helpers import register_warp_op_chain
 from nvalchemiops.torch.interactions.electrostatics._util import (
+    _distribute_system_mean_cotangent_to_atoms,
     _is_sync_free_uniform_cotangent,
+    _mean_atom_values_by_system,
+    _sum_atom_values_by_system,
 )
 from nvalchemiops.torch.types import get_wp_dtype, get_wp_mat_dtype, get_wp_vec_dtype
 
@@ -52,16 +55,11 @@ def _per_system_cotangent(
     num_systems: int,
 ) -> torch.Tensor:
     """Reduce atom energy cotangents to per-system means."""
-    if grad_energy_atom.numel() == 0:
-        return torch.zeros(
-            num_systems, device=grad_energy_atom.device, dtype=torch.float64
-        )
-
-    idx = batch_idx.to(device=grad_energy_atom.device, dtype=torch.long)
-    sums = torch.zeros(num_systems, device=grad_energy_atom.device, dtype=torch.float64)
-    sums = sums.index_add(0, idx, grad_energy_atom.reshape(-1).to(torch.float64))
-    counts = torch.bincount(idx, minlength=num_systems).to(torch.float64)
-    return sums / counts.clamp_min(1.0)
+    return _mean_atom_values_by_system(
+        grad_energy_atom.reshape(-1).to(torch.float64),
+        batch_idx,
+        num_systems,
+    )
 
 
 def _cotangent_per_system_uniform(
@@ -95,13 +93,12 @@ def _distribute_system_values(
     num_atoms: int,
 ) -> torch.Tensor:
     """Distribute per-system values to per-atom cotangents by atom count."""
-    if num_atoms == 0:
-        return torch.zeros(0, device=system_values.device, dtype=torch.float64)
-
-    idx = batch_idx.to(device=system_values.device, dtype=torch.long)
-    counts = torch.bincount(idx, minlength=system_values.shape[0]).to(torch.float64)
-    values = system_values / counts.clamp_min(1.0)
-    return values.index_select(0, idx)
+    return _distribute_system_mean_cotangent_to_atoms(
+        system_values,
+        batch_idx,
+        system_values.shape[0],
+        num_atoms,
+    )
 
 
 def _run_moments(
@@ -492,13 +489,7 @@ def _slab_double_backward_launch(
     )
     atom_dot = (base_pos.to(torch.float64) * h_pos.to(torch.float64)).sum(dim=1)
     atom_dot = atom_dot + base_q * h_charge.reshape(-1).to(torch.float64)
-    system_dot = torch.zeros(num_systems, device=positions.device, dtype=torch.float64)
-    if num_atoms > 0:
-        system_dot = system_dot.index_add(
-            0,
-            batch_idx.to(device=positions.device, dtype=torch.long),
-            atom_dot,
-        )
+    system_dot = _sum_atom_values_by_system(atom_dot, batch_idx, num_systems)
     system_dot = system_dot + (
         base_cell.to(torch.float64) * h_cell.to(torch.float64)
     ).sum(dim=(1, 2))

--- a/nvalchemiops/torch/interactions/electrostatics/_util.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_util.py
@@ -392,7 +392,7 @@ def _distribute_system_mean_cotangent_to_atoms(
         batch_idx,
         num_systems,
         num_atoms,
-    ).clone()
+    )
 
 
 def _energy_cotangents(

--- a/nvalchemiops/torch/interactions/electrostatics/_util.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_util.py
@@ -308,6 +308,93 @@ def _num_systems_from_state(
     return int(batch_idx.max().item()) + 1
 
 
+def _sum_atom_values_by_system(
+    values: torch.Tensor,
+    batch_idx: torch.Tensor | None,
+    num_systems: int,
+) -> torch.Tensor:
+    """Reduce atom-major values to per-system sums."""
+    if num_systems == 1:
+        return values.sum(dim=0, keepdim=True)
+
+    if batch_idx is None:
+        raise RuntimeError("batch_idx is required for multi-system atom reduction")
+
+    result = values.new_zeros((num_systems, *values.shape[1:]))
+    return result.index_add(0, batch_idx, values)
+
+
+def _mean_atom_values_by_system(
+    values: torch.Tensor,
+    batch_idx: torch.Tensor | None,
+    num_systems: int,
+) -> torch.Tensor:
+    """Reduce atom-major values to guarded per-system means."""
+    if values.shape[0] == 0:
+        return values.new_zeros((num_systems, *values.shape[1:]))
+    if num_systems == 1:
+        return values.mean(dim=0, keepdim=True)
+
+    sums = _sum_atom_values_by_system(values, batch_idx, num_systems)
+    counts = _sum_atom_values_by_system(
+        values.new_ones((values.shape[0],)),
+        batch_idx,
+        num_systems,
+    )
+    count_shape = (num_systems, *([1] * (values.ndim - 1)))
+    return sums / counts.clamp_min(1).reshape(count_shape)
+
+
+def _broadcast_system_values_to_atoms(
+    per_system: torch.Tensor,
+    batch_idx: torch.Tensor | None,
+    num_systems: int,
+    num_atoms: int,
+) -> torch.Tensor:
+    """Broadcast per-system values to atom-major values."""
+    if num_atoms == 0:
+        return per_system.new_empty((0, *per_system.shape[1:]))
+    if num_systems == 1:
+        return per_system[0].expand((num_atoms, *per_system.shape[1:]))
+
+    if batch_idx is None:
+        raise RuntimeError("batch_idx is required for multi-system atom broadcast")
+
+    return per_system.index_select(0, batch_idx)
+
+
+def _distribute_system_mean_cotangent_to_atoms(
+    per_system: torch.Tensor,
+    batch_idx: torch.Tensor | None,
+    num_systems: int,
+    num_atoms: int,
+) -> torch.Tensor:
+    """Apply the adjoint of per-system mean reduction."""
+    if num_atoms == 0:
+        return per_system.new_empty((0, *per_system.shape[1:]))
+    if num_systems == 1:
+        return (
+            per_system[0]
+            .div(float(num_atoms))
+            .expand((num_atoms, *per_system.shape[1:]))
+            .clone()
+        )
+
+    counts = _sum_atom_values_by_system(
+        per_system.new_ones((num_atoms,)),
+        batch_idx,
+        num_systems,
+    )
+    count_shape = (num_systems, *([1] * (per_system.ndim - 1)))
+    scaled = per_system / counts.clamp_min(1).reshape(count_shape)
+    return _broadcast_system_values_to_atoms(
+        scaled,
+        batch_idx,
+        num_systems,
+        num_atoms,
+    ).clone()
+
+
 def _energy_cotangents(
     grad_energy: torch.Tensor,
     batch_idx: torch.Tensor | None,
@@ -334,11 +421,7 @@ def _energy_cotangents(
     if grad.numel() == num_systems:
         grad_system = grad
     elif grad.numel() == num_atoms:
-        sums = grad.new_zeros((num_systems,))
-        sums = sums.index_add(0, bidx, grad)
-        counts = grad.new_zeros((num_systems,))
-        counts = counts.index_add(0, bidx, torch.ones_like(grad))
-        grad_system = sums / counts.clamp_min(1)
+        grad_system = _mean_atom_values_by_system(grad, bidx, num_systems)
     elif grad.numel() == 1:
         grad_system = grad.expand(num_systems)
     else:
@@ -346,7 +429,12 @@ def _energy_cotangents(
             "Energy cotangent must be per-system, per-atom, or scalar for "
             "_InjectChargeGrad backward"
         )
-    atom_grad = grad_system.index_select(0, bidx)
+    atom_grad = _broadcast_system_values_to_atoms(
+        grad_system,
+        bidx,
+        num_systems,
+        num_atoms,
+    )
     return grad_system, atom_grad
 
 

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -233,6 +233,16 @@ def _atom_ranges(
     (the existing batched-Ewald contract); ``atom_start``/``atom_end`` are int32.
     """
     device = batch_idx.device
+    if num_systems == 1:
+        starts = torch.zeros((1,), dtype=torch.int32, device=device)
+        ends = torch.full(
+            (1,),
+            batch_idx.shape[0],
+            dtype=torch.int32,
+            device=device,
+        )
+        return starts, ends
+
     counts = torch.zeros(num_systems, dtype=torch.long, device=device)
     counts = counts.index_add(
         0,
@@ -525,12 +535,15 @@ def _apply_reciprocal_corrections(
     if batch_idx is None:
         total_charge = charges.sum().reshape(1)
         return ewald_energy_corrections(e_ksum, charges, volume, alpha, total_charge)
-    total_charges = torch.zeros(
-        volume.shape[0],
-        dtype=charges.dtype,
-        device=charges.device,
-    )
-    total_charges = total_charges.index_add(0, batch_idx.to(torch.long), charges)
+    if volume.shape[0] == 1:
+        total_charges = charges.sum().reshape(1)
+    else:
+        total_charges = torch.zeros(
+            volume.shape[0],
+            dtype=charges.dtype,
+            device=charges.device,
+        )
+        total_charges = total_charges.index_add(0, batch_idx.to(torch.long), charges)
     return ewald_energy_corrections_batch(
         e_ksum,
         charges,

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -470,12 +470,15 @@ def _pme_convolve_forward(
     alpha: torch.Tensor,
     volume: torch.Tensor,
     is_batch: bool,
+    is_compiled: bool,
 ) -> torch.Tensor:
     """Run the fused Warp convolve kernel on ``mesh_fft``. No autograd here —
     callers wrap this in ``_PMEFusedConvolve`` for the autograd-aware version.
 
     ``moduli_x/y/z`` are precomputed 1D B-spline modulus LUTs
     (``sinc(m/N)^spline_order`` per axis); see ``compute_bspline_moduli_1d``.
+    ``is_compiled`` is registered-autograd metadata and does not affect the
+    numerical forward.
     """
     from nvalchemiops.interactions.electrostatics.pme_kernels import (
         batch_pme_convolve as _batch_pme_convolve,
@@ -1803,6 +1806,60 @@ def _virial_bg_correction_backward_launch(
     return grad_charges, grad_cell, grad_alpha, grad_virial.clone()
 
 
+def _pme_convolve_backward_args(
+    grad_outputs: tuple[torch.Tensor, ...],
+    forward_inputs: tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        bool,
+        bool,
+    ],
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    bool,
+]:
+    """Order fused-convolve backward inputs with a compiled-only cotangent copy."""
+    (
+        mesh_fft,
+        k_squared,
+        moduli_x,
+        moduli_y,
+        moduli_z,
+        alpha,
+        volume,
+        is_batch,
+        is_compiled,
+    ) = forward_inputs
+    grad_convolved = grad_outputs[0]
+    if is_compiled:
+        # Materialize before the opaque custom-op consumer so Inductor keeps
+        # Hermitian RFFT interior-frequency weighting ahead of it.
+        grad_convolved = grad_convolved * 1.0
+    return (
+        mesh_fft,
+        grad_convolved,
+        k_squared,
+        moduli_x,
+        moduli_y,
+        moduli_z,
+        alpha,
+        volume,
+        is_batch,
+    )
+
+
 def register_pme_ops() -> None:
     """Register PME Torch custom ops once."""
     global _PME_OPS_REGISTERED
@@ -1817,20 +1874,8 @@ def register_pme_ops() -> None:
         backward_fake=_convolve_backward_fake,
         backward_return_arity=4,
         diff_input_positions=(0, 5, 6, 1),
-        n_forward_inputs=8,
-        backward_args=lambda g, f: (
-            f[0],
-            # Materialize the cotangent before the opaque custom-op consumer so
-            # Inductor keeps Hermitian RFFT interior-frequency weighting ahead of it.
-            g[0] * 1.0,
-            f[1],
-            f[2],
-            f[3],
-            f[4],
-            f[5],
-            f[6],
-            f[7],
-        ),
+        n_forward_inputs=9,
+        backward_args=_pme_convolve_backward_args,
         double_backward=_pme_convolve_double_backward,
         double_backward_fake=_convolve_double_backward_fake,
         double_backward_return_arity=5,
@@ -2706,8 +2751,9 @@ def _pme_reciprocal_space_impl(
     #
     # cuFFT emits non-contiguous output; under torch.compile we must copy
     # to match the convolve launcher's stride contract, in eager we don't.
+    is_compiled = torch.compiler.is_compiling()
     mesh_fft = torch.fft.rfftn(mesh_grid, norm="backward", dim=fft_dims)
-    if torch.compiler.is_compiling():
+    if is_compiled:
         mesh_fft = mesh_fft.contiguous()
     need_virial_output = compute_virial or cache_virial
     mesh_fft_raw = mesh_fft if need_virial_output else None
@@ -2721,6 +2767,7 @@ def _pme_reciprocal_space_impl(
         alpha_gsf,
         volume,
         is_batch,
+        is_compiled,
     )
     potential_mesh = torch.fft.irfftn(
         convolved_mesh, norm="forward", s=mesh_dimensions, dim=fft_dims

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -201,6 +201,7 @@ from nvalchemiops.torch.interactions.electrostatics._util import (
     _InjectCachedEvalGradWithFallback,
     _InjectChargeGrad,
     _is_uniform_cotangent,
+    _sum_atom_values_by_system,
     _unpack_electrostatic_outputs,
 )
 from nvalchemiops.torch.interactions.electrostatics.ewald import (
@@ -1577,10 +1578,13 @@ def pme_energy_corrections(
             volumes = volume.to(input_dtype)
 
         # Compute total charge per system
-        total_charges = torch.zeros(
-            num_systems, dtype=input_dtype, device=raw_energies.device
-        )
-        total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
+        if num_systems == 1:
+            total_charges = charges.to(input_dtype).sum().reshape(1)
+        else:
+            total_charges = torch.zeros(
+                num_systems, dtype=input_dtype, device=raw_energies.device
+            )
+            total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
 
         result = _batch_pme_energy_corrections(
             raw_energies,
@@ -1670,10 +1674,13 @@ def pme_energy_corrections_with_charge_grad(
             volumes = volume.to(input_dtype)
 
         # Compute total charge per system
-        total_charges = torch.zeros(
-            num_systems, dtype=input_dtype, device=raw_energies.device
-        )
-        total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
+        if num_systems == 1:
+            total_charges = charges.to(input_dtype).sum().reshape(1)
+        else:
+            total_charges = torch.zeros(
+                num_systems, dtype=input_dtype, device=raw_energies.device
+            )
+            total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
 
         return _batch_pme_energy_corrections_with_charge_grad(
             raw_energies,
@@ -1813,7 +1820,9 @@ def register_pme_ops() -> None:
         n_forward_inputs=8,
         backward_args=lambda g, f: (
             f[0],
-            g[0],
+            # Materialize the cotangent before the opaque custom-op consumer so
+            # Inductor keeps Hermitian RFFT interior-frequency weighting ahead of it.
+            g[0] * 1.0,
             f[1],
             f[2],
             f[3],
@@ -2089,21 +2098,10 @@ def _pme_cell_grad_from_virial(
     """
     cell_3d = cell if cell.dim() == 3 else cell.unsqueeze(0)
     num_systems = cell_3d.shape[0]
-    pos_term = torch.zeros(
-        num_systems,
-        3,
-        3,
-        device=positions.device,
-        dtype=torch.float64,
-    )
     outer = positions.to(torch.float64).unsqueeze(2) * dEdR.to(torch.float64).unsqueeze(
         1
     )
-    if batch_idx is None:
-        if outer.numel():
-            pos_term[0] = outer.sum(dim=0)
-    else:
-        pos_term = pos_term.index_add(0, batch_idx.to(torch.long), outer)
+    pos_term = _sum_atom_values_by_system(outer, batch_idx, num_systems)
     target = -virial.to(torch.float64) - pos_term
     if cell_inv_t is not None:
         inv_t_3d = _normalize_cell_inv_t_cache(cell_inv_t).to(torch.float64)

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -6963,6 +6963,155 @@ class TestEwaldTorchCompile:
             torch.testing.assert_close(compiled, eager, rtol=1e-7, atol=1e-9)
             torch.testing.assert_close(compiled, unbatched, rtol=1e-7, atol=1e-9)
 
+    @pytest.mark.parametrize(
+        "device",
+        ["cpu", pytest.param("cuda", marks=pytest.mark.slow)],
+    )
+    def test_explicit_batch_non_neutral_reciprocal_corrections_compile(self, device):
+        """Compiled B=1 reciprocal corrections preserve non-neutral direct outputs."""
+        if device == "cuda" and (
+            not torch.cuda.is_available() or not wp.is_cuda_available()
+        ):
+            pytest.skip("CUDA or Warp CUDA support unavailable")
+
+        torch_device = torch.device(device)
+        positions = torch.tensor(
+            [[2.0, 5.0, 5.0], [8.0, 5.0, 5.0]],
+            dtype=torch.float64,
+            device=torch_device,
+        )
+        charges = torch.tensor([1.0, -0.25], dtype=torch.float64, device=torch_device)
+        cell = (
+            torch.eye(3, dtype=torch.float64, device=torch_device).unsqueeze(0) * 10.0
+        )
+        batch_idx = torch.zeros(2, dtype=torch.int32, device=torch_device)
+        alpha = torch.tensor([0.3], dtype=torch.float64, device=torch_device)
+        k_vectors = torch.zeros((0, 3), dtype=torch.float64, device=torch_device)
+
+        assert charges.sum().item() == pytest.approx(0.75)
+
+        def direct_outputs(
+            pos: torch.Tensor,
+            q: torch.Tensor,
+            box: torch.Tensor,
+            bidx: torch.Tensor | None,
+        ) -> tuple[torch.Tensor, ...]:
+            return ewald_reciprocal_space(
+                pos,
+                q,
+                box,
+                k_vectors,
+                alpha,
+                batch_idx=bidx,
+                compute_forces=True,
+                compute_charge_gradients=True,
+                compute_virial=True,
+            )
+
+        eager_explicit = direct_outputs(positions, charges, cell, batch_idx)
+        eager_unbatched = direct_outputs(positions, charges, cell, None)
+        expected_energy, expected_charge_grad, expected_virial = (
+            _expected_zero_k_reciprocal_corrections(
+                charges,
+                cell,
+                alpha,
+                batch_idx=batch_idx,
+            )
+        )
+        torch.testing.assert_close(eager_explicit[0], expected_energy)
+        torch.testing.assert_close(eager_explicit[1], torch.zeros_like(positions))
+        torch.testing.assert_close(eager_explicit[2], expected_charge_grad)
+        torch.testing.assert_close(eager_explicit[3], expected_virial)
+        assert torch.count_nonzero(expected_virial).item() > 0
+
+        def make_loss_fn(bidx: torch.Tensor | None):
+            def loss_fn(
+                pos: torch.Tensor, q: torch.Tensor, box: torch.Tensor
+            ) -> torch.Tensor:
+                return ewald_reciprocal_space(
+                    pos,
+                    q,
+                    box,
+                    k_vectors,
+                    alpha,
+                    batch_idx=bidx,
+                ).sum()
+
+            return loss_fn
+
+        eager_explicit_grads = _ewald_energy_and_grads(
+            make_loss_fn(batch_idx),
+            positions,
+            charges,
+            cell,
+        )
+        eager_unbatched_grads = _ewald_energy_and_grads(
+            make_loss_fn(None),
+            positions,
+            charges,
+            cell,
+        )
+        assert torch.count_nonzero(eager_explicit_grads[1][2]).item() > 0
+
+        torch._dynamo.reset()
+        try:
+            compiled_explicit = torch.compile(direct_outputs, dynamic=True)(
+                positions,
+                charges,
+                cell,
+                batch_idx,
+            )
+            compiled_explicit_grads = _ewald_energy_and_grads(
+                torch.compile(make_loss_fn(batch_idx), dynamic=True),
+                positions,
+                charges,
+                cell,
+            )
+        finally:
+            torch._dynamo.reset()
+
+        for compiled, eager, unbatched in zip(
+            compiled_explicit,
+            eager_explicit,
+            eager_unbatched,
+            strict=True,
+        ):
+            torch.testing.assert_close(compiled, eager, rtol=1e-7, atol=1e-9)
+            torch.testing.assert_close(compiled, unbatched, rtol=1e-7, atol=1e-9)
+        for compiled, eager, unbatched in zip(
+            compiled_explicit_grads,
+            eager_explicit_grads,
+            eager_unbatched_grads,
+            strict=True,
+        ):
+            if isinstance(compiled, tuple):
+                for compiled_grad, eager_grad, unbatched_grad in zip(
+                    compiled,
+                    eager,
+                    unbatched,
+                    strict=True,
+                ):
+                    torch.testing.assert_close(
+                        compiled_grad,
+                        eager_grad,
+                        rtol=1e-7,
+                        atol=1e-9,
+                    )
+                    torch.testing.assert_close(
+                        compiled_grad,
+                        unbatched_grad,
+                        rtol=1e-7,
+                        atol=1e-9,
+                    )
+            else:
+                torch.testing.assert_close(compiled, eager, rtol=1e-7, atol=1e-9)
+                torch.testing.assert_close(
+                    compiled,
+                    unbatched,
+                    rtol=1e-7,
+                    atol=1e-9,
+                )
+
     @pytest.mark.skipif(
         not torch.cuda.is_available(), reason="CUDA required for torch.compile"
     )

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -38,6 +38,7 @@ import warnings
 import numpy as np
 import pytest
 import torch
+import warp as wp
 from torchpme.lib.kvectors import _generate_kvectors as _generate_kvectors_torchpme
 
 from nvalchemiops.interactions.electrostatics._factory_common import _DerivState
@@ -254,6 +255,54 @@ def create_dipole_system(
     neighbor_ptr = torch.tensor([0, 1, 2], dtype=torch.int32, device=device)
     neighbor_shifts = torch.zeros((2, 3), dtype=torch.int32, device=device)
     return positions, charges, cell, neighbor_list, neighbor_ptr, neighbor_shifts
+
+
+def _compile_ewald_setup(
+    device: torch.device,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Build fixed explicit-B=1 Ewald inputs outside compiled callables."""
+    positions, charges, cell, neighbor_list, neighbor_ptr, neighbor_shifts = (
+        create_dipole_system(device, dtype=torch.float64)
+    )
+    batch_idx = torch.zeros(positions.shape[0], dtype=torch.int32, device=device)
+    alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
+    k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=3.0)
+    return (
+        positions,
+        charges,
+        cell,
+        batch_idx,
+        alpha,
+        k_vectors,
+        neighbor_list,
+        neighbor_ptr,
+        neighbor_shifts,
+    )
+
+
+def _ewald_energy_and_grads(
+    loss_fn,
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    """Evaluate a scalar Ewald loss and its public first-order derivatives."""
+    positions = positions.clone().requires_grad_(True)
+    charges = charges.clone().requires_grad_(True)
+    cell = cell.clone().requires_grad_(True)
+    loss = loss_fn(positions, charges, cell)
+    gradients = torch.autograd.grad(loss, (positions, charges, cell))
+    return loss, gradients
 
 
 ###########################################################################################
@@ -6729,6 +6778,191 @@ class TestEwaldVirialTorchPMEParity:
 class TestEwaldTorchCompile:
     """Verify that ewald_summation under torch.compile matches eager mode."""
 
+    @pytest.mark.slow
+    @pytest.mark.parametrize("device", ["cpu", "cuda"])
+    @pytest.mark.parametrize("part", ["real", "recip", "summation"])
+    def test_explicit_batch_single_system_loss_compile_gradients(self, device, part):
+        """Compiled explicit-B=1 Ewald losses match eager energy gradients."""
+        if device == "cuda" and (
+            not torch.cuda.is_available() or not wp.is_cuda_available()
+        ):
+            pytest.skip("CUDA or Warp CUDA support unavailable")
+
+        torch_device = torch.device(device)
+        (
+            positions,
+            charges,
+            cell,
+            batch_idx,
+            alpha,
+            k_vectors,
+            neighbor_list,
+            neighbor_ptr,
+            neighbor_shifts,
+        ) = _compile_ewald_setup(torch_device)
+
+        def make_loss_fn(bidx: torch.Tensor | None):
+            def loss_fn(
+                pos: torch.Tensor, q: torch.Tensor, box: torch.Tensor
+            ) -> torch.Tensor:
+                if part == "real":
+                    energy = ewald_real_space(
+                        pos,
+                        q,
+                        box,
+                        alpha,
+                        neighbor_list=neighbor_list,
+                        neighbor_ptr=neighbor_ptr,
+                        neighbor_shifts=neighbor_shifts,
+                        batch_idx=bidx,
+                    )
+                elif part == "recip":
+                    energy = ewald_reciprocal_space(
+                        pos, q, box, k_vectors, alpha, batch_idx=bidx
+                    )
+                else:
+                    energy = ewald_summation(
+                        pos,
+                        q,
+                        box,
+                        alpha=alpha,
+                        k_vectors=k_vectors,
+                        neighbor_list=neighbor_list,
+                        neighbor_ptr=neighbor_ptr,
+                        neighbor_shifts=neighbor_shifts,
+                        batch_idx=bidx,
+                    )
+                return energy.sum()
+
+            return loss_fn
+
+        eager_explicit = _ewald_energy_and_grads(
+            make_loss_fn(batch_idx), positions, charges, cell
+        )
+        eager_unbatched = _ewald_energy_and_grads(
+            make_loss_fn(None), positions, charges, cell
+        )
+
+        torch._dynamo.reset()
+        try:
+            compiled_loss_fn = torch.compile(make_loss_fn(batch_idx), dynamic=True)
+            compiled_explicit = _ewald_energy_and_grads(
+                compiled_loss_fn, positions, charges, cell
+            )
+        finally:
+            torch._dynamo.reset()
+
+        for compiled, eager, unbatched in zip(
+            compiled_explicit, eager_explicit, eager_unbatched, strict=True
+        ):
+            if isinstance(compiled, tuple):
+                for grad_index, (
+                    compiled_grad,
+                    eager_grad,
+                    unbatched_grad,
+                ) in enumerate(zip(compiled, eager, unbatched, strict=True)):
+                    # Native erfc and eager float64 wp_erfc differ by ~1.33e-9.
+                    grad_atol = (
+                        1e-8
+                        if part == "real" and device == "cuda" and grad_index < 2
+                        else 1e-9
+                    )
+                    torch.testing.assert_close(
+                        compiled_grad, eager_grad, rtol=1e-7, atol=grad_atol
+                    )
+                    torch.testing.assert_close(
+                        compiled_grad, unbatched_grad, rtol=1e-7, atol=grad_atol
+                    )
+            else:
+                torch.testing.assert_close(compiled, eager, rtol=1e-7, atol=1e-9)
+                torch.testing.assert_close(compiled, unbatched, rtol=1e-7, atol=1e-9)
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("device", ["cpu", "cuda"])
+    def test_full_explicit_batch_direct_outputs_compile(self, device):
+        """Compiled explicit-B=1 Ewald direct outputs match eager references."""
+        if device == "cuda" and (
+            not torch.cuda.is_available() or not wp.is_cuda_available()
+        ):
+            pytest.skip("CUDA or Warp CUDA support unavailable")
+
+        torch_device = torch.device(device)
+        (
+            positions,
+            charges,
+            cell,
+            batch_idx,
+            alpha,
+            k_vectors,
+            neighbor_list,
+            neighbor_ptr,
+            neighbor_shifts,
+        ) = _compile_ewald_setup(torch_device)
+
+        def direct_outputs(
+            pos: torch.Tensor,
+            q: torch.Tensor,
+            box: torch.Tensor,
+            bidx: torch.Tensor | None,
+        ) -> tuple[torch.Tensor, ...]:
+            return ewald_summation(
+                pos,
+                q,
+                box,
+                alpha=alpha,
+                k_vectors=k_vectors,
+                neighbor_list=neighbor_list,
+                neighbor_ptr=neighbor_ptr,
+                neighbor_shifts=neighbor_shifts,
+                batch_idx=bidx,
+                compute_forces=True,
+                compute_charge_gradients=True,
+                compute_virial=True,
+            )
+
+        eager_explicit = _ewald_summation_without_direct_output_deprecation(
+            positions,
+            charges,
+            cell,
+            alpha=alpha,
+            k_vectors=k_vectors,
+            neighbor_list=neighbor_list,
+            neighbor_ptr=neighbor_ptr,
+            neighbor_shifts=neighbor_shifts,
+            batch_idx=batch_idx,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+        eager_unbatched = _ewald_summation_without_direct_output_deprecation(
+            positions,
+            charges,
+            cell,
+            alpha=alpha,
+            k_vectors=k_vectors,
+            neighbor_list=neighbor_list,
+            neighbor_ptr=neighbor_ptr,
+            neighbor_shifts=neighbor_shifts,
+            batch_idx=None,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+        )
+
+        torch._dynamo.reset()
+        try:
+            compiled_explicit = torch.compile(direct_outputs, dynamic=True)(
+                positions, charges, cell, batch_idx
+            )
+        finally:
+            torch._dynamo.reset()
+
+        for compiled, eager, unbatched in zip(
+            compiled_explicit, eager_explicit, eager_unbatched, strict=True
+        ):
+            torch.testing.assert_close(compiled, eager, rtol=1e-7, atol=1e-9)
+            torch.testing.assert_close(compiled, unbatched, rtol=1e-7, atol=1e-9)
+
     @pytest.mark.skipif(
         not torch.cuda.is_available(), reason="CUDA required for torch.compile"
     )
@@ -8165,7 +8399,7 @@ class TestEwaldQRGeometryFallback:
 class TestEwaldDoubleBackward:
     """Second-order contract: create_graph losses + gradgradcheck (real/recip/summation)."""
 
-    def _energy_fn(self, part, device, triclinic=False):
+    def _energy_fn(self, part, device, triclinic=False, explicit_batch=False):
         """Return (energy_fn, positions, charges, cell) for the requested part."""
         positions, charges, cell = _contract_dipole(device)
         if triclinic:
@@ -8176,15 +8410,33 @@ class TestEwaldDoubleBackward:
                 dtype=torch.float64,
                 device=device,
             )
-        nl, nptr, ns = cell_list(
-            positions,
-            5.0,
-            cell,
-            torch.tensor([[True, True, True]], device=device),
-            return_neighbor_list=True,
+        batch_idx = (
+            torch.zeros(positions.shape[0], dtype=torch.int32, device=device)
+            if explicit_batch
+            else None
         )
+        batch_kwargs = {"batch_idx": batch_idx} if explicit_batch else {}
+        if explicit_batch:
+            nl, nptr, ns = batch_cell_list(
+                positions,
+                5.0,
+                cell,
+                torch.tensor([[True, True, True]], device=device),
+                batch_idx=batch_idx,
+                return_neighbor_list=True,
+            )
+        else:
+            nl, nptr, ns = cell_list(
+                positions,
+                5.0,
+                cell,
+                torch.tensor([[True, True, True]], device=device),
+                return_neighbor_list=True,
+            )
         alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
-        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=2.0).squeeze(0)
+        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=2.0)
+        if not explicit_batch:
+            k_vectors = k_vectors.squeeze(0)
 
         if part == "real":
 
@@ -8197,11 +8449,19 @@ class TestEwaldDoubleBackward:
                     neighbor_list=nl,
                     neighbor_ptr=nptr,
                     neighbor_shifts=ns,
+                    **batch_kwargs,
                 )
         elif part == "recip":
 
             def energy_fn(p, q, c):
-                return ewald_reciprocal_space(p, q, c, k_vectors, alpha)
+                return ewald_reciprocal_space(
+                    p,
+                    q,
+                    c,
+                    k_vectors,
+                    alpha,
+                    **batch_kwargs,
+                )
         else:  # summation
 
             def energy_fn(p, q, c):
@@ -8214,6 +8474,7 @@ class TestEwaldDoubleBackward:
                     neighbor_list=nl,
                     neighbor_ptr=nptr,
                     neighbor_shifts=ns,
+                    **batch_kwargs,
                 )
 
         return energy_fn, positions, charges, cell
@@ -8326,6 +8587,31 @@ class TestEwaldDoubleBackward:
             cell,
             wrt=("positions", "cell"),
         )
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    @pytest.mark.parametrize(
+        ("part", "wrt", "triclinic"),
+        [
+            ("real", ("positions",), False),
+            ("real", ("positions", "cell"), True),
+            ("recip", ("charges",), False),
+            ("recip", ("cell",), False),
+            ("summation", ("positions",), False),
+        ],
+    )
+    def test_gradgradcheck_explicit_single_batch(self, device, part, wrt, triclinic):
+        """Explicit-B=1 public APIs retain focused float64 second derivatives."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        energy_fn, positions, charges, cell = self._energy_fn(
+            part,
+            device,
+            triclinic=triclinic,
+            explicit_batch=True,
+        )
+        assert gradgradcheck_energy(energy_fn, positions, charges, cell, wrt=wrt)
 
     @pytest.mark.slow
     @pytest.mark.parametrize("device", ["cuda", "cpu"])

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -4084,8 +4084,10 @@ class TestPMEVirialTorchPMEParity:
 class TestPMETorchCompile:
     """Verify that PME functions work correctly under torch.compile."""
 
-    @pytest.mark.slow
-    @pytest.mark.parametrize("device", ["cpu", "cuda"])
+    @pytest.mark.parametrize(
+        "device",
+        ["cpu", pytest.param("cuda", marks=pytest.mark.slow)],
+    )
     def test_reciprocal_compile_specializations_preserve_rfft_cotangent(self, device):
         """Mesh-8 then mesh-32 compiled reciprocal gradients match eager PME."""
         if device == "cuda" and (
@@ -4405,8 +4407,10 @@ class TestPMETorchCompile:
                     atol=1e-9,
                 )
 
-    @pytest.mark.slow
-    @pytest.mark.parametrize("device", ["cpu", "cuda"])
+    @pytest.mark.parametrize(
+        "device",
+        ["cpu", pytest.param("cuda", marks=pytest.mark.slow)],
+    )
     def test_full_pme_explicit_batch_single_system_loss_compile_gradients(self, device):
         """Compiled explicit-B=1 full PME matches eager energy gradients."""
         if device == "cuda" and (

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -45,6 +45,7 @@ from nvalchemiops.torch.interactions.electrostatics.k_vectors import (
     generate_k_vectors_pme,
 )
 from nvalchemiops.torch.interactions.electrostatics.pme import (
+    _pme_convolve_backward_args,
     _pme_reciprocal_space_impl,
     _prepare_alpha,
     pme_energy_corrections,
@@ -4083,6 +4084,36 @@ class TestPMEVirialTorchPMEParity:
 
 class TestPMETorchCompile:
     """Verify that PME functions work correctly under torch.compile."""
+
+    @pytest.mark.parametrize("dtype", [torch.complex64, torch.complex128])
+    def test_convolve_backward_args_materializes_only_compiled_cotangent(self, dtype):
+        """Eager routing preserves its cotangent while compiled routing clones it."""
+        cotangent = torch.arange(24, dtype=torch.float64).reshape(2, 3, 4).to(dtype)
+        forward_inputs = tuple(
+            torch.full((1,), index, dtype=torch.float64) for index in range(8)
+        )
+
+        eager_args = _pme_convolve_backward_args(
+            (cotangent,),
+            (*forward_inputs, False),
+        )
+        compiled_args = _pme_convolve_backward_args(
+            (cotangent,),
+            (*forward_inputs, True),
+        )
+
+        assert len(eager_args) == len(compiled_args) == 9
+        assert eager_args[0] is compiled_args[0] is forward_inputs[0]
+        for index, forward_input in enumerate(forward_inputs[1:], start=2):
+            assert eager_args[index] is compiled_args[index] is forward_input
+
+        assert eager_args[1] is cotangent
+        assert compiled_args[1] is not cotangent
+        torch.testing.assert_close(compiled_args[1], cotangent, rtol=0.0, atol=0.0)
+        assert (
+            compiled_args[1].untyped_storage().data_ptr()
+            != cotangent.untyped_storage().data_ptr()
+        )
 
     @pytest.mark.parametrize(
         "device",

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -32,9 +32,11 @@ from importlib import import_module
 
 import pytest
 import torch
+import warp as wp
 
 from nvalchemiops.torch.interactions.electrostatics import (
     compute_bspline_moduli_1d,
+    estimate_pme_parameters,
     particle_mesh_ewald,
     pme_reciprocal_space,
 )
@@ -51,7 +53,7 @@ from nvalchemiops.torch.interactions.electrostatics.pme import (
 from nvalchemiops.torch.interactions.electrostatics.pme import (
     compute_bspline_moduli_1d as pme_compute_bspline_moduli_1d,
 )
-from nvalchemiops.torch.neighbors import batch_cell_list, cell_list
+from nvalchemiops.torch.neighbors import batch_cell_list, cell_list, neighbor_list
 
 # Check for optional dependencies
 try:
@@ -116,6 +118,102 @@ def _particle_mesh_ewald_without_direct_output_deprecation(*args, **kwargs):
             category=DeprecationWarning,
         )
         return particle_mesh_ewald(*args, **kwargs)
+
+
+def _compile_pme_setup(
+    device: torch.device,
+    *,
+    full_pme: bool,
+    num_atoms: int = 2,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    dict[str, object],
+]:
+    """Build fixed explicit-B=1 PME inputs outside compiled callables."""
+    dtype = torch.float64
+    if num_atoms == 1:
+        positions = torch.tensor([[5.0, 5.0, 5.0]], dtype=dtype, device=device)
+        charges = torch.tensor([1.0], dtype=dtype, device=device)
+    else:
+        positions = torch.tensor(
+            [[2.0, 5.0, 5.0], [8.0, 5.0, 5.0]],
+            dtype=dtype,
+            device=device,
+        )
+        charges = torch.tensor([1.0, -1.0], dtype=dtype, device=device)
+    cell = torch.eye(3, dtype=dtype, device=device).unsqueeze(0) * 10.0
+    batch_idx = torch.zeros(num_atoms, dtype=torch.int32, device=device)
+
+    if num_atoms == 1:
+        pme_common: dict[str, object] = {
+            "alpha": torch.tensor([0.3], dtype=dtype, device=device),
+            "mesh_dimensions": (8, 8, 8),
+            "spline_order": 4,
+        }
+    else:
+        with torch.no_grad():
+            params = estimate_pme_parameters(
+                positions,
+                cell,
+                batch_idx=batch_idx,
+                accuracy=1e-6,
+            )
+        pme_common = {
+            "alpha": params.alpha,
+            "mesh_dimensions": tuple(params.mesh_dimensions),
+            "spline_order": 4,
+        }
+
+    if full_pme:
+        if num_atoms == 1:
+            neighbor_matrix = torch.full(
+                (1, 1),
+                num_atoms,
+                dtype=torch.int32,
+                device=device,
+            )
+            neighbor_shifts = torch.zeros(
+                (1, 1, 3),
+                dtype=torch.int32,
+                device=device,
+            )
+            max_neighbors = 1
+        else:
+            with torch.no_grad():
+                neighbor_matrix, max_neighbors, neighbor_shifts = neighbor_list(
+                    positions=positions,
+                    cell=cell,
+                    pbc=torch.ones((1, 3), dtype=torch.bool, device=device),
+                    cutoff=params.real_space_cutoff.max().item(),
+                    batch_idx=batch_idx,
+                    fill_value=num_atoms,
+                )
+            max_neighbors = max(int(max_neighbors.max()), 1)
+        pme_common.update(
+            neighbor_matrix=neighbor_matrix[:, :max_neighbors].to(torch.int32),
+            neighbor_matrix_shifts=neighbor_shifts[:, :max_neighbors].to(torch.int32),
+            mask_value=num_atoms,
+            accuracy=1e-6,
+        )
+    return positions, charges, cell, batch_idx, pme_common
+
+
+def _pme_energy_and_grads(
+    loss_fn,
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    """Evaluate a scalar PME loss and its public first-order derivatives."""
+    positions = positions.clone().requires_grad_(True)
+    charges = charges.clone().requires_grad_(True)
+    cell = cell.clone().requires_grad_(True)
+    loss = loss_fn(positions, charges, cell)
+    gradients = torch.autograd.grad(loss, (positions, charges, cell))
+    return loss, gradients
 
 
 def create_simple_system(
@@ -3986,6 +4084,491 @@ class TestPMEVirialTorchPMEParity:
 class TestPMETorchCompile:
     """Verify that PME functions work correctly under torch.compile."""
 
+    @pytest.mark.slow
+    @pytest.mark.parametrize("device", ["cpu", "cuda"])
+    def test_reciprocal_compile_specializations_preserve_rfft_cotangent(self, device):
+        """Mesh-8 then mesh-32 compiled reciprocal gradients match eager PME."""
+        if device == "cuda" and (
+            not torch.cuda.is_available() or not wp.is_cuda_available()
+        ):
+            pytest.skip("CUDA or Warp CUDA support unavailable")
+
+        torch._dynamo.reset()
+        torch_device = torch.device(device)
+        one_positions, one_charges, one_cell, one_batch_idx, one_pme_common = (
+            _compile_pme_setup(
+                torch_device,
+                full_pme=False,
+                num_atoms=1,
+            )
+        )
+        two_positions, two_charges, two_cell, two_batch_idx, two_pme_common = (
+            _compile_pme_setup(
+                torch_device,
+                full_pme=False,
+                num_atoms=2,
+            )
+        )
+        two_pme_common["mesh_dimensions"] = (32, 32, 32)
+
+        def loss_fn(
+            pos: torch.Tensor,
+            q: torch.Tensor,
+            box: torch.Tensor,
+            alpha: torch.Tensor,
+            batch_idx: torch.Tensor | None,
+            mesh_dimensions: tuple[int, int, int],
+        ) -> torch.Tensor:
+            return pme_reciprocal_space(
+                pos,
+                q,
+                box,
+                alpha=alpha,
+                mesh_dimensions=mesh_dimensions,
+                spline_order=4,
+                batch_idx=batch_idx,
+            ).sum()
+
+        def make_loss_fn(
+            pme_common: dict[str, object],
+            batch_idx: torch.Tensor | None,
+            evaluator=loss_fn,
+        ):
+            def bound_loss_fn(
+                pos: torch.Tensor,
+                q: torch.Tensor,
+                box: torch.Tensor,
+            ) -> torch.Tensor:
+                return evaluator(
+                    pos,
+                    q,
+                    box,
+                    pme_common["alpha"],
+                    batch_idx,
+                    pme_common["mesh_dimensions"],
+                )
+
+            return bound_loss_fn
+
+        eager_explicit = _pme_energy_and_grads(
+            make_loss_fn(two_pme_common, two_batch_idx),
+            two_positions,
+            two_charges,
+            two_cell,
+        )
+        eager_unbatched = _pme_energy_and_grads(
+            make_loss_fn(two_pme_common, None),
+            two_positions,
+            two_charges,
+            two_cell,
+        )
+
+        try:
+            compiled_loss_fn = torch.compile(loss_fn, dynamic=True)
+            compiled_one = make_loss_fn(
+                one_pme_common,
+                one_batch_idx,
+                compiled_loss_fn,
+            )
+            _pme_energy_and_grads(
+                compiled_one,
+                one_positions,
+                one_charges,
+                one_cell,
+            )
+            compiled_two = make_loss_fn(
+                two_pme_common,
+                two_batch_idx,
+                compiled_loss_fn,
+            )
+            compiled_explicit = _pme_energy_and_grads(
+                compiled_two,
+                two_positions,
+                two_charges,
+                two_cell,
+            )
+        finally:
+            torch._dynamo.reset()
+
+        for compiled_grad, eager_grad, unbatched_grad in zip(
+            compiled_explicit[1],
+            eager_explicit[1],
+            eager_unbatched[1],
+            strict=True,
+        ):
+            torch.testing.assert_close(
+                compiled_grad,
+                eager_grad,
+                rtol=1e-7,
+                atol=1e-9,
+            )
+            torch.testing.assert_close(
+                compiled_grad,
+                unbatched_grad,
+                rtol=1e-7,
+                atol=1e-9,
+            )
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("device", ["cpu", "cuda"])
+    def test_single_system_batch_idx_conservative_forces_compile(self, device):
+        """Explicit B=1 PME forces compile and match eager and unbatched references."""
+        if device == "cuda" and (
+            not torch.cuda.is_available() or not wp.is_cuda_available()
+        ):
+            pytest.skip("CUDA or Warp CUDA support unavailable")
+
+        torch._dynamo.reset()
+        torch_device = torch.device(device)
+        dtype = torch.float64
+        positions = torch.tensor(
+            [[2.0, 5.0, 5.0], [8.0, 5.0, 5.0]],
+            dtype=dtype,
+            device=torch_device,
+        )
+        charges = torch.tensor([1.0, -1.0], dtype=dtype, device=torch_device)
+        cell = torch.eye(3, dtype=dtype, device=torch_device).unsqueeze(0) * 10.0
+        num_atoms = positions.shape[0]
+        batch_idx = torch.zeros(num_atoms, dtype=torch.int32, device=torch_device)
+
+        with torch.no_grad():
+            params = estimate_pme_parameters(
+                positions,
+                cell,
+                batch_idx=batch_idx,
+                accuracy=1e-6,
+            )
+            neighbor_matrix, max_neighbors, neighbor_shifts = neighbor_list(
+                positions=positions,
+                cell=cell,
+                pbc=torch.tensor(
+                    [[True, True, True]],
+                    dtype=torch.bool,
+                    device=torch_device,
+                ),
+                cutoff=params.real_space_cutoff.max().item(),
+                batch_idx=batch_idx,
+                fill_value=num_atoms,
+            )
+
+        max_neighbors = max(int(max_neighbors.max()), 1)
+        pme_common = dict(
+            cell=cell,
+            alpha=params.alpha,
+            mesh_dimensions=tuple(params.mesh_dimensions),
+            spline_order=4,
+            neighbor_matrix=neighbor_matrix[:, :max_neighbors].to(torch.int32),
+            neighbor_matrix_shifts=neighbor_shifts[:, :max_neighbors].to(torch.int32),
+            mask_value=num_atoms,
+            accuracy=1e-6,
+        )
+
+        def forces(pos: torch.Tensor, bidx: torch.Tensor | None) -> torch.Tensor:
+            energy = particle_mesh_ewald(
+                positions=pos,
+                charges=charges,
+                batch_idx=bidx,
+                **pme_common,
+            ).sum()
+            (grad_pos,) = torch.autograd.grad(energy, pos, create_graph=False)
+            return -grad_pos
+
+        eager_batched = forces(positions.clone().requires_grad_(True), batch_idx)
+        eager_unbatched = forces(positions.clone().requires_grad_(True), None)
+        # Eager/direct float64 real-space currently uses a float32-grade wp_erfc
+        # approximation; atol=1e-8 covers its measured ~8.01e-9 error.
+        torch.testing.assert_close(
+            eager_batched,
+            eager_unbatched,
+            rtol=1e-7,
+            atol=1e-8,
+        )
+
+        try:
+            compiled_batched = torch.compile(forces, dynamic=True)(
+                positions.clone().requires_grad_(True),
+                batch_idx,
+            )
+        finally:
+            torch._dynamo.reset()
+        try:
+            compiled_unbatched = torch.compile(forces, dynamic=True)(
+                positions.clone().requires_grad_(True),
+                None,
+            )
+        finally:
+            torch._dynamo.reset()
+        torch.testing.assert_close(
+            compiled_batched,
+            eager_batched,
+            rtol=1e-7,
+            atol=1e-8,
+        )
+        torch.testing.assert_close(
+            compiled_batched,
+            compiled_unbatched,
+            rtol=1e-7,
+            atol=1e-8,
+        )
+
+    @pytest.mark.parametrize("device", ["cpu", "cuda"])
+    @pytest.mark.parametrize("num_atoms", [1, 2])
+    def test_reciprocal_explicit_batch_single_system_loss_compile_gradients(
+        self, device, num_atoms
+    ):
+        """Compiled explicit-B=1 reciprocal PME matches eager energy gradients."""
+        if device == "cuda" and (
+            not torch.cuda.is_available() or not wp.is_cuda_available()
+        ):
+            pytest.skip("CUDA or Warp CUDA support unavailable")
+
+        torch_device = torch.device(device)
+        positions, charges, cell, batch_idx, pme_common = _compile_pme_setup(
+            torch_device,
+            full_pme=False,
+            num_atoms=num_atoms,
+        )
+
+        def make_loss_fn(bidx: torch.Tensor | None):
+            def loss_fn(pos: torch.Tensor, q: torch.Tensor, box: torch.Tensor):
+                return pme_reciprocal_space(
+                    pos,
+                    q,
+                    box,
+                    batch_idx=bidx,
+                    **pme_common,
+                ).sum()
+
+            return loss_fn
+
+        eager_explicit = _pme_energy_and_grads(
+            make_loss_fn(batch_idx),
+            positions,
+            charges,
+            cell,
+        )
+        eager_unbatched = _pme_energy_and_grads(
+            make_loss_fn(None),
+            positions,
+            charges,
+            cell,
+        )
+
+        torch._dynamo.reset()
+        try:
+            compiled_loss_fn = torch.compile(make_loss_fn(batch_idx), dynamic=True)
+            compiled_explicit = _pme_energy_and_grads(
+                compiled_loss_fn,
+                positions,
+                charges,
+                cell,
+            )
+        finally:
+            torch._dynamo.reset()
+
+        for compiled, eager, unbatched in zip(
+            compiled_explicit,
+            eager_explicit,
+            eager_unbatched,
+            strict=True,
+        ):
+            if isinstance(compiled, tuple):
+                for compiled_grad, eager_grad, unbatched_grad in zip(
+                    compiled,
+                    eager,
+                    unbatched,
+                    strict=True,
+                ):
+                    torch.testing.assert_close(
+                        compiled_grad,
+                        eager_grad,
+                        rtol=1e-7,
+                        atol=1e-9,
+                    )
+                    torch.testing.assert_close(
+                        compiled_grad,
+                        unbatched_grad,
+                        rtol=1e-7,
+                        atol=1e-9,
+                    )
+            else:
+                torch.testing.assert_close(
+                    compiled,
+                    eager,
+                    rtol=1e-7,
+                    atol=1e-9,
+                )
+                torch.testing.assert_close(
+                    compiled,
+                    unbatched,
+                    rtol=1e-7,
+                    atol=1e-9,
+                )
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("device", ["cpu", "cuda"])
+    def test_full_pme_explicit_batch_single_system_loss_compile_gradients(self, device):
+        """Compiled explicit-B=1 full PME matches eager energy gradients."""
+        if device == "cuda" and (
+            not torch.cuda.is_available() or not wp.is_cuda_available()
+        ):
+            pytest.skip("CUDA or Warp CUDA support unavailable")
+
+        torch_device = torch.device(device)
+        positions, charges, cell, batch_idx, pme_common = _compile_pme_setup(
+            torch_device,
+            full_pme=True,
+        )
+
+        def make_loss_fn(bidx: torch.Tensor | None):
+            def loss_fn(pos: torch.Tensor, q: torch.Tensor, box: torch.Tensor):
+                return particle_mesh_ewald(
+                    pos,
+                    q,
+                    box,
+                    batch_idx=bidx,
+                    **pme_common,
+                ).sum()
+
+            return loss_fn
+
+        eager_explicit = _pme_energy_and_grads(
+            make_loss_fn(batch_idx),
+            positions,
+            charges,
+            cell,
+        )
+        eager_unbatched = _pme_energy_and_grads(
+            make_loss_fn(None),
+            positions,
+            charges,
+            cell,
+        )
+
+        torch._dynamo.reset()
+        try:
+            compiled_loss_fn = torch.compile(make_loss_fn(batch_idx), dynamic=True)
+            compiled_explicit = _pme_energy_and_grads(
+                compiled_loss_fn,
+                positions,
+                charges,
+                cell,
+            )
+        finally:
+            torch._dynamo.reset()
+
+        for compiled, eager, unbatched in zip(
+            compiled_explicit,
+            eager_explicit,
+            eager_unbatched,
+            strict=True,
+        ):
+            if isinstance(compiled, tuple):
+                for compiled_grad, eager_grad, unbatched_grad in zip(
+                    compiled,
+                    eager,
+                    unbatched,
+                    strict=True,
+                ):
+                    torch.testing.assert_close(
+                        compiled_grad,
+                        eager_grad,
+                        rtol=1e-7,
+                        atol=1e-9,
+                    )
+                    torch.testing.assert_close(
+                        compiled_grad,
+                        unbatched_grad,
+                        rtol=1e-7,
+                        atol=1e-9,
+                    )
+            else:
+                torch.testing.assert_close(
+                    compiled,
+                    eager,
+                    rtol=1e-7,
+                    atol=1e-9,
+                )
+                torch.testing.assert_close(
+                    compiled,
+                    unbatched,
+                    rtol=1e-7,
+                    atol=1e-9,
+                )
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("device", ["cpu", "cuda"])
+    def test_full_pme_explicit_batch_direct_outputs_compile(self, device):
+        """Compiled explicit-B=1 full PME direct outputs match eager references."""
+        if device == "cuda" and (
+            not torch.cuda.is_available() or not wp.is_cuda_available()
+        ):
+            pytest.skip("CUDA or Warp CUDA support unavailable")
+
+        torch_device = torch.device(device)
+        positions, charges, cell, batch_idx, pme_common = _compile_pme_setup(
+            torch_device,
+            full_pme=True,
+        )
+
+        def direct_outputs(
+            pos: torch.Tensor,
+            q: torch.Tensor,
+            box: torch.Tensor,
+            bidx: torch.Tensor | None,
+        ) -> tuple[torch.Tensor, ...]:
+            return particle_mesh_ewald(
+                pos,
+                q,
+                box,
+                batch_idx=bidx,
+                compute_forces=True,
+                compute_charge_gradients=True,
+                compute_virial=True,
+                **pme_common,
+            )
+
+        eager_explicit = _particle_mesh_ewald_without_direct_output_deprecation(
+            positions,
+            charges,
+            cell,
+            batch_idx=batch_idx,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+            **pme_common,
+        )
+        eager_unbatched = _particle_mesh_ewald_without_direct_output_deprecation(
+            positions,
+            charges,
+            cell,
+            batch_idx=None,
+            compute_forces=True,
+            compute_charge_gradients=True,
+            compute_virial=True,
+            **pme_common,
+        )
+
+        torch._dynamo.reset()
+        try:
+            compiled_explicit = torch.compile(direct_outputs, dynamic=True)(
+                positions,
+                charges,
+                cell,
+                batch_idx,
+            )
+        finally:
+            torch._dynamo.reset()
+
+        for compiled, eager, unbatched in zip(
+            compiled_explicit,
+            eager_explicit,
+            eager_unbatched,
+            strict=True,
+        ):
+            torch.testing.assert_close(compiled, eager, rtol=1e-7, atol=1e-9)
+            torch.testing.assert_close(compiled, unbatched, rtol=1e-7, atol=1e-9)
+
     @pytest.mark.skipif(
         not torch.cuda.is_available(), reason="CUDA required for torch.compile"
     )
@@ -5491,7 +6074,7 @@ class TestPMEQRGeometryFallback:
 class TestPMEDoubleBackward:
     """Second-order contract: create_graph losses + gradgradcheck (recip + full)."""
 
-    def _build(self, which, device, triclinic=False):
+    def _build(self, which, device, triclinic=False, explicit_batch=False):
         positions, charges, cell = _pme_contract_dipole(device)
         if triclinic:
             # Non-cubic cell: exercises the mixed d2E/dpos.dcell second order that a
@@ -5502,14 +6085,31 @@ class TestPMEDoubleBackward:
                 device=device,
             )
         alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
+        batch_idx = (
+            torch.zeros(positions.shape[0], dtype=torch.int32, device=device)
+            if explicit_batch
+            else None
+        )
+        batch_kwargs = {"batch_idx": batch_idx} if explicit_batch else {}
         if which == "recip":
 
             def energy_fn(p, q, c):
                 return pme_reciprocal_space(
-                    p, q, c, alpha=alpha, mesh_dimensions=_MESH, compute_forces=False
+                    p,
+                    q,
+                    c,
+                    alpha=alpha,
+                    mesh_dimensions=_MESH,
+                    compute_forces=False,
+                    **batch_kwargs,
                 )
         else:
-            nl, nptr, ns = _pme_full_neighbors(positions, cell, device)
+            nl, nptr, ns = _pme_full_neighbors(
+                positions,
+                cell,
+                device,
+                batch_idx=batch_idx,
+            )
 
             def energy_fn(p, q, c):
                 return particle_mesh_ewald(
@@ -5522,6 +6122,7 @@ class TestPMEDoubleBackward:
                     neighbor_ptr=nptr,
                     neighbor_shifts=ns,
                     compute_forces=False,
+                    **batch_kwargs,
                 )
 
         return energy_fn, positions, charges, cell
@@ -5675,6 +6276,40 @@ class TestPMEDoubleBackward:
             cell,
             wrt=("positions", "cell"),
         )
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    @pytest.mark.parametrize(
+        ("which", "wrt", "triclinic"),
+        [
+            ("recip", ("positions",), False),
+            ("recip", ("cell",), False),
+            ("full", ("charges",), False),
+            ("full", ("positions", "cell"), True),
+        ],
+    )
+    def test_gradgradcheck_explicit_single_batch(self, device, which, wrt, triclinic):
+        """Explicit-B=1 public APIs retain focused float64 second derivatives."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        energy_fn, positions, charges, cell = self._build(
+            which,
+            device,
+            triclinic=triclinic,
+            explicit_batch=True,
+        )
+        if wrt == ("positions", "cell"):
+            positions_leaf = positions.clone().requires_grad_(True)
+            cell_leaf = cell.clone().requires_grad_(True)
+            (grad_positions,) = torch.autograd.grad(
+                energy_fn(positions_leaf, charges, cell_leaf).sum(),
+                positions_leaf,
+                create_graph=True,
+            )
+            (mixed_grad,) = torch.autograd.grad(grad_positions.sum(), cell_leaf)
+            assert mixed_grad.abs().max() > 1e-8
+        assert gradgradcheck_energy(energy_fn, positions, charges, cell, wrt=wrt)
 
     @pytest.mark.slow
     @pytest.mark.parametrize("device", ["cuda", "cpu"])

--- a/test/interactions/electrostatics/bindings/torch/test_slab.py
+++ b/test/interactions/electrostatics/bindings/torch/test_slab.py
@@ -1204,8 +1204,10 @@ class TestSlabTorchCompile:
         for actual, expected in zip(compiled_grads, eager_grads, strict=True):
             torch.testing.assert_close(actual, expected, rtol=1e-10, atol=1e-12)
 
-    @pytest.mark.slow
-    @pytest.mark.parametrize("device", ["cpu", "cuda"])
+    @pytest.mark.parametrize(
+        "device",
+        ["cpu", pytest.param("cuda", marks=pytest.mark.slow)],
+    )
     def test_full_slab_explicit_batch_loss_compile_gradients(self, device):
         """Compiled explicit-B=1 slab Ewald losses match eager energy gradients."""
         if device == "cuda" and (

--- a/test/interactions/electrostatics/bindings/torch/test_slab.py
+++ b/test/interactions/electrostatics/bindings/torch/test_slab.py
@@ -33,6 +33,7 @@ import warnings
 
 import pytest
 import torch
+import warp as wp
 
 from nvalchemiops.torch.interactions.electrostatics import (
     compute_slab_correction,
@@ -194,6 +195,39 @@ def _make_triclinic_ewald_inputs(dtype=torch.float64, device="cpu"):
         positions, cell, REAL_SPACE_CUTOFF, [True, True, False], device
     )
     return positions, charges, cell, pbc, neighbor_list, neighbor_ptr, neighbor_shifts
+
+
+def _compile_slab_ewald_setup(device: torch.device):
+    """Build fixed explicit-B=1 inputs for compiled slab Ewald tests."""
+    dtype = torch.float64
+    positions, charges, cell, pbc, neighbor_list, neighbor_ptr, neighbor_shifts = (
+        _make_triclinic_ewald_inputs(dtype, device)
+    )
+    batch_idx = torch.zeros(positions.shape[0], dtype=torch.int32, device=device)
+    k_vectors = generate_k_vectors_ewald_summation(
+        cell.detach(),
+        TRICLINIC_EWALD_K_CUTOFF,
+    )
+    return (
+        positions,
+        charges,
+        cell,
+        pbc.unsqueeze(0),
+        batch_idx,
+        k_vectors,
+        neighbor_list,
+        neighbor_ptr,
+        neighbor_shifts,
+    )
+
+
+def _slab_energy_and_grads(loss_fn, positions, charges, cell):
+    """Evaluate a scalar loss and its first derivatives for slab inputs."""
+    pos = positions.clone().requires_grad_(True)
+    q = charges.clone().requires_grad_(True)
+    box = cell.clone().requires_grad_(True)
+    loss = loss_fn(pos, q, box)
+    return loss, torch.autograd.grad(loss, (pos, q, box))
 
 
 def _build_neighbor_list(positions, cell, cutoff, pbc, device="cpu"):
@@ -472,8 +506,9 @@ class TestAnalyticalVsAutograd:
 class TestSlabEnergyDerivativeContract:
     """Slab energy should support the PME/Ewald energy-derivative contract."""
 
+    @pytest.mark.parametrize("batch_mode", ("none", "explicit_b1"))
     @pytest.mark.slow
-    def test_energy_gradgradcheck_positions_charges_cell(self, device):
+    def test_energy_gradgradcheck_positions_charges_cell(self, device, batch_mode):
         """Energy-only slab correction supports second derivatives."""
         dtype = torch.float64
 
@@ -481,6 +516,13 @@ class TestSlabEnergyDerivativeContract:
         positions = positions.clone().detach().requires_grad_(True)
         charges = charges.clone().detach().requires_grad_(True)
         cell = cell.clone().detach().requires_grad_(True)
+        slab_kwargs = {}
+        if batch_mode == "explicit_b1":
+            slab_kwargs["batch_idx"] = torch.zeros(
+                positions.shape[0],
+                dtype=torch.int32,
+                device=device,
+            )
 
         def slab_energy(positions_in, charges_in, cell_in):
             return compute_slab_correction(
@@ -488,6 +530,7 @@ class TestSlabEnergyDerivativeContract:
                 charges_in,
                 cell_in,
                 pbc,
+                **slab_kwargs,
             ).sum()
 
         assert torch.autograd.gradgradcheck(
@@ -1111,6 +1154,7 @@ class TestEwaldSlabDtypes:
 class TestSlabTorchCompile:
     """Standalone slab correction should compile without tracing raw Warp setup."""
 
+    @pytest.mark.slow
     @pytest.mark.skipif(
         not torch.cuda.is_available(), reason="CUDA required for torch.compile"
     )
@@ -1142,19 +1186,168 @@ class TestSlabTorchCompile:
         compiled_pos = positions.clone().requires_grad_(True)
         compiled_chg = charges.clone().requires_grad_(True)
         compiled_cell = cell.clone().requires_grad_(True)
-        compiled = torch.compile(slab_direct)(
-            compiled_pos,
-            compiled_chg,
-            compiled_cell,
-        )
-        compiled_grads = torch.autograd.grad(
-            compiled[0].sum(), (compiled_pos, compiled_chg, compiled_cell)
-        )
+        torch._dynamo.reset()
+        try:
+            compiled = torch.compile(slab_direct)(
+                compiled_pos,
+                compiled_chg,
+                compiled_cell,
+            )
+            compiled_grads = torch.autograd.grad(
+                compiled[0].sum(), (compiled_pos, compiled_chg, compiled_cell)
+            )
+        finally:
+            torch._dynamo.reset()
 
         for actual, expected in zip(compiled, eager, strict=True):
             torch.testing.assert_close(actual, expected, rtol=1e-12, atol=1e-14)
         for actual, expected in zip(compiled_grads, eager_grads, strict=True):
             torch.testing.assert_close(actual, expected, rtol=1e-10, atol=1e-12)
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("device", ["cpu", "cuda"])
+    def test_full_slab_explicit_batch_loss_compile_gradients(self, device):
+        """Compiled explicit-B=1 slab Ewald losses match eager energy gradients."""
+        if device == "cuda" and (
+            not torch.cuda.is_available() or not wp.is_cuda_available()
+        ):
+            pytest.skip("CUDA or Warp CUDA support unavailable")
+
+        torch_device = torch.device(device)
+        (
+            positions,
+            charges,
+            cell,
+            pbc,
+            batch_idx,
+            k_vectors,
+            neighbor_list,
+            neighbor_ptr,
+            neighbor_shifts,
+        ) = _compile_slab_ewald_setup(torch_device)
+
+        def make_loss_fn(bidx: torch.Tensor | None):
+            def loss_fn(
+                pos: torch.Tensor, q: torch.Tensor, box: torch.Tensor
+            ) -> torch.Tensor:
+                return ewald_summation(
+                    pos,
+                    q,
+                    box,
+                    alpha=EWALD_ALPHA,
+                    k_vectors=k_vectors,
+                    neighbor_list=neighbor_list,
+                    neighbor_ptr=neighbor_ptr,
+                    neighbor_shifts=neighbor_shifts,
+                    batch_idx=bidx,
+                    pbc=pbc if bidx is not None else pbc[0],
+                    slab_correction=True,
+                ).sum()
+
+            return loss_fn
+
+        eager_explicit = _slab_energy_and_grads(
+            make_loss_fn(batch_idx), positions, charges, cell
+        )
+        eager_unbatched = _slab_energy_and_grads(
+            make_loss_fn(None), positions, charges, cell
+        )
+
+        torch._dynamo.reset()
+        try:
+            compiled_loss_fn = torch.compile(make_loss_fn(batch_idx), dynamic=True)
+            compiled_explicit = _slab_energy_and_grads(
+                compiled_loss_fn, positions, charges, cell
+            )
+        finally:
+            torch._dynamo.reset()
+
+        for compiled, eager, unbatched in zip(
+            compiled_explicit, eager_explicit, eager_unbatched, strict=True
+        ):
+            if isinstance(compiled, tuple):
+                for grad_index, (
+                    compiled_grad,
+                    eager_grad,
+                    unbatched_grad,
+                ) in enumerate(zip(compiled, eager, unbatched, strict=True)):
+                    # Eager/direct real-space uses the deferred float32-grade
+                    # wp_erfc approximation.
+                    grad_atol = 1e-7 if device == "cuda" and grad_index == 1 else 1e-9
+                    torch.testing.assert_close(
+                        compiled_grad, eager_grad, rtol=1e-7, atol=grad_atol
+                    )
+                    torch.testing.assert_close(
+                        compiled_grad, unbatched_grad, rtol=1e-7, atol=grad_atol
+                    )
+            else:
+                torch.testing.assert_close(compiled, eager, rtol=1e-7, atol=1e-9)
+                torch.testing.assert_close(compiled, unbatched, rtol=1e-7, atol=1e-9)
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("device", ["cpu", "cuda"])
+    def test_full_slab_explicit_batch_direct_outputs_compile(self, device):
+        """Compiled explicit-B=1 slab direct outputs match eager references."""
+        if device == "cuda" and (
+            not torch.cuda.is_available() or not wp.is_cuda_available()
+        ):
+            pytest.skip("CUDA or Warp CUDA support unavailable")
+
+        torch_device = torch.device(device)
+        (
+            positions,
+            charges,
+            cell,
+            pbc,
+            batch_idx,
+            k_vectors,
+            neighbor_list,
+            neighbor_ptr,
+            neighbor_shifts,
+        ) = _compile_slab_ewald_setup(torch_device)
+
+        def direct_outputs(
+            pos: torch.Tensor,
+            q: torch.Tensor,
+            box: torch.Tensor,
+            bidx: torch.Tensor | None,
+        ) -> tuple[torch.Tensor, ...]:
+            return ewald_summation(
+                pos,
+                q,
+                box,
+                alpha=EWALD_ALPHA,
+                k_vectors=k_vectors,
+                neighbor_list=neighbor_list,
+                neighbor_ptr=neighbor_ptr,
+                neighbor_shifts=neighbor_shifts,
+                batch_idx=bidx,
+                compute_forces=True,
+                compute_charge_gradients=True,
+                compute_virial=True,
+                pbc=pbc if bidx is not None else pbc[0],
+                slab_correction=True,
+            )
+
+        eager_explicit = direct_outputs(positions, charges, cell, batch_idx)
+        eager_unbatched = direct_outputs(positions, charges, cell, None)
+
+        torch._dynamo.reset()
+        try:
+            compiled_explicit = torch.compile(direct_outputs, dynamic=True)(
+                positions,
+                charges,
+                cell,
+                batch_idx,
+            )
+        finally:
+            torch._dynamo.reset()
+
+        for compiled, eager, unbatched in zip(
+            compiled_explicit, eager_explicit, eager_unbatched, strict=True
+        ):
+            torch.testing.assert_close(compiled, eager, rtol=1e-7, atol=1e-9)
+            torch.testing.assert_close(compiled, unbatched, rtol=1e-7, atol=1e-9)
 
 
 # ==============================================================================

--- a/test/interactions/electrostatics/test_util.py
+++ b/test/interactions/electrostatics/test_util.py
@@ -247,3 +247,123 @@ def test_ewald_uniform_predicates_keep_cuda_per_system_constants_conservative(de
     expected = device == "cpu"
     assert real_chain._cotangent_per_system_uniform(grad, batch_idx, 2) is expected
     assert recip_chain._cotangent_per_system_uniform(grad, batch_idx, 2) is expected
+
+
+@pytest.mark.parametrize("device", _available_devices())
+def test_single_system_sum_and_mean_avoid_segmented_reduction(device):
+    """Single-system reductions produce direct sums and means for scalar through matrix values."""
+    batch_idx = torch.zeros(3, dtype=torch.int32, device=device)
+    values = torch.tensor(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+            [[9.0, 10.0], [11.0, 12.0]],
+        ],
+        dtype=DT,
+        device=device,
+    )
+
+    sums = _util._sum_atom_values_by_system(values, batch_idx, 1)
+    means = _util._mean_atom_values_by_system(values, batch_idx, 1)
+
+    assert torch.equal(sums, values.sum(dim=0, keepdim=True))
+    assert torch.equal(means, values.mean(dim=0, keepdim=True))
+
+
+@pytest.mark.parametrize("device", _available_devices())
+def test_single_system_empty_reductions_have_exact_shapes(device):
+    """Empty B=1 reductions retain a leading system dimension and trailing shape."""
+    batch_idx = torch.empty(0, dtype=torch.int32, device=device)
+    values = torch.empty((0, 3, 3), dtype=DT, device=device)
+
+    sums = _util._sum_atom_values_by_system(values, batch_idx, 1)
+    means = _util._mean_atom_values_by_system(values, batch_idx, 1)
+
+    assert sums.shape == (1, 3, 3)
+    assert means.shape == (1, 3, 3)
+    assert torch.equal(sums, torch.zeros_like(sums))
+    assert torch.equal(means, torch.zeros_like(means))
+
+
+@pytest.mark.parametrize("device", _available_devices())
+def test_single_system_broadcast_and_mean_adjoint(device):
+    """B=1 broadcasts directly and distributes a mean cotangent with 1/N scaling."""
+    batch_idx = torch.zeros(3, dtype=torch.int32, device=device)
+    per_system = torch.tensor([[6.0, -3.0]], dtype=DT, device=device)
+
+    broadcast = _util._broadcast_system_values_to_atoms(per_system, batch_idx, 1, 3)
+    distributed = _util._distribute_system_mean_cotangent_to_atoms(
+        per_system, batch_idx, 1, 3
+    )
+
+    assert torch.equal(broadcast, per_system.expand(3, 2))
+    assert torch.equal(distributed, (per_system / 3.0).expand(3, 2))
+    assert distributed._base is None
+
+
+@pytest.mark.parametrize("device", _available_devices())
+def test_heterogeneous_two_system_helpers_match_explicit_references(device):
+    """B=2 helpers preserve segmented behavior for unequal atom counts."""
+    batch_idx = torch.tensor([0, 1, 1, 1], dtype=torch.int32, device=device)
+    values = torch.tensor(
+        [[2.0, 4.0], [3.0, 9.0], [6.0, 8.0], [5.0, 10.0]],
+        dtype=DT,
+        device=device,
+    )
+    per_system_cotangent = torch.tensor(
+        [[6.0, -3.0], [-9.0, 12.0]],
+        dtype=DT,
+        device=device,
+    )
+    expected_sum = torch.zeros((2, 2), dtype=DT, device=device).index_add(
+        0, batch_idx, values
+    )
+    counts = torch.zeros(2, dtype=DT, device=device).index_add(
+        0, batch_idx, torch.ones(4, dtype=DT, device=device)
+    )
+    expected_mean = expected_sum / counts.clamp_min(1)[:, None]
+    expected_broadcast = per_system_cotangent.index_select(0, batch_idx)
+    expected_distributed = (
+        per_system_cotangent / counts.clamp_min(1)[:, None]
+    ).index_select(0, batch_idx)
+
+    assert torch.equal(counts, torch.tensor([1.0, 3.0], dtype=DT, device=device))
+    assert torch.equal(
+        _util._sum_atom_values_by_system(values, batch_idx, 2), expected_sum
+    )
+    assert torch.equal(
+        _util._mean_atom_values_by_system(values, batch_idx, 2), expected_mean
+    )
+    assert torch.equal(
+        _util._broadcast_system_values_to_atoms(per_system_cotangent, batch_idx, 2, 4),
+        expected_broadcast,
+    )
+    assert torch.equal(
+        _util._distribute_system_mean_cotangent_to_atoms(
+            per_system_cotangent, batch_idx, 2, 4
+        ),
+        expected_distributed,
+    )
+
+
+def test_compiled_single_system_reduction_graph_has_no_atomic_scatter():
+    """The B=1 helper graph contains no index/scatter atomic reduction."""
+    graphs = []
+    batch_idx = torch.zeros(3, dtype=torch.int32)
+
+    def backend(graph_module, _example_inputs):
+        graphs.append(graph_module)
+        return graph_module.forward
+
+    def reduction(values):
+        return _util._mean_atom_values_by_system(values, batch_idx, 1)
+
+    compiled = torch.compile(reduction, backend=backend, fullgraph=True)
+    actual = compiled(torch.tensor([2.0, 4.0, 9.0], dtype=DT))
+
+    assert torch.equal(actual, torch.tensor([5.0], dtype=DT))
+    assert graphs
+    graph_text = "\n".join(str(graph.graph) for graph in graphs)
+    assert "index_add" not in graph_text
+    assert "scatter_add" not in graph_text
+    assert "index_put" not in graph_text

--- a/test/math/test_spline.py
+++ b/test/math/test_spline.py
@@ -912,19 +912,24 @@ def _bspline_via_convolution(u: np.ndarray, order: int, h: float = 1e-4) -> np.n
     Independent oracle for the analytical pieces — provides a check that
     the polynomial coefficients in :func:`bspline_weight` actually
     represent the n-fold convolution of ``χ_[0,1)`` rather than just
-    matching the closed-form truncated-power expression. With
-    ``h = 1e-4`` the trapezoidal-rule convolution converges to ~1e-8
-    accuracy, which is well below the breakpoint behavior we want to
-    detect (the cardinal pieces match to machine precision; if any
-    polynomial were wrong even by one term the residual would be O(1)).
+    matching the closed-form truncated-power expression.
+
+    Convolution with a sampled unit box is a moving sum. Prefix sums compute
+    that linear convolution in O(N) per fold, avoiding the O(N²)
+    ``np.convolve`` runtime and its sensitivity to thread oversubscription.
+    The rectangular-rule discretization converges with O(h) error; any wrong
+    polynomial piece would still give an O(1) residual.
     """
-    n = order
-    grid = np.arange(0, n + 1, h)
-    box = ((grid >= 0) & (grid < 1)).astype(np.float64)
-    spline = box.copy()
-    for _ in range(n - 1):
-        spline = np.convolve(spline, box) * h
-    out_grid = np.arange(0, len(spline)) * h
+    box_size = int(round(1.0 / h))
+    spline = np.ones(box_size, dtype=np.float64)
+    for _ in range(order - 1):
+        output_size = spline.size + box_size - 1
+        output_idx = np.arange(output_size)
+        prefix = np.concatenate((np.zeros(1, dtype=np.float64), np.cumsum(spline)))
+        start = np.maximum(output_idx - box_size + 1, 0)
+        stop = np.minimum(output_idx + 1, spline.size)
+        spline = (prefix[stop] - prefix[start]) * h
+    out_grid = np.arange(spline.size) * h
     return np.interp(u, out_grid, spline)
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Fix `torch.compile` for a logically single Ewald/PME/slab system when callers provide an explicit `batch_idx=zeros(N)`.

Without this change, the backward path treats explicit `B=1` input as a segmented batch and reduces atom values with `index_add` or scatter operations into a tensor whose leading dimension is one. PyTorch Inductor's CPU vector-atomic code generation can reject that size-one destination, even though the equivalent unbatched call (`batch_idx=None`) compiles because it uses a direct mean.

The same atom-to-system pattern appears in energy cotangents, double backward, cell and virial gradients, charge corrections, direct-k Ewald, and slab correction. The fix centralizes those operations and specializes only the structural `num_systems == 1` case:

```python
if num_systems == 1:
    return values.sum(dim=0, keepdim=True)

result = values.new_zeros((num_systems, *values.shape[1:]))
return result.index_add(0, batch_idx, values)
```

Explicit `batch_idx` remains intact, so batched custom-op and Warp-kernel dispatch does not change. Multi-system inputs continue to use segmented reductions.

The reciprocal PME autograd chain also materializes the Hermitian-weighted RFFT cotangent before passing it to the opaque convolution backward:

```python
backward_args=lambda g, f: (
    f[0],
    g[0] * 1.0,
    # ...
)
```

This prevents Inductor from scheduling the interior-frequency weighting after the custom backward has already consumed the cotangent.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Merge this PR before [#132: fix(electrostatics): avoid per-system backward recomputation](https://github.com/NVIDIA/nvalchemi-toolkit-ops/pull/132).

## Changes Made

- Add shared atom-to-system sum/mean, system-to-atom broadcast, and mean-adjoint helpers with explicit single-system and empty-input behavior.
- Route real-space, reciprocal-space, PME, slab, direct-k, correction, cell-gradient, virial, first-backward, and double-backward reductions through the shared single-system policy.
- Materialize the reciprocal PME convolution cotangent at the custom-op boundary to preserve RFFT adjoint ordering under Inductor.
- Add CPU/CUDA eager and compiled coverage for explicit `B=1` PME, Ewald, and slab energy, position/charge/cell gradients, direct outputs, and supported higher-order derivatives.
- Add exact helper coverage for empty inputs, one-atom input, and heterogeneous `B=2` segmentation with unequal atom counts and non-uniform cotangents.
- Replace the quadratic test-only n-fold boxcar convolution oracle with an equivalent linear-time prefix-sum implementation.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Focused CPU/CUDA validation passed 302 tests covering helper contracts, compile paths, first- and second-order derivatives, batch consistency, q(R), and empty inputs. The supplied explicit-`B=1` reproducer reports successful compilation for both `batch_idx=zeros(N)` and `batch_idx=None`.

`make interrogate` and `git diff --check` also pass.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

### Faster B-spline test

Optimized `test_weight_n_fold_convolution_parity` for spline orders 5 and 6 by replacing repeated `np.convolve` calls with an equivalent prefix-sum calculation. These cases now take about 1–2 ms instead of 4–10 seconds, with less than `1e-14` numerical difference. This improves test runtime only; production PME code is unchanged.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
