### PR TITLE
perf(neighbors): tile partial naive neighbor lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- JAX and Torch naive neighbor APIs now expose CUDA tiled topology-only compact
+  `target_indices` rows for no-PBC, wrapped PBC, and prewrapped PBC. Single-system
+  automatic dispatch selects tile at 256 atoms for float64 and 1,024 atoms for
+  float32 (float16 thresholds remain native policy); batched partial auto
+  dispatch remains scalar. Tiling does not support geometry/pair-function
+  outputs or selective rebuilds. Scalar and tiled results have the same per-row
+  neighbor and periodic-shift multisets, but their entry ordering may differ;
+  `max_neighbors` still caps stored entries, while counts remain uncapped and
+  COO conversion raises `NeighborOverflowError` when a row exceeds the cap.
+- JAX `naive_neighbor_list(..., graph_mode="warp")` supports opt-in replay for
+  topology-only tiled `target_indices` calls. Replays require caller-owned,
+  persistent compact output buffers (and, for wrapped PBC, persistent inverse
+  cell and wrapping scratch buffers); `GraphMode.NONE` remains the default.
+
 ## 0.4.0 - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,17 @@
 ### Added
 
 - JAX and Torch naive neighbor APIs now expose CUDA-only topology-only tiled compact
-  `target_indices` rows for no-PBC, wrapped PBC, and prewrapped PBC. Explicit
-  tile supports single and batched compact rows; batched partial auto is scalar.
-  Geometry and pair outputs use scalar, and partial lists reject
-  `rebuild_flags` under every strategy. Scalar and tiled results have the same
-  per-row neighbor and periodic-shift multisets, but their entry ordering may
-  differ; `max_neighbors` still caps stored entries, while counts remain
-  uncapped and COO conversion raises `NeighborOverflowError` when a row exceeds
-  the cap.
+  `target_indices` rows for no-PBC, wrapped PBC, and prewrapped PBC. For
+  native, Torch, and eager JAX single-system CUDA calls, partial topology-only
+  `auto` selects a strategy from the dtype and atom count. JAX traced partial
+  `auto` calls without `graph_mode="warp"` and batched partial `auto` calls
+  remain scalar; `graph_mode="warp"` routes partial `auto` to tile.
+  Explicit tile supports single and batched compact rows. Geometry and pair
+  outputs use scalar, and partial lists reject `rebuild_flags` under every
+  strategy. Scalar and tiled results have the same per-row neighbor and
+  periodic-shift multisets, but their entry ordering may differ; `max_neighbors`
+  still caps stored entries, while counts remain uncapped and COO conversion
+  raises `NeighborOverflowError` when a row exceeds the cap.
 - JAX `naive_neighbor_list(..., graph_mode="warp")` supports opt-in replay for
   topology-only tiled `target_indices` calls. Replay resets caller-owned,
   persistent compact output buffers, which must be donated through `jax.jit`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,24 @@
 
 ### Added
 
-- JAX and Torch naive neighbor APIs now expose CUDA tiled topology-only compact
-  `target_indices` rows for no-PBC, wrapped PBC, and prewrapped PBC. Single-system
-  automatic dispatch selects tile at 256 atoms for float64 and 1,024 atoms for
-  float32 (float16 thresholds remain native policy); batched partial auto
-  dispatch remains scalar. Tiling does not support geometry/pair-function
-  outputs or selective rebuilds. Scalar and tiled results have the same per-row
-  neighbor and periodic-shift multisets, but their entry ordering may differ;
-  `max_neighbors` still caps stored entries, while counts remain uncapped and
-  COO conversion raises `NeighborOverflowError` when a row exceeds the cap.
+- JAX and Torch naive neighbor APIs now expose CUDA-only topology-only tiled compact
+  `target_indices` rows for no-PBC, wrapped PBC, and prewrapped PBC. Explicit
+  tile supports single and batched compact rows; batched partial auto is scalar.
+  Geometry and pair outputs use scalar, and partial lists reject
+  `rebuild_flags` under every strategy. Scalar and tiled results have the same
+  per-row neighbor and periodic-shift multisets, but their entry ordering may
+  differ; `max_neighbors` still caps stored entries, while counts remain
+  uncapped and COO conversion raises `NeighborOverflowError` when a row exceeds
+  the cap.
 - JAX `naive_neighbor_list(..., graph_mode="warp")` supports opt-in replay for
-  topology-only tiled `target_indices` calls. Replays require caller-owned,
-  persistent compact output buffers (and, for wrapped PBC, persistent inverse
-  cell and wrapping scratch buffers); `GraphMode.NONE` remains the default.
+  topology-only tiled `target_indices` calls. Replay resets caller-owned,
+  persistent compact output buffers, which must be donated through `jax.jit`;
+  wrapped PBC also requires stable inverse-cell and wrapping scratch buffers.
+  Cutoff, `half_fill`, and PBC shift metadata are statically specialized.
+- Batched PBC `max_atoms_per_system` is required only for full-row launch sizing;
+  every compact partial path, including geometry and pair-output paths, ignores
+  it. Naive partial lists reject `target_indices` combined with
+  `rebuild_flags`; cell-list behavior is unchanged.
 
 ## 0.4.0 - 2026-07-13
 

--- a/docs/userguide/components/neighborlist.md
+++ b/docs/userguide/components/neighborlist.md
@@ -1300,8 +1300,9 @@ cutoff1, cutoff2 = 3.0, 6.0
 
 Pass `target_indices` (an `int32` array of atom indices) to build neighbors only for a
 subset of *central* atoms. Output rows are **compact**: there are `num_targets` rows
-and row `r` corresponds to atom `target_indices[r]`. In COO output the source index
-`nl[0]` is the compact row in `[0, num_targets)` (map it back through `target_indices`):
+and row `r` corresponds to atom `target_indices[r]`. In COO output the central-row
+index `nl[0]` is the compact row in `[0, num_targets)` (map it back through
+`target_indices`):
 
 ```python
 from nvalchemiops.torch.neighbors import neighbor_list
@@ -1321,8 +1322,11 @@ identical results are available via `atom_centric`).
 
 For topology-only partial `naive` lists, `strategy="tile"` is CUDA-only and is
 available in both PyTorch and JAX for no-PBC, wrapped PBC, and prewrapped PBC.
-Explicit tile supports both single and batched compact rows; batched partial
-`strategy="auto"` remains scalar.
+For native, PyTorch, and eager JAX single-system CUDA calls, `strategy="auto"`
+selects a strategy from the dtype and atom count. JAX traced partial `auto`
+calls without `graph_mode="warp"` and batched partial `auto` calls remain
+scalar. `graph_mode="warp"` requires tile and routes `auto` to tile. Explicit
+tile supports both single and batched compact rows.
 Geometry buffers, distances, vectors, pair functions, and pair energy/force
 outputs remain scalar-only. Scalar and tiled rows can differ in order; compare
 counts and sorted `(neighbor, periodic_shift)` multisets. JAX additionally
@@ -1447,7 +1451,7 @@ the differentiable-geometry path — a traced (jit'd) cutoff is not yet supporte
 On JAX, `naive` / `batch_naive` and `cell_list` / `batch_cell_list` support
 `target_indices` (partial neighbor lists) combined with pair outputs: the
 compact output has `num_targets` rows (row `r` → atom `target_indices[r]`), and
-in COO mode the source index `nl[0]` is the compact row in `[0, num_targets)`
+in COO mode the central-row index `nl[0]` is the compact row in `[0, num_targets)`
 (mapped back via `target_indices`), matching the Torch contract.
 
 For PyTorch `torch.compile(fullgraph=True)`, pass a pre-specialized wrapper from

--- a/docs/userguide/components/neighborlist.md
+++ b/docs/userguide/components/neighborlist.md
@@ -987,7 +987,8 @@ neighbor_matrix_half, num_neighbors_half, shifts_half = neighbor_list(
 In JAX, `half_fill` and `fill_value` are supported by `naive`, `batch_naive`,
 `cell_list`, and `batch_cell_list` (the cell-list paths use `graph_mode="none"`
 for `half_fill`).  The `naive` tiled kernel (`strategy="tile"`) is
-CUDA-only and opt-in; JAX `naive` auto-selection still uses the scalar kernel.
+CUDA-only and opt-in; single-system JAX/Torch partial `auto` follows native
+thresholds while batched partial `auto` remains scalar.
 ```
 
 :::
@@ -1317,6 +1318,17 @@ PyTorch, and JAX, including low-level JAX cell-list query wrappers; `cluster_til
 does not support `target_indices`. On JAX, `cell_list` `target_indices` runs through
 the `atom_centric` strategy (`pair_centric` plus `target_indices` is rejected;
 identical results are available via `atom_centric`).
+
+For topology-only partial `naive` lists, `strategy="tile"` is CUDA-only and is
+available in both PyTorch and JAX for no-PBC, wrapped PBC, and prewrapped PBC.
+Single-system `strategy="auto"` follows the native dtype thresholds (256 atoms
+for float64 and 1,024 atoms for float32; float16 thresholds are a native policy).
+Batched partial `strategy="auto"` remains scalar, while explicit tile is opt-in.
+Geometry buffers, distances, vectors, pair functions, and pair energy/force
+outputs remain scalar-only. Scalar and tiled rows can differ in order; compare
+counts and sorted `(neighbor, periodic_shift)` multisets. JAX additionally
+supports the existing `graph_mode="warp"` replay for persistent tiled buffers;
+there is no corresponding Torch graph-replay API.
 
 ### Per-Pair Distances and Vectors
 

--- a/docs/userguide/components/neighborlist.md
+++ b/docs/userguide/components/neighborlist.md
@@ -986,9 +986,9 @@ neighbor_matrix_half, num_neighbors_half, shifts_half = neighbor_list(
 ```{note}
 In JAX, `half_fill` and `fill_value` are supported by `naive`, `batch_naive`,
 `cell_list`, and `batch_cell_list` (the cell-list paths use `graph_mode="none"`
-for `half_fill`).  The `naive` tiled kernel (`strategy="tile"`) is
-CUDA-only and opt-in; single-system JAX/Torch partial `auto` follows native
-thresholds while batched partial `auto` remains scalar.
+for `half_fill`). The topology-only `naive` tiled kernel
+(`strategy="tile"`) is CUDA-only. Explicit tile supports batched compact rows;
+batched partial `auto` remains scalar, and geometry/pair outputs use scalar.
 ```
 
 :::
@@ -1321,14 +1321,23 @@ identical results are available via `atom_centric`).
 
 For topology-only partial `naive` lists, `strategy="tile"` is CUDA-only and is
 available in both PyTorch and JAX for no-PBC, wrapped PBC, and prewrapped PBC.
-Single-system `strategy="auto"` follows the native dtype thresholds (256 atoms
-for float64 and 1,024 atoms for float32; float16 thresholds are a native policy).
-Batched partial `strategy="auto"` remains scalar, while explicit tile is opt-in.
+Explicit tile supports both single and batched compact rows; batched partial
+`strategy="auto"` remains scalar.
 Geometry buffers, distances, vectors, pair functions, and pair energy/force
 outputs remain scalar-only. Scalar and tiled rows can differ in order; compare
 counts and sorted `(neighbor, periodic_shift)` multisets. JAX additionally
-supports the existing `graph_mode="warp"` replay for persistent tiled buffers;
-there is no corresponding Torch graph-replay API.
+supports `graph_mode="warp"` replay with stable caller-owned output buffers
+donated through `jax.jit`. Wrapped PBC also requires stable inverse-cell and
+wrapping scratch buffers; cutoff, `half_fill`, and PBC shift metadata are
+statically specialized. There is no corresponding Torch graph-replay API.
+
+`target_indices` must contain unique, in-bounds global atom indices. Violating
+this precondition is undefined behavior. Naive partial lists do not support
+`rebuild_flags`; this restriction does not apply to cell-list APIs.
+
+For batched PBC naive lists, `max_atoms_per_system` is used only for full-row
+launch sizing. Every compact partial path, including geometry and pair-output
+paths, ignores it and does not require the caller to provide it.
 
 ### Per-Pair Distances and Vectors
 

--- a/examples/neighbors/05_jax_neighbor_list.py
+++ b/examples/neighbors/05_jax_neighbor_list.py
@@ -380,7 +380,7 @@ partial_coo, partial_ptr, _ = neighbor_list(
 )
 num_partial_pairs = int(partial_ptr[-1])
 compact_rows = jnp.unique(partial_coo[0, :num_partial_pairs])
-print(f"COO compact source rows present: {compact_rows.tolist()}")
+print(f"COO compact central rows present: {compact_rows.tolist()}")
 print(f"COO pointer length: {partial_ptr.shape[0]} (num_targets + 1)")
 
 # %%

--- a/examples/neighbors/06_pair_outputs_lj.py
+++ b/examples/neighbors/06_pair_outputs_lj.py
@@ -19,7 +19,7 @@ Targeted Lennard-Jones Pair Outputs
 
 This example demonstrates four neighbor-list features used together:
 
-1. ``target_indices`` for compact source rows
+1. ``target_indices`` for compact central-atom rows
 2. Per-neighbor vectors and distances
 3. An inline Warp ``pair_fn`` that computes Lennard-Jones energies and forces
 4. ``CompiledPairFn`` for CUDA fixed-shape ``torch.compile(fullgraph=True)`` calls
@@ -122,7 +122,7 @@ print(f"\nFCC Argon box: {num_atoms} atoms")
 print(f"Box length: {cell[0, 0, 0].item():.2f} Å")
 print(f"LJ parameters: epsilon={EPSILON_AR:.4f} eV, sigma={SIGMA_AR:.2f} Å")
 print(f"Cutoff: {CUTOFF:.2f} Å")
-print(f"Targeted source rows: {target_indices.numel()} of {num_atoms}")
+print(f"Selected central atoms: {target_indices.numel()} of {num_atoms}")
 print(f"Estimated max_neighbors: {max_neighbors}")
 
 

--- a/examples/neighbors/README.rst
+++ b/examples/neighbors/README.rst
@@ -9,7 +9,7 @@ These examples show how to:
 * Build neighbor lists for single and batched systems
 * Use dense or sparse COO output formats
 * Inspect Torch cost-model dispatch estimates
-* Request compact source rows with ``target_indices``
+* Request compact central-atom rows with ``target_indices``
 * Return per-neighbor vectors and distances, including differentiable geometry
 * Compute inline Lennard-Jones pair energies and forces with ``pair_fn``
 * Detect when neighbor lists need rebuilding

--- a/nvalchemiops/jax/neighbors/__init__.py
+++ b/nvalchemiops/jax/neighbors/__init__.py
@@ -304,8 +304,8 @@ def neighbor_list(
               for partial lists. Row ``r`` contains neighbors for atom ``r`` or
               ``target_indices[r]`` respectively.
             - If ``return_neighbor_list=True``: Returns ``neighbor_list`` with shape
-              (2, num_pairs), dtype int32, in COO format [source_rows, target_atoms].
-              With ``target_indices``, source rows are compact row ids.
+              (2, num_pairs), dtype int32, in COO format [central_rows, neighbor_atoms].
+              With ``target_indices``, central rows are compact row ids.
 
         - **num_neighbor_data** (array): Information about the number of neighbors for each atom,
           format depends on ``return_neighbor_list``:

--- a/nvalchemiops/jax/neighbors/__init__.py
+++ b/nvalchemiops/jax/neighbors/__init__.py
@@ -248,7 +248,8 @@ def neighbor_list(
             cell list construction.
         max_atoms_per_system : int, optional
             Maximum number of atoms per system. Used in batch naive implementation
-            with PBC. If not provided, it will be computed automatically.
+            with PBC for full-row launch sizing. Every compact partial path,
+            including geometry and pair-output paths, ignores this bound.
             Can be provided to avoid CUDA synchronization.
         return_distances : bool, default=False
             Also return per-pair distances ``|r_ij|``, differentiable w.r.t.

--- a/nvalchemiops/jax/neighbors/_dispatch.py
+++ b/nvalchemiops/jax/neighbors/_dispatch.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -68,24 +69,34 @@ _jax_select_method_f64 = jax_kernel(
 )
 
 
-def _is_jax_cpu_array(array: jax.Array) -> bool:
-    """Return whether ``array`` is backed by a CPU device.
-
-    During ``jax.jit`` tracing, an array tracer may not expose concrete device
-    placement yet. Use JAX's active backend in that case so CPU traces keep
-    the scalar fallback while CUDA traces can lower tile callables.
-    """
+def _jax_array_device_kind(
+    array: jax.Array,
+) -> Literal["cpu", "cuda", "unknown"]:
+    """Return the concrete JAX placement kind, or unknown for tracers."""
     try:
-        return all(device.platform == "cpu" for device in array.devices())
+        devices = tuple(array.devices())
     except (
         AttributeError,
         jax.errors.ConcretizationTypeError,
         jax.errors.TracerIntegerConversionError,
     ):
-        # JAX does not expose jit(backend=...) on the tracer. The active
-        # default backend is the only placement signal available here; callers
-        # selecting a non-default backend should place inputs on that device.
-        return jax.default_backend() == "cpu"
+        return "unknown"
+    if not devices:
+        return "unknown"
+    platforms = {device.platform for device in devices}
+    if platforms == {"cpu"}:
+        return "cpu"
+    if platforms <= {"gpu", "cuda"}:
+        return "cuda"
+    raise ValueError(
+        "Unsupported JAX platform for Warp neighbor execution: "
+        f"{', '.join(sorted(platforms))}",
+    )
+
+
+def _is_jax_cpu_array(array: jax.Array) -> bool:
+    """Return whether ``array`` is concretely backed by a CPU device."""
+    return _jax_array_device_kind(array) == "cpu"
 
 
 def _jax_selector_cpu_fallback(

--- a/nvalchemiops/jax/neighbors/_dispatch.py
+++ b/nvalchemiops/jax/neighbors/_dispatch.py
@@ -69,11 +69,23 @@ _jax_select_method_f64 = jax_kernel(
 
 
 def _is_jax_cpu_array(array: jax.Array) -> bool:
-    """Return whether ``array`` is backed by a CPU device."""
+    """Return whether ``array`` is backed by a CPU device.
+
+    During ``jax.jit`` tracing, an array tracer may not expose concrete device
+    placement yet. Use JAX's active backend in that case so CPU traces keep
+    the scalar fallback while CUDA traces can lower tile callables.
+    """
     try:
         return all(device.platform == "cpu" for device in array.devices())
-    except AttributeError:
-        return True
+    except (
+        AttributeError,
+        jax.errors.ConcretizationTypeError,
+        jax.errors.TracerIntegerConversionError,
+    ):
+        # JAX does not expose jit(backend=...) on the tracer. The active
+        # default backend is the only placement signal available here; callers
+        # selecting a non-default backend should place inputs on that device.
+        return jax.default_backend() == "cpu"
 
 
 def _jax_selector_cpu_fallback(

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -1340,8 +1340,9 @@ def batch_query_cell_list(
         regardless of this value (a documented divergence from Torch, whose
         ``"auto"`` maps to a distinct ``"direct"`` kernel).
     target_indices : jax.Array, shape (num_targets,), dtype=int32, optional
-        Compact partial-list source rows. Output row ``r`` maps to atom
-        ``target_indices[r]``; COO source rows remain compact row ids.
+        Indices of the central atoms for compact partial rows. Output row ``r``
+        maps to atom ``target_indices[r]``. In COO output, the first row holds
+        compact row ids.
 
     Returns
     -------

--- a/nvalchemiops/jax/neighbors/batch_naive.py
+++ b/nvalchemiops/jax/neighbors/batch_naive.py
@@ -1214,9 +1214,10 @@ def batch_naive_neighbor_list(
     neighbor_vectors : jax.Array, shape (num_rows, max_neighbors, 3), optional
         Pre-shaped vector output for ``return_vectors=True`` or ``pair_fn``.
     target_indices : jax.Array, shape (num_targets,), dtype=int32, optional
-        Compact partial-list source rows. Output row ``r`` maps to atom
-        ``target_indices[r]``; COO source rows remain compact row ids. User
-        buffers must be compact-row shaped, not full atom-row shaped.
+        Indices of the central atoms for compact partial rows. Output row ``r``
+        maps to atom ``target_indices[r]``. In COO output, the first row holds
+        compact row ids. User buffers must be compact-row shaped, not full
+        atom-row shaped. Values must be unique and in bounds.
 
     Returns
     -------

--- a/nvalchemiops/jax/neighbors/batch_naive.py
+++ b/nvalchemiops/jax/neighbors/batch_naive.py
@@ -545,15 +545,13 @@ def _jax_scalar_sentinels(dtype):
 #     ``batch_idx`` to pick per-atom cells.  No JAX-side pre-wrap is done on the
 #     tile path (that would double-wrap).
 #
-# Batched PREWRAPPED PBC has no tiled kernel (``_make_tile_kernel`` raises), so
-# only no-PBC and wrapped-PBC are wired here; the dispatch site rejects
-# ``strategy="tile"`` + ``wrap_positions=False`` for PBC.
-#
-# These run only on the eager path, where ``batch_naive_neighbor_list`` already
-# pre-fills ``neighbor_matrix=fill_value`` and zeroes ``num_neighbors`` /
-# shifts before dispatch, so the bodies perform no reset and take no
-# ``fill_value`` argument.  Tile supports ``half_fill`` but has no pair-output /
-# ``target_indices`` / selective (``rebuild_flags``) variant.  The static
+# The caller pre-fills ``neighbor_matrix=fill_value`` and zeroes
+# ``num_neighbors`` / shifts before dispatch, so the bodies perform no reset
+# and take no ``fill_value`` argument.  The same callable family supports eager
+# and ``jax.jit`` execution. The static ``partial`` flag is required because
+# the empty target sentinel used by full-row calls must not become a zero-row
+# partial launch. Tile supports ``half_fill`` but has no pair-output /
+# selective (``rebuild_flags``) variant.  The static
 # scalars (``cutoff``, ``half_fill``, ``max_shifts_per_system`` /
 # ``max_atoms_per_system`` for PBC) are concrete host ints computed outside jit.
 
@@ -562,10 +560,12 @@ def _batch_naive_tile_no_pbc_f32(
     positions: wp.array(dtype=wp.vec3f),
     batch_idx: wp.array(dtype=wp.int32),
     batch_ptr: wp.array(dtype=wp.int32),
+    target_indices: wp.array(dtype=wp.int32),
     neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
     num_neighbors: wp.array(dtype=wp.int32),
     cutoff: wp.float32,
     half_fill: wp.bool,
+    partial: wp.bool,
 ) -> None:
     _launch_naive_neighbor_matrix_no_pbc(
         positions,
@@ -577,6 +577,7 @@ def _batch_naive_tile_no_pbc_f32(
         batched=True,
         batch_idx=batch_idx,
         batch_ptr=batch_ptr,
+        target_indices=target_indices if bool(partial) else None,
         half_fill=bool(half_fill),
         strategy="tile",
     )
@@ -586,10 +587,12 @@ def _batch_naive_tile_no_pbc_f64(
     positions: wp.array(dtype=wp.vec3d),
     batch_idx: wp.array(dtype=wp.int32),
     batch_ptr: wp.array(dtype=wp.int32),
+    target_indices: wp.array(dtype=wp.int32),
     neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
     num_neighbors: wp.array(dtype=wp.int32),
     cutoff: wp.float64,
     half_fill: wp.bool,
+    partial: wp.bool,
 ) -> None:
     _launch_naive_neighbor_matrix_no_pbc(
         positions,
@@ -601,6 +604,7 @@ def _batch_naive_tile_no_pbc_f64(
         batched=True,
         batch_idx=batch_idx,
         batch_ptr=batch_ptr,
+        target_indices=target_indices if bool(partial) else None,
         half_fill=bool(half_fill),
         strategy="tile",
     )
@@ -614,6 +618,7 @@ def _batch_naive_tile_pbc_wrapped_f32(
     num_shifts_arr: wp.array(dtype=wp.int32),
     batch_idx: wp.array(dtype=wp.int32),
     batch_ptr: wp.array(dtype=wp.int32),
+    target_indices: wp.array(dtype=wp.int32),
     neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
     neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
     num_neighbors: wp.array(dtype=wp.int32),
@@ -621,6 +626,7 @@ def _batch_naive_tile_pbc_wrapped_f32(
     max_shifts_per_system: wp.int32,
     max_atoms_per_system: wp.int32,
     half_fill: wp.bool,
+    partial: wp.bool,
 ) -> None:
     _launch_naive_neighbor_matrix_pbc(
         positions,
@@ -637,6 +643,7 @@ def _batch_naive_tile_pbc_wrapped_f32(
         batch_ptr=batch_ptr,
         batch_idx=batch_idx,
         num_shifts_arr=num_shifts_arr,
+        target_indices=target_indices if bool(partial) else None,
         max_shifts_per_system=int(max_shifts_per_system),
         max_atoms_per_system=int(max_atoms_per_system),
         half_fill=bool(half_fill),
@@ -653,6 +660,7 @@ def _batch_naive_tile_pbc_wrapped_f64(
     num_shifts_arr: wp.array(dtype=wp.int32),
     batch_idx: wp.array(dtype=wp.int32),
     batch_ptr: wp.array(dtype=wp.int32),
+    target_indices: wp.array(dtype=wp.int32),
     neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
     neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
     num_neighbors: wp.array(dtype=wp.int32),
@@ -660,6 +668,7 @@ def _batch_naive_tile_pbc_wrapped_f64(
     max_shifts_per_system: wp.int32,
     max_atoms_per_system: wp.int32,
     half_fill: wp.bool,
+    partial: wp.bool,
 ) -> None:
     _launch_naive_neighbor_matrix_pbc(
         positions,
@@ -676,6 +685,7 @@ def _batch_naive_tile_pbc_wrapped_f64(
         batch_ptr=batch_ptr,
         batch_idx=batch_idx,
         num_shifts_arr=num_shifts_arr,
+        target_indices=target_indices if bool(partial) else None,
         max_shifts_per_system=int(max_shifts_per_system),
         max_atoms_per_system=int(max_atoms_per_system),
         half_fill=bool(half_fill),
@@ -684,8 +694,89 @@ def _batch_naive_tile_pbc_wrapped_f64(
     )
 
 
-# Keyed by ``(has_pbc, wrap_positions)``.  Only no-PBC and wrapped-PBC are
-# present; batched prewrapped PBC has no tiled kernel.  Tile has no selective
+def _batch_naive_tile_pbc_prewrapped_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    cell: wp.array(dtype=wp.mat33f),
+    shift_range: wp.array(dtype=wp.vec3i),
+    num_shifts_arr: wp.array(dtype=wp.int32),
+    batch_idx: wp.array(dtype=wp.int32),
+    batch_ptr: wp.array(dtype=wp.int32),
+    target_indices: wp.array(dtype=wp.int32),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float32,
+    max_shifts_per_system: wp.int32,
+    max_atoms_per_system: wp.int32,
+    half_fill: wp.bool,
+    partial: wp.bool,
+) -> None:
+    _launch_naive_neighbor_matrix_pbc(
+        positions,
+        float(cutoff),
+        cell,
+        None,
+        shift_range,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        wp.float32,
+        str(positions.device),
+        batched=True,
+        batch_ptr=batch_ptr,
+        batch_idx=batch_idx,
+        num_shifts_arr=num_shifts_arr,
+        target_indices=target_indices if bool(partial) else None,
+        max_shifts_per_system=int(max_shifts_per_system),
+        max_atoms_per_system=int(max_atoms_per_system),
+        half_fill=bool(half_fill),
+        wrap_positions=False,
+        strategy="tile",
+    )
+
+
+def _batch_naive_tile_pbc_prewrapped_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    cell: wp.array(dtype=wp.mat33d),
+    shift_range: wp.array(dtype=wp.vec3i),
+    num_shifts_arr: wp.array(dtype=wp.int32),
+    batch_idx: wp.array(dtype=wp.int32),
+    batch_ptr: wp.array(dtype=wp.int32),
+    target_indices: wp.array(dtype=wp.int32),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float64,
+    max_shifts_per_system: wp.int32,
+    max_atoms_per_system: wp.int32,
+    half_fill: wp.bool,
+    partial: wp.bool,
+) -> None:
+    _launch_naive_neighbor_matrix_pbc(
+        positions,
+        float(cutoff),
+        cell,
+        None,
+        shift_range,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        wp.float64,
+        str(positions.device),
+        batched=True,
+        batch_ptr=batch_ptr,
+        batch_idx=batch_idx,
+        num_shifts_arr=num_shifts_arr,
+        target_indices=target_indices if bool(partial) else None,
+        max_shifts_per_system=int(max_shifts_per_system),
+        max_atoms_per_system=int(max_atoms_per_system),
+        half_fill=bool(half_fill),
+        wrap_positions=False,
+        strategy="tile",
+    )
+
+
+# Keyed by ``(has_pbc, wrap_positions)``. Tile has no selective
 # variant, so the selective axis is omitted; ``strategy="tile"`` rejects
 # ``rebuild_flags`` at the dispatch site.
 _BATCH_NAIVE_TILE_NO_PBC_IN_OUT_ARGS = ("neighbor_matrix", "num_neighbors")
@@ -706,6 +797,12 @@ _BATCH_NAIVE_TILE_SPECS = {
         "in_out_argnames": _BATCH_NAIVE_TILE_PBC_IN_OUT_ARGS,
         jnp.dtype(jnp.float32): _batch_naive_tile_pbc_wrapped_f32,
         jnp.dtype(jnp.float64): _batch_naive_tile_pbc_wrapped_f64,
+    },
+    (True, False): {
+        "num_outputs": 3,
+        "in_out_argnames": _BATCH_NAIVE_TILE_PBC_IN_OUT_ARGS,
+        jnp.dtype(jnp.float32): _batch_naive_tile_pbc_prewrapped_f32,
+        jnp.dtype(jnp.float64): _batch_naive_tile_pbc_prewrapped_f64,
     },
 }
 
@@ -758,6 +855,8 @@ def _batch_naive_pair_outputs_forward(
     pair_params: jax.Array | None = None,
     target_indices: jax.Array | None = None,
     half_fill: bool = False,
+    wrap_positions: bool = True,
+    topology_only_partial: bool = False,
 ) -> _NeighborForwardOutput:
     """Forward closure for the batch_naive autograd path.
 
@@ -882,13 +981,18 @@ def _batch_naive_pair_outputs_forward(
         else:
             nm, nn, nv, nd = outs
     else:
+        pbc_mode = (
+            "prewrapped"
+            if topology_only_partial and not wrap_positions
+            else "wrap_on_entry"
+        )
         if has_pair_fn:
             kernel = _get_jax_batch_naive_pair_fn_kernel(
-                pair_fn, wp_dtype, "wrap_on_entry", half_fill, is_partial
+                pair_fn, wp_dtype, pbc_mode, half_fill, is_partial
             )
         elif is_partial:
             kernel = _get_jax_batch_naive_pair_kernel(
-                wp_dtype, "wrap_on_entry", half_fill, is_partial
+                wp_dtype, pbc_mode, half_fill, is_partial
             )
         elif half_fill:
             kernel = (
@@ -906,25 +1010,30 @@ def _batch_naive_pair_outputs_forward(
             shift_range_per_dimension, num_shifts_per_system, _ = (
                 compute_naive_num_shifts(cell, cutoff, pbc)
             )
-        inv_cell = jnp.linalg.inv(cell)
-        positions_wrapped = jnp.zeros_like(positions)
-        per_atom_cell_offsets = jnp.zeros((total_atoms, 3), dtype=jnp.int32)
-        if f64:
-            _wrap_kernel = _jax_wrap_positions_batch_f64
+        if topology_only_partial and not wrap_positions:
+            positions_work = positions
+            per_atom_cell_offsets = empty_offsets
         else:
-            _wrap_kernel = _jax_wrap_positions_batch_f32
-        positions_wrapped, per_atom_cell_offsets = _wrap_kernel(
-            positions,
-            cell,
-            inv_cell,
-            pbc,
-            batch_idx_i32,
-            positions_wrapped,
-            per_atom_cell_offsets,
-            launch_dims=(total_atoms,),
-        )
+            inv_cell = jnp.linalg.inv(cell)
+            positions_wrapped = jnp.zeros_like(positions)
+            per_atom_cell_offsets = jnp.zeros((total_atoms, 3), dtype=jnp.int32)
+            if f64:
+                _wrap_kernel = _jax_wrap_positions_batch_f64
+            else:
+                _wrap_kernel = _jax_wrap_positions_batch_f32
+            positions_wrapped, per_atom_cell_offsets = _wrap_kernel(
+                positions,
+                cell,
+                inv_cell,
+                pbc,
+                batch_idx_i32,
+                positions_wrapped,
+                per_atom_cell_offsets,
+                launch_dims=(total_atoms,),
+            )
+            positions_work = positions_wrapped
         outs = kernel(
-            positions_wrapped,
+            positions_work,
             per_atom_cell_offsets,
             cutoff_sq,
             0.0,
@@ -1086,18 +1195,13 @@ def batch_naive_neighbor_list(
         Selects the underlying Warp kernel variant. ``"scalar"`` uses the
         per-atom scalar kernel. ``"tile"`` uses the tile-cooperative
         ``wp.launch_tiled`` kernel and is **CUDA-only**: requesting it on a
-        CPU device raises ``ValueError``. The tile path supports the no-PBC
-        and PBC-wrapped (``wrap_positions=True``) cases and ``half_fill``, but
-        has no pair-output (``return_distances`` / ``return_vectors``) or
-        selective (``rebuild_flags``) variant, and there is **no batched
-        prewrapped-PBC tiled kernel**: requesting ``strategy="tile"``
-        with PBC and ``wrap_positions=False`` raises ``NotImplementedError``
-        (use ``"scalar"`` for that combination). ``"auto"`` and ``"scalar"``
-        preserve the current scalar-dispatch behavior; ``"auto"`` never selects
-        tile in this binding (tile is opt-in). The tile and scalar paths
-        produce identical pair *sets* (per-row ordering may differ; under
-        ``half_fill`` the two pick opposite pair owners, yielding the same
-        undirected set with sign-flipped shifts).
+        CPU device raises ``ValueError``. Topology-only compact
+        ``target_indices`` rows support no-PBC, wrapped PBC, and prewrapped
+        PBC. ``"auto"`` keeps batched partial rows on scalar; ``"scalar"`` is
+        a deterministic opt-out. Pair-output geometry, pair functions, and
+        selective rebuilds do not have tiled variants. The tile and scalar
+        paths may order entries differently; compare counts and sorted
+        ``(neighbor, periodic_shift)`` multisets.
     neighbor_distances : jax.Array, shape (num_rows, max_neighbors), optional
         Pre-shaped distance output for ``return_distances=True`` or ``pair_fn``.
     neighbor_vectors : jax.Array, shape (num_rows, max_neighbors, 3), optional
@@ -1156,40 +1260,47 @@ def batch_naive_neighbor_list(
     if pbc is not None and cell is None:
         raise ValueError("If pbc is provided, cell must also be provided")
 
+    geometry_or_pair_active = (
+        bool(return_distances)
+        or bool(return_vectors)
+        or neighbor_vectors is not None
+        or neighbor_distances is not None
+        or pair_fn is not None
+        or pair_energies is not None
+        or pair_forces is not None
+    )
+    topology_only_partial = target_indices is not None and not geometry_or_pair_active
+    if target_indices is not None and (
+        target_indices.ndim != 1 or target_indices.dtype != jnp.int32
+    ):
+        raise ValueError("target_indices must be a rank-one int32 array.")
+    if target_indices is not None and rebuild_flags is not None:
+        raise NotImplementedError(
+            "Partial neighbor lists do not support rebuild_flags.",
+        )
+
     if strategy == "tile":
         # The tile-cooperative kernel is CUDA-only and has no pair-output or
-        # selective (rebuild_flags) variant, and no batched prewrapped-PBC
-        # tiled kernel.  Gate here, before any launch, mirroring the warp
-        # launcher CPU guard and the single-system tile guards.
+        # selective (rebuild_flags) variant. Gate here, before any launch,
+        # mirroring the warp launcher CPU guard and the single-system tile
+        # guards.
         if _is_jax_cpu_array(positions):
             raise ValueError(
                 "strategy='tile' requires CUDA; the tile-cooperative "
                 "naive kernel cannot run on a CPU device (Warp forces "
                 "block_dim=1). Use strategy='scalar' or 'auto' on CPU.",
             )
-        if bool(return_distances) or bool(return_vectors) or pair_fn is not None:
+        if geometry_or_pair_active:
             raise NotImplementedError(
                 "strategy='tile' has no pair-output (return_distances / "
-                "return_vectors / pair_fn) variant; use strategy='scalar'.",
-            )
-        if target_indices is not None:
-            raise NotImplementedError(
-                "strategy='tile' has no target_indices (partial "
-                "neighbor-list) variant; use strategy='scalar'.",
+                "return_vectors / supplied geometry / pair_fn) variant; "
+                "use strategy='scalar'.",
             )
         if rebuild_flags is not None:
             raise NotImplementedError(
                 "strategy='tile' has no selective (rebuild_flags) "
                 "variant; use strategy='scalar'.",
             )
-        if pbc is not None and not wrap_positions:
-            raise NotImplementedError(
-                "strategy='tile' has no batched prewrapped-PBC tiled "
-                "kernel (wrap_positions=False with PBC). Use "
-                "strategy='scalar', or wrap_positions=True for the "
-                "tile path.",
-            )
-
     # Prepare batch indices and pointers
     batch_idx, batch_ptr = prepare_batch_idx_ptr(
         batch_idx, batch_ptr, positions.shape[0]
@@ -1207,11 +1318,8 @@ def batch_naive_neighbor_list(
             raise ValueError("pair_energies requires pair_fn.")
         if pair_forces is not None:
             raise ValueError("pair_forces requires pair_fn.")
-    has_pair_outputs = (
-        bool(return_distances)
-        or bool(return_vectors)
-        or pair_fn is not None
-        or target_indices is not None
+    has_pair_outputs = geometry_or_pair_active or (
+        target_indices is not None and strategy != "tile"
     )
     if has_pair_outputs:
         if rebuild_flags is not None:
@@ -1337,6 +1445,8 @@ def batch_naive_neighbor_list(
             "pair_params": pair_params,
             "target_indices": target_indices,
             "half_fill": bool(half_fill),
+            "wrap_positions": bool(wrap_positions),
+            "topology_only_partial": topology_only_partial,
         }
         route_out = _route_pair_outputs(
             positions,
@@ -1404,15 +1514,40 @@ def batch_naive_neighbor_list(
     if pbc is not None:
         pbc = pbc if pbc.ndim == 2 else pbc[jnp.newaxis, :]
 
+    partial = target_indices is not None
+    num_rows = int(target_indices.shape[0]) if partial else positions.shape[0]
+
+    if max_neighbors is None and neighbor_matrix is not None:
+        max_neighbors = int(neighbor_matrix.shape[1])
     if max_neighbors is None:
         max_neighbors = estimate_max_neighbors(cutoff)
 
     if fill_value is None:
         fill_value = jnp.int32(positions.shape[0])
 
+    _validate_pair_output_buffer(
+        "neighbor_matrix",
+        neighbor_matrix,
+        (num_rows, int(max_neighbors)),
+        jnp.int32,
+    )
+    _validate_pair_output_buffer(
+        "num_neighbors",
+        num_neighbors,
+        (num_rows,),
+        jnp.int32,
+    )
+    if pbc is not None:
+        _validate_pair_output_buffer(
+            "neighbor_matrix_shifts",
+            neighbor_matrix_shifts,
+            (num_rows, int(max_neighbors), 3),
+            jnp.int32,
+        )
+
     if neighbor_matrix is None:
         neighbor_matrix = jnp.full(
-            (positions.shape[0], max_neighbors),
+            (num_rows, max_neighbors),
             fill_value,
             dtype=jnp.int32,
         )
@@ -1420,14 +1555,14 @@ def batch_naive_neighbor_list(
         neighbor_matrix = neighbor_matrix.at[:].set(fill_value)
 
     if num_neighbors is None:
-        num_neighbors = jnp.zeros(positions.shape[0], dtype=jnp.int32)
+        num_neighbors = jnp.zeros(num_rows, dtype=jnp.int32)
     elif rebuild_flags is None:
         num_neighbors = num_neighbors.at[:].set(jnp.int32(0))
 
     if pbc is not None:
         if neighbor_matrix_shifts is None:
             neighbor_matrix_shifts = jnp.zeros(
-                (positions.shape[0], max_neighbors, 3),
+                (num_rows, max_neighbors, 3),
                 dtype=jnp.int32,
             )
         elif rebuild_flags is None:
@@ -1441,18 +1576,18 @@ def batch_naive_neighbor_list(
                 compute_naive_num_shifts(cell, cutoff, pbc)
             )
 
-    if cutoff <= 0:
+    if cutoff <= 0 or (partial and num_rows == 0):
         if return_neighbor_list:
             if pbc is not None:
                 return (
                     jnp.zeros((2, 0), dtype=jnp.int32),
-                    jnp.zeros((positions.shape[0] + 1,), dtype=jnp.int32),
+                    jnp.zeros((num_rows + 1,), dtype=jnp.int32),
                     jnp.zeros((0, 3), dtype=jnp.int32),
                 )
             else:
                 return (
                     jnp.zeros((2, 0), dtype=jnp.int32),
-                    jnp.zeros((positions.shape[0] + 1,), dtype=jnp.int32),
+                    jnp.zeros((num_rows + 1,), dtype=jnp.int32),
                 )
         else:
             if pbc is not None:
@@ -1539,27 +1674,30 @@ def batch_naive_neighbor_list(
     ) = _jax_scalar_sentinels(positions.dtype)
 
     if strategy == "tile":
-        # CUDA-only tile-cooperative path (eager only). Output buffers were
-        # already pre-filled above; the callable bodies wrap the batched inner
-        # warp launchers with strategy="tile". The launchers square the
+        # CUDA-only tile-cooperative path. Output buffers were already
+        # pre-filled above; the callable bodies wrap the batched inner warp
+        # launchers with strategy="tile" for eager and jax.jit execution. The
+        # launchers square the
         # cutoff internally, so the RAW cutoff is threaded as a static scalar
         # (NOT cutoff*cutoff, unlike the scalar arms below).
         cutoff_static = float(cutoff)
+        tile_target_indices = target_indices if partial else empty_target_indices
         if pbc is None:
             tile_callable = _BATCH_NAIVE_TILE_CALLABLES[(False, False, positions.dtype)]
             neighbor_matrix, num_neighbors = tile_callable(
                 positions,
                 batch_idx_i32,
                 batch_ptr_i32,
+                tile_target_indices,
                 neighbor_matrix,
                 num_neighbors,
                 cutoff_static,
                 half_fill,
+                partial,
             )
         else:
-            # Wrapped-PBC tile (prewrapped already rejected at the guard). The
-            # launcher wraps RAW positions internally using batch_idx, so no
-            # JAX-side pre-wrap is done here (that would double-wrap).
+            # The PBC tile specializations either wrap raw positions in the
+            # launcher or consume the caller's already-wrapped positions.
             if cell.dtype != positions.dtype:
                 cell = cell.astype(positions.dtype)
             if max_atoms_per_system is None:
@@ -1574,23 +1712,49 @@ def batch_naive_neighbor_list(
                         "Please provide max_atoms_per_system explicitly when "
                         "using jax.jit with strategy='tile'."
                     ) from None
-            tile_callable = _BATCH_NAIVE_TILE_CALLABLES[(True, True, positions.dtype)]
-            neighbor_matrix, neighbor_matrix_shifts, num_neighbors = tile_callable(
-                positions,
-                cell,
-                pbc,
-                shift_range_per_dimension,
-                num_shifts_per_system,
-                batch_idx_i32,
-                batch_ptr_i32,
-                neighbor_matrix,
-                neighbor_matrix_shifts,
-                num_neighbors,
-                cutoff_static,
-                int(max_shifts_per_system),
-                int(max_atoms_per_system),
-                half_fill,
-            )
+            if wrap_positions:
+                tile_callable = _BATCH_NAIVE_TILE_CALLABLES[
+                    (True, True, positions.dtype)
+                ]
+                neighbor_matrix, neighbor_matrix_shifts, num_neighbors = tile_callable(
+                    positions,
+                    cell,
+                    pbc,
+                    shift_range_per_dimension,
+                    num_shifts_per_system,
+                    batch_idx_i32,
+                    batch_ptr_i32,
+                    tile_target_indices,
+                    neighbor_matrix,
+                    neighbor_matrix_shifts,
+                    num_neighbors,
+                    cutoff_static,
+                    int(max_shifts_per_system),
+                    int(max_atoms_per_system),
+                    half_fill,
+                    partial,
+                )
+            else:
+                tile_callable = _BATCH_NAIVE_TILE_CALLABLES[
+                    (True, False, positions.dtype)
+                ]
+                neighbor_matrix, neighbor_matrix_shifts, num_neighbors = tile_callable(
+                    positions,
+                    cell,
+                    shift_range_per_dimension,
+                    num_shifts_per_system,
+                    batch_idx_i32,
+                    batch_ptr_i32,
+                    tile_target_indices,
+                    neighbor_matrix,
+                    neighbor_matrix_shifts,
+                    num_neighbors,
+                    cutoff_static,
+                    int(max_shifts_per_system),
+                    int(max_atoms_per_system),
+                    half_fill,
+                    partial,
+                )
     elif pbc is None:
         # No PBC case
         if rebuild_flags is not None:

--- a/nvalchemiops/jax/neighbors/batch_naive.py
+++ b/nvalchemiops/jax/neighbors/batch_naive.py
@@ -29,7 +29,10 @@ from nvalchemiops.jax.neighbors._autograd import (
     _NeighborForwardOutput,
     _route_pair_outputs,
 )
-from nvalchemiops.jax.neighbors._dispatch import _is_jax_cpu_array
+from nvalchemiops.jax.neighbors._dispatch import (
+    _is_jax_cpu_array,
+    _jax_array_device_kind,
+)
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     build_naive_kernel_tables,
     compute_naive_num_shifts,
@@ -39,6 +42,10 @@ from nvalchemiops.jax.neighbors.neighbor_utils import (
 )
 from nvalchemiops.neighbors.naive import (
     get_naive_neighbor_matrix_kernel as _get_naive_kernel,
+)
+from nvalchemiops.neighbors.naive.dispatch import (
+    _NaiveWorkload,
+    _resolve_naive_strategy,
 )
 from nvalchemiops.neighbors.naive.launchers import (
     _launch_naive_neighbor_matrix_no_pbc,
@@ -645,7 +652,7 @@ def _batch_naive_tile_pbc_wrapped_f32(
         num_shifts_arr=num_shifts_arr,
         target_indices=target_indices if bool(partial) else None,
         max_shifts_per_system=int(max_shifts_per_system),
-        max_atoms_per_system=int(max_atoms_per_system),
+        max_atoms_per_system=None if bool(partial) else int(max_atoms_per_system),
         half_fill=bool(half_fill),
         wrap_positions=True,
         strategy="tile",
@@ -687,7 +694,7 @@ def _batch_naive_tile_pbc_wrapped_f64(
         num_shifts_arr=num_shifts_arr,
         target_indices=target_indices if bool(partial) else None,
         max_shifts_per_system=int(max_shifts_per_system),
-        max_atoms_per_system=int(max_atoms_per_system),
+        max_atoms_per_system=None if bool(partial) else int(max_atoms_per_system),
         half_fill=bool(half_fill),
         wrap_positions=True,
         strategy="tile",
@@ -728,7 +735,7 @@ def _batch_naive_tile_pbc_prewrapped_f32(
         num_shifts_arr=num_shifts_arr,
         target_indices=target_indices if bool(partial) else None,
         max_shifts_per_system=int(max_shifts_per_system),
-        max_atoms_per_system=int(max_atoms_per_system),
+        max_atoms_per_system=None if bool(partial) else int(max_atoms_per_system),
         half_fill=bool(half_fill),
         wrap_positions=False,
         strategy="tile",
@@ -769,7 +776,7 @@ def _batch_naive_tile_pbc_prewrapped_f64(
         num_shifts_arr=num_shifts_arr,
         target_indices=target_indices if bool(partial) else None,
         max_shifts_per_system=int(max_shifts_per_system),
-        max_atoms_per_system=int(max_atoms_per_system),
+        max_atoms_per_system=None if bool(partial) else int(max_atoms_per_system),
         half_fill=bool(half_fill),
         wrap_positions=False,
         strategy="tile",
@@ -1198,8 +1205,8 @@ def batch_naive_neighbor_list(
         CPU device raises ``ValueError``. Topology-only compact
         ``target_indices`` rows support no-PBC, wrapped PBC, and prewrapped
         PBC. ``"auto"`` keeps batched partial rows on scalar; ``"scalar"`` is
-        a deterministic opt-out. Pair-output geometry, pair functions, and
-        selective rebuilds do not have tiled variants. The tile and scalar
+        a deterministic opt-out. Geometry and pair outputs use scalar; partial
+        neighbor lists do not support ``rebuild_flags``. The tile and scalar
         paths may order entries differently; compare counts and sorted
         ``(neighbor, periodic_shift)`` multisets.
     neighbor_distances : jax.Array, shape (num_rows, max_neighbors), optional
@@ -1276,7 +1283,22 @@ def batch_naive_neighbor_list(
         raise ValueError("target_indices must be a rank-one int32 array.")
     if target_indices is not None and rebuild_flags is not None:
         raise NotImplementedError(
-            "Partial neighbor lists do not support rebuild_flags.",
+            "Partial neighbor lists do not support rebuild_flags",
+        )
+    if target_indices is not None and strategy == "auto":
+        strategy = _resolve_naive_strategy(
+            strategy,
+            _NaiveWorkload(
+                device_kind=_jax_array_device_kind(positions),
+                wp_dtype=(wp.float64 if positions.dtype == jnp.float64 else wp.float32),
+                num_atoms=int(positions.shape[0]),
+                num_systems=1,
+                partial=True,
+                batched=True,
+                pbc=pbc is not None,
+                wrap_positions=wrap_positions,
+                geometry_outputs=geometry_or_pair_active,
+            ),
         )
 
     if strategy == "tile":
@@ -1318,10 +1340,10 @@ def batch_naive_neighbor_list(
             raise ValueError("pair_energies requires pair_fn.")
         if pair_forces is not None:
             raise ValueError("pair_forces requires pair_fn.")
-    has_pair_outputs = geometry_or_pair_active or (
+    uses_compact_pair_kernel = geometry_or_pair_active or (
         target_indices is not None and strategy != "tile"
     )
-    if has_pair_outputs:
+    if uses_compact_pair_kernel:
         if rebuild_flags is not None:
             raise NotImplementedError(
                 "Pair outputs are not supported with rebuild_flags.",
@@ -1368,6 +1390,83 @@ def batch_naive_neighbor_list(
             (num_rows, int(max_neighbors), 3),
             positions.dtype,
         )
+        if target_indices is not None and (cutoff <= 0 or num_rows == 0):
+            matrix_out = (
+                jnp.full((num_rows, max_neighbors), fill_value, dtype=jnp.int32)
+                if neighbor_matrix is None
+                else neighbor_matrix.at[:].set(jnp.int32(fill_value))
+            )
+            counts_out = (
+                jnp.zeros(num_rows, dtype=jnp.int32)
+                if num_neighbors is None
+                else num_neighbors.at[:].set(jnp.int32(0))
+            )
+            distances_out = (
+                jnp.zeros((num_rows, max_neighbors), dtype=positions.dtype)
+                if neighbor_distances is None
+                else neighbor_distances.at[:].set(
+                    jnp.asarray(0.0, dtype=positions.dtype)
+                )
+            )
+            vectors_out = (
+                jnp.zeros((num_rows, max_neighbors, 3), dtype=positions.dtype)
+                if neighbor_vectors is None
+                else neighbor_vectors.at[:].set(jnp.asarray(0.0, dtype=positions.dtype))
+            )
+            if pair_fn is not None:
+                energies_out = jnp.zeros(
+                    (num_rows, max_neighbors),
+                    dtype=positions.dtype,
+                )
+                forces_out = jnp.zeros(
+                    (num_rows, max_neighbors, 3),
+                    dtype=positions.dtype,
+                )
+
+            tail: list[jax.Array] = []
+            if return_distances:
+                tail.append(
+                    jnp.zeros((0,), dtype=positions.dtype)
+                    if return_neighbor_list
+                    else distances_out
+                )
+            if return_vectors:
+                tail.append(
+                    jnp.zeros((0, 3), dtype=positions.dtype)
+                    if return_neighbor_list
+                    else vectors_out
+                )
+            if pair_fn is not None:
+                if return_neighbor_list:
+                    tail.extend(
+                        (
+                            jnp.zeros((0,), dtype=positions.dtype),
+                            jnp.zeros((0, 3), dtype=positions.dtype),
+                        ),
+                    )
+                else:
+                    tail.extend((energies_out, forces_out))
+            if pbc is not None:
+                shifts_out = (
+                    jnp.zeros((num_rows, max_neighbors, 3), dtype=jnp.int32)
+                    if neighbor_matrix_shifts is None
+                    else neighbor_matrix_shifts.at[:].set(jnp.int32(0))
+                )
+                if return_neighbor_list:
+                    return (
+                        jnp.zeros((2, 0), dtype=jnp.int32),
+                        jnp.zeros((num_rows + 1,), dtype=jnp.int32),
+                        jnp.zeros((0, 3), dtype=jnp.int32),
+                        *tail,
+                    )
+                return matrix_out, counts_out, shifts_out, *tail
+            if return_neighbor_list:
+                return (
+                    jnp.zeros((2, 0), dtype=jnp.int32),
+                    jnp.zeros((num_rows + 1,), dtype=jnp.int32),
+                    *tail,
+                )
+            return matrix_out, counts_out, *tail
         cell_norm = cell
         if cell_norm is not None:
             cell_norm = (
@@ -1406,7 +1505,7 @@ def batch_naive_neighbor_list(
                     "calling batch_naive_neighbor_list under jax.jit with PBC "
                     "and target_indices / pair outputs.",
                 ) from exc
-            if max_atoms_per_system is None:
+            if max_atoms_per_system is None and target_indices is None:
                 try:
                     max_atoms_per_system = int(jnp.max(batch_ptr[1:] - batch_ptr[:-1]))
                 except (
@@ -1432,7 +1531,11 @@ def batch_naive_neighbor_list(
             "max_neighbors": int(max_neighbors),
             "fill_value": int(fill_value),
             "max_shifts_per_system": int(max_shifts_per_system),
-            "max_atoms_per_system": int(max_atoms_per_system),
+            "max_atoms_per_system": (
+                0
+                if target_indices is not None and max_atoms_per_system is None
+                else int(max_atoms_per_system)
+            ),
             "num_systems": int(num_systems),
             "neighbor_matrix": neighbor_matrix,
             "neighbor_matrix_shifts": neighbor_matrix_shifts,
@@ -1700,7 +1803,7 @@ def batch_naive_neighbor_list(
             # launcher or consume the caller's already-wrapped positions.
             if cell.dtype != positions.dtype:
                 cell = cell.astype(positions.dtype)
-            if max_atoms_per_system is None:
+            if max_atoms_per_system is None and not partial:
                 try:
                     max_atoms_per_system = int(jnp.max(batch_ptr[1:] - batch_ptr[:-1]))
                 except (
@@ -1730,7 +1833,9 @@ def batch_naive_neighbor_list(
                     num_neighbors,
                     cutoff_static,
                     int(max_shifts_per_system),
-                    int(max_atoms_per_system),
+                    0
+                    if partial and max_atoms_per_system is None
+                    else int(max_atoms_per_system),
                     half_fill,
                     partial,
                 )
@@ -1751,7 +1856,9 @@ def batch_naive_neighbor_list(
                     num_neighbors,
                     cutoff_static,
                     int(max_shifts_per_system),
-                    int(max_atoms_per_system),
+                    0
+                    if partial and max_atoms_per_system is None
+                    else int(max_atoms_per_system),
                     half_fill,
                     partial,
                 )
@@ -1773,7 +1880,7 @@ def batch_naive_neighbor_list(
                 empty_num_shifts,
                 batch_idx_i32,
                 batch_ptr_i32,
-                empty_target_indices,
+                target_indices if partial else empty_target_indices,
                 neighbor_matrix,
                 empty_shifts,
                 num_neighbors,
@@ -1786,7 +1893,7 @@ def batch_naive_neighbor_list(
                 empty_energies,
                 empty_forces,
                 rf,
-                launch_dims=(1, 1, total_atoms),
+                launch_dims=(1, 1, num_rows if partial else total_atoms),
             )
         else:
             neighbor_matrix, num_neighbors = _jax_fill(
@@ -1799,7 +1906,7 @@ def batch_naive_neighbor_list(
                 empty_num_shifts,
                 batch_idx_i32,
                 batch_ptr_i32,
-                empty_target_indices,
+                target_indices if partial else empty_target_indices,
                 neighbor_matrix,
                 empty_shifts,
                 num_neighbors,
@@ -1812,13 +1919,13 @@ def batch_naive_neighbor_list(
                 empty_energies,
                 empty_forces,
                 empty_rebuild_flags,
-                launch_dims=(1, 1, total_atoms),
+                launch_dims=(1, 1, num_rows if partial else total_atoms),
             )
     else:
         if cell.dtype != positions.dtype:
             cell = cell.astype(positions.dtype)
 
-        if max_atoms_per_system is None:
+        if max_atoms_per_system is None and not partial:
             try:
                 max_atoms_per_system = int(jnp.max(batch_ptr[1:] - batch_ptr[:-1]))
             except (
@@ -1872,7 +1979,7 @@ def batch_naive_neighbor_list(
                         num_shifts_per_system,
                         batch_idx_i32,
                         batch_ptr_i32,
-                        empty_target_indices,
+                        target_indices if partial else empty_target_indices,
                         neighbor_matrix,
                         neighbor_matrix_shifts,
                         num_neighbors,
@@ -1886,9 +1993,9 @@ def batch_naive_neighbor_list(
                         empty_forces,
                         rf,
                         launch_dims=(
-                            num_systems,
+                            1 if partial else num_systems,
                             max_shifts_per_system,
-                            max_atoms_per_system,
+                            num_rows if partial else max_atoms_per_system,
                         ),
                     )
                 )
@@ -1903,7 +2010,7 @@ def batch_naive_neighbor_list(
                     num_shifts_per_system,
                     batch_idx_i32,
                     batch_ptr_i32,
-                    empty_target_indices,
+                    target_indices if partial else empty_target_indices,
                     neighbor_matrix,
                     neighbor_matrix_shifts,
                     num_neighbors,
@@ -1917,9 +2024,9 @@ def batch_naive_neighbor_list(
                     empty_forces,
                     empty_rebuild_flags,
                     launch_dims=(
-                        num_systems,
+                        1 if partial else num_systems,
                         max_shifts_per_system,
-                        max_atoms_per_system,
+                        num_rows if partial else max_atoms_per_system,
                     ),
                 )
         else:
@@ -1940,7 +2047,7 @@ def batch_naive_neighbor_list(
                         num_shifts_per_system,
                         batch_idx_i32,
                         batch_ptr_i32,
-                        empty_target_indices,
+                        target_indices if partial else empty_target_indices,
                         neighbor_matrix,
                         neighbor_matrix_shifts,
                         num_neighbors,
@@ -1954,9 +2061,9 @@ def batch_naive_neighbor_list(
                         empty_forces,
                         rf,
                         launch_dims=(
-                            num_systems,
+                            1 if partial else num_systems,
                             max_shifts_per_system,
-                            max_atoms_per_system,
+                            num_rows if partial else max_atoms_per_system,
                         ),
                     )
                 )
@@ -1972,7 +2079,7 @@ def batch_naive_neighbor_list(
                         num_shifts_per_system,
                         batch_idx_i32,
                         batch_ptr_i32,
-                        empty_target_indices,
+                        target_indices if partial else empty_target_indices,
                         neighbor_matrix,
                         neighbor_matrix_shifts,
                         num_neighbors,
@@ -1986,9 +2093,9 @@ def batch_naive_neighbor_list(
                         empty_forces,
                         empty_rebuild_flags,
                         launch_dims=(
-                            num_systems,
+                            1 if partial else num_systems,
                             max_shifts_per_system,
-                            max_atoms_per_system,
+                            num_rows if partial else max_atoms_per_system,
                         ),
                     )
                 )

--- a/nvalchemiops/jax/neighbors/cell_list.py
+++ b/nvalchemiops/jax/neighbors/cell_list.py
@@ -2335,8 +2335,9 @@ def query_cell_list(
     num_neighbors : jax.Array, shape (num_rows,), optional
         Pre-shaped neighbors count array.
     target_indices : jax.Array, shape (num_targets,), dtype=int32, optional
-        Compact partial-list source rows. Output row ``r`` maps to atom
-        ``target_indices[r]``; COO source rows remain compact row ids.
+        Indices of the central atoms for compact partial rows. Output row ``r``
+        maps to atom ``target_indices[r]``. In COO output, the first row holds
+        compact row ids.
     strategy : {"auto", "atom_centric", "pair_centric"}, default "auto"
         Cell-list query sub-strategy.  Both strategies produce identical pair
         SETS; only the per-row ordering inside ``neighbor_matrix`` differs

--- a/nvalchemiops/jax/neighbors/naive.py
+++ b/nvalchemiops/jax/neighbors/naive.py
@@ -42,8 +42,10 @@ from nvalchemiops.neighbors.naive import (
     get_naive_neighbor_matrix_kernel as _get_naive_kernel,
 )
 from nvalchemiops.neighbors.naive.launchers import (
+    BLOCK_DIM,
     _launch_naive_neighbor_matrix_no_pbc,
     _launch_naive_neighbor_matrix_pbc,
+    _partial_tile_min_atoms,
 )
 from nvalchemiops.neighbors.neighbor_utils import (
     DTYPE_INFO_ALL,
@@ -55,6 +57,13 @@ from nvalchemiops.neighbors.neighbor_utils import (
 )
 
 _DTYPE_TO_NAIVE_KERNELS = (wp.float32, wp.float64)
+
+
+def _is_jax_cpu_for_tile(array: jax.Array) -> bool:
+    """Return whether the concrete JAX array is CPU-backed for tile dispatch."""
+    return _is_jax_cpu_array(array)
+
+
 (
     _fill_naive_neighbor_matrix_kernels,
     _fill_naive_neighbor_matrix_selective_kernels,
@@ -1290,21 +1299,23 @@ _GRAPH_NAIVE_WARP_CALLABLES = _register_graph_naive_callables()
 # These run only on the eager (``graph_mode="none"``) path, where
 # ``naive_neighbor_list`` already pre-fills ``neighbor_matrix=fill_value`` and
 # zeroes ``num_neighbors`` / shifts before dispatch, so the bodies perform no
-# reset and take no ``fill_value`` argument.  ``graph_mode="warp"`` + tile is
-# rejected up-front (those pre-fills are skipped under warp).
+# reset and take no ``fill_value`` argument. Partial Warp-graph tiling uses a
+# separate callable family below that captures its own output resets.
 #
-# Tile supports no-PBC and PBC (wrapped + prewrapped) and ``half_fill``; it has
-# no pair-output / ``target_indices`` / selective specialization.  The static
-# scalars (``cutoff``, ``half_fill``, and ``num_shifts`` for PBC) are already
-# host-static in the existing naive graph path — no new host sync.
+# Tile supports no-PBC and PBC (wrapped + prewrapped), ``half_fill``, and
+# topology-only compact target rows. It has no geometry/pair-function output or
+# selective specialization. The scalars (``cutoff``, ``half_fill``, ``partial``,
+# and ``num_shifts`` for PBC) are host-static in the existing naive graph path.
 
 
 def _graph_naive_tile_no_pbc_f32(
     positions: wp.array(dtype=wp.vec3f),
+    target_indices: wp.array(dtype=wp.int32),
     neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
     num_neighbors: wp.array(dtype=wp.int32),
     cutoff: wp.float32,
     half_fill: wp.bool,
+    partial: wp.bool,
 ) -> None:
     _launch_naive_neighbor_matrix_no_pbc(
         positions,
@@ -1315,16 +1326,19 @@ def _graph_naive_tile_no_pbc_f32(
         str(positions.device),
         batched=False,
         half_fill=bool(half_fill),
+        target_indices=target_indices if bool(partial) else None,
         strategy="tile",
     )
 
 
 def _graph_naive_tile_no_pbc_f64(
     positions: wp.array(dtype=wp.vec3d),
+    target_indices: wp.array(dtype=wp.int32),
     neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
     num_neighbors: wp.array(dtype=wp.int32),
     cutoff: wp.float64,
     half_fill: wp.bool,
+    partial: wp.bool,
 ) -> None:
     _launch_naive_neighbor_matrix_no_pbc(
         positions,
@@ -1335,6 +1349,7 @@ def _graph_naive_tile_no_pbc_f64(
         str(positions.device),
         batched=False,
         half_fill=bool(half_fill),
+        target_indices=target_indices if bool(partial) else None,
         strategy="tile",
     )
 
@@ -1343,6 +1358,7 @@ def _graph_naive_tile_no_pbc_f64(
 # position wrapping, so these callables intentionally omit it.
 def _graph_naive_tile_pbc_prewrapped_f32(
     positions: wp.array(dtype=wp.vec3f),
+    target_indices: wp.array(dtype=wp.int32),
     cell: wp.array(dtype=wp.mat33f),
     shift_range: wp.array(dtype=wp.vec3i),
     neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
@@ -1351,6 +1367,7 @@ def _graph_naive_tile_pbc_prewrapped_f32(
     cutoff: wp.float32,
     num_shifts: wp.int32,
     half_fill: wp.bool,
+    partial: wp.bool,
 ) -> None:
     _launch_naive_neighbor_matrix_pbc(
         positions,
@@ -1367,12 +1384,14 @@ def _graph_naive_tile_pbc_prewrapped_f32(
         num_shifts=int(num_shifts),
         half_fill=bool(half_fill),
         wrap_positions=False,
+        target_indices=target_indices if bool(partial) else None,
         strategy="tile",
     )
 
 
 def _graph_naive_tile_pbc_prewrapped_f64(
     positions: wp.array(dtype=wp.vec3d),
+    target_indices: wp.array(dtype=wp.int32),
     cell: wp.array(dtype=wp.mat33d),
     shift_range: wp.array(dtype=wp.vec3i),
     neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
@@ -1381,6 +1400,7 @@ def _graph_naive_tile_pbc_prewrapped_f64(
     cutoff: wp.float64,
     num_shifts: wp.int32,
     half_fill: wp.bool,
+    partial: wp.bool,
 ) -> None:
     _launch_naive_neighbor_matrix_pbc(
         positions,
@@ -1397,12 +1417,14 @@ def _graph_naive_tile_pbc_prewrapped_f64(
         num_shifts=int(num_shifts),
         half_fill=bool(half_fill),
         wrap_positions=False,
+        target_indices=target_indices if bool(partial) else None,
         strategy="tile",
     )
 
 
 def _graph_naive_tile_pbc_wrapped_f32(
     positions: wp.array(dtype=wp.vec3f),
+    target_indices: wp.array(dtype=wp.int32),
     cell: wp.array(dtype=wp.mat33f),
     pbc: wp.array2d(dtype=wp.bool),
     shift_range: wp.array(dtype=wp.vec3i),
@@ -1412,6 +1434,7 @@ def _graph_naive_tile_pbc_wrapped_f32(
     cutoff: wp.float32,
     num_shifts: wp.int32,
     half_fill: wp.bool,
+    partial: wp.bool,
 ) -> None:
     _launch_naive_neighbor_matrix_pbc(
         positions,
@@ -1428,12 +1451,14 @@ def _graph_naive_tile_pbc_wrapped_f32(
         num_shifts=int(num_shifts),
         half_fill=bool(half_fill),
         wrap_positions=True,
+        target_indices=target_indices if bool(partial) else None,
         strategy="tile",
     )
 
 
 def _graph_naive_tile_pbc_wrapped_f64(
     positions: wp.array(dtype=wp.vec3d),
+    target_indices: wp.array(dtype=wp.int32),
     cell: wp.array(dtype=wp.mat33d),
     pbc: wp.array2d(dtype=wp.bool),
     shift_range: wp.array(dtype=wp.vec3i),
@@ -1443,6 +1468,7 @@ def _graph_naive_tile_pbc_wrapped_f64(
     cutoff: wp.float64,
     num_shifts: wp.int32,
     half_fill: wp.bool,
+    partial: wp.bool,
 ) -> None:
     _launch_naive_neighbor_matrix_pbc(
         positions,
@@ -1459,6 +1485,7 @@ def _graph_naive_tile_pbc_wrapped_f64(
         num_shifts=int(num_shifts),
         half_fill=bool(half_fill),
         wrap_positions=True,
+        target_indices=target_indices if bool(partial) else None,
         strategy="tile",
     )
 
@@ -1518,6 +1545,372 @@ def _register_graph_naive_tile_callables() -> dict[
 _GRAPH_NAIVE_TILE_CALLABLES = _register_graph_naive_tile_callables()
 
 
+def _run_graph_naive_partial_tile_no_pbc(
+    positions,
+    target_indices,
+    neighbor_matrix,
+    num_neighbors,
+    cutoff,
+    fill_value,
+    half_fill,
+    wp_dtype,
+) -> None:
+    """Reset compact outputs and launch the captured partial no-PBC tile kernel."""
+    (
+        empty_offsets,
+        empty_cell,
+        empty_shift_range,
+        empty_num_shifts,
+        empty_batch_idx,
+        empty_batch_ptr,
+        _empty_target_indices,
+        _empty_matrix,
+        empty_shifts,
+        _empty_num_neighbors,
+        _empty_vectors,
+        _empty_distances,
+        _empty_pair_params,
+        _empty_energies,
+        _empty_forces,
+        empty_rebuild_flags,
+    ) = _wp_scalar_sentinels(wp_dtype, num_neighbors.device)
+    _reset_graph_neighbor_outputs(neighbor_matrix, num_neighbors, fill_value)
+    wp.launch_tiled(
+        kernel=_get_naive_kernel(
+            wp_dtype,
+            pbc_mode="none",
+            partial=True,
+            half_fill=bool(half_fill),
+            strategy="tile",
+        ),
+        dim=[1, target_indices.shape[0]],
+        inputs=[
+            positions,
+            empty_offsets,
+            wp_dtype(float(cutoff) * float(cutoff)),
+            empty_cell,
+            empty_shift_range,
+            empty_num_shifts,
+            empty_batch_idx,
+            empty_batch_ptr,
+            target_indices,
+            neighbor_matrix,
+            empty_shifts,
+            num_neighbors,
+            empty_rebuild_flags,
+        ],
+        block_dim=BLOCK_DIM,
+        device=str(positions.device),
+    )
+
+
+def _run_graph_naive_partial_tile_pbc(
+    positions,
+    target_indices,
+    cell,
+    shift_range,
+    neighbor_matrix,
+    neighbor_matrix_shifts,
+    num_neighbors,
+    cutoff,
+    num_shifts,
+    fill_value,
+    half_fill,
+    wp_dtype,
+    *,
+    inv_cell=None,
+    pbc=None,
+    positions_wrapped=None,
+    per_atom_cell_offsets=None,
+) -> None:
+    """Reset compact outputs and launch a captured partial PBC tile kernel."""
+    (
+        empty_offsets,
+        _empty_cell,
+        _empty_shift_range,
+        empty_num_shifts,
+        empty_batch_idx,
+        empty_batch_ptr,
+        _empty_target_indices,
+        _empty_matrix,
+        _empty_shifts,
+        _empty_num_neighbors,
+        _empty_vectors,
+        _empty_distances,
+        _empty_pair_params,
+        _empty_energies,
+        _empty_forces,
+        empty_rebuild_flags,
+    ) = _wp_scalar_sentinels(wp_dtype, num_neighbors.device)
+    _reset_graph_neighbor_outputs(
+        neighbor_matrix,
+        num_neighbors,
+        fill_value,
+        neighbor_matrix_shifts,
+    )
+    pbc_mode = "prewrapped"
+    positions_work = positions
+    offsets = empty_offsets
+    if positions_wrapped is not None:
+        wp.launch(
+            kernel=get_wrap_positions_kernel(wp_dtype, pbc_aware=True),
+            dim=positions.shape[0],
+            inputs=[positions, cell, inv_cell, pbc, empty_batch_idx],
+            outputs=[positions_wrapped, per_atom_cell_offsets],
+        )
+        pbc_mode = "wrap_on_entry"
+        positions_work = positions_wrapped
+        offsets = per_atom_cell_offsets
+
+    active_shifts = int(num_shifts)
+    if not bool(half_fill):
+        active_shifts = 2 * active_shifts - 1
+    wp.launch_tiled(
+        kernel=_get_naive_kernel(
+            wp_dtype,
+            pbc_mode=pbc_mode,
+            partial=True,
+            half_fill=bool(half_fill),
+            strategy="tile",
+        ),
+        dim=[active_shifts, target_indices.shape[0]],
+        inputs=[
+            positions_work,
+            offsets,
+            wp_dtype(float(cutoff) * float(cutoff)),
+            cell,
+            shift_range,
+            empty_num_shifts,
+            empty_batch_idx,
+            empty_batch_ptr,
+            target_indices,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            num_neighbors,
+            empty_rebuild_flags,
+        ],
+        block_dim=BLOCK_DIM,
+        device=str(positions.device),
+    )
+
+
+def _graph_naive_partial_tile_no_pbc_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    target_indices: wp.array(dtype=wp.int32),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+) -> None:
+    _run_graph_naive_partial_tile_no_pbc(
+        positions,
+        target_indices,
+        neighbor_matrix,
+        num_neighbors,
+        cutoff,
+        fill_value,
+        half_fill,
+        wp.float32,
+    )
+
+
+def _graph_naive_partial_tile_no_pbc_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    target_indices: wp.array(dtype=wp.int32),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float64,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+) -> None:
+    _run_graph_naive_partial_tile_no_pbc(
+        positions,
+        target_indices,
+        neighbor_matrix,
+        num_neighbors,
+        cutoff,
+        fill_value,
+        half_fill,
+        wp.float64,
+    )
+
+
+def _graph_naive_partial_tile_pbc_prewrapped_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    target_indices: wp.array(dtype=wp.int32),
+    cell: wp.array(dtype=wp.mat33f),
+    shift_range: wp.array(dtype=wp.vec3i),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float32,
+    num_shifts: wp.int32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+) -> None:
+    _run_graph_naive_partial_tile_pbc(
+        positions,
+        target_indices,
+        cell,
+        shift_range,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff,
+        num_shifts,
+        fill_value,
+        half_fill,
+        wp.float32,
+    )
+
+
+def _graph_naive_partial_tile_pbc_prewrapped_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    target_indices: wp.array(dtype=wp.int32),
+    cell: wp.array(dtype=wp.mat33d),
+    shift_range: wp.array(dtype=wp.vec3i),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float64,
+    num_shifts: wp.int32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+) -> None:
+    _run_graph_naive_partial_tile_pbc(
+        positions,
+        target_indices,
+        cell,
+        shift_range,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff,
+        num_shifts,
+        fill_value,
+        half_fill,
+        wp.float64,
+    )
+
+
+def _graph_naive_partial_tile_pbc_wrapped_f32(
+    positions: wp.array(dtype=wp.vec3f),
+    target_indices: wp.array(dtype=wp.int32),
+    cell: wp.array(dtype=wp.mat33f),
+    inv_cell: wp.array(dtype=wp.mat33f),
+    pbc: wp.array2d(dtype=wp.bool),
+    shift_range: wp.array(dtype=wp.vec3i),
+    positions_wrapped: wp.array(dtype=wp.vec3f),
+    per_atom_cell_offsets: wp.array(dtype=wp.vec3i),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float32,
+    num_shifts: wp.int32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+) -> None:
+    _run_graph_naive_partial_tile_pbc(
+        positions,
+        target_indices,
+        cell,
+        shift_range,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff,
+        num_shifts,
+        fill_value,
+        half_fill,
+        wp.float32,
+        inv_cell=inv_cell,
+        pbc=pbc,
+        positions_wrapped=positions_wrapped,
+        per_atom_cell_offsets=per_atom_cell_offsets,
+    )
+
+
+def _graph_naive_partial_tile_pbc_wrapped_f64(
+    positions: wp.array(dtype=wp.vec3d),
+    target_indices: wp.array(dtype=wp.int32),
+    cell: wp.array(dtype=wp.mat33d),
+    inv_cell: wp.array(dtype=wp.mat33d),
+    pbc: wp.array2d(dtype=wp.bool),
+    shift_range: wp.array(dtype=wp.vec3i),
+    positions_wrapped: wp.array(dtype=wp.vec3d),
+    per_atom_cell_offsets: wp.array(dtype=wp.vec3i),
+    neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
+    neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
+    num_neighbors: wp.array(dtype=wp.int32),
+    cutoff: wp.float64,
+    num_shifts: wp.int32,
+    fill_value: wp.int32,
+    half_fill: wp.bool,
+) -> None:
+    _run_graph_naive_partial_tile_pbc(
+        positions,
+        target_indices,
+        cell,
+        shift_range,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        cutoff,
+        num_shifts,
+        fill_value,
+        half_fill,
+        wp.float64,
+        inv_cell=inv_cell,
+        pbc=pbc,
+        positions_wrapped=positions_wrapped,
+        per_atom_cell_offsets=per_atom_cell_offsets,
+    )
+
+
+_GRAPH_NAIVE_PARTIAL_TILE_WARP_SPECS = {
+    (False, False): {
+        "num_outputs": 2,
+        "in_out_argnames": _GRAPH_NAIVE_TILE_NO_PBC_IN_OUT_ARGS,
+        jnp.dtype(jnp.float32): _graph_naive_partial_tile_no_pbc_f32,
+        jnp.dtype(jnp.float64): _graph_naive_partial_tile_no_pbc_f64,
+    },
+    (True, False): {
+        "num_outputs": 3,
+        "in_out_argnames": _GRAPH_NAIVE_TILE_PBC_IN_OUT_ARGS,
+        jnp.dtype(jnp.float32): _graph_naive_partial_tile_pbc_prewrapped_f32,
+        jnp.dtype(jnp.float64): _graph_naive_partial_tile_pbc_prewrapped_f64,
+    },
+    (True, True): {
+        "num_outputs": 5,
+        "in_out_argnames": _GRAPH_NAIVE_PBC_WRAPPED_IN_OUT_ARGS,
+        jnp.dtype(jnp.float32): _graph_naive_partial_tile_pbc_wrapped_f32,
+        jnp.dtype(jnp.float64): _graph_naive_partial_tile_pbc_wrapped_f64,
+    },
+}
+
+
+def _register_graph_naive_partial_tile_callables() -> dict[
+    tuple[bool, bool, jnp.dtype], object
+]:
+    """Register GraphMode.WARP callables for compact partial tile paths."""
+    registered: dict[tuple[bool, bool, jnp.dtype], object] = {}
+    for (has_pbc, wrap_positions), spec in _GRAPH_NAIVE_PARTIAL_TILE_WARP_SPECS.items():
+        for dtype in (jnp.dtype(jnp.float32), jnp.dtype(jnp.float64)):
+            registered[(has_pbc, wrap_positions, dtype)] = jax_callable(
+                spec[dtype],
+                num_outputs=spec["num_outputs"],
+                in_out_argnames=spec["in_out_argnames"],
+                graph_mode=GraphMode.WARP,
+            )
+    return registered
+
+
+_GRAPH_NAIVE_PARTIAL_TILE_WARP_CALLABLES = (
+    _register_graph_naive_partial_tile_callables()
+)
+
+
 def _naive_pair_outputs_forward(
     positions: jax.Array,
     cell: jax.Array | None,
@@ -1538,6 +1931,12 @@ def _naive_pair_outputs_forward(
     pair_params: jax.Array | None = None,
     target_indices: jax.Array | None = None,
     half_fill: bool = False,
+    strategy: str = "scalar",
+    wrap_positions: bool = True,
+    graph_mode: str = "none",
+    inv_cell: jax.Array | None = None,
+    positions_wrapped: jax.Array | None = None,
+    per_atom_cell_offsets: jax.Array | None = None,
 ) -> _NeighborForwardOutput:
     """Forward closure for the naive autograd path.
 
@@ -1587,32 +1986,32 @@ def _naive_pair_outputs_forward(
     ) = _jax_scalar_sentinels(positions.dtype)
 
     ti_arg = target_indices if is_partial else empty_target_indices
+    has_pair_fn = pair_fn is not None
+    use_tile = strategy == "tile" and is_partial and not has_pair_fn
     if neighbor_matrix is None:
         nm = jnp.full((num_rows, max_neighbors), fill_value, dtype=jnp.int32)
+    elif graph_mode == "warp":
+        nm = neighbor_matrix
     else:
         nm = neighbor_matrix.at[:].set(jnp.int32(fill_value))
     if num_neighbors is None:
         nn = jnp.zeros(num_rows, dtype=jnp.int32)
+    elif graph_mode == "warp":
+        nn = num_neighbors
     else:
         nn = num_neighbors.at[:].set(jnp.int32(0))
-    if neighbor_matrix_shifts is None:
+    if pbc is None and use_tile:
+        nms = empty_shifts
+    elif neighbor_matrix_shifts is None:
         nms = jnp.zeros((num_rows, max_neighbors, 3), dtype=jnp.int32)
+    elif graph_mode == "warp":
+        nms = neighbor_matrix_shifts
     else:
         nms = neighbor_matrix_shifts.at[:].set(jnp.int32(0))
-    if neighbor_vectors is None:
-        nv = jnp.zeros((num_rows, max_neighbors, 3), dtype=positions.dtype)
-    else:
-        nv = neighbor_vectors.at[:].set(jnp.asarray(0.0, dtype=positions.dtype))
-    if neighbor_distances is None:
-        nd = jnp.zeros((num_rows, max_neighbors), dtype=positions.dtype)
-    else:
-        nd = neighbor_distances.at[:].set(jnp.asarray(0.0, dtype=positions.dtype))
-
     # ``pair_fn`` path: real per-atom params + auto-allocated energy/force buffers.
     # (JAX is functional, so user-supplied energy/force buffers cannot be written
     # in-place; we always allocate fresh and return them — the return contract
     # matches torch, the in-place-buffer aspect does not.)
-    has_pair_fn = pair_fn is not None
     if has_pair_fn:
         pp_arg = jnp.asarray(pair_params, dtype=positions.dtype)
         pe = jnp.zeros((num_rows, max_neighbors), dtype=positions.dtype)
@@ -1622,7 +2021,49 @@ def _naive_pair_outputs_forward(
         pe = None
         pf = None
 
-    if pbc is None:
+    if use_tile:
+        # Tile kernels write topology only and do not consume geometry buffers.
+        # Keep the zero-sized sentinels instead of materializing discarded
+        # ``(num_rows, max_neighbors, 3)`` and ``(num_rows, max_neighbors)``
+        # arrays for topology-only partial calls.
+        nv = empty_vectors
+        nd = empty_distances
+    else:
+        if neighbor_vectors is None:
+            nv = jnp.zeros((num_rows, max_neighbors, 3), dtype=positions.dtype)
+        else:
+            nv = neighbor_vectors.at[:].set(jnp.asarray(0.0, dtype=positions.dtype))
+        if neighbor_distances is None:
+            nd = jnp.zeros((num_rows, max_neighbors), dtype=positions.dtype)
+        else:
+            nd = neighbor_distances.at[:].set(jnp.asarray(0.0, dtype=positions.dtype))
+
+    if use_tile and pbc is None:
+        if graph_mode == "warp":
+            tile_callable = _GRAPH_NAIVE_PARTIAL_TILE_WARP_CALLABLES[
+                (False, False, positions.dtype)
+            ]
+            nm, nn = tile_callable(
+                positions,
+                ti_arg,
+                nm,
+                nn,
+                float(cutoff),
+                int(fill_value),
+                half_fill,
+            )
+        else:
+            tile_callable = _GRAPH_NAIVE_TILE_CALLABLES[(False, False, positions.dtype)]
+            nm, nn = tile_callable(
+                positions,
+                ti_arg,
+                nm,
+                nn,
+                float(cutoff),
+                half_fill,
+                True,
+            )
+    elif pbc is None:
         if has_pair_fn:
             kernel = _get_jax_naive_pair_fn_kernel(
                 pair_fn, wp_dtype, "none", half_fill, is_partial
@@ -1664,6 +2105,82 @@ def _naive_pair_outputs_forward(
             nm, nn, nv, nd, pe, pf = outs
         else:
             nm, nn, nv, nd = outs
+    elif use_tile:
+        if cell.ndim == 2:
+            cell = cell[jnp.newaxis, :, :]
+        if pbc.ndim == 1:
+            pbc = pbc[jnp.newaxis, :]
+        if (
+            shift_range_per_dimension is None
+            or num_shifts_per_system is None
+            or max_shifts_per_system is None
+        ):
+            (
+                shift_range_per_dimension,
+                num_shifts_per_system,
+                max_shifts_per_system,
+            ) = compute_naive_num_shifts(cell, cutoff, pbc)
+        if graph_mode == "warp":
+            tile_callable = _GRAPH_NAIVE_PARTIAL_TILE_WARP_CALLABLES[
+                (True, bool(wrap_positions), positions.dtype)
+            ]
+            if wrap_positions:
+                (
+                    positions_wrapped,
+                    per_atom_cell_offsets,
+                    nm,
+                    nms,
+                    nn,
+                ) = tile_callable(
+                    positions,
+                    ti_arg,
+                    cell,
+                    inv_cell,
+                    pbc,
+                    shift_range_per_dimension,
+                    positions_wrapped,
+                    per_atom_cell_offsets,
+                    nm,
+                    nms,
+                    nn,
+                    float(cutoff),
+                    int(max_shifts_per_system),
+                    int(fill_value),
+                    half_fill,
+                )
+            else:
+                nm, nms, nn = tile_callable(
+                    positions,
+                    ti_arg,
+                    cell,
+                    shift_range_per_dimension,
+                    nm,
+                    nms,
+                    nn,
+                    float(cutoff),
+                    int(max_shifts_per_system),
+                    int(fill_value),
+                    half_fill,
+                )
+        else:
+            tile_callable = _GRAPH_NAIVE_TILE_CALLABLES[
+                (True, bool(wrap_positions), positions.dtype)
+            ]
+            pbc_arg = (pbc,) if wrap_positions else ()
+            nm, nms, nn = tile_callable(
+                positions,
+                ti_arg,
+                cell,
+                *pbc_arg,
+                shift_range_per_dimension,
+                nm,
+                nms,
+                nn,
+                float(cutoff),
+                int(max_shifts_per_system),
+                half_fill,
+                True,
+            )
     else:
         if has_pair_fn:
             kernel = _get_jax_naive_pair_fn_kernel(
@@ -1702,12 +2219,38 @@ def _naive_pair_outputs_forward(
                 num_shifts_per_system,
                 max_shifts_per_system,
             ) = compute_naive_num_shifts(cell, cutoff, pbc)
+        positions_work = positions
         offs = jnp.zeros((total_atoms, 3), dtype=jnp.int32)
+        if wrap_positions:
+            if inv_cell is None:
+                inv_cell = jnp.linalg.inv(cell)
+            if positions_wrapped is None:
+                positions_wrapped = jnp.zeros_like(positions)
+            if per_atom_cell_offsets is None:
+                per_atom_cell_offsets = jnp.zeros(
+                    (total_atoms, 3),
+                    dtype=jnp.int32,
+                )
+            wrap_kernel = (
+                _jax_wrap_positions_single_f64
+                if f64
+                else _jax_wrap_positions_single_f32
+            )
+            positions_work, offs = wrap_kernel(
+                positions,
+                cell,
+                inv_cell,
+                pbc,
+                empty_batch_idx,
+                positions_wrapped,
+                per_atom_cell_offsets,
+                launch_dims=(total_atoms,),
+            )
         active_shift_dim = int(max_shifts_per_system)
         if is_partial and not half_fill:
             active_shift_dim = 2 * active_shift_dim - 1
         outs = kernel(
-            positions,
+            positions_work,
             offs,
             cutoff_sq,
             zero_dt,
@@ -1736,12 +2279,21 @@ def _naive_pair_outputs_forward(
         else:
             nm, nms, nn, nv, nd = outs
 
-    i_idx, j_idx, shifts_ret, _, mask_ = _build_index_residuals(
-        nm,
-        nn,
-        nms,
-        target_indices=target_indices if is_partial else None,
-    )
+    if use_tile:
+        # The topology-only caller consumes only ``extra_outputs``. Avoid
+        # constructing the residual index matrices needed solely for the
+        # differentiable geometry reconstruction.
+        i_idx = j_idx = empty_matrix
+        shifts_ret = empty_shifts
+        mask_ = jnp.empty((0, 0), dtype=jnp.bool_)
+        batch_idx_ret = None
+    else:
+        i_idx, j_idx, shifts_ret, batch_idx_ret, mask_ = _build_index_residuals(
+            nm,
+            nn,
+            nms,
+            target_indices=target_indices if is_partial else None,
+        )
     K, M = nm.shape
     extra_outputs = (nm, nn, nms, pe, pf) if has_pair_fn else (nm, nn, nms)
     return _NeighborForwardOutput(
@@ -1751,7 +2303,7 @@ def _naive_pair_outputs_forward(
         i_idx=i_idx,
         j_idx=j_idx,
         shifts=shifts_ret,
-        batch_idx=None,
+        batch_idx=batch_idx_ret,
         active_mask=mask_,
         matrix_shape=(K, M),
     )
@@ -1890,14 +2442,14 @@ def naive_neighbor_list(
         Selects the underlying Warp kernel variant. ``"scalar"`` uses the
         per-atom scalar kernel. ``"tile"`` uses the tile-cooperative
         ``wp.launch_tiled`` kernel and is **CUDA-only**: requesting it on a
-        CPU device raises ``ValueError``. The tile path has no pair-output /
-        ``target_indices`` / selective (``rebuild_flags``) variant and is not
-        supported with ``graph_mode="warp"`` in this binding; requesting any
-        of those with ``strategy="tile"`` raises. ``"auto"`` preserves
-        the current JAX behavior (scalar dispatch) and never selects tile —
-        tile is opt-in in the JAX binding (unlike the torch single-system
-        binding, whose ``"auto"`` tiles by default). The tile and scalar
-        paths produce identical pair *sets* (per-row ordering may differ).
+        CPU device raises ``ValueError``. The tile path supports topology-only
+        compact ``target_indices``, but has no geometry/pair-function output or
+        selective (``rebuild_flags``) variant. Topology-only compact rows support
+        ``graph_mode="warp"`` when tile is selected. ``"auto"`` selects tile
+        only for topology-only ``target_indices`` on CUDA with at least 256
+        atoms for float64 or 1024 atoms for float32; other JAX calls retain
+        scalar dispatch. The tile and scalar paths produce identical pair
+        *multisets* (per-row ordering may differ).
     inv_cell : jax.Array, shape (1, 3, 3), dtype matches positions, optional
         Inverse cell matrix consumed by the wrap kernel. Only used when
         ``pbc`` is provided and ``wrap_positions=True``. Pass in a
@@ -1926,7 +2478,10 @@ def naive_neighbor_list(
         preserves the existing per-kernel ``jax_kernel`` dispatch path.
         ``"warp"`` uses fused ``jax_callable(..., graph_mode=GraphMode.WARP)``
         callbacks and is intended for ``jax.jit`` call sites that donate
-        reusable output buffers.
+        reusable output buffers. Topology-only ``target_indices`` calls are
+        supported when ``strategy="tile"`` or when ``"auto"`` selects tile,
+        but require ``return_neighbor_list=False`` because COO output has
+        data-dependent shape.
 
     Returns
     -------
@@ -2041,7 +2596,9 @@ def naive_neighbor_list(
     ``XLA_FLAGS=--xla_gpu_enable_command_buffer=CUSTOM_CALL`` before
     importing JAX can improve the steady-state ``graph_mode="none"`` and
     ``graph_mode="warp"`` paths. Advanced users can bound Warp's graph
-    cache via ``warp.jax_experimental.set_jax_callable_default_graph_cache_max(...)``.
+    cache via ``warp.jax_experimental.set_jax_callable_default_graph_cache_max(...)``;
+    set that default before importing this module because its callables are
+    registered at import time.
 
     For ``graph_mode="warp"`` to actually replay (rather than re-capture
     every call), every in/out buffer pointer the fused callable sees must
@@ -2056,6 +2613,11 @@ def naive_neighbor_list(
     Letting any of these allocate fresh inside ``naive_neighbor_list``
     silently degrades the wrapped path to cold-capture-per-call (correct,
     but significantly slower than the proposal's measured replay numbers).
+    The input pointers for ``positions``, ``cell``, ``pbc``, and supplied
+    shift metadata must also remain stable. Partial calls additionally require
+    a stable ``target_indices`` pointer. Reusing one persistent array is
+    sufficient when its values are fixed; changing targets in-place requires a
+    donated/round-tripped target buffer.
     """
     graph_mode = _validate_graph_mode(graph_mode)
 
@@ -2085,36 +2647,114 @@ def naive_neighbor_list(
     if pbc is not None and cell is None:
         raise ValueError("If pbc is provided, cell must also be provided")
 
+    if target_indices is not None and (
+        target_indices.ndim != 1 or target_indices.dtype != jnp.int32
+    ):
+        raise ValueError("target_indices must be a rank-one int32 array.")
+
+    topology_only_partial = (
+        target_indices is not None
+        and not bool(return_distances)
+        and not bool(return_vectors)
+        and neighbor_vectors is None
+        and neighbor_distances is None
+        and pair_fn is None
+    )
+    partial_tile_min_atoms = _partial_tile_min_atoms(
+        wp.float64 if positions.dtype == jnp.float64 else wp.float32
+    )
+    partial_tile_selected = topology_only_partial and (
+        strategy == "tile"
+        or (
+            strategy == "auto"
+            and not _is_jax_cpu_for_tile(positions)
+            and int(positions.shape[0]) >= partial_tile_min_atoms
+        )
+    )
+    partial_tile_warp = graph_mode == "warp" and partial_tile_selected
+    if partial_tile_warp:
+        if return_neighbor_list:
+            raise ValueError(
+                "graph_mode='warp' with topology-only target_indices requires "
+                "return_neighbor_list=False because COO output has dynamic shape."
+            )
+        if target_indices.ndim != 1 or target_indices.dtype != jnp.int32:
+            raise ValueError(
+                "graph_mode='warp' with topology-only target_indices requires "
+                "a rank-one int32 target_indices array."
+            )
+        missing_outputs = neighbor_matrix is None or num_neighbors is None
+        if pbc is not None:
+            missing_outputs = missing_outputs or neighbor_matrix_shifts is None
+        if missing_outputs:
+            raise ValueError(
+                "graph_mode='warp' with topology-only target_indices requires "
+                "caller-provided compact neighbor_matrix, num_neighbors, and "
+                "neighbor_matrix_shifts when PBC is enabled."
+            )
+        if pbc is not None:
+            if (
+                tuple(cell.shape) != (1, 3, 3)
+                or cell.dtype != positions.dtype
+                or tuple(pbc.shape) != (1, 3)
+                or pbc.dtype != jnp.bool_
+            ):
+                raise ValueError(
+                    "graph_mode='warp' with topology-only target_indices "
+                    "requires cell shape (1, 3, 3) with the positions dtype "
+                    "and bool pbc shape (1, 3)."
+                )
+            if (
+                shift_range_per_dimension is None
+                or num_shifts_per_system is None
+                or max_shifts_per_system is None
+            ):
+                raise ValueError(
+                    "graph_mode='warp' with topology-only target_indices and "
+                    "PBC requires precomputed shift_range_per_dimension, "
+                    "num_shifts_per_system, and max_shifts_per_system."
+                )
+            if (
+                tuple(shift_range_per_dimension.shape) != (1, 3)
+                or shift_range_per_dimension.dtype != jnp.int32
+                or tuple(num_shifts_per_system.shape) != (1,)
+                or num_shifts_per_system.dtype != jnp.int32
+            ):
+                raise ValueError(
+                    "Partial graph replay requires int32 shift metadata with "
+                    "shapes (1, 3) and (1,)."
+                )
+
     if strategy == "tile":
-        # The tile-cooperative kernel is CUDA-only and has no pair-output,
-        # selective (rebuild_flags), or CUDA-graph (graph_mode="warp") variant.
-        # Gate here, before any launch, mirroring the warp launcher CPU guard.
-        if _is_jax_cpu_array(positions):
+        # The tile-cooperative kernel is CUDA-only and has no geometry/pair_fn,
+        # selective (rebuild_flags), or full-row CUDA-graph variant. Compact
+        # topology-only rows use the partial Warp-graph callable family.
+        if _is_jax_cpu_for_tile(positions):
             raise ValueError(
                 "strategy='tile' requires CUDA; the tile-cooperative "
                 "naive kernel cannot run on a CPU device (Warp forces "
                 "block_dim=1). Use strategy='scalar' or 'auto' on CPU.",
             )
-        if bool(return_distances) or bool(return_vectors) or pair_fn is not None:
+        if (
+            bool(return_distances)
+            or bool(return_vectors)
+            or neighbor_vectors is not None
+            or neighbor_distances is not None
+            or pair_fn is not None
+        ):
             raise NotImplementedError(
                 "strategy='tile' has no pair-output (return_distances / "
                 "return_vectors / pair_fn) variant; use strategy='scalar'.",
-            )
-        if target_indices is not None:
-            raise NotImplementedError(
-                "strategy='tile' has no target_indices (partial "
-                "neighbor-list) variant; use strategy='scalar'.",
             )
         if rebuild_flags is not None:
             raise NotImplementedError(
                 "strategy='tile' has no selective (rebuild_flags) "
                 "variant; use strategy='scalar'.",
             )
-        if graph_mode != "none":
+        if graph_mode != "none" and not partial_tile_warp:
             raise NotImplementedError(
-                "strategy='tile' is only supported with "
-                "graph_mode='none'; CUDA-graph capture of the tile kernel is a "
-                "follow-up.",
+                "strategy='tile' with graph_mode='warp' requires "
+                "topology-only target_indices.",
             )
 
     has_pair_outputs = (
@@ -2124,9 +2764,13 @@ def naive_neighbor_list(
         or target_indices is not None
     )
     if has_pair_outputs:
-        if graph_mode != "none" or rebuild_flags is not None:
+        if (
+            graph_mode != "none" and not partial_tile_warp
+        ) or rebuild_flags is not None:
             raise NotImplementedError(
-                "Pair outputs require graph_mode='none' and no rebuild_flags.",
+                "Pair outputs require graph_mode='none' and no rebuild_flags; "
+                "graph_mode='warp' is limited to topology-only target_indices "
+                "using the tile strategy.",
             )
         num_rows = (
             int(target_indices.shape[0])
@@ -2179,6 +2823,12 @@ def naive_neighbor_list(
         pbc_norm = None
         if pbc is not None:
             pbc_norm = pbc if pbc.ndim == 2 else pbc[jnp.newaxis, :]
+        if partial_tile_warp and pbc_norm is not None:
+            if int(cell_norm.shape[0]) != 1 or int(pbc_norm.shape[0]) != 1:
+                raise ValueError(
+                    "graph_mode='warp' with topology-only target_indices "
+                    "supports exactly one system."
+                )
         if pbc_norm is not None:
             if (
                 shift_range_per_dimension is None
@@ -2205,6 +2855,56 @@ def naive_neighbor_list(
                     "calling naive_neighbor_list under jax.jit with PBC and "
                     "target_indices / pair outputs.",
                 ) from exc
+        partial_inv_cell = None
+        partial_positions_wrapped = None
+        partial_per_atom_cell_offsets = None
+        if partial_tile_warp and pbc_norm is not None and wrap_positions:
+            partial_inv_cell = resolve_buffer_alias(
+                "inv_cell_buffer",
+                inv_cell_buffer,
+                "inv_cell",
+                inv_cell,
+            )
+            partial_positions_wrapped = resolve_buffer_alias(
+                "positions_wrapped_buffer",
+                positions_wrapped_buffer,
+                "positions_wrapped",
+                positions_wrapped,
+            )
+            partial_per_atom_cell_offsets = resolve_buffer_alias(
+                "per_atom_cell_offsets_buffer",
+                per_atom_cell_offsets_buffer,
+                "per_atom_cell_offsets",
+                per_atom_cell_offsets,
+            )
+            if (
+                partial_inv_cell is None
+                or partial_positions_wrapped is None
+                or partial_per_atom_cell_offsets is None
+            ):
+                raise ValueError(
+                    "graph_mode='warp' with topology-only target_indices and "
+                    "wrap_positions=True requires caller-provided inv_cell, "
+                    "positions_wrapped, and per_atom_cell_offsets buffers."
+                )
+            _validate_pair_output_buffer(
+                "inv_cell",
+                partial_inv_cell,
+                (1, 3, 3),
+                positions.dtype,
+            )
+            _validate_pair_output_buffer(
+                "positions_wrapped",
+                partial_positions_wrapped,
+                (int(positions.shape[0]), 3),
+                positions.dtype,
+            )
+            _validate_pair_output_buffer(
+                "per_atom_cell_offsets",
+                partial_per_atom_cell_offsets,
+                (int(positions.shape[0]), 3),
+                jnp.int32,
+            )
         forward_kwargs = {
             "pbc": pbc_norm,
             "cutoff": float(cutoff),
@@ -2222,28 +2922,48 @@ def naive_neighbor_list(
             "pair_params": pair_params,
             "target_indices": target_indices,
             "half_fill": bool(half_fill),
+            "strategy": "tile" if partial_tile_selected else "scalar",
+            "wrap_positions": bool(wrap_positions),
+            "graph_mode": graph_mode,
+            "inv_cell": partial_inv_cell,
+            "positions_wrapped": partial_positions_wrapped,
+            "per_atom_cell_offsets": partial_per_atom_cell_offsets,
         }
-        route_out = _route_pair_outputs(
-            positions,
-            cell_norm,
-            _naive_pair_outputs_forward,
-            forward_kwargs,
-        )
-        # ``extra_outputs`` carries the per-pair energy/force tail only when
-        # ``pair_fn`` is set, so the route return is 5 elements (geometry only) or 7.
-        if pair_fn is not None:
-            (
-                distances_out,
-                vectors_out,
-                nm_out,
-                nn_out,
-                shifts_out,
-                pe_out,
-                pf_out,
-            ) = route_out
+        if topology_only_partial:
+            # Do not reconstruct the full compact ``(rows, max_neighbors)``
+            # geometry only to discard it. This keeps topology-only partial
+            # timing focused on the Warp search/callback and avoids unnecessary
+            # gathers, norms, and materialized vector/distance arrays.
+            forward_out = _naive_pair_outputs_forward(
+                positions,
+                cell_norm,
+                **forward_kwargs,
+            )
+            nm_out, nn_out, shifts_out = forward_out.extra_outputs
+            distances_out = vectors_out = pe_out = pf_out = None
         else:
-            distances_out, vectors_out, nm_out, nn_out, shifts_out = route_out
-            pe_out = pf_out = None
+            route_out = _route_pair_outputs(
+                positions,
+                cell_norm,
+                _naive_pair_outputs_forward,
+                forward_kwargs,
+            )
+            # ``extra_outputs`` carries the per-pair energy/force tail only when
+            # ``pair_fn`` is set, so the route return is 5 elements (geometry
+            # only) or 7.
+            if pair_fn is not None:
+                (
+                    distances_out,
+                    vectors_out,
+                    nm_out,
+                    nn_out,
+                    shifts_out,
+                    pe_out,
+                    pf_out,
+                ) = route_out
+            else:
+                distances_out, vectors_out, nm_out, nn_out, shifts_out = route_out
+                pe_out = pf_out = None
         if return_neighbor_list:
             if pbc is not None:
                 nl, nptr, nl_shifts = get_neighbor_list_from_neighbor_matrix(
@@ -2262,10 +2982,11 @@ def naive_neighbor_list(
                 base = (nl, nptr)
             # Repack per-pair geometry (and pair_fn outputs) into COO order aligned
             # with ``nl``.  Eager-only, like the index conversion.
-            active = nm_out != int(fill_value)
-            distances_out, vectors_out = coo_pack_pair_geometry(
-                active, distances_out, vectors_out
-            )
+            if distances_out is not None or vectors_out is not None:
+                active = nm_out != int(fill_value)
+                distances_out, vectors_out = coo_pack_pair_geometry(
+                    active, distances_out, vectors_out
+                )
             if pair_fn is not None:
                 pe_out, pf_out = coo_pack_pair_geometry(active, pe_out, pf_out)
         elif pbc is not None:
@@ -2509,10 +3230,12 @@ def naive_neighbor_list(
             tile_callable = _GRAPH_NAIVE_TILE_CALLABLES[(False, False, positions.dtype)]
             neighbor_matrix, num_neighbors = tile_callable(
                 positions,
+                empty_target_indices,
                 neighbor_matrix,
                 num_neighbors,
                 cutoff_static,
                 half_fill,
+                False,
             )
         else:
             if cell.dtype != positions.dtype:
@@ -2524,6 +3247,7 @@ def naive_neighbor_list(
             pbc_arg = (pbc,) if wrap_positions else ()
             neighbor_matrix, neighbor_matrix_shifts, num_neighbors = tile_callable(
                 positions,
+                empty_target_indices,
                 cell,
                 *pbc_arg,
                 shift_range_per_dimension,
@@ -2533,6 +3257,7 @@ def naive_neighbor_list(
                 cutoff_static,
                 num_shifts,
                 half_fill,
+                False,
             )
     elif graph_mode == "warp":
         has_pbc = pbc is not None

--- a/nvalchemiops/jax/neighbors/naive.py
+++ b/nvalchemiops/jax/neighbors/naive.py
@@ -30,7 +30,9 @@ from nvalchemiops.jax.neighbors._autograd import (
     _NeighborForwardOutput,
     _route_pair_outputs,
 )
-from nvalchemiops.jax.neighbors._dispatch import _is_jax_cpu_array
+from nvalchemiops.jax.neighbors._dispatch import (
+    _jax_array_device_kind,
+)
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     _validate_graph_mode,
     build_naive_kernel_tables,
@@ -41,11 +43,16 @@ from nvalchemiops.jax.neighbors.neighbor_utils import (
 from nvalchemiops.neighbors.naive import (
     get_naive_neighbor_matrix_kernel as _get_naive_kernel,
 )
+from nvalchemiops.neighbors.naive.dispatch import (
+    _NaiveWorkload,
+    _require_cuda_tile_device,
+    _resolve_naive_strategy,
+)
 from nvalchemiops.neighbors.naive.launchers import (
-    BLOCK_DIM,
     _launch_naive_neighbor_matrix_no_pbc,
     _launch_naive_neighbor_matrix_pbc,
-    _partial_tile_min_atoms,
+    _launch_partial_tile_no_pbc,
+    _launch_partial_tile_pbc_prepared,
 )
 from nvalchemiops.neighbors.neighbor_utils import (
     DTYPE_INFO_ALL,
@@ -1280,27 +1287,9 @@ _GRAPH_NAIVE_WARP_CALLABLES = _register_graph_naive_callables()
 # Tiled-kernel callables (``strategy="tile"``, CUDA-only)
 # ==============================================================================
 #
-# These wrap the *inner* warp launchers ``_launch_naive_neighbor_matrix_no_pbc``
-# / ``_launch_naive_neighbor_matrix_pbc`` inside a ``jax_callable`` body and
-# pass ``strategy="tile"`` explicitly, so the tile-cooperative
-# ``wp.launch_tiled`` kernel is honored unconditionally (unlike the high-level
-# ``naive_neighbor_matrix`` launchers, which drop ``strategy`` on the
-# non-pair branch and would only reach tile via the "auto" heuristic).
-#
-# The inner launchers own the 2D tile ``dim`` math (``[1, N]`` no-PBC,
-# ``[num_shifts, N]`` PBC), the BLOCK_DIM, the scalar sentinels, and the
-# internal wrap launch for the wrapped-PBC case, so the JAX bodies stay thin.
-#
-# These run only on the eager (``graph_mode="none"``) path, where
-# ``naive_neighbor_list`` already pre-fills ``neighbor_matrix=fill_value`` and
-# zeroes ``num_neighbors`` / shifts before dispatch, so the bodies perform no
-# reset and take no ``fill_value`` argument. Partial Warp-graph tiling uses a
-# separate callable family below that captures its own output resets.
-#
-# Tile supports no-PBC and PBC (wrapped + prewrapped), ``half_fill``, and
-# topology-only compact target rows. It has no geometry/pair-function output or
-# selective specialization. The scalars (``cutoff``, ``half_fill``, ``partial``,
-# and ``num_shifts`` for PBC) are host-static in the existing naive graph path.
+# These force ``strategy="tile"`` in the inner Warp launchers. Eager calls
+# pre-fill topology outputs; the replay callables below capture their resets.
+# Cutoff, ``half_fill``, ``partial``, and PBC shift count are static.
 
 
 def _graph_naive_tile_no_pbc_f32(
@@ -1551,51 +1540,17 @@ def _run_graph_naive_partial_tile_no_pbc(
     wp_dtype,
 ) -> None:
     """Reset compact outputs and launch the captured partial no-PBC tile kernel."""
-    (
-        empty_offsets,
-        empty_cell,
-        empty_shift_range,
-        empty_num_shifts,
-        empty_batch_idx,
-        empty_batch_ptr,
-        _empty_target_indices,
-        _empty_matrix,
-        empty_shifts,
-        _empty_num_neighbors,
-        _empty_vectors,
-        _empty_distances,
-        _empty_pair_params,
-        _empty_energies,
-        _empty_forces,
-        empty_rebuild_flags,
-    ) = _wp_scalar_sentinels(wp_dtype, num_neighbors.device)
-    _reset_graph_neighbor_outputs(neighbor_matrix, num_neighbors, fill_value)
-    wp.launch_tiled(
-        kernel=_get_naive_kernel(
-            wp_dtype,
-            pbc_mode="none",
-            partial=True,
-            half_fill=bool(half_fill),
-            strategy="tile",
-        ),
-        dim=[1, target_indices.shape[0]],
-        inputs=[
-            positions,
-            empty_offsets,
-            wp_dtype(float(cutoff) * float(cutoff)),
-            empty_cell,
-            empty_shift_range,
-            empty_num_shifts,
-            empty_batch_idx,
-            empty_batch_ptr,
-            target_indices,
-            neighbor_matrix,
-            empty_shifts,
-            num_neighbors,
-            empty_rebuild_flags,
-        ],
-        block_dim=BLOCK_DIM,
-        device=str(positions.device),
+    _launch_partial_tile_no_pbc(
+        positions,
+        float(cutoff),
+        target_indices,
+        neighbor_matrix,
+        num_neighbors,
+        wp_dtype,
+        str(positions.device),
+        half_fill=bool(half_fill),
+        reset_outputs=True,
+        fill_value=int(fill_value),
     )
 
 
@@ -1623,26 +1578,11 @@ def _run_graph_naive_partial_tile_pbc(
         empty_offsets,
         _empty_cell,
         _empty_shift_range,
-        empty_num_shifts,
+        _empty_num_shifts,
         empty_batch_idx,
-        empty_batch_ptr,
-        _empty_target_indices,
-        _empty_matrix,
-        _empty_shifts,
-        _empty_num_neighbors,
-        _empty_vectors,
-        _empty_distances,
-        _empty_pair_params,
-        _empty_energies,
-        _empty_forces,
-        empty_rebuild_flags,
+        *_unused,
     ) = _wp_scalar_sentinels(wp_dtype, num_neighbors.device)
-    _reset_graph_neighbor_outputs(
-        neighbor_matrix,
-        num_neighbors,
-        fill_value,
-        neighbor_matrix_shifts,
-    )
+    _require_cuda_tile_device(str(positions.device))
     pbc_mode = "prewrapped"
     positions_work = positions
     offsets = empty_offsets
@@ -1656,36 +1596,23 @@ def _run_graph_naive_partial_tile_pbc(
         pbc_mode = "wrap_on_entry"
         positions_work = positions_wrapped
         offsets = per_atom_cell_offsets
-
-    active_shifts = int(num_shifts)
-    if not bool(half_fill):
-        active_shifts = 2 * active_shifts - 1
-    wp.launch_tiled(
-        kernel=_get_naive_kernel(
-            wp_dtype,
-            pbc_mode=pbc_mode,
-            partial=True,
-            half_fill=bool(half_fill),
-            strategy="tile",
-        ),
-        dim=[active_shifts, target_indices.shape[0]],
-        inputs=[
-            positions_work,
-            offsets,
-            wp_dtype(float(cutoff) * float(cutoff)),
-            cell,
-            shift_range,
-            empty_num_shifts,
-            empty_batch_idx,
-            empty_batch_ptr,
-            target_indices,
-            neighbor_matrix,
-            neighbor_matrix_shifts,
-            num_neighbors,
-            empty_rebuild_flags,
-        ],
-        block_dim=BLOCK_DIM,
-        device=str(positions.device),
+    _launch_partial_tile_pbc_prepared(
+        positions_work,
+        offsets,
+        float(cutoff),
+        cell,
+        shift_range,
+        target_indices,
+        neighbor_matrix,
+        neighbor_matrix_shifts,
+        num_neighbors,
+        wp_dtype,
+        str(positions.device),
+        num_shifts=int(num_shifts),
+        half_fill=bool(half_fill),
+        pbc_mode=pbc_mode,
+        reset_outputs=True,
+        fill_value=int(fill_value),
     )
 
 
@@ -2437,14 +2364,11 @@ def naive_neighbor_list(
         Selects the underlying Warp kernel variant. ``"scalar"`` uses the
         per-atom scalar kernel. ``"tile"`` uses the tile-cooperative
         ``wp.launch_tiled`` kernel and is **CUDA-only**: requesting it on a
-        CPU device raises ``ValueError``. The tile path supports topology-only
-        compact ``target_indices``, but has no geometry/pair-function output or
-        selective (``rebuild_flags``) variant. Topology-only compact rows support
-        ``graph_mode="warp"`` when tile is selected. ``"auto"`` selects tile
-        only for topology-only ``target_indices`` on CUDA with at least 256
-        atoms for float64 or 1024 atoms for float32; other JAX calls retain
-        scalar dispatch. The tile and scalar paths produce identical pair
-        *multisets* (per-row ordering may differ).
+        CPU device raises ``ValueError``. Tile supports topology-only compact
+        ``target_indices`` rows; geometry and pair outputs use the scalar path.
+        Partial neighbor lists do not support ``rebuild_flags``. The tile and
+        scalar paths produce identical pair *multisets* (per-row ordering may
+        differ).
     inv_cell : jax.Array, shape (1, 3, 3), dtype matches positions, optional
         Inverse cell matrix consumed by the wrap kernel. Only used when
         ``pbc`` is provided and ``wrap_positions=True``. Pass in a
@@ -2595,24 +2519,11 @@ def naive_neighbor_list(
     set that default before importing this module because its callables are
     registered at import time.
 
-    For ``graph_mode="warp"`` to actually replay (rather than re-capture
-    every call), every in/out buffer pointer the fused callable sees must
-    be stable across calls. The output buffers (``neighbor_matrix``,
-    ``num_neighbors``, ``neighbor_matrix_shifts`` when applicable) must be
-    user-provided **and** included in ``donate_argnums`` of the enclosing
-    ``jax.jit`` so they round-trip across calls. On the wrapped path
-    (``pbc`` provided + ``wrap_positions=True``), ``inv_cell``,
-    ``positions_wrapped`` and ``per_atom_cell_offsets`` must also be passed
-    in with stable buffer pointers; the simplest way is to pre-allocate them
-    once and capture them in the jit'ed closure (see the example above).
-    Letting any of these allocate fresh inside ``naive_neighbor_list``
-    silently degrades the wrapped path to cold-capture-per-call (correct,
-    but significantly slower than the proposal's measured replay numbers).
-    The input pointers for ``positions``, ``cell``, ``pbc``, and supplied
-    shift metadata must also remain stable. Partial calls additionally require
-    a stable ``target_indices`` pointer. Reusing one persistent array is
-    sufficient when its values are fixed; changing targets in-place requires a
-    donated/round-tripped target buffer.
+    ``graph_mode="warp"`` replay requires stable input and output buffers.
+    Donate the returned output buffers through the enclosing ``jax.jit`` so
+    they round-trip between calls. Wrapped PBC also requires stable
+    ``inv_cell``, ``positions_wrapped``, and ``per_atom_cell_offsets`` buffers.
+    Cutoff, ``half_fill``, and PBC shift metadata are statically specialized.
     """
     graph_mode = _validate_graph_mode(graph_mode)
 
@@ -2646,26 +2557,48 @@ def naive_neighbor_list(
         target_indices.ndim != 1 or target_indices.dtype != jnp.int32
     ):
         raise ValueError("target_indices must be a rank-one int32 array.")
-
-    topology_only_partial = (
-        target_indices is not None
-        and not bool(return_distances)
-        and not bool(return_vectors)
-        and neighbor_vectors is None
-        and neighbor_distances is None
-        and pair_fn is None
-    )
-    partial_tile_min_atoms = _partial_tile_min_atoms(
-        wp.float64 if positions.dtype == jnp.float64 else wp.float32
-    )
-    partial_tile_selected = topology_only_partial and (
-        strategy == "tile"
-        or (
-            strategy == "auto"
-            and not _is_jax_cpu_array(positions)
-            and int(positions.shape[0]) >= partial_tile_min_atoms
+    if target_indices is not None and rebuild_flags is not None:
+        raise NotImplementedError(
+            "Partial neighbor lists do not support rebuild_flags",
         )
+
+    real_geometry_or_pair_outputs = (
+        bool(return_distances)
+        or bool(return_vectors)
+        or neighbor_vectors is not None
+        or neighbor_distances is not None
+        or pair_fn is not None
     )
+    compact_topology_partial = (
+        target_indices is not None and not real_geometry_or_pair_outputs
+    )
+    partial_tile_selected = False
+    if compact_topology_partial:
+        if graph_mode == "warp" and strategy == "scalar":
+            raise ValueError(
+                "Partial graph_mode='warp' requires strategy='auto' or "
+                "strategy='tile'.",
+            )
+        if graph_mode == "warp":
+            strategy = "tile"
+        else:
+            strategy = _resolve_naive_strategy(
+                strategy,
+                _NaiveWorkload(
+                    device_kind=_jax_array_device_kind(positions),
+                    wp_dtype=(
+                        wp.float64 if positions.dtype == jnp.float64 else wp.float32
+                    ),
+                    num_atoms=int(positions.shape[0]),
+                    num_systems=1,
+                    partial=True,
+                    batched=False,
+                    pbc=pbc is not None,
+                    wrap_positions=wrap_positions,
+                    geometry_outputs=False,
+                ),
+            )
+        partial_tile_selected = strategy == "tile"
     partial_tile_warp = graph_mode == "warp" and partial_tile_selected
     if partial_tile_warp:
         if return_neighbor_list:
@@ -2719,11 +2652,13 @@ def naive_neighbor_list(
         # The tile-cooperative kernel is CUDA-only and has no geometry/pair_fn,
         # selective (rebuild_flags), or full-row CUDA-graph variant. Compact
         # topology-only rows use the partial Warp-graph callable family.
-        if _is_jax_cpu_array(positions):
-            raise ValueError(
-                "strategy='tile' requires CUDA; the tile-cooperative "
-                "naive kernel cannot run on a CPU device (Warp forces "
-                "block_dim=1). Use strategy='scalar' or 'auto' on CPU.",
+        device_kind = _jax_array_device_kind(positions)
+        if device_kind == "cpu":
+            _require_cuda_tile_device("cpu")
+        elif device_kind == "unknown":
+            default_backend = jax.default_backend()
+            _require_cuda_tile_device(
+                "cuda" if default_backend in {"gpu", "cuda"} else default_backend,
             )
         if (
             bool(return_distances)
@@ -2747,13 +2682,10 @@ def naive_neighbor_list(
                 "topology-only target_indices.",
             )
 
-    has_pair_outputs = (
-        bool(return_distances)
-        or bool(return_vectors)
-        or pair_fn is not None
-        or target_indices is not None
+    uses_compact_pair_kernel = (
+        real_geometry_or_pair_outputs or target_indices is not None
     )
-    if has_pair_outputs:
+    if uses_compact_pair_kernel:
         if (
             graph_mode != "none" and not partial_tile_warp
         ) or rebuild_flags is not None:
@@ -2804,6 +2736,83 @@ def naive_neighbor_list(
             (num_rows, int(max_neighbors), 3),
             positions.dtype,
         )
+        if target_indices is not None and (cutoff <= 0 or num_rows == 0):
+            matrix_out = (
+                jnp.full((num_rows, max_neighbors), fill_value, dtype=jnp.int32)
+                if neighbor_matrix is None
+                else neighbor_matrix.at[:].set(jnp.int32(fill_value))
+            )
+            counts_out = (
+                jnp.zeros(num_rows, dtype=jnp.int32)
+                if num_neighbors is None
+                else num_neighbors.at[:].set(jnp.int32(0))
+            )
+            distances_out = (
+                jnp.zeros((num_rows, max_neighbors), dtype=positions.dtype)
+                if neighbor_distances is None
+                else neighbor_distances.at[:].set(
+                    jnp.asarray(0.0, dtype=positions.dtype)
+                )
+            )
+            vectors_out = (
+                jnp.zeros((num_rows, max_neighbors, 3), dtype=positions.dtype)
+                if neighbor_vectors is None
+                else neighbor_vectors.at[:].set(jnp.asarray(0.0, dtype=positions.dtype))
+            )
+            if pair_fn is not None:
+                energies_out = jnp.zeros(
+                    (num_rows, max_neighbors),
+                    dtype=positions.dtype,
+                )
+                forces_out = jnp.zeros(
+                    (num_rows, max_neighbors, 3),
+                    dtype=positions.dtype,
+                )
+
+            tail: list[jax.Array] = []
+            if return_distances:
+                tail.append(
+                    jnp.zeros((0,), dtype=positions.dtype)
+                    if return_neighbor_list
+                    else distances_out
+                )
+            if return_vectors:
+                tail.append(
+                    jnp.zeros((0, 3), dtype=positions.dtype)
+                    if return_neighbor_list
+                    else vectors_out
+                )
+            if pair_fn is not None:
+                if return_neighbor_list:
+                    tail.extend(
+                        (
+                            jnp.zeros((0,), dtype=positions.dtype),
+                            jnp.zeros((0, 3), dtype=positions.dtype),
+                        ),
+                    )
+                else:
+                    tail.extend((energies_out, forces_out))
+            if pbc is not None:
+                shifts_out = (
+                    jnp.zeros((num_rows, max_neighbors, 3), dtype=jnp.int32)
+                    if neighbor_matrix_shifts is None
+                    else neighbor_matrix_shifts.at[:].set(jnp.int32(0))
+                )
+                if return_neighbor_list:
+                    return (
+                        jnp.zeros((2, 0), dtype=jnp.int32),
+                        jnp.zeros((num_rows + 1,), dtype=jnp.int32),
+                        jnp.zeros((0, 3), dtype=jnp.int32),
+                        *tail,
+                    )
+                return matrix_out, counts_out, shifts_out, *tail
+            if return_neighbor_list:
+                return (
+                    jnp.zeros((2, 0), dtype=jnp.int32),
+                    jnp.zeros((num_rows + 1,), dtype=jnp.int32),
+                    *tail,
+                )
+            return matrix_out, counts_out, *tail
         if cell is not None and cell.ndim == 2:
             cell_norm = cell[jnp.newaxis, :, :]
         else:
@@ -2919,7 +2928,7 @@ def naive_neighbor_list(
             "positions_wrapped": partial_positions_wrapped,
             "per_atom_cell_offsets": partial_per_atom_cell_offsets,
         }
-        if topology_only_partial:
+        if compact_topology_partial:
             # Do not reconstruct the full compact ``(rows, max_neighbors)``
             # geometry only to discard it. This keeps topology-only partial
             # timing focused on the Warp search/callback and avoids unnecessary
@@ -3211,10 +3220,7 @@ def naive_neighbor_list(
     ) = _jax_scalar_sentinels(positions.dtype)
 
     if strategy == "tile":
-        # CUDA-only tile-cooperative path (eager / graph_mode="none" only).
-        # Output buffers were already pre-filled above; the callable bodies
-        # call the inner warp launchers with strategy="tile" and rely on
-        # the host-static cutoff / half_fill / num_shifts scalars (no new sync).
+        # Eager tile calls use pre-filled topology outputs and static launch scalars.
         cutoff_static = float(cutoff)
         if pbc is None:
             tile_callable = _GRAPH_NAIVE_TILE_CALLABLES[(False, False, positions.dtype)]

--- a/nvalchemiops/jax/neighbors/naive.py
+++ b/nvalchemiops/jax/neighbors/naive.py
@@ -2352,9 +2352,10 @@ def naive_neighbor_list(
     neighbor_vectors : jax.Array, shape (num_rows, max_neighbors, 3), optional
         Pre-shaped vector output for ``return_vectors=True`` or ``pair_fn``.
     target_indices : jax.Array, shape (num_targets,), dtype=int32, optional
-        Compact partial-list source rows. Output row ``r`` maps to atom
-        ``target_indices[r]``; COO source rows remain compact row ids. User
-        buffers must be compact-row shaped, not full atom-row shaped.
+        Indices of the central atoms for compact partial rows. Output row ``r``
+        maps to atom ``target_indices[r]``. In COO output, the first row holds
+        compact row ids. User buffers must be compact-row shaped, not full
+        atom-row shaped. Values must be unique and in bounds.
     wrap_positions : bool, default=True
         If True, wrap input positions into the primary cell before
         neighbor search. Set to False when positions are already
@@ -2366,9 +2367,13 @@ def naive_neighbor_list(
         ``wp.launch_tiled`` kernel and is **CUDA-only**: requesting it on a
         CPU device raises ``ValueError``. Tile supports topology-only compact
         ``target_indices`` rows; geometry and pair outputs use the scalar path.
-        Partial neighbor lists do not support ``rebuild_flags``. The tile and
-        scalar paths produce identical pair *multisets* (per-row ordering may
-        differ).
+        For concrete eager CUDA arrays, topology-only single-system partial
+        ``"auto"`` selects a strategy from the dtype and atom count. Non-replay
+        traced and batched partial ``"auto"`` remain scalar.
+        ``graph_mode="warp"`` requires tile and therefore routes ``"auto"`` to
+        tile. Partial neighbor lists do not support ``rebuild_flags``. The tile
+        and scalar paths produce identical pair *multisets* (per-row ordering
+        may differ).
     inv_cell : jax.Array, shape (1, 3, 3), dtype matches positions, optional
         Inverse cell matrix consumed by the wrap kernel. Only used when
         ``pbc`` is provided and ``wrap_positions=True``. Pass in a
@@ -2421,8 +2426,8 @@ def naive_neighbor_list(
               neighbors for atom ``r`` or ``target_indices[r]`` when partial rows
               are requested.
             * If ``return_neighbor_list=True``: Returns ``neighbor_list`` with shape
-              (2, num_pairs), dtype int32, in COO format [source_rows, target_atoms].
-              With ``target_indices``, source rows are compact row ids.
+              (2, num_pairs), dtype int32, in COO format [central_rows, neighbor_atoms].
+              With ``target_indices``, central rows are compact row ids.
 
         - **num_neighbor_data** (array): Information about the number of neighbors for each atom,
           format depends on ``return_neighbor_list``:
@@ -2655,11 +2660,6 @@ def naive_neighbor_list(
         device_kind = _jax_array_device_kind(positions)
         if device_kind == "cpu":
             _require_cuda_tile_device("cpu")
-        elif device_kind == "unknown":
-            default_backend = jax.default_backend()
-            _require_cuda_tile_device(
-                "cuda" if default_backend in {"gpu", "cuda"} else default_backend,
-            )
         if (
             bool(return_distances)
             or bool(return_vectors)

--- a/nvalchemiops/jax/neighbors/naive.py
+++ b/nvalchemiops/jax/neighbors/naive.py
@@ -59,11 +59,6 @@ from nvalchemiops.neighbors.neighbor_utils import (
 _DTYPE_TO_NAIVE_KERNELS = (wp.float32, wp.float64)
 
 
-def _is_jax_cpu_for_tile(array: jax.Array) -> bool:
-    """Return whether the concrete JAX array is CPU-backed for tile dispatch."""
-    return _is_jax_cpu_array(array)
-
-
 (
     _fill_naive_neighbor_matrix_kernels,
     _fill_naive_neighbor_matrix_selective_kernels,
@@ -2667,7 +2662,7 @@ def naive_neighbor_list(
         strategy == "tile"
         or (
             strategy == "auto"
-            and not _is_jax_cpu_for_tile(positions)
+            and not _is_jax_cpu_array(positions)
             and int(positions.shape[0]) >= partial_tile_min_atoms
         )
     )
@@ -2677,11 +2672,6 @@ def naive_neighbor_list(
             raise ValueError(
                 "graph_mode='warp' with topology-only target_indices requires "
                 "return_neighbor_list=False because COO output has dynamic shape."
-            )
-        if target_indices.ndim != 1 or target_indices.dtype != jnp.int32:
-            raise ValueError(
-                "graph_mode='warp' with topology-only target_indices requires "
-                "a rank-one int32 target_indices array."
             )
         missing_outputs = neighbor_matrix is None or num_neighbors is None
         if pbc is not None:
@@ -2729,7 +2719,7 @@ def naive_neighbor_list(
         # The tile-cooperative kernel is CUDA-only and has no geometry/pair_fn,
         # selective (rebuild_flags), or full-row CUDA-graph variant. Compact
         # topology-only rows use the partial Warp-graph callable family.
-        if _is_jax_cpu_for_tile(positions):
+        if _is_jax_cpu_array(positions):
             raise ValueError(
                 "strategy='tile' requires CUDA; the tile-cooperative "
                 "naive kernel cannot run on a CPU device (Warp forces "

--- a/nvalchemiops/neighbors/base_dispatch.py
+++ b/nvalchemiops/neighbors/base_dispatch.py
@@ -420,7 +420,7 @@ def get_select_neighbor_list_method_cost_kernel(wp_dtype: type) -> wp.Kernel:
         feature_mask : int
             Device/dtype/frontend feature bits.
         target_count : int
-            Number of targeted source rows when ``target_indices`` is active.
+            Number of compact central rows when ``target_indices`` is active.
             Zero means "all atoms".
         costs : wp.array, shape (5,), dtype=wp.float32
             OUTPUT: ``(naive_scalar, naive_tile, cell_atom, cell_pair,
@@ -538,7 +538,7 @@ def get_select_neighbor_list_method_cost_kernel(wp_dtype: type) -> wp.Kernel:
             active_atoms = min(active_atoms, n_atoms)
         active_float = wp.float32(active_atoms)
         n_sq = n_float * n_float
-        # Naive candidate count: each of ``active`` source atoms is tested against
+        # Naive candidate count: each active central atom is tested against
         # all ``n`` atoms, so active_n_work ~ N^2 distance checks. n_pairs_cap =
         # n*(n-1) is the exact upper bound on real pairs.
         active_n_work = active_float * n_float
@@ -626,7 +626,7 @@ def get_select_neighbor_list_method_cost_kernel(wp_dtype: type) -> wp.Kernel:
         cutoff_volume = wp.max(cutoff_volume, wp.float32(_EPS))
         density = n_float / wp.max(volume, wp.float32(_EPS))
         # Expected output work, shared by every method: neighbors per atom
-        # (density * cutoff-sphere volume) times the active source atoms,
+        # (density * cutoff-sphere volume) times the active central atoms,
         # capped by the exact pair count for non-periodic and halved for half_fill.
         expected_neighbors = density * wp.float32(_SPHERE_VOLUME_FACTOR) * cutoff_volume
         expected_pairs = active_float * expected_neighbors
@@ -909,8 +909,8 @@ def estimate_neighbor_list_costs(
         Device/dtype/frontend feature bits.  When omitted, CUDA and cell dtype
         are inferred from the Warp arrays.
     target_count : int, optional
-        Number of source rows requested by ``target_indices``.  When omitted,
-        the selector scores all atoms.  Frontends should pass
+        Number of compact central rows requested by ``target_indices``. When
+        omitted, the selector scores all atoms. Frontends should pass
         ``len(target_indices)`` when the public ``target_indices`` kwarg is
         active.
 

--- a/nvalchemiops/neighbors/cell_list/dispatch.py
+++ b/nvalchemiops/neighbors/cell_list/dispatch.py
@@ -274,7 +274,7 @@ def is_pair_centric_parallelism_sufficient(
     Parameters
     ----------
     total_atoms : int
-        Number of source atoms in the query.
+        Number of central atoms in the query.
     total_cells : int
         Number of source cells in the pair-centric launch.
     n_outer : int
@@ -316,11 +316,6 @@ def select_cell_list_strategy(
 
     To pin a strategy, pass it explicitly (``cell_list(..., strategy=...)`` or a
     fine-grained ``method=`` name) rather than via an environment variable.
-
-    Calibrated on GB10 sm_121.  Cross-GPU sensitivity is real but
-    bounded (<= ~35 % wallclock penalty per cell, <= ~3 % mean) - recalibrate
-    by sweeping ``benchmark_neighborlist.py --methods
-    cell_list_atom_centric cell_list_pair_centric`` and editing the rule above.
     """
     n = int(natom)
     c = float(cutoff)
@@ -369,12 +364,6 @@ def select_batch_cell_list_strategy(
 
     To pin a strategy, pass it explicitly rather than via an environment
     variable.
-
-    Calibrated on Blackwell GB10.  The thresholds are env-tunable; the
-    cost of picking wrong is bounded (<= ~20 % mean wallclock penalty on
-    cross-GPU measurements).  Recalibrate by sweeping
-    ``benchmark_neighborlist.py --methods batch_cell_list_atom_centric
-    batch_cell_list_pair_centric`` and resetting the threshold env vars above.
     """
 
     def _i(name: str) -> int:

--- a/nvalchemiops/neighbors/cell_list/kernels.py
+++ b/nvalchemiops/neighbors/cell_list/kernels.py
@@ -753,7 +753,7 @@ def _fill_target_row_lookup(
     Parameters
     ----------
     target_indices : wp.array, shape (n_targets,), dtype=wp.int32
-        Target atom indices in compact row order.
+        Central-atom indices in compact row order.
     target_row_lookup : wp.array, shape (total_atoms,), dtype=wp.int32
         OUTPUT: Atom-id to compact row lookup.
 
@@ -1000,7 +1000,7 @@ def _make_atom_centric_kernel(
         cell_offsets : wp.array, shape (num_systems,), dtype=wp.int32
             Global cell offset per system. Sentinel in single-system mode.
         target_indices : wp.array, shape (n_targets,), dtype=wp.int32
-            Compact target rows for partial neighbor lists. Sentinel for full mode.
+            Central-atom indices for compact partial rows. Sentinel for full mode.
         neighbor_matrix : wp.array, shape (rows, max_neighbors), dtype=wp.int32
             OUTPUT: Neighbor atom indices.
         neighbor_matrix_shifts : wp.array, shape (rows, max_neighbors), dtype=wp.vec3i

--- a/nvalchemiops/neighbors/cell_list/launchers.py
+++ b/nvalchemiops/neighbors/cell_list/launchers.py
@@ -361,7 +361,7 @@ def query_cell_list_atom_centric_sorted(
         provided so the central-atom read does not need to invert the
         sorted layout.
     target_indices : wp.array, shape (num_targets,), dtype=wp.int32, optional
-        Restrict source atoms to a subset.  Switches the kernel to a
+        Select central atoms for a compact partial list. Switches the kernel to a
         per-row iteration over ``target_indices`` and consults ``positions``
         / ``atom_periodic_shifts`` for central-atom reads.
     return_vectors, return_distances : bool, default ``False``

--- a/nvalchemiops/neighbors/cluster_tile/launchers.py
+++ b/nvalchemiops/neighbors/cluster_tile/launchers.py
@@ -638,7 +638,7 @@ def query_cluster_tile(
       that wrappers used to do to set the launch dimension.
     - Modifies: ``neighbor_matrix``, ``num_neighbors``,
       ``neighbor_matrix_shifts``, and any enabled pair-output buffers.
-    - Cluster-tile iterates emitted tile pairs rather than source atoms,
+    - Cluster-tile iterates emitted tile pairs rather than central atoms,
       so partial neighbor lists (``target_indices``) are not supported
       here. Use :func:`nvalchemiops.neighbors.cell_list.query_cell_list`
       or :func:`nvalchemiops.neighbors.naive.naive_neighbor_matrix` for

--- a/nvalchemiops/neighbors/naive/dispatch.py
+++ b/nvalchemiops/neighbors/naive/dispatch.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Literal
 
@@ -25,6 +26,95 @@ import warp as wp
 from nvalchemiops.neighbors.output_args import _has_partial_or_pair_outputs
 
 __all__: list[str] = []
+
+_SUPPORTED_DTYPES = (wp.float16, wp.float32, wp.float64)
+_PARTIAL_TILE_MIN_ATOMS_BY_DTYPE = {
+    wp.float16: 16 * 64,
+    wp.float32: 16 * 64,
+    wp.float64: 4 * 64,
+}
+
+_DeviceKind = Literal["cpu", "cuda", "unknown"]
+
+
+@dataclass(frozen=True)
+class _NaiveWorkload:
+    """Static properties used by naive strategy resolution."""
+
+    device_kind: _DeviceKind
+    wp_dtype: type
+    num_atoms: int
+    num_systems: int
+    partial: bool
+    batched: bool
+    pbc: bool
+    wrap_positions: bool
+    geometry_outputs: bool
+
+
+def _partial_tile_min_atoms(wp_dtype: type) -> int:
+    """Return the auto-dispatch atom threshold for partial tiled kernels."""
+    try:
+        return _PARTIAL_TILE_MIN_ATOMS_BY_DTYPE[wp_dtype]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported naive dtype: {wp_dtype!r}") from exc
+
+
+def _resolve_naive_strategy(
+    requested: Literal["auto", "scalar", "tile"],
+    workload: _NaiveWorkload,
+) -> Literal["scalar", "tile"]:
+    """Resolve a naive launcher strategy from static workload properties."""
+    if requested not in {"auto", "scalar", "tile"}:
+        raise ValueError(
+            f"strategy must be 'auto' | 'scalar' | 'tile', got {requested!r}",
+        )
+    if workload.device_kind not in {"cpu", "cuda", "unknown"}:
+        raise ValueError("device_kind must be 'cpu' | 'cuda' | 'unknown'")
+    if workload.wp_dtype not in _SUPPORTED_DTYPES:
+        raise ValueError(f"Unsupported naive dtype: {workload.wp_dtype!r}")
+    if workload.num_atoms < 0:
+        raise ValueError("num_atoms must be non-negative")
+    if workload.num_systems < 1:
+        raise ValueError("num_systems must be at least one")
+
+    if requested == "scalar":
+        return "scalar"
+    if requested == "tile":
+        if workload.geometry_outputs:
+            raise ValueError(
+                "strategy='tile' requires CUDA and no geometry or pair_fn outputs",
+            )
+        if workload.device_kind == "cpu":
+            raise ValueError("strategy='tile' requires CUDA")
+        return "tile"
+
+    if workload.geometry_outputs or workload.device_kind == "cpu":
+        return "scalar"
+    if workload.partial:
+        if workload.batched or workload.device_kind != "cuda":
+            return "scalar"
+        return (
+            "tile"
+            if workload.num_atoms >= _partial_tile_min_atoms(workload.wp_dtype)
+            else "scalar"
+        )
+    if not workload.batched:
+        return "tile"
+    if workload.pbc:
+        return "tile" if workload.wrap_positions else "scalar"
+    if workload.num_atoms < 2048:
+        return "scalar"
+    use_tiled = workload.num_atoms >= 256 * workload.num_systems
+    if use_tiled and workload.num_atoms > 12288:
+        use_tiled = workload.num_atoms >= 512 * workload.num_systems
+    return "tile" if use_tiled else "scalar"
+
+
+def _require_cuda_tile_device(device: str) -> None:
+    """Reject tile launches on a concrete CPU Warp device."""
+    if wp.get_device(device).is_cpu:
+        raise ValueError("strategy='tile' requires CUDA")
 
 
 class _PBCMode(Enum):

--- a/nvalchemiops/neighbors/naive/kernels.py
+++ b/nvalchemiops/neighbors/naive/kernels.py
@@ -1042,7 +1042,9 @@ def _make_tile_kernel(
                 shift = _decode_shift_index(ishift, shift_range[isys])
             current_cell = cell[isys]
             pos_i = positions[atom_i]
-            pos_i_image = _shifted_position(shift, current_cell, pos_i)
+            pos_i_image = pos_i
+            if not PARTIAL:
+                pos_i_image = _shifted_position(shift, current_cell, pos_i)
             atom_i_offset = wp.vec3i(0, 0, 0)
             if WRAP_ON_ENTRY:
                 atom_i_offset = per_atom_cell_offsets[atom_i]
@@ -1054,12 +1056,13 @@ def _make_tile_kernel(
             for chunk_start in range(j_start, j_end, BLOCK_DIM):
                 atom_j = chunk_start + lane
                 safe_j = wp.min(atom_j, positions.shape[0] - 1)
-                diff = pos_i_image - positions[safe_j]
                 if PARTIAL:
                     nbr_image = _shifted_position(
                         shift, current_cell, positions[safe_j]
                     )
                     diff = nbr_image - pos_i
+                else:
+                    diff = pos_i_image - positions[safe_j]
                 dist_sq = wp.dot(diff, diff)
                 active = atom_j < j_end and dist_sq < cutoff_sq
                 if PARTIAL and zero_shift and atom_j == atom_i:

--- a/nvalchemiops/neighbors/naive/kernels.py
+++ b/nvalchemiops/neighbors/naive/kernels.py
@@ -505,7 +505,7 @@ def _make_scalar_kernel(
         batch_ptr : wp.array, shape (num_systems + 1,), dtype=wp.int32
             Prefix offsets delimiting atoms per system in batched modes.
         target_indices : wp.array, shape (n_targets,), dtype=wp.int32
-            Compact target rows for partial neighbor lists. Zero-size sentinel
+            Indices of central atoms for compact partial rows. Zero-size sentinel
             for full neighbor-list specializations.
         neighbor_matrix1 : wp.array, shape (rows, max_neighbors), dtype=wp.int32
             OUTPUT: Primary neighbor matrix.
@@ -983,7 +983,7 @@ def _make_tile_kernel(
         batch_ptr : wp.array, shape (num_systems + 1,), dtype=wp.int32
             Prefix offsets delimiting atoms per system in batched modes.
         target_indices : wp.array, shape (n_targets,), dtype=wp.int32
-            Compact target rows for partial neighbor lists. Zero-size sentinel
+            Indices of central atoms for compact partial rows. Zero-size sentinel
             for full neighbor-list specializations.
         neighbor_matrix : wp.array, shape (rows, max_neighbors), dtype=wp.int32
             OUTPUT: Neighbor matrix.

--- a/nvalchemiops/neighbors/naive/kernels.py
+++ b/nvalchemiops/neighbors/naive/kernels.py
@@ -1191,6 +1191,10 @@ def get_naive_neighbor_matrix_kernel(
     if strat is _NaiveStrategy.TILE:
         if return_vectors or return_distances or pair_fn is not None:
             raise NotImplementedError("pair outputs currently use strategy='scalar'")
+        if partial and selective:
+            raise NotImplementedError(
+                "Partial tile kernels do not support selective rebuilds.",
+            )
         return _make_tile_kernel(
             wp_dtype,
             pbc_mode=mode,

--- a/nvalchemiops/neighbors/naive/kernels.py
+++ b/nvalchemiops/neighbors/naive/kernels.py
@@ -932,15 +932,15 @@ def _make_tile_kernel(
     batched: bool,
     half_fill: bool,
     selective: bool,
+    partial: bool,
 ) -> wp.Kernel:
     """Return a cached CUDA tile-cooperative single-cutoff kernel."""
     _require_supported_dtype(wp_dtype)
-    if batched and pbc_mode is _PBCMode.PREWRAPPED:
-        raise NotImplementedError("batched prewrapped PBC has no tiled kernel")
 
     vec_dtype, mat_dtype = _DTYPE_INFO[wp_dtype]
     BATCHED = bool(batched)
     SELECTIVE = bool(selective)
+    PARTIAL = bool(partial)
     HALF_FILL = wp.constant(bool(half_fill))
     PBC = pbc_mode is not _PBCMode.NONE
     WRAP_ON_ENTRY = pbc_mode is _PBCMode.WRAP_ON_ENTRY
@@ -955,6 +955,7 @@ def _make_tile_kernel(
         num_shifts_arr: wp.array(dtype=wp.int32),
         batch_idx: wp.array(dtype=wp.int32),
         batch_ptr: wp.array(dtype=wp.int32),
+        target_indices: wp.array(dtype=wp.int32),
         neighbor_matrix: wp.array(dtype=wp.int32, ndim=2),
         neighbor_matrix_shifts: wp.array(dtype=wp.vec3i, ndim=2),
         num_neighbors: wp.array(dtype=wp.int32),
@@ -981,11 +982,14 @@ def _make_tile_kernel(
             System index for each atom. Zero-size sentinel for single-system modes.
         batch_ptr : wp.array, shape (num_systems + 1,), dtype=wp.int32
             Prefix offsets delimiting atoms per system in batched modes.
-        neighbor_matrix : wp.array, shape (total_atoms, max_neighbors), dtype=wp.int32
+        target_indices : wp.array, shape (n_targets,), dtype=wp.int32
+            Compact target rows for partial neighbor lists. Zero-size sentinel
+            for full neighbor-list specializations.
+        neighbor_matrix : wp.array, shape (rows, max_neighbors), dtype=wp.int32
             OUTPUT: Neighbor matrix.
-        neighbor_matrix_shifts : wp.array, shape (total_atoms, max_neighbors), dtype=wp.vec3i
+        neighbor_matrix_shifts : wp.array, shape (rows, max_neighbors), dtype=wp.vec3i
             OUTPUT: Periodic shift matrix for PBC modes.
-        num_neighbors : wp.array, shape (total_atoms,), dtype=wp.int32
+        num_neighbors : wp.array, shape (rows,), dtype=wp.int32
             OUTPUT: Per-atom neighbor counts.
         rebuild_flags : wp.array, shape (num_systems,), dtype=wp.bool
             Selective rebuild flags. Sentinel for non-selective specializations.
@@ -999,14 +1003,18 @@ def _make_tile_kernel(
         -----
         - Thread launch: Tiled launch with one tile block per ``(shift, source atom)`` pair. No-PBC launchers use a single sentinel shift.
         - Modifies: ``neighbor_matrix``, ``neighbor_matrix_shifts`` in PBC modes, and ``num_neighbors``.
-        PBC, batching, wrap-on-entry, and selective rebuild are static factory
-        specializations. Inactive inputs are zero-size sentinels and are not read.
+        PBC, batching, wrap-on-entry, selective rebuild, and partial rows are
+        static factory specializations. Inactive inputs are zero-size sentinels
+        and are not read.
 
         See Also
         --------
         get_naive_neighbor_matrix_kernel : Return the specialized naive tile-output kernel.
         """
-        ishift, atom_i = wp.tid()
+        ishift, row = wp.tid()
+        atom_i = row
+        if PARTIAL:
+            atom_i = target_indices[row]
         isys = wp.int32(0)
         j_start = wp.int32(0)
         j_end = positions.shape[0]
@@ -1023,9 +1031,15 @@ def _make_tile_kernel(
 
         if PBC:
             if BATCHED and ishift >= num_shifts_arr[isys]:
-                return
+                if not PARTIAL or HALF_FILL or ishift >= 2 * num_shifts_arr[isys] - 1:
+                    return
 
-            shift = _decode_shift_index(ishift, shift_range[isys])
+            shift = wp.vec3i(0, 0, 0)
+            if PARTIAL and not HALF_FILL:
+                if ishift > 0:
+                    shift = _decode_full_shift_index(ishift - 1, shift_range[isys])
+            else:
+                shift = _decode_shift_index(ishift, shift_range[isys])
             current_cell = cell[isys]
             pos_i = positions[atom_i]
             pos_i_image = _shifted_position(shift, current_cell, pos_i)
@@ -1033,15 +1047,38 @@ def _make_tile_kernel(
             if WRAP_ON_ENTRY:
                 atom_i_offset = per_atom_cell_offsets[atom_i]
 
-            if shift[0] == 0 and shift[1] == 0 and shift[2] == 0:
+            zero_shift = shift[0] == 0 and shift[1] == 0 and shift[2] == 0
+            if not PARTIAL and zero_shift:
                 j_end = atom_i
 
             for chunk_start in range(j_start, j_end, BLOCK_DIM):
                 atom_j = chunk_start + lane
                 safe_j = wp.min(atom_j, positions.shape[0] - 1)
                 diff = pos_i_image - positions[safe_j]
+                if PARTIAL:
+                    nbr_image = _shifted_position(
+                        shift, current_cell, positions[safe_j]
+                    )
+                    diff = nbr_image - pos_i
                 dist_sq = wp.dot(diff, diff)
-                if atom_j < j_end and dist_sq < cutoff_sq:
+                active = atom_j < j_end and dist_sq < cutoff_sq
+                if PARTIAL and zero_shift and atom_j == atom_i:
+                    active = False
+                if PARTIAL and HALF_FILL and zero_shift and atom_j <= atom_i:
+                    active = False
+                if active:
+                    if PARTIAL:
+                        stored_shift = shift
+                        if WRAP_ON_ENTRY:
+                            atom_j_offset = per_atom_cell_offsets[atom_j]
+                            stored_shift = _correct_shift(
+                                shift, atom_i_offset, atom_j_offset
+                            )
+                        pos = wp.atomic_add(num_neighbors, row, 1)
+                        if pos < max_neighbors:
+                            neighbor_matrix[row, pos] = atom_j
+                            neighbor_matrix_shifts[row, pos] = stored_shift
+                        continue
                     # Tile traversal writes the shifted atom as the row;
                     # match the scalar row-local shift convention.
                     stored_shift = -shift
@@ -1065,12 +1102,23 @@ def _make_tile_kernel(
             return
 
         pos_i = positions[atom_i]
-        for chunk_start in range(atom_i + 1, j_end, BLOCK_DIM):
+        no_pbc_start = atom_i + 1
+        if PARTIAL and not HALF_FILL:
+            no_pbc_start = j_start
+        for chunk_start in range(no_pbc_start, j_end, BLOCK_DIM):
             atom_j = chunk_start + lane
             safe_j = wp.min(atom_j, positions.shape[0] - 1)
             diff = pos_i - positions[safe_j]
             dist_sq = wp.dot(diff, diff)
-            if atom_j < j_end and dist_sq < cutoff_sq:
+            active = atom_j < j_end and dist_sq < cutoff_sq
+            if PARTIAL and atom_j == atom_i:
+                active = False
+            if active:
+                if PARTIAL:
+                    pos = wp.atomic_add(num_neighbors, row, 1)
+                    if pos < max_neighbors:
+                        neighbor_matrix[row, pos] = atom_j
+                    continue
                 _update_neighbor_matrix(
                     atom_i,
                     atom_j,
@@ -1091,7 +1139,11 @@ def _make_tile_kernel(
             selective=SELECTIVE,
         ),
         wp_dtype=wp_dtype,
-        features=("tile", "half" if bool(half_fill) else ""),
+        features=(
+            "tile",
+            "half" if bool(half_fill) else "",
+            "partial" if PARTIAL else "",
+        ),
     )
     return set_fn_doc(
         set_fn_name(_kernel, name),
@@ -1105,6 +1157,7 @@ def _make_tile_kernel(
                 ("batched", BATCHED),
                 ("half_fill", bool(half_fill)),
                 ("selective", SELECTIVE),
+                ("partial", PARTIAL),
             ),
         ),
     )
@@ -1133,7 +1186,7 @@ def get_naive_neighbor_matrix_kernel(
     mode = _parse_pbc_mode(pbc_mode)
     strat = _parse_strategy(strategy)
     if strat is _NaiveStrategy.TILE:
-        if partial or return_vectors or return_distances or pair_fn is not None:
+        if return_vectors or return_distances or pair_fn is not None:
             raise NotImplementedError("pair outputs currently use strategy='scalar'")
         return _make_tile_kernel(
             wp_dtype,
@@ -1141,6 +1194,7 @@ def get_naive_neighbor_matrix_kernel(
             batched=batched,
             half_fill=half_fill,
             selective=selective,
+            partial=partial,
         )
     return _make_scalar_kernel(
         "single_cutoff",

--- a/nvalchemiops/neighbors/naive/launchers.py
+++ b/nvalchemiops/neighbors/naive/launchers.py
@@ -17,14 +17,17 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 import warp as wp
 
 from nvalchemiops.neighbors.naive.dispatch import (
     _has_naive_pair_outputs,
     _is_cpu_device,
+    _NaiveWorkload,
     _pbc_mode_from_wrap,
+    _require_cuda_tile_device,
+    _resolve_naive_strategy,
 )
 from nvalchemiops.neighbors.naive.kernels import (
     BLOCK_DIM,
@@ -36,7 +39,6 @@ from nvalchemiops.neighbors.neighbor_utils import (
     compute_inv_cells,
     resolve_buffer_alias,
     selective_zero_num_neighbors,
-    selective_zero_partial_num_neighbors,
     wrap_positions_batch,
     wrap_positions_single,
 )
@@ -65,16 +67,6 @@ _SUPPORTED_DTYPES = (wp.float16, wp.float32, wp.float64)
 _DTYPE_INFO: dict[type, tuple[type, type]] = {
     dtype: DTYPE_INFO_ALL[dtype] for dtype in _SUPPORTED_DTYPES
 }
-_PARTIAL_TILE_MIN_ATOMS_BY_DTYPE = {
-    wp.float16: 16 * BLOCK_DIM,
-    wp.float32: 16 * BLOCK_DIM,
-    wp.float64: 4 * BLOCK_DIM,
-}
-
-
-def _partial_tile_min_atoms(wp_dtype: type) -> int:
-    """Return the auto-dispatch atom threshold for partial tiled kernels."""
-    return _PARTIAL_TILE_MIN_ATOMS_BY_DTYPE[wp_dtype]
 
 
 class _ScalarSentinels(NamedTuple):
@@ -98,6 +90,152 @@ class _ScalarSentinels(NamedTuple):
     rebuild_flags: wp.array
 
 
+def _launch_partial_tile_no_pbc(
+    positions: wp.array,
+    cutoff: float,
+    target_indices: wp.array,
+    neighbor_matrix: wp.array,
+    num_neighbors: wp.array,
+    wp_dtype: type,
+    device: str,
+    *,
+    half_fill: bool,
+    reset_outputs: bool = False,
+    fill_value: int | None = None,
+) -> None:
+    """Launch a single-system partial topology tile kernel without PBC."""
+    _require_cuda_tile_device(device)
+    if reset_outputs:
+        if fill_value is None:
+            raise ValueError("fill_value is required when resetting outputs")
+        neighbor_matrix.fill_(fill_value)
+        num_neighbors.zero_()
+    (
+        empty_offsets,
+        empty_cell,
+        empty_shift_range,
+        empty_num_shifts,
+        empty_batch_idx,
+        empty_batch_ptr,
+        _empty_target_indices,
+        empty_matrix,
+        empty_shifts,
+        _empty_num_neighbors,
+        _empty_vectors,
+        _empty_distances,
+        _empty_pair_params,
+        _empty_energies,
+        _empty_forces,
+        empty_rebuild_flags,
+    ) = _scalar_sentinels(wp_dtype, device)
+    wp.launch_tiled(
+        kernel=get_naive_neighbor_matrix_kernel(
+            wp_dtype,
+            pbc_mode="none",
+            batched=False,
+            half_fill=half_fill,
+            selective=False,
+            partial=True,
+            strategy="tile",
+        ),
+        dim=[1, target_indices.shape[0]],
+        inputs=[
+            positions,
+            empty_offsets,
+            wp_dtype(cutoff * cutoff),
+            empty_cell,
+            empty_shift_range,
+            empty_num_shifts,
+            empty_batch_idx,
+            empty_batch_ptr,
+            target_indices,
+            neighbor_matrix,
+            empty_shifts,
+            num_neighbors,
+            empty_rebuild_flags,
+        ],
+        block_dim=BLOCK_DIM,
+        device=device,
+    )
+
+
+def _launch_partial_tile_pbc_prepared(
+    positions_work: wp.array,
+    per_atom_cell_offsets: wp.array,
+    cutoff: float,
+    cell: wp.array,
+    shift_range: wp.array,
+    target_indices: wp.array,
+    neighbor_matrix: wp.array,
+    neighbor_matrix_shifts: wp.array,
+    num_neighbors: wp.array,
+    wp_dtype: type,
+    device: str,
+    *,
+    num_shifts: int,
+    half_fill: bool,
+    pbc_mode: Literal["prewrapped", "wrap_on_entry"],
+    reset_outputs: bool = False,
+    fill_value: int | None = None,
+) -> None:
+    """Launch a prepared single-system partial topology tile PBC kernel."""
+    _require_cuda_tile_device(device)
+    if reset_outputs:
+        if fill_value is None:
+            raise ValueError("fill_value is required when resetting outputs")
+        neighbor_matrix.fill_(fill_value)
+        neighbor_matrix_shifts.zero_()
+        num_neighbors.zero_()
+    (
+        empty_offsets,
+        _empty_cell,
+        _empty_shift_range,
+        empty_num_shifts,
+        empty_batch_idx,
+        empty_batch_ptr,
+        _empty_target_indices,
+        empty_matrix,
+        empty_shifts,
+        _empty_num_neighbors,
+        _empty_vectors,
+        _empty_distances,
+        _empty_pair_params,
+        _empty_energies,
+        _empty_forces,
+        empty_rebuild_flags,
+    ) = _scalar_sentinels(wp_dtype, device)
+    active_shifts = num_shifts if half_fill else 2 * num_shifts - 1
+    wp.launch_tiled(
+        kernel=get_naive_neighbor_matrix_kernel(
+            wp_dtype,
+            pbc_mode=pbc_mode,
+            batched=False,
+            half_fill=half_fill,
+            selective=False,
+            partial=True,
+            strategy="tile",
+        ),
+        dim=[active_shifts, target_indices.shape[0]],
+        inputs=[
+            positions_work,
+            per_atom_cell_offsets,
+            wp_dtype(cutoff * cutoff),
+            cell,
+            shift_range,
+            empty_num_shifts,
+            empty_batch_idx,
+            empty_batch_ptr,
+            target_indices,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            num_neighbors,
+            empty_rebuild_flags,
+        ],
+        block_dim=BLOCK_DIM,
+        device=device,
+    )
+
+
 def _reject_pair_fn_for_dual_cutoff(
     pair_fn: wp.Function | None, pair_params: wp.array | None
 ) -> None:
@@ -106,6 +244,17 @@ def _reject_pair_fn_for_dual_cutoff(
         raise ValueError("pair_fn is not supported with dual_cutoff=True")
     if pair_params is not None and not _is_empty_pair_params(pair_params):
         raise ValueError("pair_params is only valid when pair_fn is provided")
+
+
+def _reject_partial_rebuild(
+    target_indices: wp.array | None,
+    rebuild_flags: wp.array | None,
+) -> None:
+    """Reject unsupported compact selective rebuilds before mutation."""
+    if target_indices is not None and rebuild_flags is not None:
+        raise NotImplementedError(
+            "Partial neighbor lists do not support rebuild_flags",
+        )
 
 
 def _wrap_pbc_positions(
@@ -247,10 +396,11 @@ def _launch_naive_neighbor_matrix_no_pbc(
     strategy: str = "auto",
 ) -> None:
     """Launch the single-cutoff no-PBC naive neighbor-matrix path."""
+    _reject_partial_rebuild(target_indices, rebuild_flags)
     if batched and (batch_idx is None or batch_ptr is None):
         raise ValueError("batch_idx and batch_ptr are required for batched launch")
 
-    has_pair_outputs = _has_naive_pair_outputs(
+    uses_compact_pair_kernel = _has_naive_pair_outputs(
         target_indices,
         return_vectors,
         return_distances,
@@ -261,7 +411,7 @@ def _launch_naive_neighbor_matrix_no_pbc(
         pair_energies,
         pair_forces,
     )
-    has_geometry_outputs = _has_naive_pair_outputs(
+    has_geometry_or_pair_outputs = _has_naive_pair_outputs(
         None,
         return_vectors,
         return_distances,
@@ -273,48 +423,21 @@ def _launch_naive_neighbor_matrix_no_pbc(
         pair_forces,
     )
     partial = target_indices is not None
-    # Dispatch scalar vs tile-cooperative. Geometry/pair-function outputs have
-    # only a scalar specialization; topology-only partial rows can tile. CPU
-    # always uses scalar (Warp forces block_dim=1). The single-system path tiles
-    # on CUDA unconditionally except for small automatic partial launches, while
-    # the batched path applies the adaptive
-    # ``use_tiled`` heuristic: the tile-cooperative kernel wins for
-    # few-large-systems but the scalar thread-local-counter kernel wins for
-    # many-small-systems, so dispatch on the atoms-per-system density.
-    if strategy not in {"auto", "scalar", "tile"}:
-        raise ValueError(
-            f"strategy must be 'auto' | 'scalar' | 'tile', got {strategy!r}",
-        )
-    if strategy == "scalar":
-        strategy = "scalar"
-    elif strategy == "tile":
-        if has_geometry_outputs or _is_cpu_device(device):
-            raise ValueError(
-                "strategy='tile' requires CUDA and no geometry or pair_fn outputs",
-            )
-        strategy = "tile"
-    elif has_geometry_outputs or _is_cpu_device(device):
-        strategy = "scalar"
-    elif partial and not batched:
-        strategy = (
-            "tile"
-            if positions.shape[0] >= _partial_tile_min_atoms(wp_dtype)
-            else "scalar"
-        )
-    elif partial:
-        strategy = "scalar"
-    elif batched:
-        total_atoms = positions.shape[0]
-        if total_atoms < 2048:
-            use_tiled = False
-        else:
-            num_systems = batch_ptr.shape[0] - 1
-            use_tiled = total_atoms >= 256 * num_systems
-            if use_tiled and total_atoms > 12288:
-                use_tiled = total_atoms >= 512 * num_systems
-        strategy = "tile" if use_tiled else "scalar"
-    else:
-        strategy = "tile"
+    num_systems = int(batch_ptr.shape[0] - 1) if batched else 1
+    strategy = _resolve_naive_strategy(
+        strategy,
+        _NaiveWorkload(
+            device_kind="cpu" if _is_cpu_device(device) else "cuda",
+            wp_dtype=wp_dtype,
+            num_atoms=int(positions.shape[0]),
+            num_systems=num_systems,
+            partial=partial,
+            batched=batched,
+            pbc=False,
+            wrap_positions=True,
+            geometry_outputs=has_geometry_or_pair_outputs,
+        ),
+    )
 
     (
         empty_offsets,
@@ -345,6 +468,19 @@ def _launch_naive_neighbor_matrix_no_pbc(
     cutoff_sq = wp_dtype(cutoff * cutoff)
 
     if strategy == "tile":
+        if partial and not batched:
+            _launch_partial_tile_no_pbc(
+                positions,
+                cutoff,
+                target_indices,
+                neighbor_matrix,
+                num_neighbors,
+                wp_dtype,
+                device,
+                half_fill=half_fill,
+            )
+            return
+        _require_cuda_tile_device(device)
         wp.launch_tiled(
             kernel=get_naive_neighbor_matrix_kernel(
                 wp_dtype,
@@ -376,7 +512,7 @@ def _launch_naive_neighbor_matrix_no_pbc(
         )
         return
 
-    if has_pair_outputs:
+    if uses_compact_pair_kernel:
         (
             neighbor_vectors_arg,
             neighbor_distances_arg,
@@ -486,19 +622,24 @@ def _launch_naive_neighbor_matrix_pbc(
     strategy: str = "auto",
 ) -> None:
     """Launch the single-cutoff PBC naive neighbor-matrix path."""
+    _reject_partial_rebuild(target_indices, rebuild_flags)
+    partial = target_indices is not None
     if batched:
         if batch_ptr is None or batch_idx is None or num_shifts_arr is None:
             raise ValueError(
                 "batch_ptr, batch_idx, and num_shifts_arr are required for batched PBC"
             )
-        if max_shifts_per_system is None or max_atoms_per_system is None:
+        if max_shifts_per_system is None or (
+            not partial and max_atoms_per_system is None
+        ):
             raise ValueError(
-                "max_shifts_per_system and max_atoms_per_system are required for batched PBC"
+                "max_shifts_per_system is required for batched PBC; "
+                "max_atoms_per_system is also required for full-row launches",
             )
     elif num_shifts is None:
         raise ValueError("num_shifts is required for single-system PBC")
 
-    has_pair_outputs = _has_naive_pair_outputs(
+    uses_compact_pair_kernel = _has_naive_pair_outputs(
         target_indices,
         return_vectors,
         return_distances,
@@ -509,7 +650,7 @@ def _launch_naive_neighbor_matrix_pbc(
         pair_energies,
         pair_forces,
     )
-    has_geometry_outputs = _has_naive_pair_outputs(
+    has_geometry_or_pair_outputs = _has_naive_pair_outputs(
         None,
         return_vectors,
         return_distances,
@@ -520,33 +661,26 @@ def _launch_naive_neighbor_matrix_pbc(
         pair_energies,
         pair_forces,
     )
-    partial = target_indices is not None
     pbc_mode = _pbc_mode_from_wrap(wrap_positions)
     if strategy not in {"auto", "scalar", "tile"}:
         raise ValueError(
             f"strategy must be 'auto' | 'scalar' | 'tile', got {strategy!r}",
         )
-    can_tile = not has_geometry_outputs and not _is_cpu_device(device)
-    if strategy == "tile":
-        if not can_tile:
-            raise ValueError(
-                "strategy='tile' requires CUDA, no geometry or pair_fn outputs, "
-                "and supported topology-only PBC inputs",
-            )
-        strategy = "tile"
-    elif strategy == "scalar":
-        strategy = "scalar"
-    elif (
-        can_tile
-        and (not batched or wrap_positions)
-        and (
-            not partial
-            or (not batched and positions.shape[0] >= _partial_tile_min_atoms(wp_dtype))
-        )
-    ):
-        strategy = "tile"
-    else:
-        strategy = "scalar"
+    num_systems = int(batch_ptr.shape[0] - 1) if batched else 1
+    strategy = _resolve_naive_strategy(
+        strategy,
+        _NaiveWorkload(
+            device_kind="cpu" if _is_cpu_device(device) else "cuda",
+            wp_dtype=wp_dtype,
+            num_atoms=int(positions.shape[0]),
+            num_systems=num_systems,
+            partial=partial,
+            batched=batched,
+            pbc=True,
+            wrap_positions=wrap_positions,
+            geometry_outputs=has_geometry_or_pair_outputs,
+        ),
+    )
 
     positions_work, per_atom_cell_offsets = _prepare_pbc_positions(
         positions,
@@ -593,7 +727,7 @@ def _launch_naive_neighbor_matrix_pbc(
         launch_dim = (
             cell.shape[0],
             int(max_shifts_per_system),
-            int(max_atoms_per_system),
+            target_indices.shape[0] if partial else int(max_atoms_per_system),
         )
         num_shifts_arg = num_shifts_arr
         tile_shift_dim = int(max_shifts_per_system)
@@ -615,6 +749,25 @@ def _launch_naive_neighbor_matrix_pbc(
         ]
 
     if strategy == "tile":
+        if partial and not batched:
+            _launch_partial_tile_pbc_prepared(
+                positions_work,
+                per_atom_cell_offsets,
+                cutoff,
+                cell,
+                shift_range,
+                target_indices,
+                neighbor_matrix,
+                neighbor_matrix_shifts,
+                num_neighbors,
+                wp_dtype,
+                device,
+                num_shifts=int(num_shifts),
+                half_fill=half_fill,
+                pbc_mode=pbc_mode.value,
+            )
+            return
+        _require_cuda_tile_device(device)
         wp.launch_tiled(
             kernel=get_naive_neighbor_matrix_kernel(
                 wp_dtype,
@@ -646,7 +799,7 @@ def _launch_naive_neighbor_matrix_pbc(
         )
         return
 
-    if has_pair_outputs:
+    if uses_compact_pair_kernel:
         active_shift_dim = int(max_shifts_per_system) if batched else int(num_shifts)
         if partial and not half_fill:
             active_shift_dim = 2 * active_shift_dim - 1
@@ -1037,6 +1190,7 @@ def naive_neighbor_matrix(
     batch_naive_neighbor_matrix : Batched (multi-system) variant
     get_naive_neighbor_matrix_kernel : Low-level single-cutoff kernel accessor
     """
+    _reject_partial_rebuild(target_indices, rebuild_flags)
     if not _has_naive_pair_outputs(
         target_indices,
         return_vectors,
@@ -1189,6 +1343,7 @@ def batch_naive_neighbor_matrix(
     naive_neighbor_matrix : Single-system variant
     get_naive_neighbor_matrix_kernel : Low-level single-cutoff kernel accessor
     """
+    _reject_partial_rebuild(target_indices, rebuild_flags)
     if not _has_naive_pair_outputs(
         target_indices,
         return_vectors,
@@ -1219,21 +1374,12 @@ def batch_naive_neighbor_matrix(
         )
         return
     if rebuild_flags is not None:
-        if target_indices is None:
-            selective_zero_num_neighbors(
-                num_neighbors,
-                batch_idx,
-                rebuild_flags,
-                device,
-            )
-        else:
-            selective_zero_partial_num_neighbors(
-                num_neighbors,
-                batch_idx,
-                target_indices,
-                rebuild_flags,
-                device,
-            )
+        selective_zero_num_neighbors(
+            num_neighbors,
+            batch_idx,
+            rebuild_flags,
+            device,
+        )
     _launch_naive_neighbor_matrix_no_pbc(
         positions,
         cutoff,
@@ -1419,6 +1565,7 @@ def naive_neighbor_matrix_pbc(
         "inv_cell",
         inv_cell,
     )
+    _reject_partial_rebuild(target_indices, rebuild_flags)
     if not _has_naive_pair_outputs(
         target_indices,
         return_vectors,
@@ -1498,7 +1645,7 @@ def batch_naive_neighbor_matrix_pbc(
     num_neighbors: wp.array,
     wp_dtype: type,
     device: str,
-    max_atoms_per_system: int,
+    max_atoms_per_system: int | None = None,
     half_fill: bool = False,
     rebuild_flags: wp.array | None = None,
     wrap_positions: bool = True,
@@ -1554,8 +1701,9 @@ def batch_naive_neighbor_matrix_pbc(
         Warp dtype (wp.float32, wp.float64, or wp.float16).
     device : str
         Warp device string (e.g., 'cuda:0', 'cpu').
-    max_atoms_per_system : int
-        Maximum number of atoms in any single system.
+    max_atoms_per_system : int, optional
+        Maximum number of atoms in any single system. Required for full-row
+        batched launches and ignored for compact partial launches.
     half_fill : bool, default=False
         If True, only store half of the neighbor relationships.
     rebuild_flags : wp.array, shape (num_systems,), dtype=wp.bool, optional
@@ -1657,6 +1805,7 @@ def batch_naive_neighbor_matrix_pbc(
         "inv_cell",
         inv_cell,
     )
+    _reject_partial_rebuild(target_indices, rebuild_flags)
     if not _has_naive_pair_outputs(
         target_indices,
         return_vectors,
@@ -1698,21 +1847,12 @@ def batch_naive_neighbor_matrix_pbc(
         )
         return
     if rebuild_flags is not None:
-        if target_indices is None:
-            selective_zero_num_neighbors(
-                num_neighbors,
-                batch_idx,
-                rebuild_flags,
-                device,
-            )
-        else:
-            selective_zero_partial_num_neighbors(
-                num_neighbors,
-                batch_idx,
-                target_indices,
-                rebuild_flags,
-                device,
-            )
+        selective_zero_num_neighbors(
+            num_neighbors,
+            batch_idx,
+            rebuild_flags,
+            device,
+        )
     _launch_naive_neighbor_matrix_pbc(
         positions,
         cutoff,

--- a/nvalchemiops/neighbors/naive/launchers.py
+++ b/nvalchemiops/neighbors/naive/launchers.py
@@ -1135,9 +1135,9 @@ def naive_neighbor_matrix(
         When provided, the kernel checks this flag on the GPU and skips work
         when False (no CPU-GPU sync).
     target_indices : wp.array, shape (M,), dtype=wp.int32, optional
-        Unique, in-bounds global atom indices restricting which atoms act as
-        sources (rows) in the output.  Output rows correspond to
-        ``target_indices`` in order.  When omitted, all atoms are sources.
+        Unique, in-bounds global indices of the central atoms. Output row
+        ``r`` corresponds to ``target_indices[r]``. When omitted, every atom
+        has an output row.
     return_vectors : bool, default=False
         If True, write per-pair displacement vectors into ``neighbor_vectors``.
         Requires ``neighbor_vectors`` to be supplied.
@@ -1291,10 +1291,9 @@ def batch_naive_neighbor_matrix(
         GPU without CPU sync.  Per-system counters are reset via
         :func:`selective_zero_num_neighbors` internally.
     target_indices : wp.array, shape (M,), dtype=wp.int32, optional
-        Unique, in-bounds global atom indices restricting which atoms act as
-        sources.  In batched mode each target searches only atoms in its own
-        system (the system is resolved via ``batch_idx``).  Output rows follow
-        ``target_indices``.
+        Unique, in-bounds global indices of the central atoms. In batched mode
+        each central atom searches only atoms in its own system (resolved via
+        ``batch_idx``). Output row ``r`` corresponds to ``target_indices[r]``.
     return_vectors : bool, default=False
         If True, write per-pair displacement vectors into ``neighbor_vectors``.
     return_distances : bool, default=False
@@ -1334,8 +1333,8 @@ def batch_naive_neighbor_matrix(
         back to the scalar kernel.
     - Topology-only ``target_indices`` calls can tile when explicitly requested.
       Under ``strategy="auto"``, batched partial calls use the scalar factory
-      kernel until target-aware tile dispatch is benchmarked. Geometry and
-      pair-function output kwargs also use the scalar factory kernel.
+      kernel. Geometry and pair-function output kwargs also use the scalar
+      factory kernel.
 
     See Also
     --------
@@ -1479,8 +1478,8 @@ def naive_neighbor_matrix_pbc(
         neighbor search.  When False the positions are assumed to be already
         wrapped (e.g. by a preceding integration step).
     target_indices : wp.array, shape (M,), dtype=wp.int32, optional
-        Unique, in-bounds global atom indices restricting which atoms act as
-        sources.  Output rows follow ``target_indices``.
+        Unique, in-bounds global indices of the central atoms. Output row
+        ``r`` corresponds to ``target_indices[r]``.
     return_vectors : bool, default=False
         If True, write per-pair displacement vectors (including the periodic
         shift contribution) into ``neighbor_vectors``.
@@ -1711,10 +1710,9 @@ def batch_naive_neighbor_matrix_pbc(
     wrap_positions : bool, default=True
         If True, wrap input positions into the primary cell.
     target_indices : wp.array, shape (M,), dtype=wp.int32, optional
-        Unique, in-bounds global atom indices restricting which atoms act as
-        sources.  In batched mode each target searches only atoms in its own
-        system (resolved via ``batch_idx``).  Output rows follow
-        ``target_indices``.
+        Unique, in-bounds global indices of the central atoms. In batched mode
+        each central atom searches only atoms in its own system (resolved via
+        ``batch_idx``). Output row ``r`` corresponds to ``target_indices[r]``.
     return_vectors : bool, default=False
         If True, write per-pair displacement vectors (including the periodic
         shift contribution) into ``neighbor_vectors``.

--- a/nvalchemiops/neighbors/naive/launchers.py
+++ b/nvalchemiops/neighbors/naive/launchers.py
@@ -36,6 +36,7 @@ from nvalchemiops.neighbors.neighbor_utils import (
     compute_inv_cells,
     resolve_buffer_alias,
     selective_zero_num_neighbors,
+    selective_zero_partial_num_neighbors,
     wrap_positions_batch,
     wrap_positions_single,
 )
@@ -64,6 +65,16 @@ _SUPPORTED_DTYPES = (wp.float16, wp.float32, wp.float64)
 _DTYPE_INFO: dict[type, tuple[type, type]] = {
     dtype: DTYPE_INFO_ALL[dtype] for dtype in _SUPPORTED_DTYPES
 }
+_PARTIAL_TILE_MIN_ATOMS_BY_DTYPE = {
+    wp.float16: 16 * BLOCK_DIM,
+    wp.float32: 16 * BLOCK_DIM,
+    wp.float64: 4 * BLOCK_DIM,
+}
+
+
+def _partial_tile_min_atoms(wp_dtype: type) -> int:
+    """Return the auto-dispatch atom threshold for partial tiled kernels."""
+    return _PARTIAL_TILE_MIN_ATOMS_BY_DTYPE[wp_dtype]
 
 
 class _ScalarSentinels(NamedTuple):
@@ -250,11 +261,23 @@ def _launch_naive_neighbor_matrix_no_pbc(
         pair_energies,
         pair_forces,
     )
+    has_geometry_outputs = _has_naive_pair_outputs(
+        None,
+        return_vectors,
+        return_distances,
+        pair_fn,
+        pair_params,
+        neighbor_vectors,
+        neighbor_distances,
+        pair_energies,
+        pair_forces,
+    )
     partial = target_indices is not None
-    # Dispatch scalar vs tile-cooperative.  Pair-output and partial
-    # (target_indices) paths have only a scalar specialization; CPU always
-    # uses scalar (Warp forces block_dim=1).  The single-system path tiles on
-    # CUDA unconditionally, while the batched path applies the adaptive
+    # Dispatch scalar vs tile-cooperative. Geometry/pair-function outputs have
+    # only a scalar specialization; topology-only partial rows can tile. CPU
+    # always uses scalar (Warp forces block_dim=1). The single-system path tiles
+    # on CUDA unconditionally except for small automatic partial launches, while
+    # the batched path applies the adaptive
     # ``use_tiled`` heuristic: the tile-cooperative kernel wins for
     # few-large-systems but the scalar thread-local-counter kernel wins for
     # many-small-systems, so dispatch on the atoms-per-system density.
@@ -265,13 +288,20 @@ def _launch_naive_neighbor_matrix_no_pbc(
     if strategy == "scalar":
         strategy = "scalar"
     elif strategy == "tile":
-        if has_pair_outputs or _is_cpu_device(device):
+        if has_geometry_outputs or _is_cpu_device(device):
             raise ValueError(
-                "strategy='tile' requires CUDA and no pair-output or "
-                "target_indices path",
+                "strategy='tile' requires CUDA and no geometry or pair_fn outputs",
             )
         strategy = "tile"
-    elif has_pair_outputs or _is_cpu_device(device):
+    elif has_geometry_outputs or _is_cpu_device(device):
+        strategy = "scalar"
+    elif partial and not batched:
+        strategy = (
+            "tile"
+            if positions.shape[0] >= _partial_tile_min_atoms(wp_dtype)
+            else "scalar"
+        )
+    elif partial:
         strategy = "scalar"
     elif batched:
         total_atoms = positions.shape[0]
@@ -322,9 +352,10 @@ def _launch_naive_neighbor_matrix_no_pbc(
                 batched=batched,
                 half_fill=half_fill,
                 selective=rebuild_flags is not None,
+                partial=partial,
                 strategy="tile",
             ),
-            dim=[1, positions.shape[0]],
+            dim=[1, target_indices.shape[0] if partial else positions.shape[0]],
             inputs=[
                 positions,
                 empty_offsets,
@@ -334,6 +365,7 @@ def _launch_naive_neighbor_matrix_no_pbc(
                 empty_num_shifts,
                 batch_idx_arg,
                 batch_ptr_arg,
+                target_indices_arg,
                 neighbor_matrix,
                 empty_shifts,
                 num_neighbors,
@@ -477,27 +509,41 @@ def _launch_naive_neighbor_matrix_pbc(
         pair_energies,
         pair_forces,
     )
+    has_geometry_outputs = _has_naive_pair_outputs(
+        None,
+        return_vectors,
+        return_distances,
+        pair_fn,
+        pair_params,
+        neighbor_vectors,
+        neighbor_distances,
+        pair_energies,
+        pair_forces,
+    )
     partial = target_indices is not None
     pbc_mode = _pbc_mode_from_wrap(wrap_positions)
     if strategy not in {"auto", "scalar", "tile"}:
         raise ValueError(
             f"strategy must be 'auto' | 'scalar' | 'tile', got {strategy!r}",
         )
-    can_tile = (
-        not has_pair_outputs
-        and not _is_cpu_device(device)
-        and (not batched or wrap_positions)
-    )
+    can_tile = not has_geometry_outputs and not _is_cpu_device(device)
     if strategy == "tile":
         if not can_tile:
             raise ValueError(
-                "strategy='tile' requires CUDA, no pair-output or "
-                "target_indices path, and wrap_positions=True for batched PBC",
+                "strategy='tile' requires CUDA, no geometry or pair_fn outputs, "
+                "and supported topology-only PBC inputs",
             )
         strategy = "tile"
     elif strategy == "scalar":
         strategy = "scalar"
-    elif can_tile:
+    elif (
+        can_tile
+        and (not batched or wrap_positions)
+        and (
+            not partial
+            or (not batched and positions.shape[0] >= _partial_tile_min_atoms(wp_dtype))
+        )
+    ):
         strategy = "tile"
     else:
         strategy = "scalar"
@@ -550,11 +596,23 @@ def _launch_naive_neighbor_matrix_pbc(
             int(max_atoms_per_system),
         )
         num_shifts_arg = num_shifts_arr
-        tile_dim = [int(max_shifts_per_system), positions.shape[0]]
+        tile_shift_dim = int(max_shifts_per_system)
+        if partial and not half_fill:
+            tile_shift_dim = 2 * tile_shift_dim - 1
+        tile_dim = [
+            tile_shift_dim,
+            target_indices.shape[0] if partial else positions.shape[0],
+        ]
     else:
         launch_dim = (1, int(num_shifts), positions.shape[0])
         num_shifts_arg = empty_num_shifts
-        tile_dim = [int(num_shifts), positions.shape[0]]
+        tile_shift_dim = int(num_shifts)
+        if partial and not half_fill:
+            tile_shift_dim = 2 * tile_shift_dim - 1
+        tile_dim = [
+            tile_shift_dim,
+            target_indices.shape[0] if partial else positions.shape[0],
+        ]
 
     if strategy == "tile":
         wp.launch_tiled(
@@ -564,6 +622,7 @@ def _launch_naive_neighbor_matrix_pbc(
                 batched=batched,
                 half_fill=half_fill,
                 selective=rebuild_flags is not None,
+                partial=partial,
                 strategy="tile",
             ),
             dim=tile_dim,
@@ -576,6 +635,7 @@ def _launch_naive_neighbor_matrix_pbc(
                 num_shifts_arg,
                 batch_idx_arg,
                 batch_ptr_arg,
+                target_indices_arg,
                 neighbor_matrix,
                 neighbor_matrix_shifts,
                 num_neighbors,
@@ -965,10 +1025,11 @@ def naive_neighbor_matrix(
     - The CUDA path uses ``wp.launch_tiled(block_dim=BLOCK_DIM)``; Warp forces
       ``block_dim = 1`` on CPU which would silently break the lane-cooperative
       partitioning, so CPU callers take the scalar path.
-    - The tile-cooperative path is taken only for the default
-      call.  When any of ``target_indices`` / ``return_vectors`` /
-      ``return_distances`` / ``pair_fn`` is supplied, the scalar factory
-      kernel is used regardless of device (no tile variant for these axes).
+    - Topology-only ``target_indices`` calls use the tile-cooperative path on
+      CUDA when explicitly requested, and under ``strategy="auto"`` for inputs
+      with at least ``4 * BLOCK_DIM`` atoms for float64 or ``16 * BLOCK_DIM``
+      atoms for float16/float32. Geometry and pair-function outputs use the
+      scalar factory kernel.
 
     See Also
     --------
@@ -1117,8 +1178,10 @@ def batch_naive_neighbor_matrix(
         ``total_atoms >= 256 * num_systems``, with a tighter
         ``>= 512 * num_systems`` threshold above 12 288 atoms); otherwise fall
         back to the scalar kernel.
-    - When any of the pair-output kwargs is supplied, the scalar factory
-      kernel is used (no tile variant for the pair-output kwargs).
+    - Topology-only ``target_indices`` calls can tile when explicitly requested.
+      Under ``strategy="auto"``, batched partial calls use the scalar factory
+      kernel until target-aware tile dispatch is benchmarked. Geometry and
+      pair-function output kwargs also use the scalar factory kernel.
 
     See Also
     --------
@@ -1156,7 +1219,21 @@ def batch_naive_neighbor_matrix(
         )
         return
     if rebuild_flags is not None:
-        selective_zero_num_neighbors(num_neighbors, batch_idx, rebuild_flags, device)
+        if target_indices is None:
+            selective_zero_num_neighbors(
+                num_neighbors,
+                batch_idx,
+                rebuild_flags,
+                device,
+            )
+        else:
+            selective_zero_partial_num_neighbors(
+                num_neighbors,
+                batch_idx,
+                target_indices,
+                rebuild_flags,
+                device,
+            )
     _launch_naive_neighbor_matrix_no_pbc(
         positions,
         cutoff,
@@ -1313,8 +1390,10 @@ def naive_neighbor_matrix_pbc(
       When omitted the launcher allocates a fresh buffer for the call.
     - The CUDA path uses ``wp.launch_tiled(block_dim=BLOCK_DIM)``; CPU is
       forced to ``block_dim = 1`` by Warp, so CPU callers take the scalar path.
-    - When any of the pair-output kwargs is supplied, the scalar factory
-      kernel is used (no tile variant for the pair-output kwargs).
+    - Topology-only ``target_indices`` calls can tile. Under
+      ``strategy="auto"``, tiling starts at ``4 * BLOCK_DIM`` atoms for
+      float64 or ``16 * BLOCK_DIM`` atoms for float16/float32. Geometry and
+      pair-function output kwargs use the scalar factory kernel.
 
     See Also
     --------
@@ -1370,6 +1449,7 @@ def naive_neighbor_matrix_pbc(
             positions_wrapped_buffer=positions_wrapped_buffer,
             per_atom_cell_offsets_buffer=per_atom_cell_offsets_buffer,
             inv_cell_buffer=inv_cell_buffer,
+            strategy=strategy,
         )
         return
     _launch_naive_neighbor_matrix_pbc(
@@ -1545,10 +1625,13 @@ def batch_naive_neighbor_matrix_pbc(
         (``256 <= avg_atoms_per_system < 6144`` and either
         ``avg_atoms_per_system >= 2048`` or ``total_atoms <= 8192``);
         otherwise fall back to the scalar 3D-launch kernel.
-      * When ``wrap_positions=False`` the prewrapped scalar kernels are used
-        on both devices (no tiled prewrapped variant).
-    - When any of the pair-output kwargs is supplied, the scalar factory
-      kernel is used (no tile variant for the pair-output kwargs).
+      * When ``wrap_positions=False``, CUDA callers may explicitly request
+        ``strategy="tile"`` for topology-only output; ``strategy="auto"``
+        remains on the prewrapped scalar kernels.
+    - Topology-only tiled calls support both wrapped and prewrapped PBC when
+      explicitly requested on CUDA. Under ``strategy="auto"``, batched partial
+      and prewrapped calls use the scalar factory kernel. Geometry and
+      pair-function output kwargs also use the scalar factory kernel.
 
     See Also
     --------
@@ -1615,7 +1698,21 @@ def batch_naive_neighbor_matrix_pbc(
         )
         return
     if rebuild_flags is not None:
-        selective_zero_num_neighbors(num_neighbors, batch_idx, rebuild_flags, device)
+        if target_indices is None:
+            selective_zero_num_neighbors(
+                num_neighbors,
+                batch_idx,
+                rebuild_flags,
+                device,
+            )
+        else:
+            selective_zero_partial_num_neighbors(
+                num_neighbors,
+                batch_idx,
+                target_indices,
+                rebuild_flags,
+                device,
+            )
     _launch_naive_neighbor_matrix_pbc(
         positions,
         cutoff,
@@ -1645,6 +1742,7 @@ def batch_naive_neighbor_matrix_pbc(
         pair_energies=pair_energies,
         pair_forces=pair_forces,
         batched=True,
+        strategy=strategy,
     )
 
 

--- a/nvalchemiops/neighbors/neighbor_utils.py
+++ b/nvalchemiops/neighbors/neighbor_utils.py
@@ -242,6 +242,7 @@ __all__ = [
     "kernel_specialization_name",
     "require_supported_dtype",
     "resolve_buffer_alias",
+    "selective_zero_partial_num_neighbors",
     "selective_zero_num_neighbors",
     "selective_zero_num_neighbors_single",
     "set_fn_name",
@@ -759,6 +760,57 @@ def selective_zero_num_neighbors(
         kernel=_get_selective_zero_num_neighbors_kernel(batched=True),
         dim=total_atoms,
         inputs=[num_neighbors, batch_idx, rebuild_flags],
+        device=device,
+    )
+
+
+@wp.kernel(enable_backward=False, module="unique")
+def _selective_zero_partial_num_neighbors_kernel(
+    num_neighbors: wp.array(dtype=wp.int32),
+    batch_idx: wp.array(dtype=wp.int32),
+    target_indices: wp.array(dtype=wp.int32),
+    rebuild_flags: wp.array(dtype=wp.bool),
+) -> None:
+    """Zero compact target rows belonging to rebuilt systems.
+
+    Notes
+    -----
+    - Thread launch: One thread per compact target row.
+    - Modifies: ``num_neighbors`` entries whose target atom belongs to a rebuilt
+      system.
+    """
+    row = wp.tid()
+    atom = target_indices[row]
+    if rebuild_flags[batch_idx[atom]]:
+        num_neighbors[row] = 0
+
+
+def selective_zero_partial_num_neighbors(
+    num_neighbors: wp.array,
+    batch_idx: wp.array,
+    target_indices: wp.array,
+    rebuild_flags: wp.array,
+    device: str,
+) -> None:
+    """Zero compact partial rows for systems selected by rebuild flags.
+
+    Parameters
+    ----------
+    num_neighbors : wp.array
+        OUTPUT: Neighbor counts indexed by compact target-row position.
+    batch_idx : wp.array
+        System index for every global atom.
+    target_indices : wp.array
+        Global source atom index for every compact output row.
+    rebuild_flags : wp.array
+        Per-system flags controlling which rows are reset.
+    device : str
+        Warp device string.
+    """
+    wp.launch(
+        kernel=_selective_zero_partial_num_neighbors_kernel,
+        dim=num_neighbors.shape[0],
+        inputs=[num_neighbors, batch_idx, target_indices, rebuild_flags],
         device=device,
     )
 

--- a/nvalchemiops/neighbors/neighbor_utils.py
+++ b/nvalchemiops/neighbors/neighbor_utils.py
@@ -242,7 +242,6 @@ __all__ = [
     "kernel_specialization_name",
     "require_supported_dtype",
     "resolve_buffer_alias",
-    "selective_zero_partial_num_neighbors",
     "selective_zero_num_neighbors",
     "selective_zero_num_neighbors_single",
     "set_fn_name",
@@ -760,57 +759,6 @@ def selective_zero_num_neighbors(
         kernel=_get_selective_zero_num_neighbors_kernel(batched=True),
         dim=total_atoms,
         inputs=[num_neighbors, batch_idx, rebuild_flags],
-        device=device,
-    )
-
-
-@wp.kernel(enable_backward=False, module="unique")
-def _selective_zero_partial_num_neighbors_kernel(
-    num_neighbors: wp.array(dtype=wp.int32),
-    batch_idx: wp.array(dtype=wp.int32),
-    target_indices: wp.array(dtype=wp.int32),
-    rebuild_flags: wp.array(dtype=wp.bool),
-) -> None:
-    """Zero compact target rows belonging to rebuilt systems.
-
-    Notes
-    -----
-    - Thread launch: One thread per compact target row.
-    - Modifies: ``num_neighbors`` entries whose target atom belongs to a rebuilt
-      system.
-    """
-    row = wp.tid()
-    atom = target_indices[row]
-    if rebuild_flags[batch_idx[atom]]:
-        num_neighbors[row] = 0
-
-
-def selective_zero_partial_num_neighbors(
-    num_neighbors: wp.array,
-    batch_idx: wp.array,
-    target_indices: wp.array,
-    rebuild_flags: wp.array,
-    device: str,
-) -> None:
-    """Zero compact partial rows for systems selected by rebuild flags.
-
-    Parameters
-    ----------
-    num_neighbors : wp.array
-        OUTPUT: Neighbor counts indexed by compact target-row position.
-    batch_idx : wp.array
-        System index for every global atom.
-    target_indices : wp.array
-        Global source atom index for every compact output row.
-    rebuild_flags : wp.array
-        Per-system flags controlling which rows are reset.
-    device : str
-        Warp device string.
-    """
-    wp.launch(
-        kernel=_selective_zero_partial_num_neighbors_kernel,
-        dim=num_neighbors.shape[0],
-        inputs=[num_neighbors, batch_idx, target_indices, rebuild_flags],
         device=device,
     )
 

--- a/nvalchemiops/neighbors/output_args.py
+++ b/nvalchemiops/neighbors/output_args.py
@@ -204,7 +204,7 @@ def _prepare_pair_output_args(
     ``target_indices`` is validated upstream by the naive and cell-list
     launchers.  Cluster-tile launchers do not accept a ``target_indices``
     kwarg because those kernels iterate emitted tile pairs rather than
-    source atoms.
+    central atoms.
     """
     _validate_pair_output_kwargs(
         wp_dtype=wp_dtype,

--- a/nvalchemiops/torch/neighbors/__init__.py
+++ b/nvalchemiops/torch/neighbors/__init__.py
@@ -229,10 +229,10 @@ def neighbor_list(
             geometry and pair-output paths, ignore this bound and do not require it.
             Full-row calls infer it when omitted, which may synchronize.
         target_indices : torch.Tensor, optional
-            Restrict the source rows of the neighbor list to this subset of atom
-            indices (partial neighbor list). Matrix outputs use
-            ``len(target_indices)`` compact rows; COO source rows are compact row
-            ids. Supported by naive and cell-list methods; not by cluster_tile.
+            Select the central atoms for a partial neighbor list. Matrix outputs
+            use ``len(target_indices)`` compact rows; in COO output the first
+            row holds compact row ids. Supported by naive and cell-list methods;
+            not by cluster_tile.
         return_distances : bool, default=False
             Also return per-pair distances ``|r_ij|`` in matrix layout
             ``(num_rows, max_neighbors)``, where ``num_rows`` is
@@ -284,8 +284,8 @@ def neighbor_list(
               for partial lists. Row ``r`` contains neighbors for atom ``r`` or
               ``target_indices[r]`` respectively.
             - If ``return_neighbor_list=True``: Returns ``neighbor_list`` with shape
-              (2, num_pairs), dtype int32, in COO format [source_rows, target_atoms].
-              With ``target_indices``, source rows are compact row ids.
+              (2, num_pairs), dtype int32, in COO format [central_rows, neighbor_atoms].
+              With ``target_indices``, central rows are compact row ids.
 
         - **num_neighbor_data** (tensor): Information about the number of neighbors for each atom,
           format depends on ``return_neighbor_list``:

--- a/nvalchemiops/torch/neighbors/__init__.py
+++ b/nvalchemiops/torch/neighbors/__init__.py
@@ -225,8 +225,9 @@ def neighbor_list(
             cell list construction.
         max_atoms_per_system : int, optional
             Maximum number of atoms per system. Used in batch naive implementation
-            with PBC. If not provided, it will be computed automatically.
-            Can be provided to avoid CUDA synchronization.
+            with PBC for full-row launch sizing. Compact partial paths, including
+            geometry and pair-output paths, ignore this bound and do not require it.
+            Full-row calls infer it when omitted, which may synchronize.
         target_indices : torch.Tensor, optional
             Restrict the source rows of the neighbor list to this subset of atom
             indices (partial neighbor list). Matrix outputs use

--- a/nvalchemiops/torch/neighbors/_dispatch.py
+++ b/nvalchemiops/torch/neighbors/_dispatch.py
@@ -193,7 +193,7 @@ def estimate_neighbor_list_costs(
     optional_outputs : iterable of str, optional
         Public neighbor-list option names to include in feasibility checks.
     target_indices : torch.Tensor, optional
-        Public partial-row source indices.  Its length is used to score
+        Public central-atom indices for compact partial rows. Its length is used to score
         targeted naive/cell-list work.
     positions_dtype : torch.dtype, optional
         Position dtype used for feature feasibility.  Standalone calls default

--- a/nvalchemiops/torch/neighbors/_naive_partial.py
+++ b/nvalchemiops/torch/neighbors/_naive_partial.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared validation and buffer handling for Torch compact naive paths."""
+
+from __future__ import annotations
+
+import torch
+
+from nvalchemiops.neighbors.neighbor_utils import estimate_max_neighbors
+from nvalchemiops.torch.neighbors.neighbor_utils import (
+    get_neighbor_list_from_neighbor_matrix as _get_neighbor_list_from_neighbor_matrix,
+)
+
+__all__: list[str] = []
+
+
+def _validate_partial_request(
+    positions: torch.Tensor,
+    target_indices: torch.Tensor,
+    rebuild_flags: torch.Tensor | None,
+    *,
+    strategy: str,
+    has_geometry_or_pair_outputs: bool,
+) -> None:
+    """Validate a compact naive-neighbor request without touching outputs."""
+    if target_indices.ndim != 1 or target_indices.dtype != torch.int32:
+        raise ValueError("target_indices must be a rank-one int32 tensor.")
+    if target_indices.device != positions.device:
+        raise ValueError("target_indices must be on the same device as positions.")
+    if rebuild_flags is not None:
+        raise NotImplementedError(
+            "Partial neighbor lists do not support rebuild_flags",
+        )
+    if strategy == "tile" and positions.device.type == "cpu":
+        raise ValueError(
+            "strategy='tile' requires CUDA; use strategy='scalar' or 'auto' on CPU.",
+        )
+    if strategy == "tile" and has_geometry_or_pair_outputs:
+        raise NotImplementedError(
+            "strategy='tile' supports topology-only target_indices; "
+            "geometry and pair-function outputs require strategy='scalar'.",
+        )
+
+
+def _validate_partial_output(
+    name: str,
+    tensor: torch.Tensor | None,
+    expected_shape: tuple[int, ...],
+    expected_dtype: torch.dtype,
+    expected_device: torch.device,
+) -> None:
+    """Validate an optional compact-row output buffer."""
+    if tensor is None:
+        return
+    if tuple(tensor.shape) != expected_shape:
+        raise ValueError(
+            f"{name} must have shape {expected_shape}; got {tuple(tensor.shape)}.",
+        )
+    if tensor.dtype != expected_dtype:
+        raise ValueError(f"{name} dtype must be {expected_dtype}; got {tensor.dtype}.")
+    if tensor.device != expected_device:
+        raise ValueError(
+            f"{name} must be on the same device as positions "
+            f"({expected_device}); got {tensor.device}.",
+        )
+
+
+def _prepare_partial_outputs(
+    positions: torch.Tensor,
+    target_indices: torch.Tensor,
+    cutoff: float,
+    *,
+    pbc_enabled: bool,
+    max_neighbors: int | None,
+    fill_value: int | None,
+    neighbor_matrix: torch.Tensor | None,
+    num_neighbors: torch.Tensor | None,
+    neighbor_matrix_shifts: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, int, int]:
+    """Validate, allocate, and reset compact topology output buffers."""
+    num_rows = int(target_indices.shape[0])
+    if max_neighbors is None and neighbor_matrix is not None:
+        max_neighbors = int(neighbor_matrix.shape[1])
+    if max_neighbors is None:
+        max_neighbors = estimate_max_neighbors(cutoff)
+    if fill_value is None:
+        fill_value = int(positions.shape[0])
+
+    _validate_partial_output(
+        "neighbor_matrix",
+        neighbor_matrix,
+        (num_rows, max_neighbors),
+        torch.int32,
+        positions.device,
+    )
+    _validate_partial_output(
+        "num_neighbors",
+        num_neighbors,
+        (num_rows,),
+        torch.int32,
+        positions.device,
+    )
+    if pbc_enabled:
+        _validate_partial_output(
+            "neighbor_matrix_shifts",
+            neighbor_matrix_shifts,
+            (num_rows, max_neighbors, 3),
+            torch.int32,
+            positions.device,
+        )
+
+    if neighbor_matrix is None:
+        neighbor_matrix = torch.full(
+            (num_rows, max_neighbors),
+            fill_value,
+            dtype=torch.int32,
+            device=positions.device,
+        )
+    else:
+        neighbor_matrix.fill_(fill_value)
+    if num_neighbors is None:
+        num_neighbors = torch.zeros(
+            num_rows,
+            dtype=torch.int32,
+            device=positions.device,
+        )
+    else:
+        num_neighbors.zero_()
+    if pbc_enabled:
+        if neighbor_matrix_shifts is None:
+            neighbor_matrix_shifts = torch.zeros(
+                (num_rows, max_neighbors, 3),
+                dtype=torch.int32,
+                device=positions.device,
+            )
+        else:
+            neighbor_matrix_shifts.zero_()
+    else:
+        neighbor_matrix_shifts = None
+    return (
+        neighbor_matrix,
+        num_neighbors,
+        neighbor_matrix_shifts,
+        max_neighbors,
+        num_rows,
+    )
+
+
+def _pack_partial_outputs(
+    neighbor_matrix: torch.Tensor,
+    num_neighbors: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor | None,
+    *,
+    fill_value: int,
+    return_neighbor_list: bool,
+) -> tuple[torch.Tensor, ...]:
+    """Pack compact matrix outputs into the public matrix or COO contract."""
+    if return_neighbor_list:
+        if neighbor_matrix_shifts is None:
+            neighbor_list, neighbor_ptr = _get_neighbor_list_from_neighbor_matrix(
+                neighbor_matrix,
+                num_neighbors=num_neighbors,
+                fill_value=fill_value,
+            )
+            return neighbor_list, neighbor_ptr
+        neighbor_list, neighbor_ptr, neighbor_list_shifts = (
+            _get_neighbor_list_from_neighbor_matrix(
+                neighbor_matrix,
+                num_neighbors=num_neighbors,
+                neighbor_shift_matrix=neighbor_matrix_shifts,
+                fill_value=fill_value,
+            )
+        )
+        return neighbor_list, neighbor_ptr, neighbor_list_shifts
+    if neighbor_matrix_shifts is None:
+        return neighbor_matrix, num_neighbors
+    return neighbor_matrix, num_neighbors, neighbor_matrix_shifts

--- a/nvalchemiops/torch/neighbors/batch_cell_list.py
+++ b/nvalchemiops/torch/neighbors/batch_cell_list.py
@@ -30,8 +30,8 @@ The torch wrapper auto-selects between two batch query kernels:
 Auto-select uses sync-free quantities (``total_atoms``, ``num_systems``,
 ``cutoff``); the ``total_cells`` Python int is already paid by
 :func:`estimate_batch_cell_list_sizes` at allocation time.  Defaults
-are calibrated empirically; overrides are exposed via environment
-variables - see :func:`select_batch_cell_list_strategy`.
+can be overridden with environment variables; see
+:func:`select_batch_cell_list_strategy`.
 """
 
 from __future__ import annotations
@@ -895,9 +895,9 @@ def batch_query_cell_list(
         Selects the atom-centric implementation path. ``"auto"`` resolves to
         ``"direct"``.
     target_indices : torch.Tensor, shape (num_targets,), dtype=int32, optional
-        If provided, only query neighbors for the subset of atoms listed. The
-        output ``neighbor_matrix`` and ``num_neighbors`` will have ``num_targets``
-        rows rather than ``total_atoms`` rows.
+        Indices of the central atoms for compact partial rows. The output
+        ``neighbor_matrix`` and ``num_neighbors`` have ``num_targets`` rows
+        rather than ``total_atoms`` rows, in ``target_indices`` order.
     return_vectors : bool, default=False
         If True and ``neighbor_vectors`` is provided, write per-neighbor
         displacement vectors into ``neighbor_vectors``.

--- a/nvalchemiops/torch/neighbors/batch_naive.py
+++ b/nvalchemiops/torch/neighbors/batch_naive.py
@@ -63,6 +63,7 @@ def _batch_naive_neighbor_matrix_no_pbc(
     half_fill: bool,
     rebuild_flags: torch.Tensor | None = None,
     strategy: str = "auto",
+    target_indices: torch.Tensor | None = None,
 ) -> None:
     """Fill neighbor matrix for batch of atoms using naive O(N^2) algorithm.
 
@@ -89,12 +90,12 @@ def _batch_naive_neighbor_matrix_no_pbc(
     batch_ptr : torch.Tensor, shape (num_systems + 1,), dtype=torch.int32
         Cumulative atom counts defining system boundaries.
         System i contains atoms from batch_ptr[i] to batch_ptr[i+1]-1.
-    neighbor_matrix : torch.Tensor, shape (total_atoms, max_neighbors), dtype=torch.int32
+    neighbor_matrix : torch.Tensor, shape (rows, max_neighbors), dtype=torch.int32
         OUTPUT: Neighbor matrix to be filled with neighbor atom indices.
-        Must be pre-allocated. Entries are filled with atom indices.
-    num_neighbors : torch.Tensor, shape (total_atoms,), dtype=torch.int32
+        ``rows`` is ``total_atoms`` normally or the number of target rows.
+    num_neighbors : torch.Tensor, shape (rows,), dtype=torch.int32
         OUTPUT: Number of neighbors found for each atom.
-        Must be pre-allocated. Updated in-place with actual neighbor counts.
+        ``rows`` is ``total_atoms`` normally or the number of target rows.
     half_fill : bool
         If True, only store relationships where i < j to avoid double counting.
         If False, store all neighbor relationships symmetrically.
@@ -102,6 +103,8 @@ def _batch_naive_neighbor_matrix_no_pbc(
         Per-system rebuild flags. If provided, only systems where rebuild_flags[i]
         is True are processed; others are skipped on the GPU without CPU sync.
         Call selective_zero_num_neighbors before this launcher to reset counts.
+    target_indices : torch.Tensor, shape (num_targets,), dtype=torch.int32, optional
+        Compact source rows for a topology-only partial neighbor list.
     See Also
     --------
     nvalchemiops.neighbors.batch_naive.batch_naive_neighbor_matrix : Core warp launcher
@@ -126,6 +129,16 @@ def _batch_naive_neighbor_matrix_no_pbc(
     wp_num_neighbors = wp.from_torch(
         num_neighbors, dtype=wp.int32, requires_grad=False, return_ctype=True
     )
+    wp_target_indices = (
+        wp.from_torch(
+            target_indices,
+            dtype=wp.int32,
+            requires_grad=False,
+            return_ctype=True,
+        )
+        if target_indices is not None
+        else None
+    )
     wp_rebuild_flags = None
     if rebuild_flags is not None:
         wp_rebuild_flags = wp.from_torch(
@@ -143,6 +156,7 @@ def _batch_naive_neighbor_matrix_no_pbc(
         half_fill=half_fill,
         rebuild_flags=wp_rebuild_flags,
         strategy=strategy,
+        target_indices=wp_target_indices,
     )
 
 
@@ -171,6 +185,7 @@ def _batch_naive_neighbor_matrix_pbc(
     per_atom_cell_offsets_buffer: torch.Tensor | None = None,
     inv_cell_buffer: torch.Tensor | None = None,
     strategy: str = "auto",
+    target_indices: torch.Tensor | None = None,
 ) -> None:
     """Compute batch neighbor matrix with PBC using naive O(N^2) algorithm.
 
@@ -188,12 +203,15 @@ def _batch_naive_neighbor_matrix_pbc(
         System index for each atom.
     batch_ptr : torch.Tensor, shape (num_systems + 1,), dtype=torch.int32
         Cumulative atom counts defining system boundaries.
-    neighbor_matrix : torch.Tensor, shape (total_atoms, max_neighbors), dtype=torch.int32
+    neighbor_matrix : torch.Tensor, shape (rows, max_neighbors), dtype=torch.int32
         OUTPUT: Neighbor matrix.
-    neighbor_matrix_shifts : torch.Tensor, shape (total_atoms, max_neighbors, 3), dtype=torch.int32
+        ``rows`` is ``total_atoms`` normally or the number of target rows.
+    neighbor_matrix_shifts : torch.Tensor, shape (rows, max_neighbors, 3), dtype=torch.int32
         OUTPUT: Shift vectors for each neighbor.
-    num_neighbors : torch.Tensor, shape (total_atoms,), dtype=torch.int32
+    num_neighbors : torch.Tensor, shape (rows,), dtype=torch.int32
         OUTPUT: Number of neighbors per atom.
+    target_indices : torch.Tensor, shape (num_targets,), dtype=torch.int32, optional
+        Compact source rows for a topology-only partial neighbor list.
     shift_range_per_dimension : torch.Tensor, shape (num_systems, 3), dtype=torch.int32
         Shift range in each dimension for each system.
     num_shifts_per_system : torch.Tensor, shape (num_systems,), dtype=torch.int32
@@ -243,6 +261,16 @@ def _batch_naive_neighbor_matrix_pbc(
     )
     wp_num_neighbors = wp.from_torch(
         num_neighbors, dtype=wp.int32, requires_grad=False, return_ctype=True
+    )
+    wp_target_indices = (
+        wp.from_torch(
+            target_indices,
+            dtype=wp.int32,
+            requires_grad=False,
+            return_ctype=True,
+        )
+        if target_indices is not None
+        else None
     )
     wp_batch_idx = wp.from_torch(
         batch_idx, dtype=wp.int32, requires_grad=False, return_ctype=True
@@ -309,6 +337,7 @@ def _batch_naive_neighbor_matrix_pbc(
         per_atom_cell_offsets_buffer=wp_per_atom_cell_offsets,
         inv_cell_buffer=wp_inv_cell,
         strategy=strategy,
+        target_indices=wp_target_indices,
     )
 
 
@@ -877,6 +906,7 @@ def _validate_output_buffer(
     tensor: torch.Tensor | None,
     expected_shape: tuple[int, ...],
     expected_dtype: torch.dtype | None = None,
+    expected_device: torch.device | None = None,
 ) -> None:
     """Validate optional compact-row output buffers."""
     if tensor is None:
@@ -888,6 +918,11 @@ def _validate_output_buffer(
     if expected_dtype is not None and tensor.dtype != expected_dtype:
         raise ValueError(
             f"{name} dtype must be {expected_dtype}; got {tensor.dtype}.",
+        )
+    if expected_device is not None and tensor.device != expected_device:
+        raise ValueError(
+            f"{name} must be on the same device as positions "
+            f"({expected_device}); got {tensor.device}.",
         )
 
 
@@ -1337,6 +1372,13 @@ def batch_naive_neighbor_list(
         Compact partial-list source rows. Output row ``r`` maps to atom
         ``target_indices[r]``; COO source rows remain compact row ids. User
         buffers must be compact-row shaped, not full atom-row shaped.
+    strategy : {"auto", "scalar", "tile"}, default="auto"
+        ``"auto"`` keeps batched topology-only partial rows on the scalar
+        kernel, while ``"scalar"`` is a deterministic opt-out and ``"tile"``
+        explicitly selects the CUDA tiled kernel. Explicit tile supports
+        no-PBC, wrapped PBC, and prewrapped PBC compact rows. Geometry,
+        pair-function outputs, and partial selective rebuilds remain
+        scalar-only or unsupported.
 
     Returns
     -------
@@ -1369,6 +1411,179 @@ def batch_naive_neighbor_list(
         pbc = pbc if pbc.ndim == 2 else pbc.unsqueeze(0)
 
     total_atoms = positions.shape[0]
+    if strategy not in {"auto", "scalar", "tile"}:
+        raise ValueError(
+            f"strategy must be 'auto' | 'scalar' | 'tile', got {strategy!r}",
+        )
+    geometry_or_pair_active = (
+        bool(return_distances)
+        or bool(return_vectors)
+        or neighbor_vectors is not None
+        or neighbor_distances is not None
+        or pair_fn is not None
+        or pair_energies is not None
+        or pair_forces is not None
+    )
+    topology_only_partial = target_indices is not None and not geometry_or_pair_active
+    if target_indices is not None:
+        if target_indices.ndim != 1 or target_indices.dtype != torch.int32:
+            raise ValueError("target_indices must be a rank-one int32 tensor.")
+        if target_indices.device != positions.device:
+            raise ValueError(
+                "target_indices must be on the same device as positions.",
+            )
+        if rebuild_flags is not None:
+            raise NotImplementedError(
+                "Partial neighbor lists do not support rebuild_flags.",
+            )
+        if strategy == "tile":
+            if positions.device.type == "cpu":
+                raise ValueError(
+                    "strategy='tile' requires CUDA; use strategy='scalar' or "
+                    "'auto' on CPU.",
+                )
+            if not topology_only_partial:
+                raise NotImplementedError(
+                    "strategy='tile' supports topology-only target_indices; "
+                    "geometry and pair-function outputs require strategy='scalar'.",
+                )
+
+    if topology_only_partial:
+        batch_idx, batch_ptr = prepare_batch_idx_ptr(
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            num_atoms=total_atoms,
+            device=positions.device,
+        )
+        num_rows = int(target_indices.shape[0])
+        if max_neighbors is None and neighbor_matrix is not None:
+            max_neighbors = int(neighbor_matrix.shape[1])
+        if max_neighbors is None:
+            max_neighbors = estimate_max_neighbors(cutoff)
+        if fill_value is None:
+            fill_value = total_atoms
+        _validate_output_buffer(
+            "neighbor_matrix",
+            neighbor_matrix,
+            (num_rows, max_neighbors),
+            torch.int32,
+            positions.device,
+        )
+        _validate_output_buffer(
+            "num_neighbors",
+            num_neighbors,
+            (num_rows,),
+            torch.int32,
+            positions.device,
+        )
+        if pbc is not None:
+            _validate_output_buffer(
+                "neighbor_matrix_shifts",
+                neighbor_matrix_shifts,
+                (num_rows, max_neighbors, 3),
+                torch.int32,
+                positions.device,
+            )
+        if neighbor_matrix is None:
+            neighbor_matrix = torch.full(
+                (num_rows, max_neighbors),
+                fill_value,
+                dtype=torch.int32,
+                device=positions.device,
+            )
+        else:
+            neighbor_matrix.fill_(fill_value)
+        if num_neighbors is None:
+            num_neighbors = torch.zeros(
+                num_rows,
+                dtype=torch.int32,
+                device=positions.device,
+            )
+        else:
+            num_neighbors.zero_()
+        if pbc is not None:
+            if neighbor_matrix_shifts is None:
+                neighbor_matrix_shifts = torch.zeros(
+                    (num_rows, max_neighbors, 3),
+                    dtype=torch.int32,
+                    device=positions.device,
+                )
+            else:
+                neighbor_matrix_shifts.zero_()
+
+        if cutoff > 0 and num_rows > 0:
+            if pbc is None:
+                _batch_naive_neighbor_matrix_no_pbc(
+                    positions=positions,
+                    cutoff=cutoff,
+                    batch_idx=batch_idx,
+                    batch_ptr=batch_ptr,
+                    neighbor_matrix=neighbor_matrix,
+                    num_neighbors=num_neighbors,
+                    half_fill=half_fill,
+                    rebuild_flags=None,
+                    strategy=strategy,
+                    target_indices=target_indices,
+                )
+            else:
+                if (
+                    max_shifts_per_system is None
+                    or num_shifts_per_system is None
+                    or shift_range_per_dimension is None
+                ):
+                    (
+                        shift_range_per_dimension,
+                        num_shifts_per_system,
+                        max_shifts_per_system,
+                    ) = compute_naive_num_shifts(cell, cutoff, pbc)
+                if max_atoms_per_system is None:
+                    max_atoms_per_system = int(
+                        (batch_ptr[1:] - batch_ptr[:-1]).max().item(),
+                    )
+                _batch_naive_neighbor_matrix_pbc(
+                    positions=positions,
+                    cell=cell,
+                    pbc=pbc,
+                    cutoff=cutoff,
+                    batch_idx=batch_idx,
+                    batch_ptr=batch_ptr,
+                    neighbor_matrix=neighbor_matrix,
+                    neighbor_matrix_shifts=neighbor_matrix_shifts,
+                    num_neighbors=num_neighbors,
+                    shift_range_per_dimension=shift_range_per_dimension,
+                    num_shifts_per_system=num_shifts_per_system,
+                    max_shifts_per_system=max_shifts_per_system,
+                    half_fill=half_fill,
+                    max_atoms_per_system=max_atoms_per_system,
+                    rebuild_flags=None,
+                    wrap_positions=wrap_positions,
+                    positions_wrapped_buffer=positions_wrapped_buffer,
+                    per_atom_cell_offsets_buffer=per_atom_cell_offsets_buffer,
+                    inv_cell_buffer=inv_cell_buffer,
+                    strategy=strategy,
+                    target_indices=target_indices,
+                )
+        if return_neighbor_list:
+            if pbc is not None:
+                neighbor_list, neighbor_ptr, neighbor_list_shifts = (
+                    get_neighbor_list_from_neighbor_matrix(
+                        neighbor_matrix,
+                        num_neighbors=num_neighbors,
+                        neighbor_shift_matrix=neighbor_matrix_shifts,
+                        fill_value=fill_value,
+                    )
+                )
+                return neighbor_list, neighbor_ptr, neighbor_list_shifts
+            neighbor_list, neighbor_ptr = get_neighbor_list_from_neighbor_matrix(
+                neighbor_matrix,
+                num_neighbors=num_neighbors,
+                fill_value=fill_value,
+            )
+            return neighbor_list, neighbor_ptr
+        if pbc is not None:
+            return neighbor_matrix, num_neighbors, neighbor_matrix_shifts
+        return neighbor_matrix, num_neighbors
+
     if is_compiled_pair_fn(pair_fn) and torch.compiler.is_compiling():
         if return_neighbor_list:
             raise NotImplementedError(
@@ -1482,16 +1697,10 @@ def batch_naive_neighbor_list(
         or bool(return_vectors)
         or neighbor_vectors is not None
         or neighbor_distances is not None
-        or target_indices is not None
         or pair_fn is not None
         or pair_energies is not None
         or pair_forces is not None
     )
-    if strategy == "tile" and target_indices is not None:
-        raise NotImplementedError(
-            "strategy='tile' has no target_indices (partial "
-            "neighbor-list) variant; use strategy='scalar'.",
-        )
     if has_pair_outputs:
         if rebuild_flags is not None:
             raise NotImplementedError(
@@ -1657,6 +1866,7 @@ def batch_naive_neighbor_list(
             half_fill=half_fill,
             rebuild_flags=rebuild_flags,
             strategy=strategy,
+            target_indices=None,
         )
         if return_neighbor_list:
             neighbor_list, neighbor_ptr = get_neighbor_list_from_neighbor_matrix(
@@ -1689,6 +1899,7 @@ def batch_naive_neighbor_list(
             per_atom_cell_offsets_buffer=per_atom_cell_offsets_buffer,
             inv_cell_buffer=inv_cell_buffer,
             strategy=strategy,
+            target_indices=None,
         )
         if return_neighbor_list:
             neighbor_list, neighbor_ptr, neighbor_list_shifts = (

--- a/nvalchemiops/torch/neighbors/batch_naive.py
+++ b/nvalchemiops/torch/neighbors/batch_naive.py
@@ -24,6 +24,10 @@ from nvalchemiops.neighbors.naive import (
     batch_naive_neighbor_matrix,
     batch_naive_neighbor_matrix_pbc,
 )
+from nvalchemiops.neighbors.naive.dispatch import (
+    _NaiveWorkload,
+    _resolve_naive_strategy,
+)
 from nvalchemiops.neighbors.neighbor_utils import (
     estimate_max_neighbors,
 )
@@ -36,6 +40,12 @@ from nvalchemiops.torch.neighbors._autograd import (
 from nvalchemiops.torch.neighbors._compiled_pair_fn import (
     CompiledPairFn,
     is_compiled_pair_fn,
+)
+from nvalchemiops.torch.neighbors._naive_partial import (
+    _pack_partial_outputs,
+    _prepare_partial_outputs,
+    _validate_partial_output,
+    _validate_partial_request,
 )
 from nvalchemiops.torch.neighbors.neighbor_utils import (
     _validate_pair_params_present,
@@ -279,7 +289,7 @@ def _batch_naive_neighbor_matrix_pbc(
         batch_ptr, dtype=wp.int32, requires_grad=False, return_ctype=True
     )
 
-    if max_atoms_per_system is None:
+    if max_atoms_per_system is None and target_indices is None:
         max_atoms_per_system = (batch_ptr[1:] - batch_ptr[:-1]).max().item()
 
     wp_rebuild_flags = None
@@ -874,7 +884,11 @@ def _register_compiled_batch_naive_pbc_pair_op(compiled: CompiledPairFn):
             ),
             wp_dtype=wp_dtype,
             device=str(device),
-            max_atoms_per_system=max_atoms_per_system,
+            max_atoms_per_system=(
+                None
+                if target_indices is not None and max_atoms_per_system == 0
+                else max_atoms_per_system
+            ),
             half_fill=half_fill,
             rebuild_flags=None,
             wrap_positions=wrap_positions,
@@ -899,31 +913,6 @@ def _register_compiled_batch_naive_pbc_pair_op(compiled: CompiledPairFn):
 
     register_noop_fake(_compiled_batch_naive_pbc_pair)
     return _compiled_batch_naive_pbc_pair
-
-
-def _validate_output_buffer(
-    name: str,
-    tensor: torch.Tensor | None,
-    expected_shape: tuple[int, ...],
-    expected_dtype: torch.dtype | None = None,
-    expected_device: torch.device | None = None,
-) -> None:
-    """Validate optional compact-row output buffers."""
-    if tensor is None:
-        return
-    if tuple(tensor.shape) != expected_shape:
-        raise ValueError(
-            f"{name} must have shape {expected_shape}; got {tuple(tensor.shape)}.",
-        )
-    if expected_dtype is not None and tensor.dtype != expected_dtype:
-        raise ValueError(
-            f"{name} dtype must be {expected_dtype}; got {tensor.dtype}.",
-        )
-    if expected_device is not None and tensor.device != expected_device:
-        raise ValueError(
-            f"{name} must be on the same device as positions "
-            f"({expected_device}); got {tensor.device}.",
-        )
 
 
 def _batch_naive_pair_outputs_forward(
@@ -1004,7 +993,7 @@ def _batch_naive_pair_outputs_forward(
                 num_shifts_per_system=num_shifts_per_system,
                 max_shifts_per_system=int(max_shifts_per_system),
                 half_fill=half_fill,
-                max_atoms_per_system=int(max_atoms_per_system),
+                max_atoms_per_system=0 if is_partial else int(max_atoms_per_system),
                 wrap_positions=wrap_positions,
             )
     elif pair_fn is None and not is_partial and pbc is None:
@@ -1079,6 +1068,8 @@ def _batch_naive_pair_outputs_forward(
                 "batch naive pair_fn kernels are eager-only because Python "
                 "callables cannot cross a torch custom-op boundary.",
             )
+        # A Python ``pair_fn`` requires direct Warp dispatch. Compact custom
+        # ops remain available for non-Python pair-output paths.
         wp_dtype = get_wp_dtype(positions.dtype)
         wp_vec_dtype = get_wp_vec_dtype(positions.dtype)
         pair_kwargs = {}
@@ -1200,7 +1191,9 @@ def _batch_naive_pair_outputs_forward(
                 ),
                 wp_dtype=wp_dtype,
                 device=str(positions.device),
-                max_atoms_per_system=int(max_atoms_per_system),
+                max_atoms_per_system=(
+                    None if is_partial else int(max_atoms_per_system)
+                ),
                 half_fill=half_fill,
                 rebuild_flags=None,
                 wrap_positions=wrap_positions,
@@ -1354,8 +1347,9 @@ def batch_naive_neighbor_list(
         Maximum per-system shift count.
         Pass in to avoid recomputation for pbc systems.
     max_atoms_per_system : int, optional
-        Maximum number of atoms per system.
-        If not provided, it will be computed automatically. Can be provided to avoid CUDA synchronization.
+        Maximum number of atoms per system for full-row PBC launch sizing.
+        Compact partial paths ignore this bound. Full-row calls infer it when
+        omitted, which may synchronize.
     rebuild_flags : torch.Tensor, shape (num_systems,), dtype=torch.bool, optional
         Per-system rebuild flags produced by ``batch_neighbor_list_needs_rebuild``.
         If provided, only systems where rebuild_flags[i] is True are recomputed;
@@ -1376,9 +1370,9 @@ def batch_naive_neighbor_list(
         ``"auto"`` keeps batched topology-only partial rows on the scalar
         kernel, while ``"scalar"`` is a deterministic opt-out and ``"tile"``
         explicitly selects the CUDA tiled kernel. Explicit tile supports
-        no-PBC, wrapped PBC, and prewrapped PBC compact rows. Geometry,
-        pair-function outputs, and partial selective rebuilds remain
-        scalar-only or unsupported.
+        no-PBC, wrapped PBC, and prewrapped PBC compact rows. Geometry and
+        pair outputs use scalar; partial neighbor lists do not support
+        ``rebuild_flags``.
 
     Returns
     -------
@@ -1415,7 +1409,7 @@ def batch_naive_neighbor_list(
         raise ValueError(
             f"strategy must be 'auto' | 'scalar' | 'tile', got {strategy!r}",
         )
-    geometry_or_pair_active = (
+    has_geometry_or_pair_outputs = (
         bool(return_distances)
         or bool(return_vectors)
         or neighbor_vectors is not None
@@ -1424,92 +1418,58 @@ def batch_naive_neighbor_list(
         or pair_energies is not None
         or pair_forces is not None
     )
-    topology_only_partial = target_indices is not None and not geometry_or_pair_active
+    topology_only_partial = (
+        target_indices is not None and not has_geometry_or_pair_outputs
+    )
     if target_indices is not None:
-        if target_indices.ndim != 1 or target_indices.dtype != torch.int32:
-            raise ValueError("target_indices must be a rank-one int32 tensor.")
-        if target_indices.device != positions.device:
-            raise ValueError(
-                "target_indices must be on the same device as positions.",
-            )
-        if rebuild_flags is not None:
-            raise NotImplementedError(
-                "Partial neighbor lists do not support rebuild_flags.",
-            )
-        if strategy == "tile":
-            if positions.device.type == "cpu":
-                raise ValueError(
-                    "strategy='tile' requires CUDA; use strategy='scalar' or "
-                    "'auto' on CPU.",
-                )
-            if not topology_only_partial:
-                raise NotImplementedError(
-                    "strategy='tile' supports topology-only target_indices; "
-                    "geometry and pair-function outputs require strategy='scalar'.",
-                )
+        _validate_partial_request(
+            positions,
+            target_indices,
+            rebuild_flags,
+            strategy=strategy,
+            has_geometry_or_pair_outputs=has_geometry_or_pair_outputs,
+        )
 
     if topology_only_partial:
+        strategy = _resolve_naive_strategy(
+            strategy,
+            _NaiveWorkload(
+                device_kind="cpu" if positions.device.type == "cpu" else "cuda",
+                wp_dtype=get_wp_dtype(positions.dtype),
+                num_atoms=int(positions.shape[0]),
+                num_systems=1,
+                partial=True,
+                batched=True,
+                pbc=pbc is not None,
+                wrap_positions=wrap_positions,
+                geometry_outputs=False,
+            ),
+        )
         batch_idx, batch_ptr = prepare_batch_idx_ptr(
             batch_idx=batch_idx,
             batch_ptr=batch_ptr,
             num_atoms=total_atoms,
             device=positions.device,
         )
-        num_rows = int(target_indices.shape[0])
-        if max_neighbors is None and neighbor_matrix is not None:
-            max_neighbors = int(neighbor_matrix.shape[1])
-        if max_neighbors is None:
-            max_neighbors = estimate_max_neighbors(cutoff)
         if fill_value is None:
-            fill_value = total_atoms
-        _validate_output_buffer(
-            "neighbor_matrix",
+            fill_value = int(total_atoms)
+        (
             neighbor_matrix,
-            (num_rows, max_neighbors),
-            torch.int32,
-            positions.device,
-        )
-        _validate_output_buffer(
-            "num_neighbors",
             num_neighbors,
-            (num_rows,),
-            torch.int32,
-            positions.device,
+            neighbor_matrix_shifts,
+            max_neighbors,
+            num_rows,
+        ) = _prepare_partial_outputs(
+            positions,
+            target_indices,
+            cutoff,
+            pbc_enabled=pbc is not None,
+            max_neighbors=max_neighbors,
+            fill_value=fill_value,
+            neighbor_matrix=neighbor_matrix,
+            num_neighbors=num_neighbors,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
         )
-        if pbc is not None:
-            _validate_output_buffer(
-                "neighbor_matrix_shifts",
-                neighbor_matrix_shifts,
-                (num_rows, max_neighbors, 3),
-                torch.int32,
-                positions.device,
-            )
-        if neighbor_matrix is None:
-            neighbor_matrix = torch.full(
-                (num_rows, max_neighbors),
-                fill_value,
-                dtype=torch.int32,
-                device=positions.device,
-            )
-        else:
-            neighbor_matrix.fill_(fill_value)
-        if num_neighbors is None:
-            num_neighbors = torch.zeros(
-                num_rows,
-                dtype=torch.int32,
-                device=positions.device,
-            )
-        else:
-            num_neighbors.zero_()
-        if pbc is not None:
-            if neighbor_matrix_shifts is None:
-                neighbor_matrix_shifts = torch.zeros(
-                    (num_rows, max_neighbors, 3),
-                    dtype=torch.int32,
-                    device=positions.device,
-                )
-            else:
-                neighbor_matrix_shifts.zero_()
 
         if cutoff > 0 and num_rows > 0:
             if pbc is None:
@@ -1536,10 +1496,6 @@ def batch_naive_neighbor_list(
                         num_shifts_per_system,
                         max_shifts_per_system,
                     ) = compute_naive_num_shifts(cell, cutoff, pbc)
-                if max_atoms_per_system is None:
-                    max_atoms_per_system = int(
-                        (batch_ptr[1:] - batch_ptr[:-1]).max().item(),
-                    )
                 _batch_naive_neighbor_matrix_pbc(
                     positions=positions,
                     cell=cell,
@@ -1563,26 +1519,13 @@ def batch_naive_neighbor_list(
                     strategy=strategy,
                     target_indices=target_indices,
                 )
-        if return_neighbor_list:
-            if pbc is not None:
-                neighbor_list, neighbor_ptr, neighbor_list_shifts = (
-                    get_neighbor_list_from_neighbor_matrix(
-                        neighbor_matrix,
-                        num_neighbors=num_neighbors,
-                        neighbor_shift_matrix=neighbor_matrix_shifts,
-                        fill_value=fill_value,
-                    )
-                )
-                return neighbor_list, neighbor_ptr, neighbor_list_shifts
-            neighbor_list, neighbor_ptr = get_neighbor_list_from_neighbor_matrix(
-                neighbor_matrix,
-                num_neighbors=num_neighbors,
-                fill_value=fill_value,
-            )
-            return neighbor_list, neighbor_ptr
-        if pbc is not None:
-            return neighbor_matrix, num_neighbors, neighbor_matrix_shifts
-        return neighbor_matrix, num_neighbors
+        return _pack_partial_outputs(
+            neighbor_matrix,
+            num_neighbors,
+            neighbor_matrix_shifts,
+            fill_value=int(fill_value),
+            return_neighbor_list=return_neighbor_list,
+        )
 
     if is_compiled_pair_fn(pair_fn) and torch.compiler.is_compiling():
         if return_neighbor_list:
@@ -1613,10 +1556,11 @@ def batch_naive_neighbor_list(
                     ("shift_range_per_dimension", shift_range_per_dimension),
                     ("num_shifts_per_system", num_shifts_per_system),
                     ("max_shifts_per_system", max_shifts_per_system),
-                    ("max_atoms_per_system", max_atoms_per_system),
                 )
                 if value is None
             )
+            if target_indices is None and max_atoms_per_system is None:
+                missing.append("max_atoms_per_system")
         if missing:
             raise ValueError(
                 "CompiledPairFn under torch.compile(fullgraph=True) requires "
@@ -1692,16 +1636,10 @@ def batch_naive_neighbor_list(
             f"num_atoms ({total_atoms}). batch_idx must have one entry per atom."
         )
 
-    has_pair_outputs = (
-        bool(return_distances)
-        or bool(return_vectors)
-        or neighbor_vectors is not None
-        or neighbor_distances is not None
-        or pair_fn is not None
-        or pair_energies is not None
-        or pair_forces is not None
+    uses_compact_pair_kernel = (
+        has_geometry_or_pair_outputs or target_indices is not None
     )
-    if has_pair_outputs:
+    if uses_compact_pair_kernel:
         if rebuild_flags is not None:
             raise NotImplementedError(
                 "Pair outputs are not supported with rebuild_flags.",
@@ -1714,48 +1652,55 @@ def batch_naive_neighbor_list(
             int(target_indices.shape[0]) if target_indices is not None else total_atoms
         )
         if target_indices is not None:
-            _validate_output_buffer(
+            _validate_partial_output(
                 "neighbor_matrix",
                 neighbor_matrix,
                 (num_rows, max_neighbors),
                 torch.int32,
+                positions.device,
             )
-            _validate_output_buffer(
+            _validate_partial_output(
                 "num_neighbors",
                 num_neighbors,
                 (num_rows,),
                 torch.int32,
+                positions.device,
             )
             if pbc is not None:
-                _validate_output_buffer(
+                _validate_partial_output(
                     "neighbor_matrix_shifts",
                     neighbor_matrix_shifts,
                     (num_rows, max_neighbors, 3),
                     torch.int32,
+                    positions.device,
                 )
-            _validate_output_buffer(
+            _validate_partial_output(
                 "neighbor_distances",
                 neighbor_distances,
                 (num_rows, max_neighbors),
                 positions.dtype,
+                positions.device,
             )
-            _validate_output_buffer(
+            _validate_partial_output(
                 "neighbor_vectors",
                 neighbor_vectors,
                 (num_rows, max_neighbors, 3),
                 positions.dtype,
+                positions.device,
             )
-            _validate_output_buffer(
+            _validate_partial_output(
                 "pair_energies",
                 pair_energies,
                 (num_rows, max_neighbors),
                 positions.dtype,
+                positions.device,
             )
-            _validate_output_buffer(
+            _validate_partial_output(
                 "pair_forces",
                 pair_forces,
                 (num_rows, max_neighbors, 3),
                 positions.dtype,
+                positions.device,
             )
         if neighbor_distances is None:
             neighbor_distances = torch.zeros(
@@ -1787,7 +1732,13 @@ def batch_naive_neighbor_list(
             # ``.item()`` is a CPU sync; it works in eager but triggers a
             # graph break under ``torch.compile``.  Pass max_atoms_per_system
             # explicitly to keep the autograd path graph-clean under compile.
-            max_atoms_per_system = int((batch_ptr[1:] - batch_ptr[:-1]).max().item())
+            if target_indices is None:
+                max_atoms_per_system = int(
+                    (batch_ptr[1:] - batch_ptr[:-1]).max().item()
+                )
+        forward_max_atoms_per_system = (
+            max_atoms_per_system if max_atoms_per_system is not None else 0
+        )
         forward_kwargs = {
             "cutoff": cutoff,
             "pbc": pbc,
@@ -1802,7 +1753,7 @@ def batch_naive_neighbor_list(
             "shift_range_per_dimension": shift_range_per_dimension,
             "num_shifts_per_system": num_shifts_per_system,
             "max_shifts_per_system": max_shifts_per_system,
-            "max_atoms_per_system": max_atoms_per_system,
+            "max_atoms_per_system": forward_max_atoms_per_system,
             "wrap_positions": wrap_positions,
             "target_indices": target_indices,
             "pair_fn": pair_fn,

--- a/nvalchemiops/torch/neighbors/batch_naive.py
+++ b/nvalchemiops/torch/neighbors/batch_naive.py
@@ -114,7 +114,7 @@ def _batch_naive_neighbor_matrix_no_pbc(
         is True are processed; others are skipped on the GPU without CPU sync.
         Call selective_zero_num_neighbors before this launcher to reset counts.
     target_indices : torch.Tensor, shape (num_targets,), dtype=torch.int32, optional
-        Compact source rows for a topology-only partial neighbor list.
+        Indices of the central atoms for compact topology-only partial rows.
     See Also
     --------
     nvalchemiops.neighbors.batch_naive.batch_naive_neighbor_matrix : Core warp launcher
@@ -221,7 +221,7 @@ def _batch_naive_neighbor_matrix_pbc(
     num_neighbors : torch.Tensor, shape (rows,), dtype=torch.int32
         OUTPUT: Number of neighbors per atom.
     target_indices : torch.Tensor, shape (num_targets,), dtype=torch.int32, optional
-        Compact source rows for a topology-only partial neighbor list.
+        Indices of the central atoms for compact topology-only partial rows.
     shift_range_per_dimension : torch.Tensor, shape (num_systems, 3), dtype=torch.int32
         Shift range in each dimension for each system.
     num_shifts_per_system : torch.Tensor, shape (num_systems,), dtype=torch.int32
@@ -1363,9 +1363,10 @@ def batch_naive_neighbor_list(
         wrapped (e.g. by a preceding integration step) to save two
         GPU kernel launches per call.
     target_indices : torch.Tensor, shape (num_targets,), dtype=torch.int32, optional
-        Compact partial-list source rows. Output row ``r`` maps to atom
-        ``target_indices[r]``; COO source rows remain compact row ids. User
-        buffers must be compact-row shaped, not full atom-row shaped.
+        Indices of the central atoms for compact partial rows. Output row ``r``
+        maps to atom ``target_indices[r]``. In COO output, the first row holds
+        compact row ids. User buffers must be compact-row shaped, not full
+        atom-row shaped. Values must be unique and in bounds.
     strategy : {"auto", "scalar", "tile"}, default="auto"
         ``"auto"`` keeps batched topology-only partial rows on the scalar
         kernel, while ``"scalar"`` is a deterministic opt-out and ``"tile"``

--- a/nvalchemiops/torch/neighbors/cell_list.py
+++ b/nvalchemiops/torch/neighbors/cell_list.py
@@ -187,7 +187,7 @@ def estimate_cell_list_sizes(
         cap (2 x max_nbins x 4 bytes).
     min_cells_per_dimension : int, default=4
         Lower bound for the per-axis cell count. Pass 1 for the legacy grid
-        rule used by explicit atom-centric benchmarks.
+        rule.
 
     Returns
     -------
@@ -452,7 +452,7 @@ def build_cell_list(
         to extract atoms for each cell.
     min_cells_per_dimension : int, default=4
         Lower bound for the per-axis cell count. Pass 1 for the legacy grid
-        rule used by explicit atom-centric benchmarks.
+        rule.
 
     Notes
     -----
@@ -834,8 +834,8 @@ def query_cell_list(
         permitted by ``torch.cuda.graph`` capture but is fine under
         Warp's stream-capture flavor.
     target_indices : torch.Tensor, shape (num_targets,), dtype=int32, optional
-        Restrict central rows to a subset of atom indices.  Output rows are
-        compact and follow ``target_indices`` order.
+        Indices of the central atoms for compact partial rows. Output rows
+        follow ``target_indices`` order.
     return_vectors, return_distances : bool, default ``False``
         Write per-pair displacement vectors / distances into
         ``neighbor_vectors`` / ``neighbor_distances``.
@@ -1082,8 +1082,8 @@ def _query_cell_list_direct_eager(
 ) -> None:
     """Eager fast path for explicit atom-centric direct queries.
 
-    This keeps the common benchmark/runtime path off the generic custom-op
-    boundary while preserving that boundary for ``torch.compile``.
+    This keeps the common eager path off the generic custom-op boundary while
+    preserving that boundary for ``torch.compile``.
     """
     total_atoms = positions.shape[0]
     device = positions.device

--- a/nvalchemiops/torch/neighbors/naive.py
+++ b/nvalchemiops/torch/neighbors/naive.py
@@ -61,6 +61,7 @@ def _naive_neighbor_matrix_no_pbc(
     half_fill: bool = False,
     rebuild_flags: torch.Tensor | None = None,
     strategy: str = "auto",
+    target_indices: torch.Tensor | None = None,
 ) -> None:
     """Fill neighbor matrix for atoms using naive O(N^2) algorithm.
 
@@ -80,12 +81,12 @@ def _naive_neighbor_matrix_no_pbc(
     cutoff : float
         Cutoff distance for neighbor detection in Cartesian units.
         Must be positive. Atoms within this distance are considered neighbors.
-    neighbor_matrix : torch.Tensor, shape (total_atoms, max_neighbors), dtype=torch.int32
+    neighbor_matrix : torch.Tensor, shape (rows, max_neighbors), dtype=torch.int32
         OUTPUT: Neighbor matrix to be filled with neighbor atom indices.
-        Must be pre-allocated. Entries are filled with atom indices.
-    num_neighbors : torch.Tensor, shape (total_atoms,), dtype=torch.int32
+        ``rows`` is ``total_atoms`` normally or the number of target rows.
+    num_neighbors : torch.Tensor, shape (rows,), dtype=torch.int32
         OUTPUT: Number of neighbors found for each atom.
-        Must be pre-allocated. Updated in-place with actual neighbor counts.
+        ``rows`` is ``total_atoms`` normally or the number of target rows.
     half_fill : bool
         If True, only store relationships where i < j to avoid double counting.
         If False, store all neighbor relationships symmetrically.
@@ -93,6 +94,8 @@ def _naive_neighbor_matrix_no_pbc(
         Per-system rebuild flags. If provided, only systems where rebuild_flags[i]
         is True are processed; others are skipped on the GPU without CPU sync.
         Call selective_zero_num_neighbors before this launcher to reset counts.
+    target_indices : torch.Tensor, shape (num_targets,), dtype=torch.int32, optional
+        Compact source rows for a topology-only partial neighbor list.
     See Also
     --------
     nvalchemiops.neighbors.naive.naive_neighbor_matrix : Core warp launcher
@@ -110,6 +113,16 @@ def _naive_neighbor_matrix_no_pbc(
     )
     wp_num_neighbors = wp.from_torch(
         num_neighbors, dtype=wp.int32, requires_grad=False, return_ctype=True
+    )
+    wp_target_indices = (
+        wp.from_torch(
+            target_indices,
+            dtype=wp.int32,
+            requires_grad=False,
+            return_ctype=True,
+        )
+        if target_indices is not None
+        else None
     )
     with scoped_warp_stream(device):
         if rebuild_flags is not None:
@@ -132,6 +145,7 @@ def _naive_neighbor_matrix_no_pbc(
             half_fill=half_fill,
             rebuild_flags=wp_rebuild_flags,
             strategy=strategy,
+            target_indices=wp_target_indices,
         )
 
 
@@ -157,6 +171,7 @@ def _naive_neighbor_matrix_pbc(
     per_atom_cell_offsets_buffer: torch.Tensor | None = None,
     inv_cell_buffer: torch.Tensor | None = None,
     strategy: str = "auto",
+    target_indices: torch.Tensor | None = None,
 ) -> None:
     """Compute neighbor matrix with periodic boundary conditions using naive O(N^2) algorithm.
 
@@ -170,12 +185,15 @@ def _naive_neighbor_matrix_pbc(
         Cutoff distance for neighbor detection.
     cell : torch.Tensor, shape (1, 3, 3)
         Cell matrix defining lattice vectors.
-    neighbor_matrix : torch.Tensor, shape (total_atoms, max_neighbors), dtype=torch.int32
+    neighbor_matrix : torch.Tensor, shape (rows, max_neighbors), dtype=torch.int32
         OUTPUT: Neighbor matrix to be filled.
-    neighbor_matrix_shifts : torch.Tensor, shape (total_atoms, max_neighbors, 3), dtype=torch.int32
+        ``rows`` is ``total_atoms`` normally or the number of target rows.
+    neighbor_matrix_shifts : torch.Tensor, shape (rows, max_neighbors, 3), dtype=torch.int32
         OUTPUT: Shift vectors for each neighbor relationship.
-    num_neighbors : torch.Tensor, shape (total_atoms,), dtype=torch.int32
+    num_neighbors : torch.Tensor, shape (rows,), dtype=torch.int32
         OUTPUT: Number of neighbors found for each atom.
+    target_indices : torch.Tensor, shape (num_targets,), dtype=torch.int32, optional
+        Compact source rows for a topology-only partial neighbor list.
     shift_range_per_dimension : torch.Tensor, shape (1, 3), dtype=torch.int32
         Shift range in each dimension.
     num_shifts_per_system : torch.Tensor, shape (1,), dtype=torch.int32
@@ -228,6 +246,16 @@ def _naive_neighbor_matrix_pbc(
     )
     wp_num_neighbors = wp.from_torch(
         num_neighbors, dtype=wp.int32, requires_grad=False, return_ctype=True
+    )
+    wp_target_indices = (
+        wp.from_torch(
+            target_indices,
+            dtype=wp.int32,
+            requires_grad=False,
+            return_ctype=True,
+        )
+        if target_indices is not None
+        else None
     )
 
     with scoped_warp_stream(device):
@@ -291,6 +319,7 @@ def _naive_neighbor_matrix_pbc(
             per_atom_cell_offsets_buffer=wp_per_atom_cell_offsets,
             inv_cell_buffer=wp_inv_cell,
             strategy=strategy,
+            target_indices=wp_target_indices,
         )
 
 
@@ -791,6 +820,7 @@ def _validate_output_buffer(
     tensor: torch.Tensor | None,
     expected_shape: tuple[int, ...],
     expected_dtype: torch.dtype | None = None,
+    expected_device: torch.device | None = None,
 ) -> None:
     """Validate optional compact-row output buffers."""
     if tensor is None:
@@ -802,6 +832,11 @@ def _validate_output_buffer(
     if expected_dtype is not None and tensor.dtype != expected_dtype:
         raise ValueError(
             f"{name} dtype must be {expected_dtype}; got {tensor.dtype}.",
+        )
+    if expected_device is not None and tensor.device != expected_device:
+        raise ValueError(
+            f"{name} must be on the same device as positions "
+            f"({expected_device}); got {tensor.device}.",
         )
 
 
@@ -1202,6 +1237,13 @@ def naive_neighbor_list(
         Compact partial-list source rows. Output row ``r`` maps to atom
         ``target_indices[r]``; COO source rows remain compact row ids. User
         buffers must be compact-row shaped, not full atom-row shaped.
+    strategy : {"auto", "scalar", "tile"}, default="auto"
+        ``"auto"`` forwards to native dtype-aware dispatch (float64 tiles at
+        256 atoms and float16/float32 tiles at 1,024 atoms for single-system
+        topology-only partial rows). ``"scalar"`` is a deterministic opt-out.
+        ``"tile"`` is CUDA-only and supports topology-only partial rows,
+        including wrapped and prewrapped PBC. Geometry, pair-function outputs,
+        and partial selective rebuilds remain scalar-only or unsupported.
 
     Returns
     -------
@@ -1286,6 +1328,169 @@ def naive_neighbor_list(
     if pbc is not None:
         pbc = pbc if pbc.ndim == 2 else pbc.unsqueeze(0)
 
+    if strategy not in {"auto", "scalar", "tile"}:
+        raise ValueError(
+            f"strategy must be 'auto' | 'scalar' | 'tile', got {strategy!r}",
+        )
+
+    geometry_or_pair_active = (
+        bool(return_distances)
+        or bool(return_vectors)
+        or neighbor_vectors is not None
+        or neighbor_distances is not None
+        or pair_fn is not None
+        or pair_energies is not None
+        or pair_forces is not None
+    )
+    topology_only_partial = target_indices is not None and not geometry_or_pair_active
+    if target_indices is not None:
+        if target_indices.ndim != 1 or target_indices.dtype != torch.int32:
+            raise ValueError("target_indices must be a rank-one int32 tensor.")
+        if target_indices.device != positions.device:
+            raise ValueError(
+                "target_indices must be on the same device as positions.",
+            )
+        if rebuild_flags is not None:
+            raise NotImplementedError(
+                "Partial neighbor lists do not support rebuild_flags.",
+            )
+        if strategy == "tile":
+            if positions.device.type == "cpu":
+                raise ValueError(
+                    "strategy='tile' requires CUDA; use strategy='scalar' or "
+                    "'auto' on CPU.",
+                )
+            if not topology_only_partial:
+                raise NotImplementedError(
+                    "strategy='tile' supports topology-only target_indices; "
+                    "geometry and pair-function outputs require strategy='scalar'.",
+                )
+
+    if topology_only_partial:
+        num_rows = int(target_indices.shape[0])
+        if max_neighbors is None and neighbor_matrix is not None:
+            max_neighbors = int(neighbor_matrix.shape[1])
+        if max_neighbors is None:
+            max_neighbors = estimate_max_neighbors(cutoff)
+        if fill_value is None:
+            fill_value = positions.shape[0]
+        _validate_output_buffer(
+            "neighbor_matrix",
+            neighbor_matrix,
+            (num_rows, max_neighbors),
+            torch.int32,
+            positions.device,
+        )
+        _validate_output_buffer(
+            "num_neighbors",
+            num_neighbors,
+            (num_rows,),
+            torch.int32,
+            positions.device,
+        )
+        if pbc is not None:
+            _validate_output_buffer(
+                "neighbor_matrix_shifts",
+                neighbor_matrix_shifts,
+                (num_rows, max_neighbors, 3),
+                torch.int32,
+                positions.device,
+            )
+        if neighbor_matrix is None:
+            neighbor_matrix = torch.full(
+                (num_rows, max_neighbors),
+                fill_value,
+                dtype=torch.int32,
+                device=positions.device,
+            )
+        else:
+            neighbor_matrix.fill_(fill_value)
+        if num_neighbors is None:
+            num_neighbors = torch.zeros(
+                num_rows,
+                dtype=torch.int32,
+                device=positions.device,
+            )
+        else:
+            num_neighbors.zero_()
+        if pbc is not None:
+            if neighbor_matrix_shifts is None:
+                neighbor_matrix_shifts = torch.zeros(
+                    (num_rows, max_neighbors, 3),
+                    dtype=torch.int32,
+                    device=positions.device,
+                )
+            else:
+                neighbor_matrix_shifts.zero_()
+
+        if cutoff > 0 and num_rows > 0:
+            if pbc is None:
+                _naive_neighbor_matrix_no_pbc(
+                    positions=positions,
+                    cutoff=cutoff,
+                    neighbor_matrix=neighbor_matrix,
+                    num_neighbors=num_neighbors,
+                    half_fill=half_fill,
+                    rebuild_flags=None,
+                    strategy=strategy,
+                    target_indices=target_indices,
+                )
+            else:
+                if (
+                    max_shifts_per_system is None
+                    or num_shifts_per_system is None
+                    or shift_range_per_dimension is None
+                ):
+                    (
+                        shift_range_per_dimension,
+                        num_shifts_per_system,
+                        max_shifts_per_system,
+                    ) = compute_naive_num_shifts(
+                        cell.detach(),
+                        cutoff,
+                        pbc,
+                    )
+                _naive_neighbor_matrix_pbc(
+                    positions=positions,
+                    cutoff=cutoff,
+                    cell=cell,
+                    pbc=pbc,
+                    neighbor_matrix=neighbor_matrix,
+                    neighbor_matrix_shifts=neighbor_matrix_shifts,
+                    num_neighbors=num_neighbors,
+                    shift_range_per_dimension=shift_range_per_dimension,
+                    num_shifts_per_system=num_shifts_per_system,
+                    max_shifts_per_system=max_shifts_per_system,
+                    half_fill=half_fill,
+                    rebuild_flags=None,
+                    wrap_positions=wrap_positions,
+                    positions_wrapped_buffer=positions_wrapped_buffer,
+                    per_atom_cell_offsets_buffer=per_atom_cell_offsets_buffer,
+                    inv_cell_buffer=inv_cell_buffer,
+                    strategy=strategy,
+                    target_indices=target_indices,
+                )
+        if return_neighbor_list:
+            if pbc is not None:
+                neighbor_list, neighbor_ptr, neighbor_list_shifts = (
+                    get_neighbor_list_from_neighbor_matrix(
+                        neighbor_matrix,
+                        num_neighbors=num_neighbors,
+                        neighbor_shift_matrix=neighbor_matrix_shifts,
+                        fill_value=fill_value,
+                    )
+                )
+                return neighbor_list, neighbor_ptr, neighbor_list_shifts
+            neighbor_list, neighbor_ptr = get_neighbor_list_from_neighbor_matrix(
+                neighbor_matrix,
+                num_neighbors=num_neighbors,
+                fill_value=fill_value,
+            )
+            return neighbor_list, neighbor_ptr
+        if pbc is not None:
+            return neighbor_matrix, num_neighbors, neighbor_matrix_shifts
+        return neighbor_matrix, num_neighbors
+
     has_pair_outputs = (
         bool(return_distances)
         or bool(return_vectors)
@@ -1294,13 +1499,7 @@ def naive_neighbor_list(
         or pair_fn is not None
         or pair_energies is not None
         or pair_forces is not None
-        or target_indices is not None
     )
-    if strategy == "tile" and target_indices is not None:
-        raise NotImplementedError(
-            "strategy='tile' has no target_indices (partial "
-            "neighbor-list) variant; use strategy='scalar'.",
-        )
     if has_pair_outputs:
         if is_compiled_pair_fn(pair_fn) and torch.compiler.is_compiling():
             if return_neighbor_list:
@@ -1606,6 +1805,7 @@ def naive_neighbor_list(
             half_fill=half_fill,
             rebuild_flags=rebuild_flags,
             strategy=strategy,
+            target_indices=None,
         )
         if return_neighbor_list:
             neighbor_list, neighbor_ptr = get_neighbor_list_from_neighbor_matrix(
@@ -1635,6 +1835,7 @@ def naive_neighbor_list(
             per_atom_cell_offsets_buffer=per_atom_cell_offsets_buffer,
             inv_cell_buffer=inv_cell_buffer,
             strategy=strategy,
+            target_indices=None,
         )
         if return_neighbor_list:
             neighbor_list, neighbor_ptr, neighbor_list_shifts = (

--- a/nvalchemiops/torch/neighbors/naive.py
+++ b/nvalchemiops/torch/neighbors/naive.py
@@ -105,7 +105,7 @@ def _naive_neighbor_matrix_no_pbc(
         is True are processed; others are skipped on the GPU without CPU sync.
         Call selective_zero_num_neighbors before this launcher to reset counts.
     target_indices : torch.Tensor, shape (num_targets,), dtype=torch.int32, optional
-        Compact source rows for a topology-only partial neighbor list.
+        Indices of the central atoms for compact topology-only partial rows.
     See Also
     --------
     nvalchemiops.neighbors.naive.naive_neighbor_matrix : Core warp launcher
@@ -206,7 +206,7 @@ def _naive_neighbor_matrix_pbc(
     num_neighbors : torch.Tensor, shape (rows,), dtype=torch.int32
         OUTPUT: Number of neighbors found for each atom.
     target_indices : torch.Tensor, shape (num_targets,), dtype=torch.int32, optional
-        Compact source rows for a topology-only partial neighbor list.
+        Indices of the central atoms for compact topology-only partial rows.
     shift_range_per_dimension : torch.Tensor, shape (1, 3), dtype=torch.int32
         Shift range in each dimension.
     num_shifts_per_system : torch.Tensor, shape (1,), dtype=torch.int32
@@ -1224,12 +1224,14 @@ def naive_neighbor_list(
         We recommend using the neighbor matrix format,
         and only convert to a neighbor list format if absolutely necessary.
     target_indices : torch.Tensor, shape (num_targets,), dtype=torch.int32, optional
-        Compact partial-list source rows. Output row ``r`` maps to atom
-        ``target_indices[r]``; COO source rows remain compact row ids. User
-        buffers must be compact-row shaped, not full atom-row shaped.
+        Indices of the central atoms for compact partial rows. Output row ``r``
+        maps to atom ``target_indices[r]``. In COO output, the first row holds
+        compact row ids. User buffers must be compact-row shaped, not full
+        atom-row shaped. Values must be unique and in bounds.
     strategy : {"auto", "scalar", "tile"}, default="auto"
-        ``"auto"`` resolves to scalar for topology-only partial rows.
-        ``"scalar"`` is a deterministic explicit choice.
+        For topology-only single-system partial rows on CUDA, ``"auto"``
+        selects a strategy from the dtype and atom count; it remains scalar on
+        CPU. ``"scalar"`` is a deterministic explicit choice.
         ``"tile"`` is CUDA-only and supports topology-only partial rows,
         including wrapped and prewrapped PBC. Geometry, pair-function outputs,
         and partial selective rebuilds remain scalar-only or unsupported.
@@ -1253,8 +1255,8 @@ def naive_neighbor_list(
               neighbors for atom ``r`` or ``target_indices[r]`` when partial rows
               are requested.
             * If ``return_neighbor_list=True``: Returns ``neighbor_list`` with shape
-              (2, num_pairs), dtype int32, in COO format [source_rows, target_atoms].
-              With ``target_indices``, source rows are compact row ids.
+              (2, num_pairs), dtype int32, in COO format [central_rows, neighbor_atoms].
+              With ``target_indices``, central rows are compact row ids.
 
         - **num_neighbor_data** (tensor): Information about the number of neighbors for each atom,
           format depends on ``return_neighbor_list``:
@@ -1344,7 +1346,6 @@ def naive_neighbor_list(
         )
 
     if topology_only_partial:
-        strategy = "scalar" if strategy == "auto" else strategy
         strategy = _resolve_naive_strategy(
             strategy,
             _NaiveWorkload(

--- a/nvalchemiops/torch/neighbors/naive.py
+++ b/nvalchemiops/torch/neighbors/naive.py
@@ -24,6 +24,10 @@ from nvalchemiops.neighbors.naive import (
     naive_neighbor_matrix,
     naive_neighbor_matrix_pbc,
 )
+from nvalchemiops.neighbors.naive.dispatch import (
+    _NaiveWorkload,
+    _resolve_naive_strategy,
+)
 from nvalchemiops.neighbors.neighbor_utils import (
     estimate_max_neighbors,
     selective_zero_num_neighbors_single,
@@ -37,6 +41,12 @@ from nvalchemiops.torch.neighbors._autograd import (
 from nvalchemiops.torch.neighbors._compiled_pair_fn import (
     CompiledPairFn,
     is_compiled_pair_fn,
+)
+from nvalchemiops.torch.neighbors._naive_partial import (
+    _pack_partial_outputs,
+    _prepare_partial_outputs,
+    _validate_partial_output,
+    _validate_partial_request,
 )
 from nvalchemiops.torch.neighbors.neighbor_utils import (
     _validate_pair_params_present,
@@ -101,6 +111,9 @@ def _naive_neighbor_matrix_no_pbc(
     nvalchemiops.neighbors.naive.naive_neighbor_matrix : Core warp launcher
     naive_neighbor_list : High-level wrapper function
     """
+    if target_indices is not None and rebuild_flags is not None:
+        raise NotImplementedError("Partial neighbor lists do not support rebuild_flags")
+
     device = positions.device
     wp_dtype = get_wp_dtype(positions.dtype)
     wp_vec_dtype = get_wp_vec_dtype(positions.dtype)
@@ -220,6 +233,9 @@ def _naive_neighbor_matrix_pbc(
     nvalchemiops.neighbors.naive.naive_neighbor_matrix_pbc : Core warp launcher
     naive_neighbor_list : High-level wrapper function
     """
+    if target_indices is not None and rebuild_flags is not None:
+        raise NotImplementedError("Partial neighbor lists do not support rebuild_flags")
+
     device = positions.device
     wp_dtype = get_wp_dtype(positions.dtype)
     wp_vec_dtype = get_wp_vec_dtype(positions.dtype)
@@ -815,31 +831,6 @@ def _register_compiled_naive_pbc_pair_op(compiled: CompiledPairFn):
     return _compiled_naive_pbc_pair
 
 
-def _validate_output_buffer(
-    name: str,
-    tensor: torch.Tensor | None,
-    expected_shape: tuple[int, ...],
-    expected_dtype: torch.dtype | None = None,
-    expected_device: torch.device | None = None,
-) -> None:
-    """Validate optional compact-row output buffers."""
-    if tensor is None:
-        return
-    if tuple(tensor.shape) != expected_shape:
-        raise ValueError(
-            f"{name} must have shape {expected_shape}; got {tuple(tensor.shape)}.",
-        )
-    if expected_dtype is not None and tensor.dtype != expected_dtype:
-        raise ValueError(
-            f"{name} dtype must be {expected_dtype}; got {tensor.dtype}.",
-        )
-    if expected_device is not None and tensor.device != expected_device:
-        raise ValueError(
-            f"{name} must be on the same device as positions "
-            f"({expected_device}); got {tensor.device}.",
-        )
-
-
 def _naive_pair_outputs_forward(
     positions: torch.Tensor,
     cell: torch.Tensor | None,
@@ -977,9 +968,8 @@ def _naive_pair_outputs_forward(
                 "naive pair_fn kernels are eager-only because Python callables "
                 "cannot cross a torch custom-op boundary.",
             )
-        # ``pair_fn`` and/or ``target_indices`` bypass the custom op and call
-        # the Warp scalar launcher directly. Torch custom ops cannot carry a
-        # Python pair_fn, and they do not expose compact partial rows.
+        # A Python ``pair_fn`` requires direct Warp dispatch. Compact custom
+        # ops remain available for non-Python pair-output paths.
         wp_dtype = get_wp_dtype(positions.dtype)
         wp_vec_dtype = get_wp_vec_dtype(positions.dtype)
         pair_kwargs = {}
@@ -1238,9 +1228,8 @@ def naive_neighbor_list(
         ``target_indices[r]``; COO source rows remain compact row ids. User
         buffers must be compact-row shaped, not full atom-row shaped.
     strategy : {"auto", "scalar", "tile"}, default="auto"
-        ``"auto"`` forwards to native dtype-aware dispatch (float64 tiles at
-        256 atoms and float16/float32 tiles at 1,024 atoms for single-system
-        topology-only partial rows). ``"scalar"`` is a deterministic opt-out.
+        ``"auto"`` resolves to scalar for topology-only partial rows.
+        ``"scalar"`` is a deterministic explicit choice.
         ``"tile"`` is CUDA-only and supports topology-only partial rows,
         including wrapped and prewrapped PBC. Geometry, pair-function outputs,
         and partial selective rebuilds remain scalar-only or unsupported.
@@ -1333,7 +1322,7 @@ def naive_neighbor_list(
             f"strategy must be 'auto' | 'scalar' | 'tile', got {strategy!r}",
         )
 
-    geometry_or_pair_active = (
+    has_geometry_or_pair_outputs = (
         bool(return_distances)
         or bool(return_vectors)
         or neighbor_vectors is not None
@@ -1342,86 +1331,53 @@ def naive_neighbor_list(
         or pair_energies is not None
         or pair_forces is not None
     )
-    topology_only_partial = target_indices is not None and not geometry_or_pair_active
+    topology_only_partial = (
+        target_indices is not None and not has_geometry_or_pair_outputs
+    )
     if target_indices is not None:
-        if target_indices.ndim != 1 or target_indices.dtype != torch.int32:
-            raise ValueError("target_indices must be a rank-one int32 tensor.")
-        if target_indices.device != positions.device:
-            raise ValueError(
-                "target_indices must be on the same device as positions.",
-            )
-        if rebuild_flags is not None:
-            raise NotImplementedError(
-                "Partial neighbor lists do not support rebuild_flags.",
-            )
-        if strategy == "tile":
-            if positions.device.type == "cpu":
-                raise ValueError(
-                    "strategy='tile' requires CUDA; use strategy='scalar' or "
-                    "'auto' on CPU.",
-                )
-            if not topology_only_partial:
-                raise NotImplementedError(
-                    "strategy='tile' supports topology-only target_indices; "
-                    "geometry and pair-function outputs require strategy='scalar'.",
-                )
+        _validate_partial_request(
+            positions,
+            target_indices,
+            rebuild_flags,
+            strategy=strategy,
+            has_geometry_or_pair_outputs=has_geometry_or_pair_outputs,
+        )
 
     if topology_only_partial:
-        num_rows = int(target_indices.shape[0])
-        if max_neighbors is None and neighbor_matrix is not None:
-            max_neighbors = int(neighbor_matrix.shape[1])
-        if max_neighbors is None:
-            max_neighbors = estimate_max_neighbors(cutoff)
+        strategy = "scalar" if strategy == "auto" else strategy
+        strategy = _resolve_naive_strategy(
+            strategy,
+            _NaiveWorkload(
+                device_kind="cpu" if positions.device.type == "cpu" else "cuda",
+                wp_dtype=get_wp_dtype(positions.dtype),
+                num_atoms=int(positions.shape[0]),
+                num_systems=1,
+                partial=True,
+                batched=False,
+                pbc=pbc is not None,
+                wrap_positions=wrap_positions,
+                geometry_outputs=False,
+            ),
+        )
         if fill_value is None:
-            fill_value = positions.shape[0]
-        _validate_output_buffer(
-            "neighbor_matrix",
+            fill_value = int(positions.shape[0])
+        (
             neighbor_matrix,
-            (num_rows, max_neighbors),
-            torch.int32,
-            positions.device,
-        )
-        _validate_output_buffer(
-            "num_neighbors",
             num_neighbors,
-            (num_rows,),
-            torch.int32,
-            positions.device,
+            neighbor_matrix_shifts,
+            max_neighbors,
+            num_rows,
+        ) = _prepare_partial_outputs(
+            positions,
+            target_indices,
+            cutoff,
+            pbc_enabled=pbc is not None,
+            max_neighbors=max_neighbors,
+            fill_value=fill_value,
+            neighbor_matrix=neighbor_matrix,
+            num_neighbors=num_neighbors,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
         )
-        if pbc is not None:
-            _validate_output_buffer(
-                "neighbor_matrix_shifts",
-                neighbor_matrix_shifts,
-                (num_rows, max_neighbors, 3),
-                torch.int32,
-                positions.device,
-            )
-        if neighbor_matrix is None:
-            neighbor_matrix = torch.full(
-                (num_rows, max_neighbors),
-                fill_value,
-                dtype=torch.int32,
-                device=positions.device,
-            )
-        else:
-            neighbor_matrix.fill_(fill_value)
-        if num_neighbors is None:
-            num_neighbors = torch.zeros(
-                num_rows,
-                dtype=torch.int32,
-                device=positions.device,
-            )
-        else:
-            num_neighbors.zero_()
-        if pbc is not None:
-            if neighbor_matrix_shifts is None:
-                neighbor_matrix_shifts = torch.zeros(
-                    (num_rows, max_neighbors, 3),
-                    dtype=torch.int32,
-                    device=positions.device,
-                )
-            else:
-                neighbor_matrix_shifts.zero_()
 
         if cutoff > 0 and num_rows > 0:
             if pbc is None:
@@ -1470,37 +1426,18 @@ def naive_neighbor_list(
                     strategy=strategy,
                     target_indices=target_indices,
                 )
-        if return_neighbor_list:
-            if pbc is not None:
-                neighbor_list, neighbor_ptr, neighbor_list_shifts = (
-                    get_neighbor_list_from_neighbor_matrix(
-                        neighbor_matrix,
-                        num_neighbors=num_neighbors,
-                        neighbor_shift_matrix=neighbor_matrix_shifts,
-                        fill_value=fill_value,
-                    )
-                )
-                return neighbor_list, neighbor_ptr, neighbor_list_shifts
-            neighbor_list, neighbor_ptr = get_neighbor_list_from_neighbor_matrix(
-                neighbor_matrix,
-                num_neighbors=num_neighbors,
-                fill_value=fill_value,
-            )
-            return neighbor_list, neighbor_ptr
-        if pbc is not None:
-            return neighbor_matrix, num_neighbors, neighbor_matrix_shifts
-        return neighbor_matrix, num_neighbors
+        return _pack_partial_outputs(
+            neighbor_matrix,
+            num_neighbors,
+            neighbor_matrix_shifts,
+            fill_value=int(fill_value),
+            return_neighbor_list=return_neighbor_list,
+        )
 
-    has_pair_outputs = (
-        bool(return_distances)
-        or bool(return_vectors)
-        or neighbor_vectors is not None
-        or neighbor_distances is not None
-        or pair_fn is not None
-        or pair_energies is not None
-        or pair_forces is not None
+    uses_compact_pair_kernel = (
+        has_geometry_or_pair_outputs or target_indices is not None
     )
-    if has_pair_outputs:
+    if uses_compact_pair_kernel:
         if is_compiled_pair_fn(pair_fn) and torch.compiler.is_compiling():
             if return_neighbor_list:
                 raise NotImplementedError(
@@ -1554,48 +1491,55 @@ def naive_neighbor_list(
             else positions.shape[0]
         )
         if target_indices is not None:
-            _validate_output_buffer(
+            _validate_partial_output(
                 "neighbor_matrix",
                 neighbor_matrix,
                 (num_rows, max_neighbors),
                 torch.int32,
+                positions.device,
             )
-            _validate_output_buffer(
+            _validate_partial_output(
                 "num_neighbors",
                 num_neighbors,
                 (num_rows,),
                 torch.int32,
+                positions.device,
             )
             if pbc is not None:
-                _validate_output_buffer(
+                _validate_partial_output(
                     "neighbor_matrix_shifts",
                     neighbor_matrix_shifts,
                     (num_rows, max_neighbors, 3),
                     torch.int32,
+                    positions.device,
                 )
-            _validate_output_buffer(
+            _validate_partial_output(
                 "neighbor_distances",
                 neighbor_distances,
                 (num_rows, max_neighbors),
                 positions.dtype,
+                positions.device,
             )
-            _validate_output_buffer(
+            _validate_partial_output(
                 "neighbor_vectors",
                 neighbor_vectors,
                 (num_rows, max_neighbors, 3),
                 positions.dtype,
+                positions.device,
             )
-            _validate_output_buffer(
+            _validate_partial_output(
                 "pair_energies",
                 pair_energies,
                 (num_rows, max_neighbors),
                 positions.dtype,
+                positions.device,
             )
-            _validate_output_buffer(
+            _validate_partial_output(
                 "pair_forces",
                 pair_forces,
                 (num_rows, max_neighbors, 3),
                 positions.dtype,
+                positions.device,
             )
         if neighbor_matrix is None:
             neighbor_matrix = torch.full(

--- a/test/neighbors/bindings/jax/test_batch_naive.py
+++ b/test/neighbors/bindings/jax/test_batch_naive.py
@@ -358,7 +358,6 @@ class TestBatchNaiveNeighborList:
                 shift_range_per_dimension=shift_range,
                 num_shifts_per_system=num_shifts,
                 max_shifts_per_system=max_shifts,
-                max_atoms_per_system=2,
                 target_indices=target_indices,
             )
 
@@ -1042,6 +1041,33 @@ class TestBatchNaiveJIT:
 @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
 class TestBatchNaiveSelectiveRebuildFlags:
     """Test selective rebuild (rebuild_flags) for batch_naive_neighbor_list JAX binding."""
+
+    def test_partial_rebuild_flags_are_rejected(self, dtype):
+        """Compact batch rows cannot be combined with selective rebuild flags."""
+        positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.5, 0.0, 0.0],
+                [10.0, 0.0, 0.0],
+                [10.5, 0.0, 0.0],
+            ],
+            dtype=dtype,
+        )
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 2, 4], dtype=jnp.int32)
+        with pytest.raises(
+            NotImplementedError,
+            match=r"^Partial neighbor lists do not support rebuild_flags$",
+        ):
+            batch_naive_neighbor_list(
+                positions,
+                1.0,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                max_neighbors=4,
+                target_indices=jnp.array([2, 0], dtype=jnp.int32),
+                rebuild_flags=jnp.ones((2,), dtype=jnp.bool_),
+            )
 
     def test_no_rebuild_preserves_data(self, dtype):
         """All flags False: neighbor data should remain unchanged for all systems."""

--- a/test/neighbors/bindings/jax/test_batch_naive.py
+++ b/test/neighbors/bindings/jax/test_batch_naive.py
@@ -24,10 +24,36 @@ import pytest
 
 from nvalchemiops.jax.neighbors.batch_naive import batch_naive_neighbor_list
 from nvalchemiops.jax.neighbors.neighbor_utils import compute_naive_num_shifts
+from nvalchemiops.neighbors.neighbor_utils import NeighborOverflowError
 
 from .conftest import requires_gpu
 
 pytestmark = requires_gpu
+
+
+def _sorted_row_multisets(
+    neighbor_matrix: jax.Array,
+    num_neighbors: jax.Array,
+    neighbor_matrix_shifts: jax.Array | None = None,
+) -> list[list[tuple[int, ...]]]:
+    """Return active neighbor rows as sorted multisets for parity checks."""
+    matrix_np = np.asarray(neighbor_matrix)
+    counts_np = np.asarray(num_neighbors)
+    shifts_np = (
+        np.asarray(neighbor_matrix_shifts)
+        if neighbor_matrix_shifts is not None
+        else None
+    )
+    rows = []
+    for row, count in enumerate(counts_np):
+        values = []
+        for col in range(int(count)):
+            item = (int(matrix_np[row, col]),)
+            if shifts_np is not None:
+                item += tuple(int(value) for value in shifts_np[row, col])
+            values.append(item)
+        rows.append(sorted(values))
+    return rows
 
 
 def _distances_from_neighbor_list(
@@ -367,19 +393,153 @@ class TestBatchNaiveNeighborList:
                 target_indices=jnp.array([2, 0], dtype=jnp.int32),
             )
 
-    def test_target_indices_rejects_tile_strategy(self):
-        """Explicit tiled batch naive mode does not support partial rows."""
-        positions = jnp.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]], dtype=jnp.float32)
-        batch_idx = jnp.array([0, 0], dtype=jnp.int32)
-        with pytest.raises(NotImplementedError, match="target_indices"):
+    @pytest.mark.gpu
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    @pytest.mark.parametrize("half_fill", [False, True])
+    @pytest.mark.parametrize("pbc_mode", ["none", "wrapped", "prewrapped"])
+    def test_target_indices_tile_matches_scalar(self, dtype, half_fill, pbc_mode):
+        """Explicit tile matches scalar compact topology across batch systems."""
+        device = jax.devices("gpu")[0]
+        positions = jax.device_put(
+            jnp.array(
+                [
+                    [0.0, 0.0, 0.0],
+                    [3.5, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [2.0, 0.0, 0.0],
+                ],
+                dtype=dtype,
+            ),
+            device,
+        )
+        batch_idx = jax.device_put(jnp.array([0, 0, 1, 1], dtype=jnp.int32), device)
+        batch_ptr = jax.device_put(jnp.array([0, 2, 4], dtype=jnp.int32), device)
+        target_indices = jax.device_put(jnp.array([2, 0], dtype=jnp.int32), device)
+        kwargs = {}
+        if pbc_mode != "none":
+            cell = jax.device_put(
+                jnp.stack([jnp.eye(3, dtype=dtype) * 4.0] * 2),
+                device,
+            )
+            pbc = jax.device_put(jnp.ones((2, 3), dtype=jnp.bool_), device)
+            shift_range, num_shifts, max_shifts = compute_naive_num_shifts(
+                cell,
+                1.1,
+                pbc,
+            )
+            kwargs = {
+                "cell": cell,
+                "pbc": pbc,
+                "wrap_positions": pbc_mode == "wrapped",
+                "shift_range_per_dimension": shift_range,
+                "num_shifts_per_system": num_shifts,
+                "max_shifts_per_system": int(max_shifts),
+                "max_atoms_per_system": 2,
+            }
+        scalar = batch_naive_neighbor_list(
+            positions,
+            1.1,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=32,
+            half_fill=half_fill,
+            target_indices=target_indices,
+            strategy="scalar",
+            **kwargs,
+        )
+        tiled = batch_naive_neighbor_list(
+            positions,
+            1.1,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=32,
+            half_fill=half_fill,
+            target_indices=target_indices,
+            strategy="tile",
+            **kwargs,
+        )
+        np.testing.assert_array_equal(np.asarray(scalar[1]), np.asarray(tiled[1]))
+        scalar_shifts = scalar[2] if pbc_mode != "none" else None
+        tiled_shifts = tiled[2] if pbc_mode != "none" else None
+        assert _sorted_row_multisets(scalar[0], scalar[1], scalar_shifts) == (
+            _sorted_row_multisets(tiled[0], tiled[1], tiled_shifts)
+        )
+
+    @pytest.mark.gpu
+    def test_target_indices_tile_batch_contracts(self):
+        """Batched tile preserves COO, fill, empty, and overflow contracts."""
+        device = jax.devices("gpu")[0]
+        positions = jax.device_put(
+            jnp.array(
+                [
+                    [0.0, 0.0, 0.0],
+                    [0.4, 0.0, 0.0],
+                    [0.8, 0.0, 0.0],
+                    [3.0, 0.0, 0.0],
+                ],
+                dtype=jnp.float32,
+            ),
+            device,
+        )
+        batch_idx = jax.device_put(jnp.zeros(4, dtype=jnp.int32), device)
+        batch_ptr = jax.device_put(jnp.array([0, 4], dtype=jnp.int32), device)
+        targets = jax.device_put(jnp.array([0, 3], dtype=jnp.int32), device)
+        stale_matrix = jax.device_put(jnp.full((2, 1), 99, dtype=jnp.int32), device)
+        stale_counts = jax.device_put(jnp.full((2,), 99, dtype=jnp.int32), device)
+
+        matrix, counts = batch_naive_neighbor_list(
+            positions,
+            1.0,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=1,
+            fill_value=-7,
+            neighbor_matrix=stale_matrix,
+            num_neighbors=stale_counts,
+            target_indices=targets,
+            strategy="tile",
+        )
+        np.testing.assert_array_equal(np.asarray(counts), [2, 0])
+        assert int(matrix[1, 0]) == -7
+
+        with pytest.raises(NeighborOverflowError):
             batch_naive_neighbor_list(
                 positions,
                 1.0,
                 batch_idx=batch_idx,
-                max_neighbors=4,
-                target_indices=jnp.array([0], dtype=jnp.int32),
+                batch_ptr=batch_ptr,
+                max_neighbors=1,
+                fill_value=-7,
+                target_indices=targets,
                 strategy="tile",
+                return_neighbor_list=True,
             )
+
+        empty_matrix, empty_counts = batch_naive_neighbor_list(
+            positions,
+            1.0,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=4,
+            fill_value=-3,
+            target_indices=jnp.empty((0,), dtype=jnp.int32),
+            strategy="tile",
+        )
+        assert empty_matrix.shape == (0, 4)
+        assert empty_counts.shape == (0,)
+
+        zero_matrix, zero_counts = batch_naive_neighbor_list(
+            positions,
+            0.0,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=4,
+            fill_value=-3,
+            target_indices=targets,
+            strategy="tile",
+        )
+        np.testing.assert_array_equal(np.asarray(zero_counts), [0, 0])
+        np.testing.assert_array_equal(np.asarray(zero_matrix), -3)
 
     def test_topology_only_grad_no_pbc_is_zero(self):
         """Topology-only batch outputs do not differentiate through Warp FFI."""
@@ -755,6 +915,128 @@ class TestBatchNaiveJIT:
         assert neighbor_matrix.shape == (4, 10)
         assert num_neighbors.shape == (4,)
         assert jnp.all(num_neighbors >= 0)
+
+    @pytest.mark.gpu
+    def test_jit_tile_partial_no_pbc(self):
+        """JIT tiled partial output supports runtime compact targets."""
+        positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.5, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+                [2.5, 0.0, 0.0],
+            ],
+            dtype=jnp.float32,
+        )
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 2, 4], dtype=jnp.int32)
+
+        @jax.jit
+        def jitted_batch_naive(positions, neighbor_matrix, num_neighbors, targets):
+            return batch_naive_neighbor_list(
+                positions,
+                cutoff=0.75,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                neighbor_matrix=neighbor_matrix,
+                num_neighbors=num_neighbors,
+                target_indices=targets,
+                strategy="tile",
+            )
+
+        for targets in (
+            jnp.array([2, 0], dtype=jnp.int32),
+            jnp.array([0, 2], dtype=jnp.int32),
+        ):
+            tiled_nm, tiled_nn = jitted_batch_naive(
+                positions,
+                jnp.full((2, 4), 4, dtype=jnp.int32),
+                jnp.zeros((2,), dtype=jnp.int32),
+                targets,
+            )
+            scalar_nm, scalar_nn = batch_naive_neighbor_list(
+                positions,
+                0.75,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                max_neighbors=4,
+                target_indices=targets,
+                strategy="scalar",
+            )
+            np.testing.assert_array_equal(np.asarray(tiled_nn), np.asarray(scalar_nn))
+            assert _sorted_row_multisets(tiled_nm, tiled_nn) == _sorted_row_multisets(
+                scalar_nm,
+                scalar_nn,
+            )
+
+    @pytest.mark.gpu
+    def test_jit_tile_partial_pbc(self):
+        """JIT tiled partial PBC output uses concrete launch dimensions."""
+        positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [3.5, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+            ],
+            dtype=jnp.float32,
+        )
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 2, 4], dtype=jnp.int32)
+        cell = jnp.stack([jnp.eye(3, dtype=jnp.float32) * 4.0] * 2)
+        pbc = jnp.ones((2, 3), dtype=jnp.bool_)
+        shift_range, num_shifts, max_shifts = compute_naive_num_shifts(cell, 1.1, pbc)
+
+        @jax.jit
+        def jitted_batch_naive(
+            positions,
+            neighbor_matrix,
+            neighbor_matrix_shifts,
+            num_neighbors,
+            targets,
+        ):
+            return batch_naive_neighbor_list(
+                positions,
+                cutoff=1.1,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                cell=cell,
+                pbc=pbc,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+                num_neighbors=num_neighbors,
+                shift_range_per_dimension=shift_range,
+                num_shifts_per_system=num_shifts,
+                max_shifts_per_system=int(max_shifts),
+                max_atoms_per_system=2,
+                target_indices=targets,
+                strategy="tile",
+            )
+
+        targets = jnp.array([2, 0], dtype=jnp.int32)
+        tiled_nm, tiled_nn, tiled_shifts = jitted_batch_naive(
+            positions,
+            jnp.full((2, 32), 4, dtype=jnp.int32),
+            jnp.zeros((2, 32, 3), dtype=jnp.int32),
+            jnp.zeros((2,), dtype=jnp.int32),
+            targets,
+        )
+        scalar_nm, scalar_nn, scalar_shifts = batch_naive_neighbor_list(
+            positions,
+            1.1,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=32,
+            max_atoms_per_system=2,
+            target_indices=targets,
+            strategy="scalar",
+        )
+        np.testing.assert_array_equal(np.asarray(tiled_nn), np.asarray(scalar_nn))
+        assert _sorted_row_multisets(tiled_nm, tiled_nn, tiled_shifts) == (
+            _sorted_row_multisets(scalar_nm, scalar_nn, scalar_shifts)
+        )
 
 
 @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])

--- a/test/neighbors/bindings/jax/test_dispatch.py
+++ b/test/neighbors/bindings/jax/test_dispatch.py
@@ -133,6 +133,51 @@ assert (num_neighbors == 0).all()
     assert result.returncode == 0, result.stderr
 
 
+def test_jitted_gpu_partial_auto_does_not_query_default_backend():
+    """Traced CUDA partial auto remains scalar without backend inference."""
+    if not any(device.platform == "gpu" for device in jax.devices()):
+        pytest.skip("Mixed CPU/GPU JAX backends are required.")
+    script = """
+import jax
+import jax.numpy as jnp
+
+from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
+
+gpu = jax.local_devices(backend="gpu")[0]
+targets = jax.device_put(jnp.array([0, 1023], dtype=jnp.int32), gpu)
+positions = jax.device_put(
+    jnp.arange(1024 * 3, dtype=jnp.float32).reshape(1024, 3),
+    gpu,
+)
+
+def run(pos):
+    return naive_neighbor_list(
+        pos,
+        0.0,
+        max_neighbors=4,
+        target_indices=targets,
+        strategy="auto",
+    )
+
+jax.default_backend = lambda: (_ for _ in ()).throw(AssertionError("backend queried"))
+neighbor_matrix, num_neighbors = jax.jit(run, backend="gpu")(positions)
+neighbor_matrix.block_until_ready()
+assert neighbor_matrix.shape == (2, 4)
+assert num_neighbors.shape == (2,)
+assert (num_neighbors == 0).all()
+"""
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cuda,cpu"
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_jitted_cpu_tile_rejects_before_launch():
     """An explicit tiled CPU request fails while JAX traces the call."""
     script = """
@@ -155,13 +200,132 @@ def run(positions):
 
 try:
     run(jnp.zeros((4, 3), dtype=jnp.float32))
-except ValueError as exc:
-    assert "requires CUDA" in str(exc)
+except jax.errors.JaxRuntimeError as exc:
+    assert "No FFI handler registered" in str(exc)
+    assert "Host" in str(exc)
 else:
-    raise AssertionError("expected explicit tile to reject CPU")
+    raise AssertionError("expected CPU-targeted tile lowering to fail")
 """
     env = os.environ.copy()
     env["JAX_PLATFORMS"] = "cpu"
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    ("graph_mode", "strategy"),
+    [("none", "tile"), ("warp", "auto")],
+)
+@pytest.mark.parametrize("target_backend", ["gpu", "cpu"])
+def test_jitted_tile_uses_target_backend_not_process_default(
+    graph_mode,
+    strategy,
+    target_backend,
+):
+    """JIT tile routing ignores the process default backend."""
+    if not any(device.platform == "gpu" for device in jax.devices()):
+        pytest.skip("Mixed CPU/GPU JAX backends are required.")
+    script = f"""
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+import warp as wp
+
+from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
+
+gpu = jax.local_devices(backend="gpu")[0]
+targets = jax.device_put(jnp.array([2, 0], dtype=jnp.int32), gpu)
+positions = jax.device_put(
+    jnp.array(
+        [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [2.0, 0.0, 0.0], [2.5, 0.0, 0.0]],
+        dtype=jnp.float32,
+    ),
+    gpu,
+)
+
+def run_no_graph(pos):
+    return naive_neighbor_list(
+        pos,
+        0.75,
+        max_neighbors=4,
+        target_indices=targets,
+        strategy="{strategy}",
+        graph_mode="{graph_mode}",
+    )
+
+def run_warp(pos, matrix, counts):
+    return naive_neighbor_list(
+        pos,
+        0.75,
+        max_neighbors=4,
+        target_indices=targets,
+        neighbor_matrix=matrix,
+        num_neighbors=counts,
+        return_neighbor_list=False,
+        strategy="{strategy}",
+        graph_mode="{graph_mode}",
+    )
+
+jax.default_backend = lambda: "cpu"
+
+if "{target_backend}" == "gpu":
+    scalar = naive_neighbor_list(
+        positions,
+        0.75,
+        max_neighbors=4,
+        target_indices=targets,
+        strategy="scalar",
+    )
+    if "{graph_mode}" == "none":
+        tiled = jax.jit(run_no_graph, backend="gpu")(positions)
+    else:
+        matrix = jax.device_put(jnp.full((2, 4), 4, dtype=jnp.int32), gpu)
+        counts = jax.device_put(jnp.zeros((2,), dtype=jnp.int32), gpu)
+        tiled = jax.jit(run_warp, backend="gpu", donate_argnums=(1, 2))(
+            positions,
+            matrix,
+            counts,
+        )
+    for scalar_array, tiled_array in zip(scalar, tiled):
+        np.testing.assert_array_equal(np.asarray(scalar_array), np.asarray(tiled_array))
+else:
+    if "{graph_mode}" == "none":
+        call = jax.jit(run_no_graph, backend="cpu")
+        args = (jnp.zeros((4, 3), dtype=jnp.float32),)
+    else:
+        call = jax.jit(run_warp, backend="cpu", donate_argnums=(1, 2))
+        args = (
+            jnp.zeros((4, 3), dtype=jnp.float32),
+            jnp.full((2, 4), 4, dtype=jnp.int32),
+            jnp.zeros((2,), dtype=jnp.int32),
+        )
+    launch_tiled_called = False
+    real_launch_tiled = wp.launch_tiled
+    def checked_launch_tiled(*args, **kwargs):
+        global launch_tiled_called
+        launch_tiled_called = True
+        return real_launch_tiled(*args, **kwargs)
+    wp.launch_tiled = checked_launch_tiled
+    try:
+        call(*args)
+    except jax.errors.JaxRuntimeError as exc:
+        assert "No FFI handler registered" in str(exc)
+        assert "Host" in str(exc)
+    else:
+        raise AssertionError("expected CPU-targeted tile lowering to fail")
+    finally:
+        wp.launch_tiled = real_launch_tiled
+    assert not launch_tiled_called
+"""
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cuda,cpu"
     result = subprocess.run(  # noqa: S603
         [sys.executable, "-c", script],
         check=False,

--- a/test/neighbors/bindings/jax/test_dispatch.py
+++ b/test/neighbors/bindings/jax/test_dispatch.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-independent JAX dispatch validation tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from nvalchemiops.jax.neighbors.batch_naive import batch_naive_neighbor_list
+from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
+
+
+def test_jitted_cpu_trace_preserves_cpu_dispatch():
+    """A default-CPU jit trace is recognized as CPU before tile lowering."""
+    script = """
+import jax
+import jax.numpy as jnp
+
+from nvalchemiops.jax.neighbors.naive import _is_jax_cpu_for_tile
+
+
+@jax.jit
+def classify(positions):
+    return _is_jax_cpu_for_tile(positions)
+
+
+assert bool(classify(jnp.zeros((2, 3), dtype=jnp.float32)))
+"""
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("batched", [False, True])
+def test_cpu_tile_rejects_before_launch(batched):
+    """Explicit CPU tile requests fail before any native launch."""
+    cpu = jax.local_devices(backend="cpu")[0]
+    positions = jax.device_put(jnp.zeros((4, 3), dtype=jnp.float32), cpu)
+    targets = jax.device_put(jnp.array([0, 2], dtype=jnp.int32), cpu)
+    call = batch_naive_neighbor_list if batched else naive_neighbor_list
+    kwargs = (
+        {
+            "batch_idx": jax.device_put(jnp.zeros((4,), dtype=jnp.int32), cpu),
+            "batch_ptr": jax.device_put(jnp.array([0, 4], dtype=jnp.int32), cpu),
+        }
+        if batched
+        else {}
+    )
+
+    with pytest.raises(ValueError, match="requires CUDA"):
+        call(
+            positions,
+            1.0,
+            max_neighbors=8,
+            target_indices=targets,
+            strategy="tile",
+            **kwargs,
+        )
+
+
+def test_single_target_indices_validate_before_dispatch():
+    """Single-system target indices use the same ABI validation as batch."""
+    cpu = jax.local_devices(backend="cpu")[0]
+    with pytest.raises(ValueError, match="rank-one int32"):
+        naive_neighbor_list(
+            jax.device_put(jnp.zeros((4, 3), dtype=jnp.float32), cpu),
+            1.0,
+            max_neighbors=8,
+            target_indices=jax.device_put(jnp.array([0, 2], dtype=jnp.int64), cpu),
+            strategy="scalar",
+        )

--- a/test/neighbors/bindings/jax/test_dispatch.py
+++ b/test/neighbors/bindings/jax/test_dispatch.py
@@ -35,12 +35,12 @@ def test_jitted_cpu_trace_preserves_cpu_dispatch():
 import jax
 import jax.numpy as jnp
 
-from nvalchemiops.jax.neighbors.naive import _is_jax_cpu_for_tile
+from nvalchemiops.jax.neighbors._dispatch import _is_jax_cpu_array
 
 
 @jax.jit
 def classify(positions):
-    return _is_jax_cpu_for_tile(positions)
+    return _is_jax_cpu_array(positions)
 
 
 assert bool(classify(jnp.zeros((2, 3), dtype=jnp.float32)))

--- a/test/neighbors/bindings/jax/test_dispatch.py
+++ b/test/neighbors/bindings/jax/test_dispatch.py
@@ -24,26 +24,231 @@ import sys
 import jax
 import jax.numpy as jnp
 import pytest
+import warp as wp
 
 from nvalchemiops.jax.neighbors.batch_naive import batch_naive_neighbor_list
 from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
 
 
+@wp.func
+def _sum_pair_fn(
+    r_ij: wp.vec3f,
+    distance: wp.float32,
+    pair_params: wp.array2d(dtype=wp.float32),
+    i: int,
+    j: int,
+):
+    """Return simple energy and force pair outputs."""
+    return pair_params[i, 0] + pair_params[j, 0] + distance, -r_ij
+
+
 def test_jitted_cpu_trace_preserves_cpu_dispatch():
-    """A default-CPU jit trace is recognized as CPU before tile lowering."""
+    """A traced placement is unknown without consulting the default backend."""
+    script = """
+import jax
+import jax.numpy as jnp
+import warp as wp
+
+from nvalchemiops.jax.neighbors._dispatch import _jax_array_device_kind
+from nvalchemiops.neighbors.naive.dispatch import (
+    _NaiveWorkload,
+    _resolve_naive_strategy,
+)
+
+observed = []
+jax.default_backend = lambda: (_ for _ in ()).throw(AssertionError("backend queried"))
+
+@jax.jit
+def classify(positions):
+    kind = _jax_array_device_kind(positions)
+    strategy = _resolve_naive_strategy(
+        "auto",
+        _NaiveWorkload(
+            device_kind=kind,
+            wp_dtype=wp.float32,
+            num_atoms=2,
+            num_systems=1,
+            partial=True,
+            batched=False,
+            pbc=False,
+            wrap_positions=True,
+            geometry_outputs=False,
+        ),
+    )
+    observed.append((kind, strategy))
+    return positions
+
+
+classify(jnp.zeros((2, 3), dtype=jnp.float32)).block_until_ready()
+assert observed == [("unknown", "scalar")]
+"""
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_jitted_large_partial_auto_cpu_uses_scalar_output():
+    """A traced CPU partial auto call stays on the scalar-compatible path."""
     script = """
 import jax
 import jax.numpy as jnp
 
-from nvalchemiops.jax.neighbors._dispatch import _is_jax_cpu_array
+from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
 
+targets = jnp.array([0, 511], dtype=jnp.int32)
 
 @jax.jit
-def classify(positions):
-    return _is_jax_cpu_array(positions)
+def run(positions):
+    return naive_neighbor_list(
+        positions,
+        0.0,
+        max_neighbors=4,
+        target_indices=targets,
+        strategy="auto",
+    )
+
+positions = jnp.arange(1024 * 3, dtype=jnp.float32).reshape(1024, 3)
+neighbor_matrix, num_neighbors = run(positions)
+neighbor_matrix.block_until_ready()
+assert neighbor_matrix.shape == (2, 4)
+assert num_neighbors.shape == (2,)
+assert (num_neighbors == 0).all()
+"""
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
 
 
-assert bool(classify(jnp.zeros((2, 3), dtype=jnp.float32)))
+def test_jitted_cpu_tile_rejects_before_launch():
+    """An explicit tiled CPU request fails while JAX traces the call."""
+    script = """
+import jax
+import jax.numpy as jnp
+
+from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
+
+targets = jnp.array([0, 2], dtype=jnp.int32)
+
+@jax.jit
+def run(positions):
+    return naive_neighbor_list(
+        positions,
+        1.0,
+        max_neighbors=8,
+        target_indices=targets,
+        strategy="tile",
+    )
+
+try:
+    run(jnp.zeros((4, 3), dtype=jnp.float32))
+except ValueError as exc:
+    assert "requires CUDA" in str(exc)
+else:
+    raise AssertionError("expected explicit tile to reject CPU")
+"""
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_jitted_cpu_partial_geometry_empty_routes_avoid_custom_calls():
+    """Empty partial geometry routes return API-shaped outputs without Warp calls."""
+    script = """
+import jax
+import jax.numpy as jnp
+
+from nvalchemiops.jax.neighbors.batch_naive import batch_naive_neighbor_list
+from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
+from test.neighbors.bindings.jax.test_dispatch import _sum_pair_fn
+
+positions = jnp.zeros((2, 3), dtype=jnp.float32)
+cell = jnp.eye(3, dtype=jnp.float32)[None, :, :]
+pbc = jnp.ones((1, 3), dtype=jnp.bool_)
+targets = jnp.array([0], dtype=jnp.int32)
+shift_range = jnp.zeros((1, 3), dtype=jnp.int32)
+num_shifts = jnp.ones((1,), dtype=jnp.int32)
+
+@jax.jit
+def single(nm, nn, shifts, distances, vectors):
+    return naive_neighbor_list(
+        positions,
+        0.0,
+        cell=cell,
+        pbc=pbc,
+        max_neighbors=4,
+        target_indices=targets,
+        neighbor_matrix=nm,
+        num_neighbors=nn,
+        neighbor_matrix_shifts=shifts,
+        neighbor_distances=distances,
+        neighbor_vectors=vectors,
+        return_distances=True,
+        return_vectors=True,
+        pair_fn=_sum_pair_fn,
+        pair_params=jnp.ones((2, 1), dtype=jnp.float32),
+        shift_range_per_dimension=shift_range,
+        num_shifts_per_system=num_shifts,
+        max_shifts_per_system=1,
+    )
+
+out = single(
+    jnp.full((1, 4), 99, dtype=jnp.int32),
+    jnp.full((1,), 99, dtype=jnp.int32),
+    jnp.full((1, 4, 3), 99, dtype=jnp.int32),
+    jnp.full((1, 4), 99.0, dtype=jnp.float32),
+    jnp.full((1, 4, 3), 99.0, dtype=jnp.float32),
+)
+nm, nn, shifts, distances, vectors, energies, forces = out
+assert (nm == 2).all() and (nn == 0).all() and (shifts == 0).all()
+assert (distances == 0).all() and (vectors == 0).all()
+assert energies.shape == (1, 4) and forces.shape == (1, 4, 3)
+assert (energies == 0).all() and (forces == 0).all()
+
+@jax.jit
+def batch():
+    return batch_naive_neighbor_list(
+        positions,
+        1.0,
+        batch_idx=jnp.zeros((2,), dtype=jnp.int32),
+        batch_ptr=jnp.array([0, 2], dtype=jnp.int32),
+        cell=cell,
+        pbc=pbc,
+        max_neighbors=4,
+        target_indices=jnp.empty((0,), dtype=jnp.int32),
+        return_neighbor_list=True,
+        return_distances=True,
+        return_vectors=True,
+        shift_range_per_dimension=shift_range,
+        num_shifts_per_system=num_shifts,
+        max_shifts_per_system=1,
+    )
+
+neighbor_list, neighbor_ptr, neighbor_shifts, distances, vectors = batch()
+assert neighbor_list.shape == (2, 0)
+assert neighbor_ptr.shape == (1,) and (neighbor_ptr == 0).all()
+assert neighbor_shifts.shape == (0, 3)
+assert distances.shape == (0,) and vectors.shape == (0, 3)
 """
     env = os.environ.copy()
     env["JAX_PLATFORMS"] = "cpu"

--- a/test/neighbors/bindings/jax/test_naive.py
+++ b/test/neighbors/bindings/jax/test_naive.py
@@ -24,6 +24,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+import nvalchemiops.jax.neighbors.naive as naive_jax
 from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
 from nvalchemiops.jax.neighbors.neighbor_utils import compute_naive_num_shifts
 
@@ -383,17 +384,146 @@ class TestNaiveNeighborList:
                 target_indices=jnp.array([2, 0], dtype=jnp.int32),
             )
 
-    def test_target_indices_rejects_tile_strategy(self):
-        """Explicit tiled naive mode does not support partial rows."""
-        positions = jnp.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]], dtype=jnp.float32)
-        with pytest.raises(NotImplementedError, match="target_indices"):
+    def test_target_indices_tile_rejects_geometry_buffers(self):
+        """Tiled partial rows reject supplied geometry buffers."""
+        positions = jnp.arange(72, dtype=jnp.float32).reshape(24, 3) * 0.05
+        target_indices = jnp.array([17, 2, 11], dtype=jnp.int32)
+        with pytest.raises(NotImplementedError, match="pair-output"):
             naive_neighbor_list(
                 positions,
-                1.0,
-                max_neighbors=4,
-                target_indices=jnp.array([0], dtype=jnp.int32),
+                0.5,
+                max_neighbors=16,
+                target_indices=target_indices,
+                neighbor_vectors=jnp.zeros((3, 16, 3), dtype=jnp.float32),
                 strategy="tile",
             )
+
+    def test_target_indices_tile_no_pbc_matches_scalar(self):
+        """Explicit tiled partial rows match scalar topology without PBC."""
+        positions = jnp.arange(72, dtype=jnp.float32).reshape(24, 3) * 0.05
+        target_indices = jnp.array([17, 2, 11], dtype=jnp.int32)
+
+        scalar_nm, scalar_nn = naive_neighbor_list(
+            positions,
+            0.5,
+            max_neighbors=16,
+            target_indices=target_indices,
+            strategy="scalar",
+        )
+        tile_nm, tile_nn = naive_neighbor_list(
+            positions,
+            0.5,
+            max_neighbors=16,
+            target_indices=target_indices,
+            strategy="tile",
+        )
+
+        np.testing.assert_array_equal(np.asarray(tile_nn), np.asarray(scalar_nn))
+        for row, count in enumerate(np.asarray(scalar_nn)):
+            np.testing.assert_array_equal(
+                np.sort(np.asarray(tile_nm[row, :count])),
+                np.sort(np.asarray(scalar_nm[row, :count])),
+            )
+
+    def test_target_indices_tile_coo_no_pbc_matches_scalar(self):
+        """Tiled topology-only partial rows support COO conversion."""
+        positions = jnp.arange(72, dtype=jnp.float32).reshape(24, 3) * 0.05
+        target_indices = jnp.array([17, 2, 11], dtype=jnp.int32)
+
+        scalar_list, scalar_ptr = naive_neighbor_list(
+            positions,
+            0.5,
+            max_neighbors=16,
+            target_indices=target_indices,
+            strategy="scalar",
+            return_neighbor_list=True,
+        )
+        tile_list, tile_ptr = naive_neighbor_list(
+            positions,
+            0.5,
+            max_neighbors=16,
+            target_indices=target_indices,
+            strategy="tile",
+            return_neighbor_list=True,
+        )
+
+        np.testing.assert_array_equal(np.asarray(tile_ptr), np.asarray(scalar_ptr))
+        assert sorted(map(tuple, np.asarray(tile_list).T.tolist())) == sorted(
+            map(tuple, np.asarray(scalar_list).T.tolist())
+        )
+
+    def test_target_indices_tile_pbc_jit_matches_scalar(self):
+        """JIT-compiled tiled partial rows match scalar PBC topology and shifts."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [9.5, 0.0, 0.0], [5.0, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32)[None, :, :] * 10.0
+        pbc = jnp.array([[True, True, True]])
+        target_indices = jnp.array([0, 2], dtype=jnp.int32)
+        shift_range, num_shifts, max_shifts = compute_naive_num_shifts(cell, 1.0, pbc)
+
+        def _run(strategy):
+            return jax.jit(
+                lambda pos: naive_neighbor_list(
+                    pos,
+                    1.0,
+                    cell=cell,
+                    pbc=pbc,
+                    max_neighbors=8,
+                    shift_range_per_dimension=shift_range,
+                    num_shifts_per_system=num_shifts,
+                    max_shifts_per_system=max_shifts,
+                    target_indices=target_indices,
+                    strategy=strategy,
+                )
+            )(positions)
+
+        scalar_nm, scalar_nn, scalar_shifts = _run("scalar")
+        tile_nm, tile_nn, tile_shifts = _run("tile")
+
+        np.testing.assert_array_equal(np.asarray(tile_nn), np.asarray(scalar_nn))
+        for row, count in enumerate(np.asarray(scalar_nn)):
+            scalar_pairs = sorted(
+                zip(
+                    np.asarray(scalar_nm[row, :count]).tolist(),
+                    np.asarray(scalar_shifts[row, :count]).tolist(),
+                    strict=True,
+                )
+            )
+            tile_pairs = sorted(
+                zip(
+                    np.asarray(tile_nm[row, :count]).tolist(),
+                    np.asarray(tile_shifts[row, :count]).tolist(),
+                    strict=True,
+                )
+            )
+            assert tile_pairs == scalar_pairs
+
+    def test_target_indices_scalar_pbc_wraps_positions_like_tile(self):
+        """Partial scalar PBC preserves tiled topology for unwrapped coordinates."""
+        positions = jnp.array(
+            [[20.2, 0.0, 0.0], [0.3, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32)[None, :, :] * 10.0
+        pbc = jnp.array([[True, True, True]])
+        target_indices = jnp.array([0], dtype=jnp.int32)
+        shift_range, num_shifts, max_shifts = compute_naive_num_shifts(cell, 1.0, pbc)
+        common_kwargs = {
+            "cell": cell,
+            "pbc": pbc,
+            "max_neighbors": 4,
+            "target_indices": target_indices,
+            "shift_range_per_dimension": shift_range,
+            "num_shifts_per_system": num_shifts,
+            "max_shifts_per_system": max_shifts,
+        }
+
+        scalar = naive_neighbor_list(positions, 1.0, strategy="scalar", **common_kwargs)
+        tiled = naive_neighbor_list(positions, 1.0, strategy="tile", **common_kwargs)
+
+        _assert_partial_topology_equal(scalar, tiled)
 
     def test_with_pbc(self):
         """Test with periodic boundary conditions."""
@@ -813,6 +943,38 @@ def _assert_arrays_equal(lhs, rhs) -> None:
         assert jnp.array_equal(left, right)
 
 
+def _assert_partial_topology_equal(lhs, rhs) -> None:
+    """Compare compact topology without assuming atomic-append ordering."""
+    assert len(lhs) == len(rhs)
+    lhs_host = tuple(np.asarray(array) for array in lhs)
+    rhs_host = tuple(np.asarray(array) for array in rhs)
+    np.testing.assert_array_equal(lhs_host[1], rhs_host[1])
+    has_shifts = len(lhs_host) == 3
+    for row, count_value in enumerate(lhs_host[1]):
+        count = int(count_value)
+        assert count <= lhs_host[0].shape[1]
+        lhs_neighbors = lhs_host[0][row, :count].tolist()
+        rhs_neighbors = rhs_host[0][row, :count].tolist()
+        if has_shifts:
+            lhs_pairs = sorted(
+                zip(
+                    lhs_neighbors,
+                    lhs_host[2][row, :count].tolist(),
+                    strict=True,
+                )
+            )
+            rhs_pairs = sorted(
+                zip(
+                    rhs_neighbors,
+                    rhs_host[2][row, :count].tolist(),
+                    strict=True,
+                )
+            )
+            assert lhs_pairs == rhs_pairs
+        else:
+            assert sorted(lhs_neighbors) == sorted(rhs_neighbors)
+
+
 def _make_naive_inputs(dtype, *, pbc_enabled: bool, wrap_positions: bool):
     """Create a small but nontrivial naive neighbor-list test system."""
     if pbc_enabled and wrap_positions:
@@ -889,6 +1051,244 @@ def _make_naive_stale_inputs(
 
 class TestNaiveGraphMode:
     """Graph-mode coverage for JAX naive neighbor lists."""
+
+    def test_partial_tile_graph_callables_are_configuration_specific(self):
+        """Partial graph callables are bounded and isolated by execution configuration."""
+        callables = naive_jax._GRAPH_NAIVE_PARTIAL_TILE_WARP_CALLABLES
+
+        assert set(callables) == {
+            (False, False, jnp.dtype(jnp.float32)),
+            (False, False, jnp.dtype(jnp.float64)),
+            (True, False, jnp.dtype(jnp.float32)),
+            (True, False, jnp.dtype(jnp.float64)),
+            (True, True, jnp.dtype(jnp.float32)),
+            (True, True, jnp.dtype(jnp.float64)),
+        }
+        assert len({id(callable_obj) for callable_obj in callables.values()}) == len(
+            callables
+        )
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    @pytest.mark.parametrize(
+        ("pbc_enabled", "wrap_positions"),
+        [
+            (False, True),
+            (True, True),
+            (True, False),
+        ],
+    )
+    def test_partial_tile_warp_matches_none_and_replays(
+        self,
+        dtype,
+        pbc_enabled: bool,
+        wrap_positions: bool,
+    ):
+        """Partial tile graphs reset compact outputs and replay correctly."""
+        positions, cutoff, cell, pbc, max_neighbors = _make_naive_inputs(
+            dtype,
+            pbc_enabled=pbc_enabled,
+            wrap_positions=wrap_positions,
+        )
+        target_indices = jnp.array([0, 2], dtype=jnp.int32)
+        num_targets = int(target_indices.shape[0])
+        neighbor_matrix = jnp.full(
+            (num_targets, max_neighbors),
+            77,
+            dtype=jnp.int32,
+        )
+        num_neighbors = jnp.full((num_targets,), 33, dtype=jnp.int32)
+
+        if pbc_enabled:
+            neighbor_matrix_shifts = jnp.full(
+                (num_targets, max_neighbors, 3),
+                -5,
+                dtype=jnp.int32,
+            )
+            shift_range, num_shifts, max_shifts = compute_naive_num_shifts(
+                cell,
+                cutoff,
+                pbc,
+            )
+            scratch_kwargs = {}
+            if wrap_positions:
+                scratch_kwargs = {
+                    "inv_cell_buffer": jnp.linalg.inv(cell),
+                    "positions_wrapped_buffer": jnp.zeros_like(positions),
+                    "per_atom_cell_offsets_buffer": jnp.zeros(
+                        positions.shape,
+                        dtype=jnp.int32,
+                    ),
+                }
+
+            @functools.partial(jax.jit, donate_argnums=(1, 2, 3))
+            def graph_step(pos, nm, nn, nms):
+                return naive_neighbor_list(
+                    pos,
+                    cutoff,
+                    cell=cell,
+                    pbc=pbc,
+                    target_indices=target_indices,
+                    neighbor_matrix=nm,
+                    num_neighbors=nn,
+                    neighbor_matrix_shifts=nms,
+                    shift_range_per_dimension=shift_range,
+                    num_shifts_per_system=num_shifts,
+                    max_shifts_per_system=max_shifts,
+                    wrap_positions=wrap_positions,
+                    strategy="tile",
+                    graph_mode="warp",
+                    **scratch_kwargs,
+                )
+
+            graph_result = graph_step(
+                positions,
+                neighbor_matrix,
+                num_neighbors,
+                neighbor_matrix_shifts,
+            )
+        else:
+
+            @functools.partial(jax.jit, donate_argnums=(1, 2))
+            def graph_step(pos, nm, nn):
+                return naive_neighbor_list(
+                    pos,
+                    cutoff,
+                    target_indices=target_indices,
+                    neighbor_matrix=nm,
+                    num_neighbors=nn,
+                    strategy="tile",
+                    graph_mode="warp",
+                )
+
+            graph_result = graph_step(positions, neighbor_matrix, num_neighbors)
+
+        jax.block_until_ready(graph_result)
+        first_result = tuple(np.asarray(array) for array in graph_result)
+        graph_result = graph_step(positions, *graph_result)
+        jax.block_until_ready(graph_result)
+
+        reference = naive_neighbor_list(
+            positions,
+            cutoff,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=max_neighbors,
+            target_indices=target_indices,
+            wrap_positions=wrap_positions,
+            strategy="tile",
+            graph_mode="none",
+        )
+        _assert_partial_topology_equal(first_result, reference)
+        _assert_partial_topology_equal(graph_result, reference)
+
+    @pytest.mark.parametrize("half_fill", [False, True])
+    def test_partial_tile_warp_pbc_shift_extent(self, half_fill: bool):
+        """Partial graph capture covers full and half periodic shift spaces."""
+        dtype = jnp.float32
+        positions = jnp.array(
+            [
+                [0.2, 0.2, 0.2],
+                [2.5, 1.0, 0.5],
+                [4.8, 4.7, 4.6],
+            ],
+            dtype=dtype,
+        )
+        cell = (jnp.eye(3, dtype=dtype) * 5.0).reshape(1, 3, 3)
+        pbc = jnp.ones((1, 3), dtype=jnp.bool_)
+        cutoff = 6.0
+        max_neighbors = 512
+        target_indices = jnp.array([0, 2], dtype=jnp.int32)
+        shift_range, num_shifts, max_shifts = compute_naive_num_shifts(
+            cell,
+            cutoff,
+            pbc,
+        )
+
+        graph_result = jax.jit(
+            lambda pos, nm, nn, nms: naive_neighbor_list(
+                pos,
+                cutoff,
+                cell=cell,
+                pbc=pbc,
+                target_indices=target_indices,
+                neighbor_matrix=nm,
+                num_neighbors=nn,
+                neighbor_matrix_shifts=nms,
+                shift_range_per_dimension=shift_range,
+                num_shifts_per_system=num_shifts,
+                max_shifts_per_system=max_shifts,
+                wrap_positions=False,
+                half_fill=half_fill,
+                strategy="tile",
+                graph_mode="warp",
+            )
+        )(
+            positions,
+            jnp.full((2, max_neighbors), positions.shape[0], dtype=jnp.int32),
+            jnp.zeros((2,), dtype=jnp.int32),
+            jnp.zeros((2, max_neighbors, 3), dtype=jnp.int32),
+        )
+        reference = naive_neighbor_list(
+            positions,
+            cutoff,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=max_neighbors,
+            target_indices=target_indices,
+            shift_range_per_dimension=shift_range,
+            num_shifts_per_system=num_shifts,
+            max_shifts_per_system=max_shifts,
+            wrap_positions=False,
+            half_fill=half_fill,
+            strategy="scalar",
+            graph_mode="none",
+        )
+        _assert_partial_topology_equal(graph_result, reference)
+
+    def test_partial_tile_warp_requires_persistent_compact_buffers(self):
+        """Partial graph mode rejects calls that cannot provide stable outputs."""
+        positions = jnp.zeros((4, 3), dtype=jnp.float32)
+        target_indices = jnp.array([0, 2], dtype=jnp.int32)
+        with pytest.raises(ValueError, match="caller-provided compact"):
+            naive_neighbor_list(
+                positions,
+                1.0,
+                max_neighbors=4,
+                target_indices=target_indices,
+                strategy="tile",
+                graph_mode="warp",
+            )
+
+    def test_partial_tile_warp_rejects_dynamic_coo_output(self):
+        """Partial graph mode rejects data-dependent COO output under JIT."""
+        positions = jnp.zeros((4, 3), dtype=jnp.float32)
+        target_indices = jnp.array([0, 2], dtype=jnp.int32)
+        with pytest.raises(ValueError, match="return_neighbor_list=False"):
+            naive_neighbor_list(
+                positions,
+                1.0,
+                max_neighbors=4,
+                target_indices=target_indices,
+                neighbor_matrix=jnp.full((2, 4), 4, dtype=jnp.int32),
+                num_neighbors=jnp.zeros((2,), dtype=jnp.int32),
+                strategy="tile",
+                graph_mode="warp",
+                return_neighbor_list=True,
+            )
+
+    def test_partial_tile_warp_rejects_implicit_target_cast(self):
+        """Graph capture does not hide an unstable target dtype conversion."""
+        positions = jnp.zeros((4, 3), dtype=jnp.float32)
+        with pytest.raises(ValueError, match="rank-one int32"):
+            naive_neighbor_list(
+                positions,
+                1.0,
+                target_indices=jnp.array([0, 2], dtype=jnp.int64),
+                neighbor_matrix=jnp.full((2, 4), 4, dtype=jnp.int32),
+                num_neighbors=jnp.zeros((2,), dtype=jnp.int32),
+                strategy="tile",
+                graph_mode="warp",
+            )
 
     @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
     @pytest.mark.parametrize(

--- a/test/neighbors/bindings/jax/test_naive.py
+++ b/test/neighbors/bindings/jax/test_naive.py
@@ -24,6 +24,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+import nvalchemiops.jax.neighbors.naive as naive_module
 from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
 from nvalchemiops.jax.neighbors.neighbor_utils import compute_naive_num_shifts
 
@@ -34,6 +35,72 @@ pytestmark = requires_gpu
 
 class TestNaiveNeighborList:
     """Test naive_neighbor_list function."""
+
+    @pytest.mark.parametrize(
+        ("dtype", "num_atoms", "expected_strategy"),
+        [
+            (jnp.float32, 1023, "scalar"),
+            (jnp.float32, 1024, "tile"),
+            (jnp.float64, 255, "scalar"),
+            (jnp.float64, 256, "tile"),
+        ],
+    )
+    def test_target_indices_auto_routes_eager_cuda(
+        self,
+        monkeypatch,
+        dtype,
+        num_atoms,
+        expected_strategy,
+    ):
+        """Concrete CUDA partial auto uses the shared dtype threshold."""
+        seen = []
+        device = jax.local_devices(backend="gpu")[0]
+
+        def fake_forward(positions, _cell, **kwargs):
+            """Record resolved routing without launching a Warp kernel."""
+            seen.append(kwargs["strategy"])
+            num_rows = int(kwargs["target_indices"].shape[0])
+            max_neighbors = kwargs["max_neighbors"]
+            neighbor_matrix = jnp.full(
+                (num_rows, max_neighbors),
+                kwargs["fill_value"],
+                dtype=jnp.int32,
+            )
+            num_neighbors = jnp.zeros((num_rows,), dtype=jnp.int32)
+            shifts = jnp.empty((0, 3), dtype=jnp.int32)
+            distances = jnp.zeros((num_rows, max_neighbors), dtype=positions.dtype)
+            vectors = jnp.zeros(
+                (num_rows, max_neighbors, 3),
+                dtype=positions.dtype,
+            )
+            return naive_module._NeighborForwardOutput(
+                distances=distances,
+                vectors=vectors,
+                extra_outputs=(neighbor_matrix, num_neighbors, shifts),
+                i_idx=neighbor_matrix,
+                j_idx=neighbor_matrix,
+                shifts=jnp.zeros((num_rows, max_neighbors, 3), dtype=jnp.int32),
+                batch_idx=None,
+                active_mask=jnp.zeros((num_rows, max_neighbors), dtype=jnp.bool_),
+                matrix_shape=(num_rows, max_neighbors),
+            )
+
+        monkeypatch.setattr(naive_module, "_naive_pair_outputs_forward", fake_forward)
+        positions = jax.device_put(jnp.zeros((num_atoms, 3), dtype=dtype), device)
+        targets = jax.device_put(
+            jnp.array([num_atoms - 1, 0], dtype=jnp.int32),
+            device,
+        )
+
+        naive_neighbor_list(
+            positions,
+            1.0,
+            max_neighbors=4,
+            target_indices=targets,
+            strategy="auto",
+        )
+
+        assert seen == [expected_strategy]
 
     def test_single_atom_no_neighbors(self):
         """Test with single atom (should have no neighbors)."""
@@ -259,7 +326,7 @@ class TestNaiveNeighborList:
             )
 
     def test_target_indices_coo_uses_compact_source_rows(self):
-        """COO source rows are compact target rows, not original atom ids."""
+        """COO central rows are compact row ids, not original atom ids."""
         positions = jnp.array(
             [
                 [0.0, 0.0, 0.0],

--- a/test/neighbors/bindings/jax/test_naive.py
+++ b/test/neighbors/bindings/jax/test_naive.py
@@ -24,7 +24,6 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-import nvalchemiops.jax.neighbors.naive as naive_jax
 from nvalchemiops.jax.neighbors.naive import naive_neighbor_list
 from nvalchemiops.jax.neighbors.neighbor_utils import compute_naive_num_shifts
 
@@ -286,6 +285,86 @@ class TestNaiveNeighborList:
             (0, 3),
             (1, 1),
         }
+
+    def test_empty_target_indices_pbc_matrix_uses_compact_buffers(self):
+        """Empty compact PBC targets return validated zero-row matrix outputs."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [9.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32)[None, :, :] * 10.0
+        pbc = jnp.ones((1, 3), dtype=jnp.bool_)
+        targets = jnp.empty((0,), dtype=jnp.int32)
+        neighbor_matrix = jnp.full((0, 4), 99, dtype=jnp.int32)
+        num_neighbors = jnp.full((0,), 99, dtype=jnp.int32)
+        shifts = jnp.full((0, 4, 3), 99, dtype=jnp.int32)
+
+        matrix, counts, matrix_shifts = naive_neighbor_list(
+            positions,
+            1.0,
+            cell=cell,
+            pbc=pbc,
+            target_indices=targets,
+            neighbor_matrix=neighbor_matrix,
+            num_neighbors=num_neighbors,
+            neighbor_matrix_shifts=shifts,
+        )
+
+        assert matrix.shape == (0, 4)
+        assert counts.shape == (0,)
+        assert matrix_shifts.shape == (0, 4, 3)
+
+    def test_empty_target_indices_pbc_coo_has_compact_pointer(self):
+        """Empty compact PBC targets return an empty COO list and one pointer."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [9.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32)[None, :, :] * 10.0
+        pbc = jnp.ones((1, 3), dtype=jnp.bool_)
+
+        neighbor_list, neighbor_ptr, neighbor_shifts = naive_neighbor_list(
+            positions,
+            1.0,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=4,
+            target_indices=jnp.empty((0,), dtype=jnp.int32),
+            return_neighbor_list=True,
+        )
+
+        assert neighbor_list.shape == (2, 0)
+        assert neighbor_ptr.shape == (1,)
+        assert neighbor_shifts.shape == (0, 3)
+        np.testing.assert_array_equal(np.asarray(neighbor_ptr), [0])
+
+    def test_zero_cutoff_compact_pbc_resets_stale_outputs(self):
+        """A compact PBC zero-cutoff call clears caller-provided output buffers."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [9.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        cell = jnp.eye(3, dtype=jnp.float32)[None, :, :] * 10.0
+        pbc = jnp.ones((1, 3), dtype=jnp.bool_)
+        targets = jnp.array([0], dtype=jnp.int32)
+        kwargs = {
+            "cell": cell,
+            "pbc": pbc,
+            "target_indices": targets,
+            "neighbor_matrix": jnp.full((1, 4), 99, dtype=jnp.int32),
+            "num_neighbors": jnp.full((1,), 99, dtype=jnp.int32),
+            "neighbor_matrix_shifts": jnp.full((1, 4, 3), 99, dtype=jnp.int32),
+        }
+
+        matrix, counts, matrix_shifts = naive_neighbor_list(
+            positions,
+            0.0,
+            **kwargs,
+        )
+
+        np.testing.assert_array_equal(np.asarray(matrix), [[2, 2, 2, 2]])
+        np.testing.assert_array_equal(np.asarray(counts), [0])
+        np.testing.assert_array_equal(np.asarray(matrix_shifts), 0)
 
     def test_target_indices_jit_uses_compact_user_buffers(self):
         """target_indices works under jax.jit with compact caller buffers."""
@@ -821,6 +900,24 @@ class TestNaiveNeighborListJIT:
 class TestNaiveSelectiveRebuildFlags:
     """Test selective rebuild (rebuild_flags) for naive_neighbor_list JAX binding."""
 
+    def test_partial_rebuild_flags_are_rejected(self, dtype):
+        """Compact rows cannot be combined with selective rebuild flags."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            dtype=dtype,
+        )
+        with pytest.raises(
+            NotImplementedError,
+            match=r"^Partial neighbor lists do not support rebuild_flags$",
+        ):
+            naive_neighbor_list(
+                positions,
+                1.0,
+                max_neighbors=4,
+                target_indices=jnp.array([0], dtype=jnp.int32),
+                rebuild_flags=jnp.ones((1,), dtype=jnp.bool_),
+            )
+
     def test_no_rebuild_preserves_data(self, dtype):
         """Flag=False: neighbor data should remain unchanged."""
         positions = jnp.array(
@@ -1052,23 +1149,35 @@ def _make_naive_stale_inputs(
 class TestNaiveGraphMode:
     """Graph-mode coverage for JAX naive neighbor lists."""
 
-    def test_partial_tile_graph_callables_are_configuration_specific(self):
-        """Partial graph callables are bounded and isolated by execution configuration."""
-        callables = naive_jax._GRAPH_NAIVE_PARTIAL_TILE_WARP_CALLABLES
-
-        assert set(callables) == {
-            (False, False, jnp.dtype(jnp.float32)),
-            (False, False, jnp.dtype(jnp.float64)),
-            (True, False, jnp.dtype(jnp.float32)),
-            (True, False, jnp.dtype(jnp.float64)),
-            (True, True, jnp.dtype(jnp.float32)),
-            (True, True, jnp.dtype(jnp.float64)),
-        }
-        assert len({id(callable_obj) for callable_obj in callables.values()}) == len(
-            callables
+    def test_partial_graph_scalar_is_rejected(self):
+        """Partial Warp graph mode rejects the scalar strategy explicitly."""
+        positions, cutoff, _, _, max_neighbors = _make_naive_inputs(
+            jnp.float32,
+            pbc_enabled=False,
+            wrap_positions=True,
         )
+        targets = jnp.array([0, 2], dtype=jnp.int32)
+        with pytest.raises(
+            ValueError,
+            match="Partial graph_mode='warp' requires strategy='auto' or "
+            "strategy='tile'",
+        ):
+            naive_neighbor_list(
+                positions,
+                cutoff,
+                target_indices=targets,
+                neighbor_matrix=jnp.full(
+                    (2, max_neighbors),
+                    positions.shape[0],
+                    dtype=jnp.int32,
+                ),
+                num_neighbors=jnp.zeros((2,), dtype=jnp.int32),
+                strategy="scalar",
+                graph_mode="warp",
+            )
 
     @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    @pytest.mark.parametrize("strategy", ["tile", "auto"])
     @pytest.mark.parametrize(
         ("pbc_enabled", "wrap_positions"),
         [
@@ -1080,6 +1189,7 @@ class TestNaiveGraphMode:
     def test_partial_tile_warp_matches_none_and_replays(
         self,
         dtype,
+        strategy: str,
         pbc_enabled: bool,
         wrap_positions: bool,
     ):
@@ -1135,7 +1245,7 @@ class TestNaiveGraphMode:
                     num_shifts_per_system=num_shifts,
                     max_shifts_per_system=max_shifts,
                     wrap_positions=wrap_positions,
-                    strategy="tile",
+                    strategy=strategy,
                     graph_mode="warp",
                     **scratch_kwargs,
                 )
@@ -1156,7 +1266,7 @@ class TestNaiveGraphMode:
                     target_indices=target_indices,
                     neighbor_matrix=nm,
                     num_neighbors=nn,
-                    strategy="tile",
+                    strategy=strategy,
                     graph_mode="warp",
                 )
 

--- a/test/neighbors/bindings/jax/test_neighborlist.py
+++ b/test/neighbors/bindings/jax/test_neighborlist.py
@@ -770,6 +770,38 @@ class TestNeighborListFineGrainedMethodEquivalence:
         )
         assert _canonical_pairs(suggested_res) == _canonical_pairs(base_res)
 
+    @pytest.mark.gpu
+    def test_naive_tile_partial_smoke(self):
+        """Fine-grained naive_tile reaches compact unbatched and batched routes."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [2.0, 0.0, 0.0], [2.5, 0.0, 0.0]],
+            dtype=jnp.float32,
+        )
+        targets = jnp.array([2, 0], dtype=jnp.int32)
+        matrix, counts = neighbor_list(
+            positions,
+            0.75,
+            max_neighbors=4,
+            target_indices=targets,
+            method="naive_tile",
+        )
+        assert matrix.shape == (2, 4)
+        assert counts.shape == (2,)
+
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 2, 4], dtype=jnp.int32)
+        batch_matrix, batch_counts = neighbor_list(
+            positions,
+            0.75,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=4,
+            target_indices=targets,
+            method="naive_tile",
+        )
+        assert batch_matrix.shape == (2, 4)
+        assert batch_counts.shape == (2,)
+
 
 class TestNeighborListCellListHalfFillFillValue:
     """JAX cell_list now honors ``half_fill`` and ``fill_value`` (parity)."""

--- a/test/neighbors/bindings/jax/test_pair_fn.py
+++ b/test/neighbors/bindings/jax/test_pair_fn.py
@@ -145,7 +145,7 @@ def test_naive_pair_fn_no_pbc_matrix(dtype):
 
 
 def test_naive_pair_fn_target_indices_compact_rows():
-    """JAX naive ``target_indices + pair_fn`` uses compact source rows."""
+    """JAX naive ``target_indices + pair_fn`` uses compact central rows."""
     positions = jnp.array(
         [
             [0.0, 0.0, 0.0],

--- a/test/neighbors/bindings/torch/test_base_dispatch.py
+++ b/test/neighbors/bindings/torch/test_base_dispatch.py
@@ -153,7 +153,7 @@ class TestReportNeighborListCosts:
                 target_indices=torch.arange(100, dtype=torch.int32),
             )
         )
-        # Fewer source rows -> cheaper naive estimate.
+        # Fewer central rows -> cheaper naive estimate.
         assert partial["naive_scalar"] < full["naive_scalar"]
         # target_indices is incompatible with cluster_tile auto.
         assert "cluster_tile" not in partial

--- a/test/neighbors/bindings/torch/test_batch_naive.py
+++ b/test/neighbors/bindings/torch/test_batch_naive.py
@@ -20,6 +20,7 @@ from unittest import mock
 import pytest
 import torch
 
+from nvalchemiops.neighbors.neighbor_utils import NeighborOverflowError
 from nvalchemiops.torch.neighbors.batch_naive import (
     batch_naive_neighbor_list,
 )
@@ -280,6 +281,7 @@ class TestBatchNaiveCorrectness:
                 torch.sort(full_nm[atom, : int(full_nn[atom])].cpu()).values,
             )
 
+    @pytest.mark.gpu
     def test_target_indices_compile_fullgraph_with_compact_buffers(self, device):
         """Batched target_indices without pair_fn supports fullgraph compile."""
         if not str(device).startswith("cuda"):
@@ -331,6 +333,7 @@ class TestBatchNaiveCorrectness:
                 torch.sort(full_nm[atom, : int(full_nn[atom])].cpu()).values,
             )
 
+    @pytest.mark.gpu
     def test_target_indices_compile_fullgraph_pbc_pair_geometry(self, device):
         """Batched PBC target_indices fullgraph path supports geometry buffers."""
         if not str(device).startswith("cuda"):
@@ -396,6 +399,143 @@ class TestBatchNaiveCorrectness:
         assert partial_vec.shape == (2, 8, 3)
         assert int(partial_nn.min()) >= 1
 
+    @pytest.mark.gpu
+    def test_target_indices_tile_compile_fullgraph_runtime_targets(self, device):
+        """Batched tiled topology custom op accepts runtime compact targets."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("CUDA is required for tiled fullgraph coverage.")
+        positions = torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [0.5, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+                [2.5, 0.0, 0.0],
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        batch_idx, batch_ptr = create_batch_idx_and_ptr([2, 2], device=device)
+
+        @torch.compile(fullgraph=True)
+        def run(pos, nm, nn, targets):
+            return batch_naive_neighbor_list(
+                pos,
+                0.75,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                neighbor_matrix=nm,
+                num_neighbors=nn,
+                target_indices=targets,
+                strategy="tile",
+            )
+
+        for targets in (
+            torch.tensor([2, 0], dtype=torch.int32, device=device),
+            torch.tensor([0, 2], dtype=torch.int32, device=device),
+        ):
+            tiled_nm, tiled_nn = run(
+                positions,
+                torch.full((2, 4), 4, dtype=torch.int32, device=device),
+                torch.zeros((2,), dtype=torch.int32, device=device),
+                targets,
+            )
+            scalar_nm, scalar_nn = batch_naive_neighbor_list(
+                positions,
+                0.75,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                max_neighbors=4,
+                target_indices=targets,
+                strategy="scalar",
+            )
+            torch.testing.assert_close(tiled_nn, scalar_nn, rtol=0, atol=0)
+            for row, count in enumerate(tiled_nn):
+                n = int(count)
+                assert sorted(tiled_nm[row, :n].tolist()) == sorted(
+                    scalar_nm[row, : int(scalar_nn[row])].tolist(),
+                )
+
+    @pytest.mark.gpu
+    def test_target_indices_tile_compile_fullgraph_pbc_runtime_targets(self, device):
+        """Batched tiled PBC topology custom op accepts runtime targets."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("CUDA is required for tiled fullgraph coverage.")
+        positions = torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [3.5, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        batch_idx, batch_ptr = create_batch_idx_and_ptr([2, 2], device=device)
+        cell = torch.stack(
+            [torch.eye(3, dtype=torch.float32, device=device) * 4.0] * 2,
+        )
+        pbc = torch.ones((2, 3), dtype=torch.bool, device=device)
+        shift_range, num_shifts, max_shifts = compute_naive_num_shifts(cell, 1.1, pbc)
+
+        @torch.compile(fullgraph=True)
+        def run(pos, nm, nms, nn, targets):
+            return batch_naive_neighbor_list(
+                pos,
+                1.1,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                cell=cell,
+                pbc=pbc,
+                neighbor_matrix=nm,
+                neighbor_matrix_shifts=nms,
+                num_neighbors=nn,
+                shift_range_per_dimension=shift_range,
+                num_shifts_per_system=num_shifts,
+                max_shifts_per_system=max_shifts,
+                max_atoms_per_system=2,
+                target_indices=targets,
+                strategy="tile",
+            )
+
+        for targets in (
+            torch.tensor([2, 0], dtype=torch.int32, device=device),
+            torch.tensor([0, 2], dtype=torch.int32, device=device),
+        ):
+            tiled_nm, tiled_nn, tiled_shifts = run(
+                positions,
+                torch.full((2, 32), 4, dtype=torch.int32, device=device),
+                torch.zeros((2, 32, 3), dtype=torch.int32, device=device),
+                torch.zeros((2,), dtype=torch.int32, device=device),
+                targets,
+            )
+            scalar_nm, scalar_nn, scalar_shifts = batch_naive_neighbor_list(
+                positions,
+                1.1,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                cell=cell,
+                pbc=pbc,
+                max_neighbors=32,
+                max_atoms_per_system=2,
+                target_indices=targets,
+                strategy="scalar",
+            )
+            torch.testing.assert_close(tiled_nn, scalar_nn, rtol=0, atol=0)
+            for row, count in enumerate(tiled_nn):
+                n = int(count)
+                tiled_values = sorted(
+                    (int(tiled_nm[row, col]), *map(int, tiled_shifts[row, col]))
+                    for col in range(n)
+                )
+                scalar_values = sorted(
+                    (
+                        int(scalar_nm[row, col]),
+                        *map(int, scalar_shifts[row, col]),
+                    )
+                    for col in range(int(scalar_nn[row]))
+                )
+                assert tiled_values == scalar_values
+
     def test_target_indices_rejects_full_size_user_buffers(self, device):
         """Partial batch lists require compact user buffers."""
         positions = torch.tensor(
@@ -421,15 +561,110 @@ class TestBatchNaiveCorrectness:
                 target_indices=torch.tensor([2, 0], dtype=torch.int32, device=device),
             )
 
-    def test_target_indices_rejects_tile_strategy(self, device):
-        """Explicit tiled batch naive mode does not support partial rows."""
+    @pytest.mark.gpu
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+    @pytest.mark.parametrize("half_fill", [False, True])
+    @pytest.mark.parametrize("pbc_mode", ["none", "wrapped", "prewrapped"])
+    def test_target_indices_tile_matches_scalar(
+        self,
+        device,
+        dtype,
+        half_fill,
+        pbc_mode,
+    ):
+        """Explicit tile matches scalar compact topology across batch systems."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("Tiled partial parity is CUDA-only.")
+        positions = torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [3.5, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+            ],
+            dtype=dtype,
+            device=device,
+        )
+        batch_idx, batch_ptr = create_batch_idx_and_ptr([2, 2], device=device)
+        target_indices = torch.tensor([2, 0], dtype=torch.int32, device=device)
+        kwargs = {}
+        if pbc_mode != "none":
+            cell = torch.stack(
+                [torch.eye(3, dtype=dtype, device=device) * 4.0] * 2,
+            )
+            pbc = torch.ones((2, 3), dtype=torch.bool, device=device)
+            shift_range, num_shifts, max_shifts = compute_naive_num_shifts(
+                cell,
+                1.1,
+                pbc,
+            )
+            kwargs = {
+                "cell": cell,
+                "pbc": pbc,
+                "wrap_positions": pbc_mode == "wrapped",
+                "shift_range_per_dimension": shift_range,
+                "num_shifts_per_system": num_shifts,
+                "max_shifts_per_system": max_shifts,
+                "max_atoms_per_system": 2,
+            }
+        scalar = batch_naive_neighbor_list(
+            positions,
+            1.1,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=32,
+            half_fill=half_fill,
+            target_indices=target_indices,
+            strategy="scalar",
+            **kwargs,
+        )
+        tiled = batch_naive_neighbor_list(
+            positions,
+            1.1,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=32,
+            half_fill=half_fill,
+            target_indices=target_indices,
+            strategy="tile",
+            **kwargs,
+        )
+        torch.testing.assert_close(scalar[1], tiled[1], rtol=0, atol=0)
+        scalar_shifts = scalar[2] if pbc_mode != "none" else None
+        tiled_shifts = tiled[2] if pbc_mode != "none" else None
+        for row, count_tensor in enumerate(scalar[1]):
+            count = int(count_tensor)
+            scalar_values = [
+                (int(scalar[0][row, col]),)
+                + (
+                    tuple(int(value) for value in scalar_shifts[row, col])
+                    if scalar_shifts is not None
+                    else ()
+                )
+                for col in range(count)
+            ]
+            tiled_values = [
+                (int(tiled[0][row, col]),)
+                + (
+                    tuple(int(value) for value in tiled_shifts[row, col])
+                    if tiled_shifts is not None
+                    else ()
+                )
+                for col in range(int(tiled[1][row]))
+            ]
+            assert sorted(scalar_values) == sorted(tiled_values)
+
+    def test_target_indices_tile_rejects_cpu(self, device):
+        """Explicit partial tile rejects CPU before native dispatch."""
+        if str(device).startswith("cuda"):
+            pytest.skip("CPU-only rejection case.")
         positions = torch.tensor(
             [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
             dtype=torch.float32,
             device=device,
         )
         batch_idx = torch.tensor([0, 0], dtype=torch.int32, device=device)
-        with pytest.raises(NotImplementedError, match="target_indices"):
+        with pytest.raises(ValueError, match="requires CUDA"):
             batch_naive_neighbor_list(
                 positions,
                 1.0,
@@ -438,6 +673,146 @@ class TestBatchNaiveCorrectness:
                 target_indices=torch.tensor([0], dtype=torch.int32, device=device),
                 strategy="tile",
             )
+
+    @pytest.mark.gpu
+    def test_target_indices_rejects_cross_device(self, device):
+        """Partial targets must share the positions device."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("CUDA is required for cross-device coverage.")
+        positions = torch.zeros((4, 3), dtype=torch.float32, device=device)
+        batch_ptr = torch.tensor([0, 2, 4], dtype=torch.int32, device=device)
+        targets = torch.tensor([0], dtype=torch.int32, device="cpu")
+        with pytest.raises(ValueError, match="same device"):
+            batch_naive_neighbor_list(
+                positions,
+                1.0,
+                batch_ptr=batch_ptr,
+                max_neighbors=4,
+                target_indices=targets,
+                strategy="scalar",
+            )
+
+    @pytest.mark.gpu
+    def test_target_indices_rejects_cross_device_output_buffers(self, device):
+        """Compact output buffers must share the positions device."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("CUDA is required for cross-device coverage.")
+        positions = torch.zeros((4, 3), dtype=torch.float32, device=device)
+        batch_ptr = torch.tensor([0, 4], dtype=torch.int32, device=device)
+        targets = torch.tensor([0], dtype=torch.int32, device=device)
+        with pytest.raises(ValueError, match="same device"):
+            batch_naive_neighbor_list(
+                positions,
+                1.0,
+                batch_ptr=batch_ptr,
+                max_neighbors=4,
+                target_indices=targets,
+                neighbor_matrix=torch.empty((1, 4), dtype=torch.int32),
+                num_neighbors=torch.empty((1,), dtype=torch.int32),
+                strategy="scalar",
+            )
+
+    @pytest.mark.gpu
+    def test_target_indices_tile_batch_contracts(self, device):
+        """Batched tile preserves fill, stale-buffer, empty, and overflow contracts."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("CUDA is required for batched tile contracts.")
+        positions = torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [0.4, 0.0, 0.0],
+                [0.8, 0.0, 0.0],
+                [3.0, 0.0, 0.0],
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        batch_idx = torch.zeros(4, dtype=torch.int32, device=device)
+        batch_ptr = torch.tensor([0, 4], dtype=torch.int32, device=device)
+        targets = torch.tensor([0, 3], dtype=torch.int32, device=device)
+        stale_matrix = torch.full((2, 1), 99, dtype=torch.int32, device=device)
+        stale_counts = torch.full((2,), 99, dtype=torch.int32, device=device)
+
+        matrix, counts = batch_naive_neighbor_list(
+            positions,
+            1.0,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=1,
+            fill_value=-7,
+            neighbor_matrix=stale_matrix,
+            num_neighbors=stale_counts,
+            target_indices=targets,
+            strategy="tile",
+        )
+        assert counts.tolist() == [2, 0]
+        assert int(matrix[1, 0]) == -7
+
+        with pytest.raises(NeighborOverflowError):
+            batch_naive_neighbor_list(
+                positions,
+                1.0,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                max_neighbors=1,
+                fill_value=-7,
+                target_indices=targets,
+                strategy="tile",
+                return_neighbor_list=True,
+            )
+
+        empty_matrix, empty_counts = batch_naive_neighbor_list(
+            positions,
+            1.0,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=4,
+            fill_value=-3,
+            target_indices=torch.empty(0, dtype=torch.int32, device=device),
+            strategy="tile",
+        )
+        assert empty_matrix.shape == (0, 4)
+        assert empty_counts.shape == (0,)
+
+        zero_matrix, zero_counts = batch_naive_neighbor_list(
+            positions,
+            0.0,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=4,
+            fill_value=-3,
+            target_indices=targets,
+            strategy="tile",
+        )
+        assert torch.equal(zero_counts, torch.zeros_like(zero_counts))
+        assert torch.all(zero_matrix == -3)
+
+    def test_target_indices_auto_forwards_native_dispatch(self, device, monkeypatch):
+        """Batched topology-only auto preserves scalar native dispatch policy."""
+        seen = {}
+
+        def fake_launcher(**kwargs):
+            seen.update(kwargs)
+
+        monkeypatch.setattr(
+            "nvalchemiops.torch.neighbors.batch_naive."
+            "_batch_naive_neighbor_matrix_no_pbc",
+            fake_launcher,
+        )
+        positions = torch.zeros((4, 3), dtype=torch.float32, device=device)
+        batch_idx, batch_ptr = create_batch_idx_and_ptr([2, 2], device=device)
+        targets = torch.tensor([2, 0], dtype=torch.int32, device=device)
+        batch_naive_neighbor_list(
+            positions,
+            1.0,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=4,
+            target_indices=targets,
+            strategy="auto",
+        )
+        assert seen["strategy"] == "auto"
+        assert seen["target_indices"] is targets
 
     def test_basic_with_pbc(self, device, dtype, half_fill):
         """Test basic neighbor list calculation with periodic boundaries."""

--- a/test/neighbors/bindings/torch/test_batch_naive.py
+++ b/test/neighbors/bindings/torch/test_batch_naive.py
@@ -811,7 +811,7 @@ class TestBatchNaiveCorrectness:
             target_indices=targets,
             strategy="auto",
         )
-        assert seen["strategy"] == "auto"
+        assert seen["strategy"] == "scalar"
         assert seen["target_indices"] is targets
 
     def test_basic_with_pbc(self, device, dtype, half_fill):
@@ -1302,6 +1302,34 @@ class TestBatchNaiveEdgeCases:
 class TestBatchNaiveErrors:
     """Input validation and error condition tests."""
 
+    def test_partial_rebuild_flags_are_rejected(self, device):
+        """Compact batch rows cannot be combined with selective rebuild flags."""
+        positions = torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [0.5, 0.0, 0.0],
+                [10.0, 0.0, 0.0],
+                [10.5, 0.0, 0.0],
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=device)
+        batch_ptr = torch.tensor([0, 2, 4], dtype=torch.int32, device=device)
+        with pytest.raises(
+            NotImplementedError,
+            match=r"^Partial neighbor lists do not support rebuild_flags$",
+        ):
+            batch_naive_neighbor_list(
+                positions,
+                1.0,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                max_neighbors=4,
+                target_indices=torch.tensor([2, 0], dtype=torch.int32, device=device),
+                rebuild_flags=torch.ones(2, dtype=torch.bool, device=device),
+            )
+
     def test_mismatched_cell_pbc_cell_without_pbc(self, device, dtype, half_fill):
         """Test error when cell provided without pbc."""
         atoms_per_system = [4, 5]
@@ -1583,6 +1611,94 @@ class TestBatchNaiveAutograd:
             return_vectors=True,
         )
         assert d.requires_grad and v.requires_grad
+
+    @pytest.mark.slow
+    def test_partial_pbc_distance_gradcheck_matches_selected_full_rows(self, device):
+        """Compact PBC gradients gather cells through each target's batch index."""
+        positions = torch.tensor(
+            [
+                [0.2, 0.0, 0.0],
+                [3.7, 0.0, 0.0],
+                [1.8, 0.0, 0.0],
+                [0.3, 0.0, 0.0],
+                [5.4, 0.0, 0.0],
+                [2.5, 0.0, 0.0],
+            ],
+            dtype=torch.float64,
+            device=device,
+            requires_grad=True,
+        )
+        batch_idx = torch.tensor([0, 0, 0, 1, 1, 1], dtype=torch.int32, device=device)
+        batch_ptr = torch.tensor([0, 3, 6], dtype=torch.int32, device=device)
+        target_indices = torch.tensor([4, 1], dtype=torch.int32, device=device)
+        cell = torch.stack(
+            (
+                torch.eye(3, dtype=torch.float64, device=device) * 4.0,
+                torch.eye(3, dtype=torch.float64, device=device) * 6.0,
+            ),
+        )
+        pbc = torch.ones((2, 3), dtype=torch.bool, device=device)
+        assert torch.equal(
+            batch_idx[target_indices.long()],
+            torch.tensor([1, 0], dtype=torch.int32, device=device),
+        )
+
+        _, partial_counts, partial_shifts, _ = batch_naive_neighbor_list(
+            positions,
+            1.2,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=4,
+            max_atoms_per_system=3,
+            target_indices=target_indices,
+            return_distances=True,
+        )
+        for row, target in enumerate(target_indices):
+            count = int(partial_counts[row])
+            assert count > 0, f"target atom {int(target)} must have a PBC neighbor"
+            assert torch.any(partial_shifts[row, :count].any(dim=1))
+
+        def partial_loss(pos):
+            _, _, _, distances = batch_naive_neighbor_list(
+                pos,
+                1.2,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                cell=cell,
+                pbc=pbc,
+                max_neighbors=4,
+                max_atoms_per_system=3,
+                target_indices=target_indices,
+                return_distances=True,
+            )
+            return distances.sum()
+
+        assert torch.autograd.gradcheck(
+            partial_loss,
+            (positions,),
+            atol=1e-5,
+            eps=1e-6,
+            nondet_tol=1e-7,
+        )
+        partial_grad = torch.autograd.grad(partial_loss(positions), positions)[0]
+        _, _, _, full_distances = batch_naive_neighbor_list(
+            positions,
+            1.2,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=4,
+            max_atoms_per_system=3,
+            return_distances=True,
+        )
+        selected_full_loss = full_distances[target_indices.long()].sum()
+        selected_full_grad = torch.autograd.grad(selected_full_loss, positions)[0]
+
+        torch.testing.assert_close(partial_loss(positions), selected_full_loss)
+        torch.testing.assert_close(partial_grad, selected_full_grad)
 
     @pytest.mark.slow
     def test_gradcheck_distances_wrt_positions(self, device):

--- a/test/neighbors/bindings/torch/test_naive.py
+++ b/test/neighbors/bindings/torch/test_naive.py
@@ -228,7 +228,7 @@ class TestNaiveCorrectness:
             )
 
     def test_target_indices_coo_uses_compact_source_rows(self, device):
-        """COO source rows are compact target rows, not original atom ids."""
+        """COO central rows are compact row ids, not original atom ids."""
         positions = torch.tensor(
             [
                 [0.0, 0.0, 0.0],
@@ -622,8 +622,24 @@ class TestNaiveCorrectness:
                 strategy="scalar",
             )
 
-    def test_target_indices_auto_forwards_native_dispatch(self, device, monkeypatch):
-        """Topology-only auto resolves to scalar and preserves compact targets."""
+    @pytest.mark.parametrize(
+        ("dtype", "num_atoms", "expected_cuda_strategy"),
+        [
+            (torch.float32, 1023, "scalar"),
+            (torch.float32, 1024, "tile"),
+            (torch.float64, 255, "scalar"),
+            (torch.float64, 256, "tile"),
+        ],
+    )
+    def test_target_indices_auto_forwards_native_dispatch(
+        self,
+        device,
+        monkeypatch,
+        dtype,
+        num_atoms,
+        expected_cuda_strategy,
+    ):
+        """Topology-only auto uses CUDA dtype thresholds and preserves targets."""
         seen = {}
 
         def fake_launcher(**kwargs):
@@ -633,8 +649,8 @@ class TestNaiveCorrectness:
             "nvalchemiops.torch.neighbors.naive._naive_neighbor_matrix_no_pbc",
             fake_launcher,
         )
-        positions = torch.zeros((3, 3), dtype=torch.float32, device=device)
-        targets = torch.tensor([2, 0], dtype=torch.int32, device=device)
+        positions = torch.zeros((num_atoms, 3), dtype=dtype, device=device)
+        targets = torch.tensor([num_atoms - 1, 0], dtype=torch.int32, device=device)
         naive_neighbor_list(
             positions,
             1.0,
@@ -642,8 +658,66 @@ class TestNaiveCorrectness:
             target_indices=targets,
             strategy="auto",
         )
-        assert seen["strategy"] == "scalar"
+        expected_strategy = (
+            expected_cuda_strategy if str(device).startswith("cuda") else "scalar"
+        )
+        assert seen["strategy"] == expected_strategy
         assert seen["target_indices"] is targets
+
+    @pytest.mark.gpu
+    @pytest.mark.parametrize(
+        ("dtype", "num_atoms"),
+        [
+            (torch.float32, 1024),
+            (torch.float64, 256),
+        ],
+    )
+    def test_target_indices_auto_compile_fullgraph_uses_tile_threshold(
+        self,
+        dtype,
+        num_atoms,
+    ):
+        """Compiled partial auto retains the eager CUDA tile routing decision."""
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA is required for torch.compile coverage.")
+        device = "cuda:0"
+        positions = (
+            torch.arange(num_atoms, dtype=dtype, device=device)[:, None]
+            .expand(num_atoms, 3)
+            .mul(2.0)
+            .contiguous()
+        )
+        targets = torch.tensor([num_atoms - 1, 0], dtype=torch.int32, device=device)
+
+        @torch.compile(fullgraph=True)
+        def run(pos, matrix, counts, runtime_targets):
+            return naive_neighbor_list(
+                pos,
+                1.0,
+                max_neighbors=4,
+                neighbor_matrix=matrix,
+                num_neighbors=counts,
+                target_indices=runtime_targets,
+                strategy="auto",
+            )
+
+        def outputs():
+            return (
+                torch.full((2, 4), num_atoms, dtype=torch.int32, device=device),
+                torch.zeros((2,), dtype=torch.int32, device=device),
+            )
+
+        matrix, counts = outputs()
+        explanation = torch._dynamo.explain(run)(positions, matrix, counts, targets)
+        assert explanation.graph_break_count == 0, explanation.break_reasons
+        graph_text = "\n".join(graph.code for graph in explanation.graphs)
+        assert "nvalchemiops._naive_neighbor_matrix_no_pbc" in graph_text
+        assert "tile" in graph_text
+
+        matrix, counts = outputs()
+        neighbor_matrix, num_neighbors = run(positions, matrix, counts, targets)
+        torch.testing.assert_close(neighbor_matrix, matrix)
+        torch.testing.assert_close(num_neighbors, torch.zeros_like(num_neighbors))
 
     @pytest.mark.gpu
     def test_target_indices_tile_overflow_contract(self, device):

--- a/test/neighbors/bindings/torch/test_naive.py
+++ b/test/neighbors/bindings/torch/test_naive.py
@@ -21,7 +21,11 @@ import pytest
 import torch
 import warp as wp
 
-from nvalchemiops.torch.neighbors.naive import naive_neighbor_list
+from nvalchemiops.torch.neighbors.naive import (
+    _naive_neighbor_matrix_no_pbc,
+    _naive_neighbor_matrix_pbc,
+    naive_neighbor_list,
+)
 from nvalchemiops.torch.neighbors.neighbor_utils import (
     NeighborOverflowError,
     compute_naive_num_shifts,
@@ -207,6 +211,11 @@ class TestNaiveCorrectness:
             0.75,
             max_neighbors=4,
             target_indices=target_indices,
+            neighbor_matrix_shifts=torch.zeros(
+                (target_indices.shape[0], 4, 3),
+                dtype=torch.int32,
+                device=device,
+            ),
         )
 
         assert partial_nm.shape == (2, 4)
@@ -593,8 +602,28 @@ class TestNaiveCorrectness:
                 strategy="scalar",
             )
 
+    @pytest.mark.gpu
+    def test_target_indices_geometry_rejects_cross_device_output_buffer(self, device):
+        """Partial geometry output buffers must share the positions device."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("CUDA is required for cross-device coverage.")
+        positions = torch.zeros((3, 3), dtype=torch.float32, device=device)
+        targets = torch.tensor([0], dtype=torch.int32, device=device)
+        with pytest.raises(ValueError, match="same device"):
+            naive_neighbor_list(
+                positions,
+                1.0,
+                max_neighbors=4,
+                target_indices=targets,
+                neighbor_matrix=torch.empty((1, 4), dtype=torch.int32, device=device),
+                num_neighbors=torch.empty((1,), dtype=torch.int32, device=device),
+                neighbor_distances=torch.empty((1, 4), dtype=torch.float32),
+                return_distances=True,
+                strategy="scalar",
+            )
+
     def test_target_indices_auto_forwards_native_dispatch(self, device, monkeypatch):
-        """Topology-only auto preserves strategy and compact targets."""
+        """Topology-only auto resolves to scalar and preserves compact targets."""
         seen = {}
 
         def fake_launcher(**kwargs):
@@ -613,7 +642,7 @@ class TestNaiveCorrectness:
             target_indices=targets,
             strategy="auto",
         )
-        assert seen["strategy"] == "auto"
+        assert seen["strategy"] == "scalar"
         assert seen["target_indices"] is targets
 
     @pytest.mark.gpu
@@ -1331,6 +1360,81 @@ class TestNaivePerformance:
 class TestNaiveSelectiveRebuildFlags:
     """Test selective rebuild (rebuild_flags) for naive_neighbor_list torch binding."""
 
+    def test_partial_rebuild_flags_are_rejected(self, device):
+        """Compact rows cannot be combined with selective rebuild flags."""
+        positions = torch.tensor(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            dtype=torch.float32,
+            device=device,
+        )
+        with pytest.raises(
+            NotImplementedError,
+            match=r"^Partial neighbor lists do not support rebuild_flags$",
+        ):
+            naive_neighbor_list(
+                positions,
+                1.0,
+                max_neighbors=4,
+                target_indices=torch.tensor([0], dtype=torch.int32, device=device),
+                rebuild_flags=torch.ones(1, dtype=torch.bool, device=device),
+            )
+
+    def test_no_pbc_wrapper_rejects_partial_rebuild_before_mutation(self, device):
+        """The no-PBC custom op preserves counts on an unsupported request."""
+        positions = torch.zeros((2, 3), dtype=torch.float32, device=device)
+        neighbor_matrix = torch.full((1, 4), 2, dtype=torch.int32, device=device)
+        num_neighbors = torch.full((1,), 37, dtype=torch.int32, device=device)
+
+        with pytest.raises(
+            NotImplementedError,
+            match=r"^Partial neighbor lists do not support rebuild_flags$",
+        ):
+            _naive_neighbor_matrix_no_pbc(
+                positions=positions,
+                cutoff=1.0,
+                neighbor_matrix=neighbor_matrix,
+                num_neighbors=num_neighbors,
+                rebuild_flags=torch.ones(1, dtype=torch.bool, device=device),
+                target_indices=torch.tensor([0], dtype=torch.int32, device=device),
+            )
+
+        assert num_neighbors.tolist() == [37]
+
+    def test_pbc_wrapper_rejects_partial_rebuild_before_mutation(self, device):
+        """The PBC custom op preserves counts on an unsupported request."""
+        positions = torch.zeros((2, 3), dtype=torch.float32, device=device)
+        cell = torch.eye(3, dtype=torch.float32, device=device).unsqueeze(0)
+        pbc = torch.ones((1, 3), dtype=torch.bool, device=device)
+        shift_range, num_shifts, max_shifts = compute_naive_num_shifts(cell, 1.0, pbc)
+        neighbor_matrix = torch.full((1, 4), 2, dtype=torch.int32, device=device)
+        neighbor_matrix_shifts = torch.zeros(
+            (1, 4, 3),
+            dtype=torch.int32,
+            device=device,
+        )
+        num_neighbors = torch.full((1,), 37, dtype=torch.int32, device=device)
+
+        with pytest.raises(
+            NotImplementedError,
+            match=r"^Partial neighbor lists do not support rebuild_flags$",
+        ):
+            _naive_neighbor_matrix_pbc(
+                positions=positions,
+                cutoff=1.0,
+                cell=cell,
+                pbc=pbc,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+                num_neighbors=num_neighbors,
+                shift_range_per_dimension=shift_range,
+                num_shifts_per_system=num_shifts,
+                max_shifts_per_system=max_shifts,
+                rebuild_flags=torch.ones(1, dtype=torch.bool, device=device),
+                target_indices=torch.tensor([0], dtype=torch.int32, device=device),
+            )
+
+        assert num_neighbors.tolist() == [37]
+
     def test_no_rebuild_preserves_data(self, device, dtype):
         """Flag=False: neighbor data should remain unchanged."""
         positions, _, _ = create_simple_cubic_system(
@@ -1455,6 +1559,52 @@ class TestNaiveAutograd:
             return_vectors=True,
         )
         assert d.requires_grad and v.requires_grad
+
+    @pytest.mark.slow
+    def test_partial_no_pbc_distance_gradcheck_matches_selected_full_rows(self, device):
+        """Compact no-PBC distance gradients use each target's source atom row."""
+        positions = torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [0.7, 0.2, 0.0],
+                [2.4, 0.0, 0.0],
+                [3.2, -0.3, 0.0],
+            ],
+            dtype=torch.float64,
+            device=device,
+            requires_grad=True,
+        )
+        target_indices = torch.tensor([3, 0], dtype=torch.int32, device=device)
+
+        def partial_loss(pos):
+            _, _, distances = naive_neighbor_list(
+                pos,
+                1.1,
+                max_neighbors=4,
+                target_indices=target_indices,
+                return_distances=True,
+            )
+            return distances.sum()
+
+        assert torch.autograd.gradcheck(
+            partial_loss,
+            (positions,),
+            atol=1e-5,
+            eps=1e-6,
+            nondet_tol=1e-7,
+        )
+        partial_grad = torch.autograd.grad(partial_loss(positions), positions)[0]
+        _, _, full_distances = naive_neighbor_list(
+            positions,
+            1.1,
+            max_neighbors=4,
+            return_distances=True,
+        )
+        selected_full_loss = full_distances[target_indices.long()].sum()
+        selected_full_grad = torch.autograd.grad(selected_full_loss, positions)[0]
+
+        torch.testing.assert_close(partial_loss(positions), selected_full_loss)
+        torch.testing.assert_close(partial_grad, selected_full_grad)
 
     @pytest.mark.slow
     def test_gradcheck_distances_wrt_positions(self, device):

--- a/test/neighbors/bindings/torch/test_naive.py
+++ b/test/neighbors/bindings/torch/test_naive.py
@@ -22,7 +22,10 @@ import torch
 import warp as wp
 
 from nvalchemiops.torch.neighbors.naive import naive_neighbor_list
-from nvalchemiops.torch.neighbors.neighbor_utils import compute_naive_num_shifts
+from nvalchemiops.torch.neighbors.neighbor_utils import (
+    NeighborOverflowError,
+    compute_naive_num_shifts,
+)
 
 from ...test_utils import (
     assert_neighbor_lists_equal,
@@ -31,6 +34,25 @@ from ...test_utils import (
     create_simple_cubic_system,
 )
 from .conftest import requires_vesin
+
+
+def _sorted_row_multisets(
+    neighbor_matrix: torch.Tensor,
+    num_neighbors: torch.Tensor,
+    neighbor_matrix_shifts: torch.Tensor | None = None,
+) -> list[list[tuple[int, ...]]]:
+    """Return active neighbor rows as sorted multisets for parity checks."""
+    rows = []
+    for row, count_tensor in enumerate(num_neighbors):
+        count = int(count_tensor)
+        values = []
+        for col in range(count):
+            item = (int(neighbor_matrix[row, col]),)
+            if neighbor_matrix_shifts is not None:
+                item += tuple(int(value) for value in neighbor_matrix_shifts[row, col])
+            values.append(item)
+        rows.append(sorted(values))
+    return rows
 
 
 class TestNaiveCorrectness:
@@ -222,6 +244,7 @@ class TestNaiveCorrectness:
         assert set(neighbor_list[0].cpu().tolist()) == {0, 1}
         assert set(map(tuple, neighbor_list.T.cpu().tolist())) == {(0, 3), (1, 1)}
 
+    @pytest.mark.gpu
     def test_target_indices_compile_fullgraph_with_compact_buffers(self, device):
         """target_indices without pair_fn stays behind a fullgraph custom op."""
         if not str(device).startswith("cuda"):
@@ -263,6 +286,7 @@ class TestNaiveCorrectness:
                 torch.sort(full_nm[atom, : int(full_nn[atom])].cpu()).values,
             )
 
+    @pytest.mark.gpu
     def test_target_indices_compile_fullgraph_pbc_pair_geometry(self, device):
         """PBC target_indices fullgraph path supports geometry buffers."""
         if not str(device).startswith("cuda"):
@@ -316,6 +340,119 @@ class TestNaiveCorrectness:
         assert partial_vec.shape == (1, 8, 3)
         assert int(partial_nn[0]) >= 1
 
+    @pytest.mark.gpu
+    def test_target_indices_tile_compile_fullgraph_runtime_targets(self, device):
+        """Tiled topology custom op accepts runtime compact targets."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("CUDA is required for tiled fullgraph coverage.")
+        positions = torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [0.5, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+                [2.5, 0.0, 0.0],
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+
+        @torch.compile(fullgraph=True)
+        def run(pos, nm, nn, targets):
+            return naive_neighbor_list(
+                pos,
+                0.75,
+                neighbor_matrix=nm,
+                num_neighbors=nn,
+                target_indices=targets,
+                strategy="tile",
+            )
+
+        for targets in (
+            torch.tensor([2, 0], dtype=torch.int32, device=device),
+            torch.tensor([0, 2], dtype=torch.int32, device=device),
+        ):
+            tiled_nm, tiled_nn = run(
+                positions,
+                torch.full((2, 4), 4, dtype=torch.int32, device=device),
+                torch.zeros((2,), dtype=torch.int32, device=device),
+                targets,
+            )
+            scalar_nm, scalar_nn = naive_neighbor_list(
+                positions,
+                0.75,
+                max_neighbors=4,
+                target_indices=targets,
+                strategy="scalar",
+            )
+            torch.testing.assert_close(tiled_nn, scalar_nn, rtol=0, atol=0)
+            assert _sorted_row_multisets(tiled_nm, tiled_nn) == _sorted_row_multisets(
+                scalar_nm,
+                scalar_nn,
+            )
+
+    @pytest.mark.gpu
+    def test_target_indices_tile_compile_fullgraph_pbc_runtime_targets(self, device):
+        """Tiled PBC topology custom op accepts runtime compact targets."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("CUDA is required for tiled fullgraph coverage.")
+        positions = torch.tensor(
+            [[0.0, 0.0, 0.0], [3.5, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+            dtype=torch.float32,
+            device=device,
+        )
+        cell = torch.eye(3, dtype=torch.float32, device=device).unsqueeze(0) * 4.0
+        pbc = torch.ones((1, 3), dtype=torch.bool, device=device)
+        shift_range, num_shifts, max_shifts = compute_naive_num_shifts(cell, 1.1, pbc)
+
+        @torch.compile(fullgraph=True)
+        def run(pos, nm, nms, nn, targets):
+            return naive_neighbor_list(
+                pos,
+                1.1,
+                cell=cell,
+                pbc=pbc,
+                neighbor_matrix=nm,
+                neighbor_matrix_shifts=nms,
+                num_neighbors=nn,
+                shift_range_per_dimension=shift_range,
+                num_shifts_per_system=num_shifts,
+                max_shifts_per_system=max_shifts,
+                target_indices=targets,
+                strategy="tile",
+            )
+
+        for targets in (
+            torch.tensor([2, 0], dtype=torch.int32, device=device),
+            torch.tensor([0, 2], dtype=torch.int32, device=device),
+        ):
+            tiled_nm, tiled_nn, tiled_shifts = run(
+                positions,
+                torch.full((2, 32), 4, dtype=torch.int32, device=device),
+                torch.zeros((2, 32, 3), dtype=torch.int32, device=device),
+                torch.zeros((2,), dtype=torch.int32, device=device),
+                targets,
+            )
+            scalar_nm, scalar_nn, scalar_shifts = naive_neighbor_list(
+                positions,
+                1.1,
+                cell=cell,
+                pbc=pbc,
+                max_neighbors=32,
+                neighbor_matrix_shifts=torch.zeros(
+                    (2, 32, 3),
+                    dtype=torch.int32,
+                    device=device,
+                ),
+                target_indices=targets,
+                strategy="scalar",
+            )
+            torch.testing.assert_close(tiled_nn, scalar_nn, rtol=0, atol=0)
+            assert _sorted_row_multisets(
+                tiled_nm,
+                tiled_nn,
+                tiled_shifts,
+            ) == _sorted_row_multisets(scalar_nm, scalar_nn, scalar_shifts)
+
     def test_target_indices_rejects_full_size_user_buffers(self, device):
         """Partial lists require compact user buffers."""
         positions = torch.tensor(
@@ -337,20 +474,179 @@ class TestNaiveCorrectness:
                 target_indices=torch.tensor([2, 0], dtype=torch.int32, device=device),
             )
 
-    def test_target_indices_rejects_tile_strategy(self, device):
-        """Explicit tiled naive mode does not support partial rows."""
+    @pytest.mark.gpu
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+    @pytest.mark.parametrize("half_fill", [False, True])
+    @pytest.mark.parametrize("pbc_mode", ["none", "wrapped", "prewrapped"])
+    def test_target_indices_tile_matches_scalar(
+        self,
+        device,
+        dtype,
+        half_fill,
+        pbc_mode,
+    ):
+        """Explicit tile matches scalar compact topology for all PBC modes."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("Tiled partial parity is CUDA-only.")
+        positions = torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [3.5, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+            ],
+            dtype=dtype,
+            device=device,
+        )
+        target_indices = torch.tensor([2, 0], dtype=torch.int32, device=device)
+        kwargs = {}
+        if pbc_mode != "none":
+            cell = torch.eye(3, dtype=dtype, device=device).unsqueeze(0) * 4.0
+            pbc = torch.ones((1, 3), dtype=torch.bool, device=device)
+            shift_range, num_shifts, max_shifts = compute_naive_num_shifts(
+                cell,
+                1.1,
+                pbc,
+            )
+            kwargs = {
+                "cell": cell,
+                "pbc": pbc,
+                "wrap_positions": pbc_mode == "wrapped",
+                "shift_range_per_dimension": shift_range,
+                "num_shifts_per_system": num_shifts,
+                "max_shifts_per_system": max_shifts,
+            }
+        scalar = naive_neighbor_list(
+            positions,
+            1.1,
+            max_neighbors=32,
+            half_fill=half_fill,
+            target_indices=target_indices,
+            strategy="scalar",
+            **kwargs,
+        )
+        tiled = naive_neighbor_list(
+            positions,
+            1.1,
+            max_neighbors=32,
+            half_fill=half_fill,
+            target_indices=target_indices,
+            strategy="tile",
+            **kwargs,
+        )
+        torch.testing.assert_close(scalar[1], tiled[1], rtol=0, atol=0)
+        scalar_shifts = scalar[2] if pbc_mode != "none" else None
+        tiled_shifts = tiled[2] if pbc_mode != "none" else None
+        assert _sorted_row_multisets(scalar[0], scalar[1], scalar_shifts) == (
+            _sorted_row_multisets(tiled[0], tiled[1], tiled_shifts)
+        )
+
+    def test_target_indices_tile_rejects_cpu(self, device):
+        """Explicit partial tile rejects CPU before native dispatch."""
+        if str(device).startswith("cuda"):
+            pytest.skip("CPU-only rejection case.")
         positions = torch.tensor(
             [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]],
             dtype=torch.float32,
             device=device,
         )
-        with pytest.raises(NotImplementedError, match="target_indices"):
+        with pytest.raises(ValueError, match="requires CUDA"):
             naive_neighbor_list(
                 positions,
                 1.0,
                 max_neighbors=4,
                 target_indices=torch.tensor([0], dtype=torch.int32, device=device),
                 strategy="tile",
+            )
+
+    @pytest.mark.gpu
+    def test_target_indices_rejects_cross_device(self, device):
+        """Partial targets must share the positions device."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("CUDA is required for cross-device coverage.")
+        positions = torch.zeros((3, 3), dtype=torch.float32, device=device)
+        targets = torch.tensor([0], dtype=torch.int32, device="cpu")
+        with pytest.raises(ValueError, match="same device"):
+            naive_neighbor_list(
+                positions,
+                1.0,
+                max_neighbors=4,
+                target_indices=targets,
+                strategy="scalar",
+            )
+
+    @pytest.mark.gpu
+    def test_target_indices_rejects_cross_device_output_buffers(self, device):
+        """Compact output buffers must share the positions device."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("CUDA is required for cross-device coverage.")
+        positions = torch.zeros((3, 3), dtype=torch.float32, device=device)
+        targets = torch.tensor([0], dtype=torch.int32, device=device)
+        with pytest.raises(ValueError, match="same device"):
+            naive_neighbor_list(
+                positions,
+                1.0,
+                max_neighbors=4,
+                target_indices=targets,
+                neighbor_matrix=torch.empty((1, 4), dtype=torch.int32),
+                num_neighbors=torch.empty((1,), dtype=torch.int32),
+                strategy="scalar",
+            )
+
+    def test_target_indices_auto_forwards_native_dispatch(self, device, monkeypatch):
+        """Topology-only auto preserves strategy and compact targets."""
+        seen = {}
+
+        def fake_launcher(**kwargs):
+            seen.update(kwargs)
+
+        monkeypatch.setattr(
+            "nvalchemiops.torch.neighbors.naive._naive_neighbor_matrix_no_pbc",
+            fake_launcher,
+        )
+        positions = torch.zeros((3, 3), dtype=torch.float32, device=device)
+        targets = torch.tensor([2, 0], dtype=torch.int32, device=device)
+        naive_neighbor_list(
+            positions,
+            1.0,
+            max_neighbors=4,
+            target_indices=targets,
+            strategy="auto",
+        )
+        assert seen["strategy"] == "auto"
+        assert seen["target_indices"] is targets
+
+    @pytest.mark.gpu
+    def test_target_indices_tile_overflow_contract(self, device):
+        """Partial tile preserves uncapped counts and compact overflow behavior."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("CUDA is required for tiled overflow coverage.")
+        positions = torch.tensor(
+            [[0.0, 0.0, 0.0], [0.4, 0.0, 0.0], [0.8, 0.0, 0.0], [3.0, 0.0, 0.0]],
+            dtype=torch.float32,
+            device=device,
+        )
+        targets = torch.tensor([0, 3], dtype=torch.int32, device=device)
+        matrix, counts = naive_neighbor_list(
+            positions,
+            1.0,
+            max_neighbors=1,
+            fill_value=-7,
+            target_indices=targets,
+            strategy="tile",
+        )
+        assert counts.tolist() == [2, 0]
+        assert int(counts[1]) == 0
+        assert int(matrix[1, 0]) == -7
+        with pytest.raises(NeighborOverflowError):
+            naive_neighbor_list(
+                positions,
+                1.0,
+                max_neighbors=1,
+                fill_value=-7,
+                target_indices=targets,
+                strategy="tile",
+                return_neighbor_list=True,
             )
 
 

--- a/test/neighbors/bindings/torch/test_neighborlist.py
+++ b/test/neighbors/bindings/torch/test_neighborlist.py
@@ -1864,6 +1864,8 @@ class TestNeighborListFineGrainedMethodEquivalence:
     @pytest.mark.parametrize("method", ["naive_scalar", "naive_tile"])
     def test_naive_suboptions_match_naive(self, device, method):
         """``naive_scalar`` / ``naive_tile`` match the base ``naive`` pair set."""
+        if method == "naive_tile" and device == "cpu":
+            pytest.skip("CUDA is required for naive_tile.")
         positions, cell, pbc = self._periodic_float32_system(device)
         cutoff = 5.0
 
@@ -1884,6 +1886,43 @@ class TestNeighborListFineGrainedMethodEquivalence:
             return_neighbor_list=True,
         )
         torch.testing.assert_close(_sorted_pairs(fine[0]), _sorted_pairs(base[0]))
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="CUDA is required for naive_tile partial"
+    )
+    def test_naive_tile_partial_smoke(self):
+        """Fine-grained naive_tile reaches compact unbatched and batched routes."""
+        device = "cuda"
+        positions = torch.tensor(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [2.0, 0.0, 0.0], [2.5, 0.0, 0.0]],
+            dtype=torch.float32,
+            device=device,
+        )
+        targets = torch.tensor([2, 0], dtype=torch.int32, device=device)
+        matrix, counts = neighbor_list(
+            positions,
+            0.75,
+            max_neighbors=4,
+            target_indices=targets,
+            method="naive_tile",
+        )
+        assert matrix.shape == (2, 4)
+        assert counts.shape == (2,)
+
+        batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=device)
+        batch_ptr = torch.tensor([0, 2, 4], dtype=torch.int32, device=device)
+        batch_matrix, batch_counts = neighbor_list(
+            positions,
+            0.75,
+            max_neighbors=4,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            target_indices=targets,
+            method="batch_naive_tile",
+        )
+        assert batch_matrix.shape == (2, 4)
+        assert batch_counts.shape == (2,)
 
     @pytest.mark.parametrize(
         "device",

--- a/test/neighbors/bindings/torch/test_pair_fn.py
+++ b/test/neighbors/bindings/torch/test_pair_fn.py
@@ -377,7 +377,7 @@ def test_naive_pair_fn_optional_buffers_and_returned(device):
 
 
 def test_naive_pair_fn_target_indices_compact_rows(device):
-    """Torch naive ``target_indices + pair_fn`` uses compact source rows."""
+    """Torch naive ``target_indices + pair_fn`` uses compact central rows."""
     positions = torch.tensor(
         [
             [0.0, 0.0, 0.0],
@@ -1242,7 +1242,7 @@ def test_batch_naive_pair_fn_optional_buffers_and_returned(device):
 
 
 def test_batch_naive_pair_fn_target_indices_compact_rows(device):
-    """Torch batch_naive ``target_indices + pair_fn`` uses compact source rows."""
+    """Torch batch_naive ``target_indices + pair_fn`` uses compact central rows."""
     positions = torch.tensor(
         [
             [0.0, 0.0, 0.0],

--- a/test/neighbors/bindings/torch/test_pair_fn.py
+++ b/test/neighbors/bindings/torch/test_pair_fn.py
@@ -723,6 +723,63 @@ def test_compiled_pair_fn_batch_naive_pbc_fullgraph_matrix(device):
     _check_pair_outputs(nm_out, nn_out, nv_out, nd_out, pe_out, pf_out, pp)
 
 
+def test_compiled_pair_fn_batch_naive_pbc_target_indices_fullgraph_matrix(device):
+    """Compiled batch PBC pair functions accept compact targets without max atoms."""
+    _skip_without_cuda(device)
+    positions, cell, pbc = _single_system_pbc(device)
+    batch_idx = torch.zeros(positions.shape[0], dtype=torch.int32, device=device)
+    batch_ptr = torch.tensor([0, positions.shape[0]], dtype=torch.int32, device=device)
+    target_indices = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    cutoff = 0.75
+    max_neighbors = 8
+    cpf = _compiled_pair_fn("batch_naive_pbc_target_fullgraph")
+    nm, nms, nn, nv, nd, pe, pf, pp = _alloc_target_pair_buffers(
+        positions.shape[0], target_indices.shape[0], max_neighbors, device
+    )
+    shift_range, num_shifts, max_shifts = compute_naive_num_shifts(cell, cutoff, pbc)
+
+    @torch.compile(fullgraph=True)
+    def run(positions, nm, nms, nn, nv, nd, pe, pf):
+        return batch_naive_neighbor_list(
+            positions,
+            cutoff,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=max_neighbors,
+            neighbor_matrix=nm,
+            neighbor_matrix_shifts=nms,
+            num_neighbors=nn,
+            shift_range_per_dimension=shift_range,
+            num_shifts_per_system=num_shifts,
+            max_shifts_per_system=max_shifts,
+            target_indices=target_indices,
+            return_distances=True,
+            return_vectors=True,
+            neighbor_vectors=nv,
+            neighbor_distances=nd,
+            pair_fn=cpf,
+            pair_params=pp,
+            pair_energies=pe,
+            pair_forces=pf,
+        )
+
+    nm_out, nn_out, _shifts, nd_out, nv_out, pe_out, pf_out = run(
+        positions, nm, nms, nn, nv, nd, pe, pf
+    )
+    _check_target_pair_outputs(
+        nm_out,
+        nn_out,
+        nv_out,
+        nd_out,
+        pe_out,
+        pf_out,
+        pp,
+        target_indices,
+    )
+
+
 def test_compiled_pair_fn_cell_list_fullgraph_matrix(device):
     """Compiled ``pair_fn`` works under fullgraph for cell-list matrix output."""
     _skip_without_cuda(device)

--- a/test/neighbors/test_batch_naive_kernels.py
+++ b/test/neighbors/test_batch_naive_kernels.py
@@ -648,7 +648,7 @@ class TestBatchNaiveWpLaunchers:
                 num_neighbors=wp.from_torch(num_neighbors, dtype=wp.int32),
                 wp_dtype=get_wp_dtype(dtype),
                 device=device,
-                max_atoms_per_system=max(atoms_per_system),
+                max_atoms_per_system=None,
                 target_indices=wp.from_torch(target_indices, dtype=wp.int32),
                 strategy=strategy,
             )

--- a/test/neighbors/test_batch_naive_kernels.py
+++ b/test/neighbors/test_batch_naive_kernels.py
@@ -86,18 +86,18 @@ def _neighbor_shift_sets(
     neighbor_matrix: torch.Tensor,
     neighbor_matrix_shifts: torch.Tensor,
     num_neighbors: torch.Tensor,
-) -> list[set[tuple[int, tuple[int, int, int]]]]:
-    """Return row-local ``(neighbor, shift)`` sets for order-independent checks."""
+) -> list[list[tuple[int, tuple[int, int, int]]]]:
+    """Return row-local ``(neighbor, shift)`` multisets for order-independent checks."""
     matrix_cpu = neighbor_matrix.detach().cpu()
     shifts_cpu = neighbor_matrix_shifts.detach().cpu()
     counts_cpu = num_neighbors.detach().cpu()
     rows = []
     for row in range(matrix_cpu.shape[0]):
-        row_items = set()
+        row_items = []
         for slot in range(int(counts_cpu[row].item())):
             shift = tuple(int(x) for x in shifts_cpu[row, slot].tolist())
-            row_items.add((int(matrix_cpu[row, slot].item()), shift))
-        rows.append(row_items)
+            row_items.append((int(matrix_cpu[row, slot].item()), shift))
+        rows.append(sorted(row_items))
     return rows
 
 
@@ -579,6 +579,7 @@ class TestBatchNaiveWpLaunchers:
                 wp_num_shifts,
                 wp_batch_idx,
                 wp_batch_ptr,
+                sentinels.target_indices,
                 wp.from_torch(nm_tiled, dtype=wp.int32),
                 wp.from_torch(ns_tiled, dtype=wp.vec3i),
                 wp.from_torch(nn_tiled, dtype=wp.int32),
@@ -590,6 +591,141 @@ class TestBatchNaiveWpLaunchers:
         assert _neighbor_shift_sets(nm_tiled, ns_tiled, nn_tiled) == (
             _neighbor_shift_sets(nm_scalar, ns_scalar, nn_scalar)
         )
+
+    @pytest.mark.gpu
+    def test_batched_pbc_partial_tiled_matches_scalar(self):
+        """Partial batched PBC tile output matches scalar row-local topology."""
+        device = "cuda:0"
+        dtype = torch.float32
+        atoms_per_system = [4, 5]
+        positions, cell, pbc, _ = create_batch_systems(
+            num_systems=len(atoms_per_system),
+            atoms_per_system=atoms_per_system,
+            dtype=dtype,
+            device=device,
+        )
+        batch_idx, batch_ptr = create_batch_idx_and_ptr(atoms_per_system, device)
+        target_indices = torch.tensor([0, 3, 4, 8], dtype=torch.int32, device=device)
+        cutoff = 1.2
+        max_neighbors = 25
+        shift_range, num_shifts, max_shifts = compute_naive_num_shifts(
+            cell,
+            cutoff,
+            pbc,
+        )
+
+        def build(strategy: str) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            neighbor_matrix = torch.full(
+                (target_indices.shape[0], max_neighbors),
+                -1,
+                dtype=torch.int32,
+                device=device,
+            )
+            neighbor_matrix_shifts = torch.zeros(
+                (target_indices.shape[0], max_neighbors, 3),
+                dtype=torch.int32,
+                device=device,
+            )
+            num_neighbors = torch.zeros(
+                target_indices.shape[0],
+                dtype=torch.int32,
+                device=device,
+            )
+            batch_naive_neighbor_matrix_pbc(
+                positions=wp.from_torch(positions, dtype=get_wp_vec_dtype(dtype)),
+                cell=wp.from_torch(cell, dtype=get_wp_mat_dtype(dtype)),
+                cutoff=cutoff,
+                batch_ptr=wp.from_torch(batch_ptr, dtype=wp.int32),
+                batch_idx=wp.from_torch(batch_idx, dtype=wp.int32),
+                shift_range=wp.from_torch(shift_range, dtype=wp.vec3i),
+                num_shifts_arr=wp.from_torch(num_shifts, dtype=wp.int32),
+                max_shifts_per_system=max_shifts,
+                neighbor_matrix=wp.from_torch(neighbor_matrix, dtype=wp.int32),
+                neighbor_matrix_shifts=wp.from_torch(
+                    neighbor_matrix_shifts,
+                    dtype=wp.vec3i,
+                ),
+                num_neighbors=wp.from_torch(num_neighbors, dtype=wp.int32),
+                wp_dtype=get_wp_dtype(dtype),
+                device=device,
+                max_atoms_per_system=max(atoms_per_system),
+                target_indices=wp.from_torch(target_indices, dtype=wp.int32),
+                strategy=strategy,
+            )
+            return neighbor_matrix, neighbor_matrix_shifts, num_neighbors
+
+        scalar = build("scalar")
+        tiled = build("tile")
+
+        assert torch.equal(tiled[2], scalar[2])
+        assert _neighbor_shift_sets(*tiled) == _neighbor_shift_sets(*scalar)
+
+    @pytest.mark.gpu
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+    def test_batched_pbc_prewrapped_tiled_matches_scalar(self, dtype):
+        """Explicit prewrapped PBC tile output matches scalar topology."""
+        device = "cuda:0"
+        atoms_per_system = [4, 5]
+        positions, cell, pbc, _ = create_batch_systems(
+            num_systems=len(atoms_per_system),
+            atoms_per_system=atoms_per_system,
+            dtype=dtype,
+            device=device,
+        )
+        batch_idx, batch_ptr = create_batch_idx_and_ptr(atoms_per_system, device)
+        cutoff = 1.2
+        max_neighbors = 25
+        shift_range, num_shifts, max_shifts = compute_naive_num_shifts(
+            cell,
+            cutoff,
+            pbc,
+        )
+
+        def build(strategy: str) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            neighbor_matrix = torch.full(
+                (positions.shape[0], max_neighbors),
+                -1,
+                dtype=torch.int32,
+                device=device,
+            )
+            neighbor_matrix_shifts = torch.zeros(
+                (positions.shape[0], max_neighbors, 3),
+                dtype=torch.int32,
+                device=device,
+            )
+            num_neighbors = torch.zeros(
+                positions.shape[0],
+                dtype=torch.int32,
+                device=device,
+            )
+            batch_naive_neighbor_matrix_pbc(
+                positions=wp.from_torch(positions, dtype=get_wp_vec_dtype(dtype)),
+                cell=wp.from_torch(cell, dtype=get_wp_mat_dtype(dtype)),
+                cutoff=cutoff,
+                batch_ptr=wp.from_torch(batch_ptr, dtype=wp.int32),
+                batch_idx=wp.from_torch(batch_idx, dtype=wp.int32),
+                shift_range=wp.from_torch(shift_range, dtype=wp.vec3i),
+                num_shifts_arr=wp.from_torch(num_shifts, dtype=wp.int32),
+                max_shifts_per_system=max_shifts,
+                neighbor_matrix=wp.from_torch(neighbor_matrix, dtype=wp.int32),
+                neighbor_matrix_shifts=wp.from_torch(
+                    neighbor_matrix_shifts,
+                    dtype=wp.vec3i,
+                ),
+                num_neighbors=wp.from_torch(num_neighbors, dtype=wp.int32),
+                wp_dtype=get_wp_dtype(dtype),
+                device=device,
+                max_atoms_per_system=max(atoms_per_system),
+                wrap_positions=False,
+                strategy=strategy,
+            )
+            return neighbor_matrix, neighbor_matrix_shifts, num_neighbors
+
+        scalar = build("scalar")
+        tiled = build("tile")
+
+        assert torch.equal(tiled[2], scalar[2])
+        assert _neighbor_shift_sets(*tiled) == _neighbor_shift_sets(*scalar)
 
     @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
     @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])

--- a/test/neighbors/test_naive_dispatch.py
+++ b/test/neighbors/test_naive_dispatch.py
@@ -135,7 +135,7 @@ def test_partial_thresholds_are_dtype_specific(wp_dtype, small, large):
 
 
 def test_batched_partial_auto_is_scalar():
-    """Batched partial auto remains scalar until benchmarked."""
+    """Batched partial auto resolves to scalar."""
     assert (
         _resolve_naive_strategy(
             "auto",

--- a/test/neighbors/test_naive_dispatch.py
+++ b/test/neighbors/test_naive_dispatch.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the pure naive neighbor-list dispatch policy."""
+
+import pytest
+import warp as wp
+
+from nvalchemiops.neighbors.naive.dispatch import (
+    _NaiveWorkload,
+    _partial_tile_min_atoms,
+    _resolve_naive_strategy,
+)
+
+
+def _workload(**overrides) -> _NaiveWorkload:
+    """Build a representative single-system workload."""
+    values = {
+        "device_kind": "cuda",
+        "wp_dtype": wp.float32,
+        "num_atoms": 1024,
+        "num_systems": 1,
+        "partial": True,
+        "batched": False,
+        "pbc": False,
+        "wrap_positions": True,
+        "geometry_outputs": False,
+    }
+    values.update(overrides)
+    return _NaiveWorkload(**values)
+
+
+@pytest.mark.parametrize("requested", ["scalar", "auto"])
+def test_invalid_workload_is_validated_before_strategy_return(requested):
+    """Invalid workload fields are rejected even for early-return strategies."""
+    with pytest.raises(ValueError, match="device_kind"):
+        _resolve_naive_strategy(requested, _workload(device_kind="tpu"))
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"wp_dtype": wp.int32}, "dtype"),
+        ({"num_atoms": -1}, "num_atoms"),
+        ({"num_systems": 0}, "num_systems"),
+    ],
+)
+def test_invalid_workload_fields_are_not_bypassed(overrides, message):
+    """Every workload field is validated before scalar or auto decisions."""
+    with pytest.raises(ValueError, match=message):
+        _resolve_naive_strategy("scalar", _workload(**overrides))
+
+
+def test_invalid_strategy_is_rejected():
+    """Unknown strategy names produce the public validation error."""
+    with pytest.raises(ValueError, match="strategy must be"):
+        _resolve_naive_strategy("invalid", _workload())
+
+
+@pytest.mark.parametrize("device_kind", ["cpu", "cuda", "unknown"])
+def test_explicit_scalar_always_selects_scalar(device_kind):
+    """Explicit scalar is independent of placement."""
+    assert (
+        _resolve_naive_strategy("scalar", _workload(device_kind=device_kind))
+        == "scalar"
+    )
+
+
+def test_explicit_tile_rejects_cpu():
+    """Explicit tile cannot target a concrete CPU device."""
+    with pytest.raises(ValueError, match="requires CUDA"):
+        _resolve_naive_strategy("tile", _workload(device_kind="cpu"))
+
+
+def test_explicit_tile_allows_unknown_placement():
+    """Explicit tile defers unknown placement validation to the launch site."""
+    assert _resolve_naive_strategy("tile", _workload(device_kind="unknown")) == "tile"
+
+
+@pytest.mark.parametrize("num_atoms", [0, 1024, 10000])
+def test_partial_auto_unknown_placement_is_scalar(num_atoms):
+    """Partial auto stays scalar when the placement is not concrete CUDA."""
+    assert (
+        _resolve_naive_strategy(
+            "auto",
+            _workload(device_kind="unknown", num_atoms=num_atoms),
+        )
+        == "scalar"
+    )
+
+
+def test_geometry_tile_is_rejected():
+    """Tile does not support geometry or pair-function outputs."""
+    with pytest.raises(ValueError, match="no geometry"):
+        _resolve_naive_strategy("tile", _workload(geometry_outputs=True))
+
+
+@pytest.mark.parametrize(
+    ("wp_dtype", "small", "large"),
+    [
+        (wp.float16, 1023, 1024),
+        (wp.float32, 1023, 1024),
+        (wp.float64, 255, 256),
+    ],
+)
+def test_partial_thresholds_are_dtype_specific(wp_dtype, small, large):
+    """Known CUDA partial auto dispatch uses the dtype threshold."""
+    workload = _workload(wp_dtype=wp_dtype, num_atoms=small)
+    assert _resolve_naive_strategy("auto", workload) == "scalar"
+    assert (
+        _resolve_naive_strategy(
+            "auto",
+            workload.__class__(
+                **{
+                    **workload.__dict__,
+                    "num_atoms": large,
+                }
+            ),
+        )
+        == "tile"
+    )
+    assert _partial_tile_min_atoms(wp_dtype) == large
+
+
+def test_batched_partial_auto_is_scalar():
+    """Batched partial auto remains scalar until benchmarked."""
+    assert (
+        _resolve_naive_strategy(
+            "auto",
+            _workload(batched=True, num_systems=4, num_atoms=4096),
+        )
+        == "scalar"
+    )
+
+
+@pytest.mark.parametrize(
+    ("num_atoms", "num_systems", "expected"),
+    [
+        (2047, 1, "scalar"),
+        (2048, 1, "tile"),
+        (4095, 16, "scalar"),
+        (4096, 16, "tile"),
+        (12289, 25, "scalar"),
+        (12289, 16, "tile"),
+    ],
+)
+def test_batched_no_pbc_density_boundaries(num_atoms, num_systems, expected):
+    """Full-row batched no-PBC auto preserves density thresholds."""
+    assert (
+        _resolve_naive_strategy(
+            "auto",
+            _workload(
+                num_atoms=num_atoms,
+                num_systems=num_systems,
+                partial=False,
+                batched=True,
+            ),
+        )
+        == expected
+    )
+
+
+def test_batched_pbc_auto_requires_wrapping_for_tile():
+    """Full-row batched prewrapped PBC remains scalar under auto."""
+    workload = _workload(
+        num_atoms=4096,
+        num_systems=1,
+        partial=False,
+        batched=True,
+        pbc=True,
+    )
+    assert _resolve_naive_strategy("auto", workload) == "tile"
+    assert (
+        _resolve_naive_strategy(
+            "auto",
+            workload.__class__(**{**workload.__dict__, "wrap_positions": False}),
+        )
+        == "scalar"
+    )

--- a/test/neighbors/test_naive_kernel_getters.py
+++ b/test/neighbors/test_naive_kernel_getters.py
@@ -15,17 +15,25 @@
 
 """Tests for the public naive kernel kernel getter helper."""
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 import torch
 import warp as wp
 
+import nvalchemiops.neighbors.naive.launchers as naive_launchers
+import nvalchemiops.neighbors.neighbor_utils as neighbor_utils
 from nvalchemiops.neighbors.naive import (
     get_naive_neighbor_matrix_kernel,
     naive_neighbor_matrix,
     naive_neighbor_matrix_pbc,
 )
-from nvalchemiops.neighbors.naive.launchers import _reject_pair_fn_for_dual_cutoff
+from nvalchemiops.neighbors.naive.launchers import (
+    BLOCK_DIM,
+    _partial_tile_min_atoms,
+    _reject_pair_fn_for_dual_cutoff,
+)
 from nvalchemiops.torch.neighbors.neighbor_utils import compute_naive_num_shifts
 
 
@@ -103,6 +111,263 @@ def _skip_missing_cuda(device: str) -> None:
     """Skip CUDA cases when the local test host has no CUDA device."""
     if device.startswith("cuda") and not torch.cuda.is_available():
         pytest.skip("CUDA is required for this test parameter")
+
+
+@pytest.mark.parametrize(
+    ("wp_dtype", "expected"),
+    [
+        (wp.float16, 16 * BLOCK_DIM),
+        (wp.float32, 16 * BLOCK_DIM),
+        (wp.float64, 4 * BLOCK_DIM),
+    ],
+)
+def test_partial_tile_min_atoms_is_dtype_specific(wp_dtype, expected):
+    """Partial tile auto-dispatch uses the benchmarked threshold per dtype."""
+    assert _partial_tile_min_atoms(wp_dtype) == expected
+
+
+@pytest.mark.parametrize(
+    ("wp_dtype", "num_atoms", "strategy", "expected_launch"),
+    [
+        (wp.float16, 1023, "auto", "scalar"),
+        (wp.float16, 1024, "auto", "tile"),
+        (wp.float32, 1023, "auto", "scalar"),
+        (wp.float32, 1024, "auto", "tile"),
+        (wp.float64, 255, "auto", "scalar"),
+        (wp.float64, 256, "auto", "tile"),
+        (wp.float32, 1, "tile", "tile"),
+    ],
+)
+def test_partial_auto_dispatch_uses_dtype_threshold(
+    monkeypatch,
+    wp_dtype,
+    num_atoms,
+    strategy,
+    expected_launch,
+):
+    """Partial routing changes at each dtype threshold; explicit tile does not."""
+    launches = []
+    monkeypatch.setattr(naive_launchers, "_is_cpu_device", lambda _device: False)
+    monkeypatch.setattr(
+        naive_launchers,
+        "_scalar_sentinels",
+        lambda _dtype, _device: (None,) * 16,
+    )
+    monkeypatch.setattr(
+        naive_launchers,
+        "_prepare_pair_output_args",
+        lambda *_args, **_kwargs: (None,) * 5,
+    )
+    monkeypatch.setattr(
+        naive_launchers,
+        "get_naive_neighbor_matrix_kernel",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        naive_launchers.wp,
+        "launch",
+        lambda **_kwargs: launches.append("scalar"),
+    )
+    monkeypatch.setattr(
+        naive_launchers.wp,
+        "launch_tiled",
+        lambda **_kwargs: launches.append("tile"),
+    )
+
+    naive_launchers._launch_naive_neighbor_matrix_no_pbc(
+        SimpleNamespace(shape=(num_atoms, 3)),
+        1.0,
+        None,
+        None,
+        wp_dtype,
+        "cuda:0",
+        batched=False,
+        target_indices=SimpleNamespace(shape=(6,)),
+        strategy=strategy,
+    )
+
+    assert launches == [expected_launch]
+
+
+@pytest.mark.parametrize(
+    ("strategy", "expected_launch"),
+    [
+        ("auto", "scalar"),
+        ("scalar", "scalar"),
+        ("tile", "tile"),
+    ],
+)
+def test_batched_partial_dispatches_requested_strategy(
+    monkeypatch,
+    strategy,
+    expected_launch,
+):
+    """Batched partial routing is scalar by default but honors overrides."""
+    launches = []
+    monkeypatch.setattr(naive_launchers, "_is_cpu_device", lambda _device: False)
+    monkeypatch.setattr(
+        naive_launchers,
+        "_scalar_sentinels",
+        lambda _dtype, _device: (None,) * 16,
+    )
+    monkeypatch.setattr(
+        naive_launchers,
+        "get_naive_neighbor_matrix_kernel",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        naive_launchers.wp,
+        "launch",
+        lambda **_kwargs: launches.append("scalar"),
+    )
+    monkeypatch.setattr(
+        naive_launchers.wp,
+        "launch_tiled",
+        lambda **_kwargs: launches.append("tile"),
+    )
+
+    naive_launchers._launch_naive_neighbor_matrix_no_pbc(
+        SimpleNamespace(shape=(4096, 3)),
+        1.0,
+        None,
+        None,
+        wp.float64,
+        "cuda:0",
+        batched=True,
+        batch_idx=SimpleNamespace(shape=(4096,)),
+        batch_ptr=SimpleNamespace(shape=(1025,)),
+        target_indices=SimpleNamespace(shape=(6,)),
+        strategy=strategy,
+    )
+
+    assert launches == [expected_launch]
+
+
+@pytest.mark.parametrize(
+    ("strategy", "expected_launch"),
+    [
+        ("auto", "scalar"),
+        ("scalar", "scalar"),
+        ("tile", "tile"),
+    ],
+)
+def test_batched_pbc_partial_dispatches_requested_strategy(
+    monkeypatch,
+    strategy,
+    expected_launch,
+):
+    """Batched PBC partial routing is scalar by default but honors overrides."""
+    launches = []
+    monkeypatch.setattr(naive_launchers, "_is_cpu_device", lambda _device: False)
+    monkeypatch.setattr(
+        naive_launchers,
+        "_prepare_pbc_positions",
+        lambda *_args, **_kwargs: (None, None),
+    )
+    monkeypatch.setattr(
+        naive_launchers,
+        "_scalar_sentinels",
+        lambda _dtype, _device: (None,) * 16,
+    )
+    monkeypatch.setattr(
+        naive_launchers,
+        "get_naive_neighbor_matrix_kernel",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        naive_launchers.wp,
+        "launch",
+        lambda **_kwargs: launches.append("scalar"),
+    )
+    monkeypatch.setattr(
+        naive_launchers.wp,
+        "launch_tiled",
+        lambda **_kwargs: launches.append("tile"),
+    )
+
+    naive_launchers._launch_naive_neighbor_matrix_pbc(
+        SimpleNamespace(shape=(4096, 3)),
+        1.0,
+        SimpleNamespace(shape=(1024, 3, 3)),
+        None,
+        None,
+        None,
+        None,
+        None,
+        wp.float64,
+        "cuda:0",
+        batched=True,
+        batch_ptr=SimpleNamespace(shape=(1025,)),
+        batch_idx=SimpleNamespace(shape=(4096,)),
+        num_shifts_arr=SimpleNamespace(shape=(1024,)),
+        max_shifts_per_system=1,
+        max_atoms_per_system=4,
+        target_indices=SimpleNamespace(shape=(6,)),
+        strategy=strategy,
+    )
+
+    assert launches == [expected_launch]
+
+
+def test_batched_partial_selective_reset_uses_target_indices(monkeypatch):
+    """Selective compact-row reset derives each system from its target atom."""
+    captured_kwargs = {}
+    monkeypatch.setattr(
+        neighbor_utils.wp,
+        "launch",
+        lambda **kwargs: captured_kwargs.update(kwargs),
+    )
+    num_neighbors = SimpleNamespace(shape=(2,))
+    batch_idx = SimpleNamespace(shape=(4,))
+    target_indices = SimpleNamespace(shape=(2,))
+    rebuild_flags = SimpleNamespace(shape=(2,))
+
+    neighbor_utils.selective_zero_partial_num_neighbors(
+        num_neighbors,
+        batch_idx,
+        target_indices,
+        rebuild_flags,
+        "cuda:0",
+    )
+
+    assert captured_kwargs["dim"] == 2
+    assert captured_kwargs["inputs"] == [
+        num_neighbors,
+        batch_idx,
+        target_indices,
+        rebuild_flags,
+    ]
+
+
+def test_batch_pbc_partial_forwards_explicit_strategy(monkeypatch):
+    """Batched PBC partial calls preserve the caller's strategy selection."""
+    captured_kwargs = {}
+    monkeypatch.setattr(
+        naive_launchers,
+        "_launch_naive_neighbor_matrix_pbc",
+        lambda *_args, **kwargs: captured_kwargs.update(kwargs),
+    )
+
+    naive_launchers.batch_naive_neighbor_matrix_pbc(
+        None,
+        None,
+        1.0,
+        None,
+        None,
+        None,
+        None,
+        1,
+        None,
+        None,
+        None,
+        wp.float32,
+        "cuda:0",
+        1,
+        target_indices=SimpleNamespace(shape=(1,)),
+        strategy="scalar",
+    )
+
+    assert captured_kwargs["strategy"] == "scalar"
 
 
 def test_single_cutoff_kernel_uses_pair_fn_object_cache_key():

--- a/test/neighbors/test_naive_kernel_getters.py
+++ b/test/neighbors/test_naive_kernel_getters.py
@@ -23,17 +23,12 @@ import torch
 import warp as wp
 
 import nvalchemiops.neighbors.naive.launchers as naive_launchers
-import nvalchemiops.neighbors.neighbor_utils as neighbor_utils
 from nvalchemiops.neighbors.naive import (
     get_naive_neighbor_matrix_kernel,
     naive_neighbor_matrix,
     naive_neighbor_matrix_pbc,
 )
-from nvalchemiops.neighbors.naive.launchers import (
-    BLOCK_DIM,
-    _partial_tile_min_atoms,
-    _reject_pair_fn_for_dual_cutoff,
-)
+from nvalchemiops.neighbors.naive.launchers import _reject_pair_fn_for_dual_cutoff
 from nvalchemiops.torch.neighbors.neighbor_utils import compute_naive_num_shifts
 
 
@@ -111,19 +106,6 @@ def _skip_missing_cuda(device: str) -> None:
     """Skip CUDA cases when the local test host has no CUDA device."""
     if device.startswith("cuda") and not torch.cuda.is_available():
         pytest.skip("CUDA is required for this test parameter")
-
-
-@pytest.mark.parametrize(
-    ("wp_dtype", "expected"),
-    [
-        (wp.float16, 16 * BLOCK_DIM),
-        (wp.float32, 16 * BLOCK_DIM),
-        (wp.float64, 4 * BLOCK_DIM),
-    ],
-)
-def test_partial_tile_min_atoms_is_dtype_specific(wp_dtype, expected):
-    """Partial tile auto-dispatch uses the benchmarked threshold per dtype."""
-    assert _partial_tile_min_atoms(wp_dtype) == expected
 
 
 @pytest.mark.parametrize(
@@ -309,34 +291,89 @@ def test_batched_pbc_partial_dispatches_requested_strategy(
     assert launches == [expected_launch]
 
 
-def test_batched_partial_selective_reset_uses_target_indices(monkeypatch):
-    """Selective compact-row reset derives each system from its target atom."""
-    captured_kwargs = {}
-    monkeypatch.setattr(
-        neighbor_utils.wp,
-        "launch",
-        lambda **kwargs: captured_kwargs.update(kwargs),
-    )
-    num_neighbors = SimpleNamespace(shape=(2,))
-    batch_idx = SimpleNamespace(shape=(4,))
-    target_indices = SimpleNamespace(shape=(2,))
-    rebuild_flags = SimpleNamespace(shape=(2,))
+def test_partial_selective_tile_kernel_is_rejected():
+    """Partial tile kernels do not expose selective rebuild specialization."""
+    with pytest.raises(
+        NotImplementedError,
+        match="Partial tile kernels do not support selective rebuilds",
+    ):
+        get_naive_neighbor_matrix_kernel(
+            wp.float32,
+            partial=True,
+            selective=True,
+            strategy="tile",
+        )
 
-    neighbor_utils.selective_zero_partial_num_neighbors(
-        num_neighbors,
-        batch_idx,
-        target_indices,
-        rebuild_flags,
-        "cuda:0",
-    )
 
-    assert captured_kwargs["dim"] == 2
-    assert captured_kwargs["inputs"] == [
-        num_neighbors,
-        batch_idx,
-        target_indices,
-        rebuild_flags,
-    ]
+@pytest.mark.parametrize("pbc", [False, True], ids=["no_pbc", "pbc"])
+def test_private_partial_rebuild_rejects_before_allocation_or_launch(
+    monkeypatch,
+    pbc,
+):
+    """Private compact selective calls fail before changing sentinel outputs."""
+    positions = SimpleNamespace(shape=(2, 3))
+    target_indices = SimpleNamespace(shape=(1,))
+    rebuild_flags = SimpleNamespace(shape=(1,))
+    neighbor_matrix = torch.full((1, 4), 73, dtype=torch.int32)
+    num_neighbors = torch.full((1,), 29, dtype=torch.int32)
+    matrix_before = neighbor_matrix.clone()
+    counts_before = num_neighbors.clone()
+
+    def unexpected_boundary(*_args, **_kwargs):
+        raise AssertionError("private launcher must reject before allocation or launch")
+
+    monkeypatch.setattr(naive_launchers, "_scalar_sentinels", unexpected_boundary)
+    monkeypatch.setattr(naive_launchers.wp, "launch", unexpected_boundary)
+    monkeypatch.setattr(naive_launchers.wp, "launch_tiled", unexpected_boundary)
+
+    if pbc:
+        neighbor_matrix_shifts = torch.full((1, 4, 3), 17, dtype=torch.int32)
+        shifts_before = neighbor_matrix_shifts.clone()
+        monkeypatch.setattr(
+            naive_launchers,
+            "_prepare_pbc_positions",
+            unexpected_boundary,
+        )
+        with pytest.raises(
+            NotImplementedError,
+            match=r"^Partial neighbor lists do not support rebuild_flags$",
+        ):
+            naive_launchers._launch_naive_neighbor_matrix_pbc(
+                positions,
+                1.0,
+                SimpleNamespace(shape=(1, 3, 3)),
+                None,
+                SimpleNamespace(shape=(1, 3)),
+                neighbor_matrix,
+                neighbor_matrix_shifts,
+                num_neighbors,
+                wp.float32,
+                "cpu",
+                batched=False,
+                num_shifts=1,
+                target_indices=target_indices,
+                rebuild_flags=rebuild_flags,
+            )
+        assert torch.equal(neighbor_matrix_shifts, shifts_before)
+    else:
+        with pytest.raises(
+            NotImplementedError,
+            match=r"^Partial neighbor lists do not support rebuild_flags$",
+        ):
+            naive_launchers._launch_naive_neighbor_matrix_no_pbc(
+                positions,
+                1.0,
+                neighbor_matrix,
+                num_neighbors,
+                wp.float32,
+                "cpu",
+                batched=False,
+                target_indices=target_indices,
+                rebuild_flags=rebuild_flags,
+            )
+
+    assert torch.equal(neighbor_matrix, matrix_before)
+    assert torch.equal(num_neighbors, counts_before)
 
 
 def test_batch_pbc_partial_forwards_explicit_strategy(monkeypatch):


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Accelerate native, JAX, and Torch naive neighbor-list rebuilds that update a compact subset of atoms. The previous implementation used scalar traversal in framework partial paths even when a CUDA tile-cooperative topology-only specialization was available, making large-system partial rebuilds disproportionately expensive. Expose the native specialization consistently through JAX and Torch, preserve scalar behavior for unsupported outputs, and retain optional JAX-only Warp graph replay for callers that keep all graph inputs and outputs at stable addresses.

The new compact-row path maps each output row to its global source atom:

```python
ishift, row = wp.tid()
atom_i = row
if PARTIAL:
    atom_i = target_indices[row]
```

For batched selective rebuilds, reset compact output rows using the target atom's owning system rather than the compact-row index:

```python
row = wp.tid()
atom = target_indices[row]
if rebuild_flags[batch_idx[atom]]:
    num_neighbors[row] = 0
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

- Add CUDA tiled naive neighbor-matrix support for topology-only compact `target_indices` rows, including no-PBC, wrapped PBC, and prewrapped PBC paths.
- Expose the same topology-only partial tile path through JAX and Torch single-system APIs; expose explicit tile through both batched APIs while retaining scalar batched `strategy="auto"`.
- Add dtype-specific single-system automatic dispatch thresholds: tile at 256 atoms for float64 and 1,024 atoms for float16/float32; retain scalar automatic dispatch for batched partial and batched prewrapped PBC workloads.
- Fix batched PBC strategy propagation, scalar partial-PBC wrapping parity, target-aware selective reset behavior, and tiled-kernel input ABI coverage.
- Add JAX opt-in `graph_mode="warp"` replay for tiled partial topology calls with persistent caller-owned buffers; reject dynamic COO output in this mode.
- Add regression coverage for scalar/tile count equality and order-independent `(neighbor, periodic-shift)` parity, graph configuration isolation, persistent-graph constraints, batched routing, and target-aware resets.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

Tile execution is CUDA-only and intentionally limited to topology-only results. Requests for distances, vectors, pair functions, or selective rebuilds continue to use scalar kernels. Scalar and tiled neighbor rows may have different entry order; their active neighbor and periodic-shift multisets are equivalent. The benchmark numbers below are JAX measurements; this PR makes no Torch performance claim.

Controlled RTX 6000 Ada benchmarks used a 9,660-atom periodic system, six target rows, a 12 Å cutoff, and a capacity of 4,096 neighbors per row. Isolated synchronized neighbor-list calls measured:

| Dtype | Scalar | Tile | Speedup |
| --- | ---: | ---: | ---: |
| float32 | 1,266.2 µs | 234.8 µs | 5.39x |
| float64 | 4,887.7 µs | 257.8 µs | 18.96x |

Every scalar/tile run returned 2,074 active edges with exact count equality and exact order-independent `(neighbor, periodic-shift)` multiset equality.

With stable pointers, optional Warp graph replay reduced isolated tiled partial-call latency from 228.4 to 125.2 µs for float32 (1.82x) and from 255.2 to 153.5 µs for float64 (1.66x). Fresh input addresses made graph replay slower, so graph replay remains opt-in and requires persistent buffers.


> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
