### PR TITLE
fix(neighbors): fill wrapped JAX dual-cutoff PBC lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Unbatched JAX naive dual-cutoff PBC neighbor lists now populate both cutoff
+  outputs when using the default `wrap_positions=True`. Previously this path
+  wrapped positions but skipped the fill kernel, leaving zero counts and padded
+  matrices.
+
 ## 0.4.0 - 2026-07-13
 
 ### Added

--- a/nvalchemiops/jax/neighbors/naive_dual_cutoff.py
+++ b/nvalchemiops/jax/neighbors/naive_dual_cutoff.py
@@ -455,7 +455,9 @@ def naive_neighbor_list_dual_cutoff(
                     neighbor_matrix2,
                     neighbor_matrix_shifts2,
                     num_neighbors2,
-                ) = _jax_fill_pbc_selective(
+                ) = _DIRECT_NAIVE_DUAL_KERNELS[("wrap_on_entry", True)][
+                    positions.dtype
+                ](
                     positions_wrapped,
                     per_atom_cell_offsets,
                     float(cutoff1 * cutoff1),
@@ -488,7 +490,9 @@ def naive_neighbor_list_dual_cutoff(
                     neighbor_matrix2,
                     neighbor_matrix_shifts2,
                     num_neighbors2,
-                ) = _jax_fill_pbc(
+                ) = _DIRECT_NAIVE_DUAL_KERNELS[("wrap_on_entry", False)][
+                    positions.dtype
+                ](
                     positions_wrapped,
                     per_atom_cell_offsets,
                     float(cutoff1 * cutoff1),

--- a/nvalchemiops/jax/neighbors/naive_dual_cutoff.py
+++ b/nvalchemiops/jax/neighbors/naive_dual_cutoff.py
@@ -614,6 +614,79 @@ def naive_neighbor_list_dual_cutoff(
                 per_atom_cell_offsets,
                 launch_dims=(total_atoms,),
             )
+            if rebuild_flags is not None:
+                rf = rebuild_flags.flatten()[:1].astype(jnp.bool_)
+                num_neighbors1 = jnp.where(
+                    rf[0], jnp.zeros_like(num_neighbors1), num_neighbors1
+                )
+                num_neighbors2 = jnp.where(
+                    rf[0], jnp.zeros_like(num_neighbors2), num_neighbors2
+                )
+                (
+                    neighbor_matrix1,
+                    neighbor_matrix_shifts1,
+                    num_neighbors1,
+                    neighbor_matrix2,
+                    neighbor_matrix_shifts2,
+                    num_neighbors2,
+                ) = _jax_fill_pbc_selective(
+                    positions_wrapped,
+                    per_atom_cell_offsets,
+                    float(cutoff1 * cutoff1),
+                    float(cutoff2 * cutoff2),
+                    cell,
+                    shift_range_per_dimension,
+                    empty_num_shifts,
+                    empty_batch_idx,
+                    empty_batch_ptr,
+                    empty_target_indices,
+                    neighbor_matrix1,
+                    neighbor_matrix_shifts1,
+                    num_neighbors1,
+                    neighbor_matrix2,
+                    neighbor_matrix_shifts2,
+                    num_neighbors2,
+                    empty_vectors,
+                    empty_distances,
+                    empty_pair_params,
+                    empty_energies,
+                    empty_forces,
+                    rf,
+                    launch_dims=(1, max_shifts_per_system, total_atoms),
+                )
+            else:
+                (
+                    neighbor_matrix1,
+                    neighbor_matrix_shifts1,
+                    num_neighbors1,
+                    neighbor_matrix2,
+                    neighbor_matrix_shifts2,
+                    num_neighbors2,
+                ) = _jax_fill_pbc(
+                    positions_wrapped,
+                    per_atom_cell_offsets,
+                    float(cutoff1 * cutoff1),
+                    float(cutoff2 * cutoff2),
+                    cell,
+                    shift_range_per_dimension,
+                    empty_num_shifts,
+                    empty_batch_idx,
+                    empty_batch_ptr,
+                    empty_target_indices,
+                    neighbor_matrix1,
+                    neighbor_matrix_shifts1,
+                    num_neighbors1,
+                    neighbor_matrix2,
+                    neighbor_matrix_shifts2,
+                    num_neighbors2,
+                    empty_vectors,
+                    empty_distances,
+                    empty_pair_params,
+                    empty_energies,
+                    empty_forces,
+                    empty_rebuild_flags,
+                    launch_dims=(1, max_shifts_per_system, total_atoms),
+                )
         else:
             if rebuild_flags is not None:
                 rf = rebuild_flags.flatten()[:1].astype(jnp.bool_)

--- a/test/neighbors/bindings/jax/test_naive_dual_cutoff.py
+++ b/test/neighbors/bindings/jax/test_naive_dual_cutoff.py
@@ -19,13 +19,35 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
-from nvalchemiops.jax.neighbors import naive_neighbor_list_dual_cutoff
+from nvalchemiops.jax.neighbors import (
+    naive_neighbor_list,
+    naive_neighbor_list_dual_cutoff,
+)
 
 from .conftest import create_simple_cubic_system_jax, requires_gpu
 
 pytestmark = requires_gpu
+
+
+def _active_neighbor_shift_rows(
+    neighbor_matrix: jax.Array,
+    shifts: jax.Array,
+    counts: jax.Array,
+    atom_index: int,
+) -> list[tuple[int, int, int, int]]:
+    """Return sorted active ``(neighbor, sx, sy, sz)`` rows for one atom."""
+    count = int(np.asarray(counts[atom_index]))
+    rows = np.concatenate(
+        (
+            np.asarray(neighbor_matrix[atom_index, :count])[:, None],
+            np.asarray(shifts[atom_index, :count]),
+        ),
+        axis=1,
+    )
+    return sorted(tuple(row) for row in rows.tolist())
 
 
 class TestNaiveDualCutoffCorrectness:
@@ -118,6 +140,92 @@ class TestNaiveDualCutoffCorrectness:
         assert jnp.all(num_neighbors1 >= 0)
         assert jnp.all(num_neighbors2 >= 0)
         assert jnp.all(num_neighbors2 >= num_neighbors1)
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    @pytest.mark.parametrize(
+        "wrap_kwargs",
+        [
+            pytest.param({}, id="default_wrapped"),
+            pytest.param({"wrap_positions": False}, id="prewrapped"),
+        ],
+    )
+    def test_pbc_wrap_modes_match_single_cutoff(
+        self,
+        dtype,
+        wrap_kwargs,
+    ):
+        """Both PBC wrap modes match independent single-cutoff results."""
+        positions, cell, pbc = create_simple_cubic_system_jax(
+            num_atoms=8,
+            cell_size=2.0,
+            dtype=dtype,
+        )
+        cutoff1 = 1.1
+        cutoff2 = 1.5
+        max_neighbors1 = 15
+        max_neighbors2 = 25
+
+        (
+            neighbor_matrix1,
+            num_neighbors1,
+            neighbor_matrix_shifts1,
+            neighbor_matrix2,
+            num_neighbors2,
+            neighbor_matrix_shifts2,
+        ) = naive_neighbor_list_dual_cutoff(
+            positions,
+            cutoff1=cutoff1,
+            cutoff2=cutoff2,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors1=max_neighbors1,
+            max_neighbors2=max_neighbors2,
+            **wrap_kwargs,
+        )
+        reference1 = naive_neighbor_list(
+            positions,
+            cutoff=cutoff1,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=max_neighbors1,
+            **wrap_kwargs,
+        )
+        reference2 = naive_neighbor_list(
+            positions,
+            cutoff=cutoff2,
+            cell=cell,
+            pbc=pbc,
+            max_neighbors=max_neighbors2,
+            **wrap_kwargs,
+        )
+
+        assert jnp.any(num_neighbors1 > 0)
+        assert jnp.any(num_neighbors2 > 0)
+        assert jnp.array_equal(num_neighbors1, reference1[1])
+        assert jnp.array_equal(num_neighbors2, reference2[1])
+        for atom_index in range(positions.shape[0]):
+            assert _active_neighbor_shift_rows(
+                neighbor_matrix1,
+                neighbor_matrix_shifts1,
+                num_neighbors1,
+                atom_index,
+            ) == _active_neighbor_shift_rows(
+                reference1[0],
+                reference1[2],
+                reference1[1],
+                atom_index,
+            )
+            assert _active_neighbor_shift_rows(
+                neighbor_matrix2,
+                neighbor_matrix_shifts2,
+                num_neighbors2,
+                atom_index,
+            ) == _active_neighbor_shift_rows(
+                reference2[0],
+                reference2[2],
+                reference2[1],
+                atom_index,
+            )
 
 
 class TestNaiveDualCutoffEdgeCases:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Fix unbatched JAX naive dual-cutoff PBC neighbor-list construction by dispatching the existing PBC fill kernels after wrapping positions. Add parity coverage against the single-cutoff implementation and document the fix in the changelog.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- Dispatch wrapped dual-cutoff PBC fill kernels for normal and selective rebuild paths.
- Compare both dual-cutoff outputs with single-cutoff references across wrapped and prewrapped float32/float64 inputs.
- Add an Unreleased changelog entry for the corrected JAX behavior.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?


## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
