### PR TITLE
fix(electrostatics): restore reciprocal strain virial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Torch `ewald_reciprocal_space` now preserves graph-connected reciprocal
+  vectors for cell/strain autograd, restoring the physical reciprocal Ewald
+  virial when vectors are regenerated from the differentiable cell.
+
 ## 0.4.0 - 2026-07-13
 
 ### Added

--- a/docs/modules/torch/electrostatics.rst
+++ b/docs/modules/torch/electrostatics.rst
@@ -9,13 +9,17 @@ These functions accept standard ``torch.Tensor`` inputs and support automatic di
 Ewald and PME support full autograd for positions, charges, and cell parameters.
 DSF supports charge gradients via autograd; forces and virials are computed analytically.
 Setup parameters such as ``alpha``, cutoffs, mesh controls, batch metadata, and
-neighbor topology are treated as constants. Cell-derived caches such as
-``k_vectors``, ``k_squared``, ``volume``, and ``cell_inv_t`` are accepted when
-``cell.requires_grad`` is true, but they are static metadata and are assumed to
-correspond to the current ``cell``; their cache-generation derivatives are not
-recovered. Energy-returning Ewald, PME, and slab paths support atom-weighted
-losses such as ``(weights * energies).sum()`` for positions, charges, and
-supported cell derivatives.
+neighbor topology are treated as constants. On the full ``ewald_summation`` and
+``particle_mesh_ewald`` APIs, cell-derived caches such as ``k_vectors``,
+``k_squared``, ``volume``, and ``cell_inv_t`` are accepted when
+``cell.requires_grad`` is true, but they are static metadata assumed to
+correspond to the current ``cell``; cache-generation derivatives are not
+recovered. The lower-level ``ewald_reciprocal_space`` component preserves a
+supplied ``k_vectors`` autograd graph when the cell also requires gradients;
+physical strain derivatives require vectors generated from the same
+differentiable cell. Energy-returning Ewald, PME, and slab paths support
+atom-weighted losses such as ``(weights * energies).sum()`` for positions,
+charges, and supported cell derivatives.
 Point-charge Ewald/PME inputs support ``float32`` and ``float64``. Keep all
 floating inputs and precomputed metadata in a call on a consistent dtype.
 

--- a/docs/userguide/about/migration.md
+++ b/docs/userguide/about/migration.md
@@ -52,10 +52,16 @@ entry points instead of regenerating it inside hot loops.
 
 These inputs are caches, not differentiable parameters. `alpha`, cutoffs,
 mesh controls, batch metadata, neighbor topology, and PME B-spline moduli are
-treated as constants even if supplied as grad-bearing tensors. Cell-derived
-caches such as `k_vectors`, `k_squared`, `volume`, and `cell_inv_t` remain
-accepted when cell derivatives are requested, but they are static metadata
-assumed to correspond to the current `cell`.
+treated as constants even if supplied as grad-bearing tensors. For
+`ewald_summation`, caller-supplied `k_vectors` remain static metadata assumed
+to correspond to the current `cell`.
+
+The lower-level Torch `ewald_reciprocal_space` component preserves a supplied
+`k_vectors` autograd graph when the cell also requires gradients. Generate those
+vectors from the same differentiable cell to obtain a physical strain
+derivative. Detached Cartesian vectors instead define a fixed-k cell
+derivative; eager execution warns, while the advisory warning is suppressed
+under `torch.compile`.
 
 For fixed-cell loops, build metadata once from a detached or stopped-gradient
 cell and reuse it while the cell is unchanged:

--- a/docs/userguide/components/electrostatics.md
+++ b/docs/userguide/components/electrostatics.md
@@ -693,7 +693,7 @@ real_energies, real_forces = ewald_real_space(
     compute_forces=True,
 )
 
-# Reciprocal-space only (long-range, smooth)
+# Reciprocal-space only in a fixed-cell loop
 k_vectors = generate_k_vectors_ewald_summation(cell.detach(), k_cutoff=8.0)
 recip_energies, recip_forces = ewald_reciprocal_space(
     positions, charges, cell, k_vectors, alpha, compute_forces=True,
@@ -740,6 +740,25 @@ The sum of real and reciprocal components gives the Ewald energy.
 The self-energy and background corrections are embedded within
 the reciprocal energy.
 ```
+
+For a differentiable cell or strain calculation, generate the Cartesian
+reciprocal vectors inside the energy closure from that same differentiable cell.
+Use fixed Python Miller bounds so the reciprocal-index set remains constant:
+
+```python
+miller_bounds = (12, 12, 12)
+
+def reciprocal_energy(positions, charges, cell):
+    k_vectors = generate_k_vectors_ewald_summation(
+        cell, k_cutoff=8.0, miller_bounds=miller_bounds
+    )
+    return ewald_reciprocal_space(positions, charges, cell, k_vectors, alpha)
+```
+
+Passing detached vectors while differentiating with respect to `cell` holds
+their Cartesian values fixed and does not produce the physical Ewald strain
+virial. The eager Torch component API warns for this case; the advisory warning
+is suppressed under `torch.compile`.
 
 When using the Ewald component functions for slab-like systems, add the slab
 correction explicitly after computing the 3D-periodic real- and reciprocal-space

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -553,10 +553,9 @@ def _reciprocal_space_energy(
 ) -> torch.Tensor:
     """Per-atom reciprocal-space Ewald energy, connected to autograd via the chain.
 
-    Energy = k-sum (explicit chain, differentiable in positions / charges and,
-    through a preserved reciprocal-vector graph, cell) minus the Torch-native
-    self + background corrections. Leaf k-vector gradients are available only
-    while a cell-gradient path requests the reciprocal k-space VJP.
+    Energy = k-sum (explicit chain, differentiable in positions, charges, and
+    reciprocal vectors; cell-dependent paths compose through reciprocal-vector
+    and volume graphs) minus the Torch-native self + background corrections.
     """
     num_atoms = positions.shape[0]
     device = positions.device
@@ -571,10 +570,11 @@ def _reciprocal_space_energy(
     # recompute). ``cell`` flows through ``k_vectors(cell)`` / ``volume`` as before.
     need_pos = bool(positions.requires_grad)
     need_charge = bool(charges.requires_grad)
-    # The recip chain owns the cell first order via grad_kvectors / grad_volume (the
-    # k-major ``kspace`` recompute). Public k-vector leaf gradients are not part of
-    # the contract; the cell path is only valid when k-vectors were generated from
-    # this cell inside the full Ewald call.
+    # ``need_cell`` gates the k-major grad_kvectors / grad_volume backward owned by
+    # the recip chain. The public component preserves a supplied k-vector graph when
+    # both cell and k_vectors require grad; otherwise vectors are fixed Cartesian
+    # metadata for cell derivatives. Leaf vectors without a cell edge still receive
+    # dE/dk; physical strain requires vectors generated from the differentiable cell.
     need_cell = bool(cell.requires_grad)
     ensure_electrostatics_ops_registered()
     if batch_idx is None:
@@ -1404,7 +1404,11 @@ def ewald_summation(
     alpha : float, torch.Tensor, or None, default=None
         Ewald splitting parameter. Auto-estimated if None.
     k_vectors : torch.Tensor, optional
-        Pre-computed reciprocal lattice vectors.
+        Pre-computed reciprocal lattice vectors for fixed-cell reuse.
+        Caller-supplied vectors are static metadata assumed to correspond to the
+        current ``cell``; cache-generation derivatives are not recovered. For
+        physical cell/strain derivatives, omit ``k_vectors`` so vectors are
+        regenerated from the differentiable ``cell``.
     k_cutoff : float, optional
         K-space cutoff for generating k_vectors.
     miller_bounds : tuple[int, int, int] or torch.Tensor, optional, keyword-only

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -554,9 +554,9 @@ def _reciprocal_space_energy(
     """Per-atom reciprocal-space Ewald energy, connected to autograd via the chain.
 
     Energy = k-sum (explicit chain, differentiable in positions / charges and,
-    for internally generated reciprocal geometry, cell) minus the Torch-native
-    self + background corrections. Public k-vector leaf gradients are outside
-    the electrostatics contract.
+    through a preserved reciprocal-vector graph, cell) minus the Torch-native
+    self + background corrections. Leaf k-vector gradients are available only
+    while a cell-gradient path requests the reciprocal k-space VJP.
     """
     num_atoms = positions.shape[0]
     device = positions.device
@@ -634,7 +634,6 @@ def _reciprocal_space_energy(
             need_cell,
             max_atoms_bound,
         )
-
     return _apply_reciprocal_corrections(e_ksum, charges, volume, alpha, batch_idx)
 
 
@@ -1003,6 +1002,11 @@ def ewald_reciprocal_space(
         Unit cell matrices.
     k_vectors : torch.Tensor
         Reciprocal lattice vectors. Shape (K, 3) for single system, (B, K, 3) for batch.
+        When both ``cell`` and ``k_vectors`` require gradients, the supplied
+        k-vector graph is preserved. Physical strain derivatives require vectors
+        generated from the same differentiable cell. Non-differentiable vectors,
+        and grad-bearing leaf vectors without a cell edge, are fixed Cartesian
+        metadata for cell derivatives.
     alpha : torch.Tensor, shape (1,) or (B,)
         Ewald splitting parameter(s).
     batch_idx : torch.Tensor, shape (N,), optional
@@ -1048,8 +1052,11 @@ def ewald_reciprocal_space(
     ----
     Energies are always float64 for numerical stability during accumulation.
     Forces, virial, and charge gradients match the input dtype (float32 or float64).
-    ``k_vectors`` are setup metadata. Caller-supplied vectors are treated as
-    static values that correspond to the current ``cell``.
+    For eager execution, a differentiable ``cell`` paired with fixed Cartesian
+    ``k_vectors`` emits a warning because its cell derivative is not the physical
+    Ewald strain virial. This advisory warning is suppressed under
+    ``torch.compile``. Generate vectors from the differentiable cell with fixed
+    Miller bounds for physical strain derivatives.
 
     When ``charges`` is a non-leaf tensor that may depend on ``positions``
     (:math:`q = q(R)`), ordinary first-order losses may use cached partial
@@ -1058,6 +1065,26 @@ def ewald_reciprocal_space(
     losses and higher-order derivatives recompute safe partials or connected
     gradients as needed to avoid double-counting that chain term (issue #115).
     """
+    allow_cell_grad_with_k_vectors = bool(
+        cell.requires_grad and k_vectors.requires_grad
+    )
+    k_vectors_fixed_for_cell = bool(not k_vectors.requires_grad or k_vectors.is_leaf)
+    if (
+        torch.is_grad_enabled()
+        and cell.requires_grad
+        and k_vectors_fixed_for_cell
+        and not hybrid_forces
+        and not torch.compiler.is_compiling()
+    ):
+        warnings.warn(
+            "ewald_reciprocal_space received k_vectors that are fixed Cartesian "
+            "metadata for cell derivatives. If differentiated with respect to "
+            "cell or strain, this call does not produce the physical Ewald strain "
+            "virial. Generate k_vectors from the differentiable cell with fixed "
+            "miller_bounds, or use ewald_summation with k_cutoff.",
+            UserWarning,
+            stacklevel=2,
+        )
     return _ewald_reciprocal_space(
         positions=positions,
         charges=charges,
@@ -1069,7 +1096,7 @@ def ewald_reciprocal_space(
         compute_charge_gradients=compute_charge_gradients,
         compute_virial=compute_virial,
         hybrid_forces=hybrid_forces,
-        allow_cell_grad_with_k_vectors=False,
+        allow_cell_grad_with_k_vectors=allow_cell_grad_with_k_vectors,
         max_atoms_per_system=max_atoms_per_system,
     )
 

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -1618,6 +1618,7 @@ def _ewald_reciprocal_space(
         if preserve_k_vector_grad:
             energies = _select_energy(energies)
         else:
+
             def _system_fallback(
                 p,
                 q,

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -2459,7 +2459,8 @@ class TestAutogradReciprocalSpace:
             allow_unused=True,
         )
         assert torch.isfinite(grad_cell).all()
-        assert grad_k is None
+        assert grad_k is not None
+        assert torch.isfinite(grad_k).all()
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_autograd_matches_explicit_forces(self, device):
@@ -2603,7 +2604,8 @@ class TestAutogradReciprocalSpace:
             allow_unused=True,
         )
         assert torch.isfinite(grad_cell).all()
-        assert grad_k is None
+        assert grad_k is not None
+        assert torch.isfinite(grad_k).all()
 
 
 class TestAutogradFullEwald:
@@ -5437,6 +5439,24 @@ class TestEwaldRealSpaceVirial:
 class TestEwaldReciprocalSpaceVirial:
     """Test reciprocal-space Ewald virial against finite-difference."""
 
+    @staticmethod
+    def _triclinic_system(device):
+        """Return the issue-136 reciprocal virial regression system."""
+        dtype = torch.float64
+        positions = torch.tensor(
+            [[0.5, 0.5, 0.5], [3.0, 1.0, 2.0], [1.5, 3.5, 4.0], [4.5, 2.5, 1.0]],
+            dtype=dtype,
+            device=device,
+        )
+        charges = torch.tensor([1.0, -1.0, 0.7, -0.7], dtype=dtype, device=device)
+        cell = torch.tensor(
+            [[[6.0, 0.0, 0.0], [1.0, 5.0, 0.0], [0.5, 0.7, 5.5]]],
+            dtype=dtype,
+            device=device,
+        )
+        alpha = torch.tensor([0.4], dtype=dtype, device=device)
+        return positions, charges, cell, alpha
+
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_reciprocal_virial_shape(self, device):
         """Reciprocal virial output has correct shape."""
@@ -5500,6 +5520,111 @@ class TestEwaldReciprocalSpaceVirial:
             rtol=1e-3,
             msg="Reciprocal virial does not match finite-difference reference",
         )
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_generated_k_strain_autograd_matches_fd_and_direct_virial(self, device):
+        """Generated reciprocal vectors preserve the physical strain derivative."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell, alpha = self._triclinic_system(device)
+        miller_bounds = (4, 4, 4)
+
+        def energy_fn(pos, q, c):
+            k_vectors = generate_k_vectors_ewald_summation(
+                c,
+                k_cutoff=4.0,
+                miller_bounds=miller_bounds,
+            )
+            return ewald_reciprocal_space(pos, q, c, k_vectors, alpha)
+
+        fd_virial = fd_strain_virial(
+            energy_fn,
+            positions,
+            charges,
+            cell,
+            eps=1e-6,
+        )
+        autograd_virial = autograd_strain_virial(energy_fn, positions, charges, cell)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            k_vectors = generate_k_vectors_ewald_summation(
+                cell,
+                k_cutoff=4.0,
+                miller_bounds=miller_bounds,
+            )
+            _, direct_virial = ewald_reciprocal_space(
+                positions,
+                charges,
+                cell,
+                k_vectors,
+                alpha,
+                compute_virial=True,
+            )
+
+        torch.testing.assert_close(autograd_virial, fd_virial, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(
+            autograd_virial,
+            direct_virial,
+            rtol=1e-5,
+            atol=1e-6,
+        )
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_fixed_k_strain_autograd_matches_fixed_k_fd(self, device):
+        """Fixed Cartesian reciprocal vectors retain fixed-k cell derivatives."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell, alpha = self._triclinic_system(device)
+        fixed_k_vectors = generate_k_vectors_ewald_summation(
+            cell,
+            k_cutoff=4.0,
+            miller_bounds=(4, 4, 4),
+        ).detach()
+
+        def fixed_energy_fn(pos, q, c):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                return ewald_reciprocal_space(pos, q, c, fixed_k_vectors, alpha)
+
+        fd_virial = fd_strain_virial(
+            fixed_energy_fn,
+            positions,
+            charges,
+            cell,
+            eps=1e-6,
+        )
+        autograd_virial = autograd_strain_virial(
+            fixed_energy_fn,
+            positions,
+            charges,
+            cell,
+        )
+        connected_k_vectors = generate_k_vectors_ewald_summation(
+            cell,
+            k_cutoff=4.0,
+            miller_bounds=(4, 4, 4),
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            fixed_energy = ewald_reciprocal_space(
+                positions,
+                charges,
+                cell,
+                fixed_k_vectors,
+                alpha,
+            )
+        connected_energy = ewald_reciprocal_space(
+            positions,
+            charges,
+            cell,
+            connected_k_vectors,
+            alpha,
+        )
+
+        torch.testing.assert_close(autograd_virial, fd_virial, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(fixed_energy, connected_energy)
 
 
 class TestEwaldTotalVirial:
@@ -8067,9 +8192,14 @@ class TestEwaldQRGeometryFallback:
         return energy_fn
 
     def _recip_energy_fn(self, positions, cell, device, alpha):
-        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=2.0).squeeze(0)
+        miller_bounds = (4, 4, 4)
 
         def energy_fn(p, q, c):
+            k_vectors = generate_k_vectors_ewald_summation(
+                c,
+                k_cutoff=2.0,
+                miller_bounds=miller_bounds,
+            )
             return ewald_reciprocal_space(p, q, c, k_vectors, alpha)
 
         return energy_fn
@@ -8184,7 +8314,7 @@ class TestEwaldDoubleBackward:
             return_neighbor_list=True,
         )
         alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
-        k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=2.0).squeeze(0)
+        miller_bounds = (4, 4, 4)
 
         if part == "real":
 
@@ -8201,6 +8331,11 @@ class TestEwaldDoubleBackward:
         elif part == "recip":
 
             def energy_fn(p, q, c):
+                k_vectors = generate_k_vectors_ewald_summation(
+                    c,
+                    k_cutoff=2.0,
+                    miller_bounds=miller_bounds,
+                )
                 return ewald_reciprocal_space(p, q, c, k_vectors, alpha)
         else:  # summation
 

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -8444,6 +8444,33 @@ class TestEwaldDoubleBackward:
         assert gradgradcheck_energy(energy_fn, positions, charges, cell, wrt=wrt)
 
     @pytest.mark.parametrize("device", ["cuda"])
+    def test_gradgradcheck_fixed_k_recip_cell_cuda_canary(self, device):
+        """Fixed-k reciprocal cell gradgradcheck preserves second-order coverage."""
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell = _contract_dipole(device)
+        alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
+        fixed_k_vectors = generate_k_vectors_ewald_summation(
+            cell,
+            k_cutoff=2.0,
+            miller_bounds=(4, 4, 4),
+        ).detach()
+
+        def energy_fn(p, q, c):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                return ewald_reciprocal_space(p, q, c, fixed_k_vectors, alpha)
+
+        assert gradgradcheck_energy(
+            energy_fn,
+            positions,
+            charges,
+            cell,
+            wrt=("cell",),
+        )
+
+    @pytest.mark.parametrize("device", ["cuda"])
     def test_gradgradcheck_triclinic_mixed_cuda_canary(self, device):
         """Non-slow CUDA canary for triclinic mixed position-cell terms."""
         if not torch.cuda.is_available():

--- a/test/interactions/electrostatics/bindings/torch/test_gradient_contract.py
+++ b/test/interactions/electrostatics/bindings/torch/test_gradient_contract.py
@@ -163,6 +163,33 @@ def test_compiled_ewald_first_order_gradients_match_eager() -> None:
     for compiled_grad, eager_grad in zip(compiled_grads, eager_grads, strict=True):
         torch.testing.assert_close(compiled_grad, eager_grad, rtol=5e-7, atol=5e-8)
 
+    def reciprocal_loss_fn(
+        pos: torch.Tensor,
+        q: torch.Tensor,
+        lattice: torch.Tensor,
+    ) -> torch.Tensor:
+        k_vectors = generate_k_vectors_ewald_summation(
+            lattice,
+            k_cutoff=5.0,
+            miller_bounds=(5, 5, 5),
+        )
+        return ewald_reciprocal_space(pos, q, lattice, k_vectors, alpha).sum()
+
+    reciprocal_loss_fn(positions, charges, cell).detach()
+    eager_inputs = (
+        positions.detach().requires_grad_(True),
+        charges.detach().requires_grad_(True),
+        cell.detach().requires_grad_(True),
+    )
+    compiled_inputs = tuple(t.detach().requires_grad_(True) for t in eager_inputs)
+    eager_loss = reciprocal_loss_fn(*eager_inputs)
+    eager_grads = torch.autograd.grad(eager_loss, eager_inputs)
+    compiled_loss = torch.compile(reciprocal_loss_fn)(*compiled_inputs)
+    compiled_grads = torch.autograd.grad(compiled_loss, compiled_inputs)
+    torch.testing.assert_close(compiled_loss, eager_loss)
+    for compiled_grad, eager_grad in zip(compiled_grads, eager_grads, strict=True):
+        torch.testing.assert_close(compiled_grad, eager_grad, rtol=5e-7, atol=5e-8)
+
 
 def test_ewald_alpha_is_setup_constant() -> None:
     """Ewald real, reciprocal, and full APIs do not differentiate alpha."""
@@ -237,8 +264,8 @@ def test_pme_alpha_is_setup_constant() -> None:
     _assert_alpha_has_no_grad(full, alpha)
 
 
-def test_ewald_silently_accepts_k_vectors_when_cell_requires_grad() -> None:
-    """Caller-supplied Ewald k-vectors are static cell-gradient caches."""
+def test_ewald_component_leaf_k_vectors_warn_and_preserve_grad_k() -> None:
+    """Component leaf vectors warn for cell gradients and preserve dE/dk."""
     positions, charges, cell = _system()
     cell = cell.detach().requires_grad_(True)
     alpha = torch.tensor([0.35], dtype=torch.float64, device=positions.device)
@@ -251,14 +278,15 @@ def test_ewald_silently_accepts_k_vectors_when_cell_requires_grad() -> None:
     with warnings.catch_warnings(record=True) as records:
         warnings.simplefilter("always")
         reciprocal = ewald_reciprocal_space(positions, charges, cell, k_vectors, alpha)
-    _assert_no_cache_warning(records)
+    assert any("fixed Cartesian" in str(record.message) for record in records)
     grad_cell, grad_k = torch.autograd.grad(
         reciprocal.sum(),
         (cell, k_vectors),
         allow_unused=True,
     )
     assert torch.isfinite(grad_cell).all()
-    assert grad_k is None
+    assert grad_k is not None
+    assert torch.isfinite(grad_k).all()
 
     neighbor_list, neighbor_ptr, shifts = _neighbor_list()
     with warnings.catch_warnings(record=True) as records:
@@ -283,8 +311,8 @@ def test_ewald_silently_accepts_k_vectors_when_cell_requires_grad() -> None:
     assert grad_k is None
 
 
-def test_ewald_k_vector_source_cell_is_static_metadata() -> None:
-    """Gradients do not flow through the cell that produced supplied k-vectors."""
+def test_ewald_component_preserves_supplied_k_vector_graph() -> None:
+    """The component preserves a caller-supplied differentiable vector graph."""
     positions, charges, cell = _system()
     current_cell = cell.detach().requires_grad_(True)
     cache_cell = (cell.detach() * 1.02).requires_grad_(True)
@@ -304,7 +332,8 @@ def test_ewald_k_vector_source_cell_is_static_metadata() -> None:
         allow_unused=True,
     )
     assert torch.isfinite(grad_current).all()
-    assert grad_cache_cell is None
+    assert grad_cache_cell is not None
+    assert torch.isfinite(grad_cache_cell).all()
 
 
 def test_ewald_public_reciprocal_exposes_no_cache_bypass_keyword() -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Fix Torch reciprocal Ewald cell and strain autograd by preserving graph-connected reciprocal vectors when both the cell and vectors require gradients. Emit an eager advisory warning when fixed Cartesian vectors are paired with cell differentiation because that derivative is not the physical Ewald strain virial.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #136

## Changes Made

- Preserve the supplied reciprocal-vector autograd graph in `ewald_reciprocal_space` when cell gradients are requested.
- Warn in eager execution when fixed Cartesian reciprocal vectors are used with a differentiable cell.
- Add CPU, CUDA, finite-difference, direct-virial, compile, geometry-dependent charge, and double-backward regression coverage.
- Document differentiable-cell reciprocal-vector usage and update the changelog.

## Testing

- [x] Unit tests pass locally (`make pytest`) — full suite not run
- [x] Linting passes (`make lint`) — not run
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes — N/A, no new functions or classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
