### PR TITLE
fix(dispersion): handle empty DFT-D3 neighbor graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- Torch DFT-D3 custom operators now zero caller-owned energy, forces,
+  coordination-number, and virial buffers before empty-system or zero-edge
+  early returns, so reused output tensors cannot retain stale values.
+- JAX DFT-D3 CSR calls with atoms but no edges return zero-filled per-atom
+  forces and coordination numbers with shapes ``(N, 3)`` and ``(N,)``, matching
+  the neighbor-matrix contract and preserving per-system energy and virial axes.
 - JAX cell-list builds now derive search radii from their realized grids,
   preventing missed neighbors when static capacity changes the constructed
   grid. Batched `capacity_strategy="geometry"` preserves promoted grids for

--- a/nvalchemiops/jax/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/jax/interactions/dispersion/_dftd3.py
@@ -1428,34 +1428,12 @@ def _dftd3_nl_impl(
     num_atoms = positions.shape[0]
     num_edges = idx_j.shape[0]
 
-    # Handle empty case
-    if num_atoms == 0 or num_edges == 0:
-        if num_systems is None:
-            num_systems = 1
-            if batch_idx is not None:
-                try:
-                    num_systems = int(jnp.max(batch_idx)) + 1
-                except (
-                    jax.errors.ConcretizationTypeError,
-                    jax.errors.TracerIntegerConversionError,
-                ):
-                    raise ValueError(
-                        "Cannot infer num_systems inside jax.jit. "
-                        "Please provide num_systems explicitly when using jax.jit."
-                    ) from None
-        empty_energy = jnp.zeros(num_systems, dtype=jnp.float32)
-        empty_forces = jnp.zeros((0, 3), dtype=jnp.float32)
-        empty_cn = jnp.zeros((0,), dtype=jnp.float32)
-        if compute_virial:
-            empty_virial = jnp.zeros((num_systems, 3, 3), dtype=jnp.float32)
-            return empty_energy, empty_forces, empty_cn, empty_virial
-        return empty_energy, empty_forces, empty_cn
-
-    # Determine number of systems
+    # Determine number of systems before handling empty graphs so zero-edge PBC
+    # inputs retain the leading cell dimension.
     if num_systems is None:
         if cell is not None:
             num_systems = cell.shape[0]
-        elif batch_idx is not None:
+        elif batch_idx is not None and num_atoms > 0:
             try:
                 num_systems = int(jnp.max(batch_idx)) + 1
             except (
@@ -1468,6 +1446,26 @@ def _dftd3_nl_impl(
                 ) from None
         else:
             num_systems = 1
+
+    # An empty system has no per-atom outputs.
+    if num_atoms == 0:
+        empty_energy = jnp.zeros(num_systems, dtype=jnp.float32)
+        empty_forces = jnp.zeros((0, 3), dtype=jnp.float32)
+        empty_cn = jnp.zeros((0,), dtype=jnp.float32)
+        if compute_virial:
+            empty_virial = jnp.zeros((num_systems, 3, 3), dtype=jnp.float32)
+            return empty_energy, empty_forces, empty_cn, empty_virial
+        return empty_energy, empty_forces, empty_cn
+
+    # A nonempty system with no edges still returns one zero value per atom.
+    if num_edges == 0:
+        empty_energy = jnp.zeros(num_systems, dtype=jnp.float32)
+        empty_forces = jnp.zeros((num_atoms, 3), dtype=jnp.float32)
+        empty_cn = jnp.zeros((num_atoms,), dtype=jnp.float32)
+        if compute_virial:
+            empty_virial = jnp.zeros((num_systems, 3, 3), dtype=jnp.float32)
+            return empty_energy, empty_forces, empty_cn, empty_virial
+        return empty_energy, empty_forces, empty_cn
 
     # Create batch indices if not provided
     if batch_idx is None:

--- a/nvalchemiops/torch/__init__.py
+++ b/nvalchemiops/torch/__init__.py
@@ -39,6 +39,7 @@ if importlib.util.find_spec("torch") is None:
         " Please install via `pip install 'nvalchemiops[torch]'`."
     )
 
+from nvalchemiops.torch._warp_op_helpers import torch_custom_op
 from nvalchemiops.torch.fire2 import (
     fire2_compute_extended_reductions,
     fire2_step_coord,
@@ -63,6 +64,7 @@ from nvalchemiops.torch.types import (
 )
 
 __all__ = [
+    "torch_custom_op",
     "get_wp_dtype",
     "get_wp_mat_dtype",
     "get_wp_vec_dtype",

--- a/nvalchemiops/torch/_warp_op_helpers.py
+++ b/nvalchemiops/torch/_warp_op_helpers.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import inspect
 from collections.abc import Callable
 from contextlib import nullcontext
+from functools import update_wrapper
 from typing import Any
 
 import torch
@@ -58,7 +59,22 @@ __all__ = [
     "register_noop_fake",
     "register_warp_op_chain",
     "scoped_warp_stream",
+    "torch_custom_op",
 ]
+
+
+def torch_custom_op(
+    name: str,
+    *,
+    mutates_args: tuple[str, ...],
+) -> Callable[[Callable[..., Any]], Any]:
+    """Register a Torch custom op while retaining implementation metadata."""
+
+    def decorator(implementation: Callable[..., Any]) -> Any:
+        op = torch.library.custom_op(name, mutates_args=mutates_args)(implementation)
+        return update_wrapper(op, implementation)
+
+    return decorator
 
 
 def scoped_warp_stream(device: torch.device | str):

--- a/nvalchemiops/torch/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/torch/interactions/dispersion/_dftd3.py
@@ -15,10 +15,7 @@
 
 from __future__ import annotations
 
-import functools
-from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
 
 import torch
 import warp as wp
@@ -35,6 +32,7 @@ from nvalchemiops.interactions.dispersion._dftd3 import (
 from nvalchemiops.interactions.dispersion._dftd3 import (
     dftd3_pbc as wp_dftd3_pbc,
 )
+from nvalchemiops.torch import torch_custom_op
 from nvalchemiops.torch.types import get_wp_dtype, get_wp_mat_dtype, get_wp_vec_dtype
 
 __all__ = [
@@ -237,21 +235,7 @@ class D3Parameters:
 # ==============================================================================
 
 
-def _documented_custom_op(
-    name: str,
-    *,
-    mutates_args: tuple[str, ...],
-) -> Callable[[Callable[..., Any]], Any]:
-    """Register a Torch custom op while retaining implementation metadata."""
-
-    def decorator(implementation: Callable[..., Any]) -> Any:
-        op = torch.library.custom_op(name, mutates_args=mutates_args)(implementation)
-        return functools.update_wrapper(op, implementation)
-
-    return decorator
-
-
-@_documented_custom_op(
+@torch_custom_op(
     "nvalchemiops::dftd3_matrix",
     mutates_args=("energy", "forces", "coord_num", "virial"),
 )
@@ -476,7 +460,7 @@ def _dftd3_matrix_op(
     )
 
 
-@_documented_custom_op(
+@torch_custom_op(
     "nvalchemiops::dftd3_matrix_pbc",
     mutates_args=("energy", "forces", "coord_num", "virial"),
 )
@@ -727,7 +711,7 @@ def _dftd3_matrix_pbc_op(
     )
 
 
-@_documented_custom_op(
+@torch_custom_op(
     "nvalchemiops::dftd3",
     mutates_args=("energy", "forces", "coord_num", "virial"),
 )
@@ -944,7 +928,7 @@ def _dftd3_op(
     )
 
 
-@_documented_custom_op(
+@torch_custom_op(
     "nvalchemiops::dftd3_pbc",
     mutates_args=("energy", "forces", "coord_num", "virial"),
 )

--- a/nvalchemiops/torch/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/torch/interactions/dispersion/_dftd3.py
@@ -15,7 +15,10 @@
 
 from __future__ import annotations
 
+import functools
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 import torch
 import warp as wp
@@ -234,7 +237,21 @@ class D3Parameters:
 # ==============================================================================
 
 
-@torch.library.custom_op(
+def _documented_custom_op(
+    name: str,
+    *,
+    mutates_args: tuple[str, ...],
+) -> Callable[[Callable[..., Any]], Any]:
+    """Register a Torch custom op while retaining implementation metadata."""
+
+    def decorator(implementation: Callable[..., Any]) -> Any:
+        op = torch.library.custom_op(name, mutates_args=mutates_args)(implementation)
+        return functools.update_wrapper(op, implementation)
+
+    return decorator
+
+
+@_documented_custom_op(
     "nvalchemiops::dftd3_matrix",
     mutates_args=("energy", "forces", "coord_num", "virial"),
 )
@@ -329,7 +346,8 @@ def _dftd3_matrix_op(
     -------
     None
 
-    Modifies input tensors in-place: energy, forces, coord_num, virial (remains zeros)
+    Modifies input tensors in-place: energy, forces, coord_num, virial. Output
+    buffers are reset to zero on every successful call, including empty systems.
 
     Notes
     -----
@@ -359,6 +377,12 @@ def _dftd3_matrix_op(
     if fill_value is None:
         fill_value = num_atoms
 
+    # Zero output tensors
+    energy.zero_()
+    forces.zero_()
+    coord_num.zero_()
+    virial.zero_()
+
     # Handle empty case
     if num_atoms == 0:
         return
@@ -366,12 +390,6 @@ def _dftd3_matrix_op(
     # Infer device from positions if not provided
     if device is None:
         device = str(positions.device)
-
-    # Zero output tensors
-    energy.zero_()
-    forces.zero_()
-    coord_num.zero_()
-    virial.zero_()
 
     # Detect dtype and set appropriate Warp types
     wp_dtype = get_wp_dtype(positions.dtype)
@@ -458,7 +476,7 @@ def _dftd3_matrix_op(
     )
 
 
-@torch.library.custom_op(
+@_documented_custom_op(
     "nvalchemiops::dftd3_matrix_pbc",
     mutates_args=("energy", "forces", "coord_num", "virial"),
 )
@@ -562,7 +580,8 @@ def _dftd3_matrix_pbc_op(
     -------
     None
 
-    Modifies input tensors in-place: energy, forces, coord_num, virial (if compute_virial=True)
+    Modifies input tensors in-place: energy, forces, coord_num, virial. Output
+    buffers are reset to zero on every successful call, including empty systems.
 
     Notes
     -----
@@ -593,6 +612,12 @@ def _dftd3_matrix_pbc_op(
     if fill_value is None:
         fill_value = num_atoms
 
+    # Zero output tensors
+    energy.zero_()
+    forces.zero_()
+    coord_num.zero_()
+    virial.zero_()
+
     # Handle empty case
     if num_atoms == 0:
         return
@@ -600,12 +625,6 @@ def _dftd3_matrix_pbc_op(
     # Infer device from positions if not provided
     if device is None:
         device = str(positions.device)
-
-    # Zero output tensors
-    energy.zero_()
-    forces.zero_()
-    coord_num.zero_()
-    virial.zero_()
 
     # Detect dtype and set appropriate Warp types
     wp_dtype = get_wp_dtype(positions.dtype)
@@ -708,7 +727,7 @@ def _dftd3_matrix_pbc_op(
     )
 
 
-@torch.library.custom_op(
+@_documented_custom_op(
     "nvalchemiops::dftd3",
     mutates_args=("energy", "forces", "coord_num", "virial"),
 )
@@ -798,7 +817,9 @@ def _dftd3_op(
     -------
     None
 
-    Modifies input tensors in-place: energy, forces, coord_num, virial (remains zeros)
+    Modifies input tensors in-place: energy, forces, coord_num, virial. Output
+    buffers are reset to zero on every successful call, including empty systems
+    and CSR graphs with no edges. The non-PBC virial is reset but not computed.
 
     Notes
     -----
@@ -826,6 +847,12 @@ def _dftd3_op(
     num_atoms = positions.size(0)
     num_edges = idx_j.size(0)
 
+    # Zero output tensors
+    energy.zero_()
+    forces.zero_()
+    coord_num.zero_()
+    virial.zero_()
+
     # Handle empty case
     if num_atoms == 0 or num_edges == 0:
         return
@@ -833,12 +860,6 @@ def _dftd3_op(
     # Infer device from positions if not provided
     if device is None:
         device = str(positions.device)
-
-    # Zero output tensors
-    energy.zero_()
-    forces.zero_()
-    coord_num.zero_()
-    virial.zero_()
 
     # Detect dtype and set appropriate Warp types
     wp_dtype = get_wp_dtype(positions.dtype)
@@ -923,7 +944,7 @@ def _dftd3_op(
     )
 
 
-@torch.library.custom_op(
+@_documented_custom_op(
     "nvalchemiops::dftd3_pbc",
     mutates_args=("energy", "forces", "coord_num", "virial"),
 )
@@ -1023,7 +1044,9 @@ def _dftd3_pbc_op(
     -------
     None
 
-    Modifies input tensors in-place: energy, forces, coord_num, virial (if compute_virial=True)
+    Modifies input tensors in-place: energy, forces, coord_num, virial. Output
+    buffers are reset to zero on every successful call, including empty systems
+    and CSR graphs with no edges.
 
     Notes
     -----
@@ -1052,6 +1075,12 @@ def _dftd3_pbc_op(
     num_atoms = positions.size(0)
     num_edges = idx_j.size(0)
 
+    # Zero output tensors
+    energy.zero_()
+    forces.zero_()
+    coord_num.zero_()
+    virial.zero_()
+
     # Handle empty case
     if num_atoms == 0 or num_edges == 0:
         return
@@ -1059,12 +1088,6 @@ def _dftd3_pbc_op(
     # Infer device from positions if not provided
     if device is None:
         device = str(positions.device)
-
-    # Zero output tensors
-    energy.zero_()
-    forces.zero_()
-    coord_num.zero_()
-    virial.zero_()
 
     # Detect dtype and set appropriate Warp types
     wp_dtype = get_wp_dtype(positions.dtype)

--- a/test/interactions/dispersion/bindings/jax/test_dftd3.py
+++ b/test/interactions/dispersion/bindings/jax/test_dftd3.py
@@ -332,6 +332,110 @@ class TestDFT_D3Basic:
         assert forces.shape == (0, 3)
         assert coord_num.shape == (0,)
 
+    @pytest.mark.parametrize("compute_virial", [False, True])
+    def test_csr_zero_edges_preserve_per_atom_shapes(
+        self,
+        functional_params,
+        d3_params,
+        compute_virial,
+    ):
+        """Empty CSR edges retain per-atom outputs for nonempty systems."""
+        positions = jnp.zeros((2, 3), dtype=jnp.float32)
+        numbers = jnp.ones(2, dtype=jnp.int32)
+        periodic_kwargs = (
+            {
+                "cell": jnp.eye(3, dtype=jnp.float32)[jnp.newaxis, :, :],
+                "unit_shifts": jnp.zeros((0, 3), dtype=jnp.int32),
+            }
+            if compute_virial
+            else {}
+        )
+        result = dftd3(
+            positions,
+            numbers,
+            a1=functional_params["a1"],
+            a2=functional_params["a2"],
+            s8=functional_params["s8"],
+            neighbor_list=jnp.zeros((2, 0), dtype=jnp.int32),
+            neighbor_ptr=jnp.zeros(3, dtype=jnp.int32),
+            d3_params=d3_params,
+            compute_virial=compute_virial,
+            **periodic_kwargs,
+        )
+
+        assert result[0].shape == (1,)
+        assert result[1].shape == (2, 3)
+        assert result[2].shape == (2,)
+        assert jnp.allclose(result[0], 0.0)
+        assert jnp.allclose(result[1], 0.0)
+        assert jnp.allclose(result[2], 0.0)
+        if compute_virial:
+            assert result[3].shape == (1, 3, 3)
+            assert jnp.allclose(result[3], 0.0)
+
+    def test_zero_edge_csr_matches_no_neighbor_matrix(
+        self,
+        functional_params,
+        d3_params,
+    ):
+        """Zero-edge CSR and sentinel-only matrix formats are equivalent."""
+        positions = jnp.zeros((2, 3), dtype=jnp.float32)
+        numbers = jnp.ones(2, dtype=jnp.int32)
+        kwargs = {
+            "a1": functional_params["a1"],
+            "a2": functional_params["a2"],
+            "s8": functional_params["s8"],
+            "d3_params": d3_params,
+        }
+
+        matrix_result = dftd3(
+            positions,
+            numbers,
+            neighbor_matrix=jnp.full((2, 1), 2, dtype=jnp.int32),
+            **kwargs,
+        )
+        csr_result = dftd3(
+            positions,
+            numbers,
+            neighbor_list=jnp.empty((2, 0), dtype=jnp.int32),
+            neighbor_ptr=jnp.zeros(3, dtype=jnp.int32),
+            **kwargs,
+        )
+
+        for matrix_output, csr_output in zip(matrix_result, csr_result):
+            assert matrix_output.shape == csr_output.shape
+            assert jnp.allclose(matrix_output, csr_output)
+
+    def test_multisystem_csr_zero_edges_preserve_system_axes(
+        self,
+        functional_params,
+        d3_params,
+    ):
+        """Zero-edge CSR outputs retain per-system energy and virial axes."""
+        result = dftd3(
+            jnp.zeros((2, 3), dtype=jnp.float32),
+            jnp.ones(2, dtype=jnp.int32),
+            a1=functional_params["a1"],
+            a2=functional_params["a2"],
+            s8=functional_params["s8"],
+            neighbor_list=jnp.empty((2, 0), dtype=jnp.int32),
+            neighbor_ptr=jnp.zeros(3, dtype=jnp.int32),
+            cell=jnp.repeat(
+                jnp.eye(3, dtype=jnp.float32)[jnp.newaxis, :, :], 2, axis=0
+            ),
+            unit_shifts=jnp.empty((0, 3), dtype=jnp.int32),
+            batch_idx=jnp.array([0, 1], dtype=jnp.int32),
+            d3_params=d3_params,
+            compute_virial=True,
+        )
+
+        assert result[0].shape == (2,)
+        assert result[1].shape == (2, 3)
+        assert result[2].shape == (2,)
+        assert result[3].shape == (2, 3, 3)
+        for output in result:
+            assert jnp.allclose(output, 0.0)
+
     def test_missing_neighbor_format(self, h2_system, functional_params, d3_params):
         """Test error when neither neighbor format is provided."""
         positions = jnp.array(h2_system["coord"].reshape(2, 3), dtype=jnp.float32)
@@ -1323,6 +1427,56 @@ class TestDFT_D3JIT:
 
         # Dispersion should be attractive (negative)
         assert energy[0] < 0.0
+
+    @pytest.mark.parametrize("compute_virial", [False, True])
+    def test_jit_neighbor_list_zero_edges_preserves_per_atom_shapes(
+        self,
+        d3_params,
+        compute_virial,
+    ):
+        """JIT preserves nonempty zero-edge CSR output shapes."""
+
+        @jax.jit
+        def jitted_dftd3(
+            positions,
+            numbers,
+            neighbor_list,
+            neighbor_ptr,
+            cell,
+            unit_shifts,
+        ):
+            return dftd3(
+                positions,
+                numbers,
+                a1=0.4,
+                a2=4.0,
+                s8=0.8,
+                neighbor_list=neighbor_list,
+                neighbor_ptr=neighbor_ptr,
+                d3_params=d3_params,
+                compute_virial=compute_virial,
+                cell=cell if compute_virial else None,
+                unit_shifts=unit_shifts if compute_virial else None,
+            )
+
+        result = jitted_dftd3(
+            jnp.zeros((2, 3), dtype=jnp.float32),
+            jnp.ones(2, dtype=jnp.int32),
+            jnp.zeros((2, 0), dtype=jnp.int32),
+            jnp.zeros(3, dtype=jnp.int32),
+            jnp.eye(3, dtype=jnp.float32)[jnp.newaxis, :, :],
+            jnp.empty((0, 3), dtype=jnp.int32),
+        )
+
+        assert result[0].shape == (1,)
+        assert result[1].shape == (2, 3)
+        assert result[2].shape == (2,)
+        assert jnp.allclose(result[0], 0.0)
+        assert jnp.allclose(result[1], 0.0)
+        assert jnp.allclose(result[2], 0.0)
+        if compute_virial:
+            assert result[3].shape == (1, 3, 3)
+            assert jnp.allclose(result[3], 0.0)
 
 
 # ==============================================================================

--- a/test/interactions/dispersion/bindings/torch/test_dftd3.py
+++ b/test/interactions/dispersion/bindings/torch/test_dftd3.py
@@ -30,6 +30,8 @@ test/interactions/dispersion/test_dftd3.py
 
 from __future__ import annotations
 
+import inspect
+
 import numpy as np
 import pytest
 
@@ -46,7 +48,9 @@ if TORCH_AVAILABLE:
     from nvalchemiops.torch.interactions.dispersion import D3Parameters, dftd3
     from nvalchemiops.torch.interactions.dispersion._dftd3 import (
         _dftd3_matrix_op,
+        _dftd3_matrix_pbc_op,
         _dftd3_op,
+        _dftd3_pbc_op,
     )
     from nvalchemiops.torch.neighbors import (
         neighbor_list as build_neighbor_list,
@@ -67,6 +71,33 @@ pytestmark = pytest.mark.skipif(
 def numpy_to_torch(arr: np.ndarray, device: str = "cpu") -> torch.Tensor:
     """Convert numpy array to torch tensor."""
     return torch.from_numpy(arr).to(device)
+
+
+def _d3_parameter_tensors(
+    element_tables: dict[str, np.ndarray],
+    device: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Create DFT-D3 parameter tensors for a direct custom-op call."""
+    max_z_inc = element_tables["z_max_inc"]
+    return (
+        numpy_to_torch(element_tables["rcov"], device).float(),
+        numpy_to_torch(element_tables["r4r2"], device).float(),
+        numpy_to_torch(element_tables["c6ref"], device)
+        .float()
+        .reshape(max_z_inc, max_z_inc, 5, 5),
+        numpy_to_torch(element_tables["cnref_i"], device)
+        .float()
+        .reshape(max_z_inc, max_z_inc, 5, 5),
+    )
+
+
+def _d3_parameters(
+    element_tables: dict[str, np.ndarray],
+    device: str,
+) -> D3Parameters:
+    """Create validated DFT-D3 parameters for the public wrapper."""
+    rcov, r4r2, c6ab, cn_ref = _d3_parameter_tensors(element_tables, device)
+    return D3Parameters(rcov=rcov, r4r2=r4r2, c6ab=c6ab, cn_ref=cn_ref)
 
 
 # ==============================================================================
@@ -226,8 +257,8 @@ class TestCustomOpNeighborMatrix:
             .reshape(max_z_inc, max_z_inc, 5, 5)
         )
 
-        # Allocate outputs
-        energy = torch.zeros(1, dtype=torch.float32, device=device)
+        # Sentinel-filled outputs must be cleared by the empty return.
+        energy = torch.full((1,), 17.0, dtype=torch.float32, device=device)
         forces = torch.zeros((0, 3), dtype=torch.float32, device=device)
         coord_num = torch.zeros((0,), dtype=torch.float32, device=device)
         virial = torch.zeros((0, 3, 3), dtype=torch.float32, device=device)
@@ -250,9 +281,48 @@ class TestCustomOpNeighborMatrix:
             virial=virial,
             device=device,
         )
-        energy = energy.cpu().item()
+        assert torch.count_nonzero(energy) == 0
 
-        assert energy == pytest.approx(0.0)
+    @pytest.mark.usefixtures("element_tables", "device")
+    def test_custom_op_pbc_empty_system_clears_outputs(self, request):
+        """PBC matrix custom ops clear sentinels before an empty return."""
+        element_tables = request.getfixturevalue("element_tables")
+        device = request.getfixturevalue("device")
+        covalent_radii, r4r2, c6_reference, coord_num_ref = _d3_parameter_tensors(
+            element_tables, device
+        )
+        positions = torch.zeros((0, 3), dtype=torch.float32, device=device)
+        numbers = torch.zeros(0, dtype=torch.int32, device=device)
+        neighbor_matrix = torch.zeros((0, 0), dtype=torch.int32, device=device)
+        energy = torch.full((1,), 17.0, dtype=torch.float32, device=device)
+        forces = torch.zeros((0, 3), dtype=torch.float32, device=device)
+        coord_num = torch.zeros(0, dtype=torch.float32, device=device)
+        virial = torch.full((1, 3, 3), 17.0, dtype=torch.float32, device=device)
+
+        _dftd3_matrix_pbc_op(
+            positions=positions,
+            numbers=numbers,
+            neighbor_matrix=neighbor_matrix,
+            cell=torch.eye(3, dtype=torch.float32, device=device).unsqueeze(0),
+            neighbor_matrix_shifts=torch.zeros(
+                (0, 0, 3), dtype=torch.int32, device=device
+            ),
+            covalent_radii=covalent_radii,
+            r4r2=r4r2,
+            c6_reference=c6_reference,
+            coord_num_ref=coord_num_ref,
+            a1=0.4,
+            a2=4.0,
+            s8=0.8,
+            energy=energy,
+            forces=forces,
+            coord_num=coord_num,
+            virial=virial,
+            device=device,
+        )
+
+        assert torch.count_nonzero(energy) == 0
+        assert torch.count_nonzero(virial) == 0
 
 
 # ==============================================================================
@@ -331,40 +401,19 @@ class TestCustomOpNeighborList:
         """Test custom op with empty system."""
         element_tables = request.getfixturevalue("element_tables")
         device = request.getfixturevalue("device")
-
-        # Empty system
-        positions = torch.zeros((0, 3), dtype=torch.float32, device=device)
-        numbers = torch.zeros((0,), dtype=torch.int32, device=device)
-        idx_j = torch.zeros((0,), dtype=torch.int32, device=device)
-        neighbor_ptr = torch.zeros((1,), dtype=torch.int32, device=device)
-
-        # Parameters (convert from numpy)
-        max_z_inc = element_tables["z_max_inc"]
-        covalent_radii = numpy_to_torch(element_tables["rcov"], device).float()
-        r4r2 = numpy_to_torch(element_tables["r4r2"], device).float()
-        c6_reference = (
-            numpy_to_torch(element_tables["c6ref"], device)
-            .float()
-            .reshape(max_z_inc, max_z_inc, 5, 5)
+        covalent_radii, r4r2, c6_reference, coord_num_ref = _d3_parameter_tensors(
+            element_tables, device
         )
-        coord_num_ref = (
-            numpy_to_torch(element_tables["cnref_i"], device)
-            .float()
-            .reshape(max_z_inc, max_z_inc, 5, 5)
-        )
+        energy = torch.full((1,), 17.0, dtype=torch.float32, device=device)
+        forces = torch.empty((0, 3), dtype=torch.float32, device=device)
+        coord_num = torch.empty((0,), dtype=torch.float32, device=device)
+        virial = torch.full((1, 3, 3), 17.0, dtype=torch.float32, device=device)
 
-        # Allocate outputs
-        energy = torch.zeros(1, dtype=torch.float32, device=device)
-        forces = torch.zeros((0, 3), dtype=torch.float32, device=device)
-        coord_num = torch.zeros((0,), dtype=torch.float32, device=device)
-        virial = torch.zeros((0, 3, 3), dtype=torch.float32, device=device)
-
-        # Should handle empty case without error
         _dftd3_op(
-            positions=positions,
-            numbers=numbers,
-            idx_j=idx_j,
-            neighbor_ptr=neighbor_ptr,
+            positions=torch.empty((0, 3), dtype=torch.float32, device=device),
+            numbers=torch.empty((0,), dtype=torch.int32, device=device),
+            idx_j=torch.empty((0,), dtype=torch.int32, device=device),
+            neighbor_ptr=torch.zeros((1,), dtype=torch.int32, device=device),
             covalent_radii=covalent_radii,
             r4r2=r4r2,
             c6_reference=c6_reference,
@@ -379,9 +428,106 @@ class TestCustomOpNeighborList:
             device=device,
         )
 
-        energy = energy.cpu().item()
+        assert torch.count_nonzero(energy) == 0
+        assert forces.shape == (0, 3)
+        assert coord_num.shape == (0,)
+        assert torch.count_nonzero(virial) == 0
 
-        assert energy == pytest.approx(0.0)
+    @pytest.mark.usefixtures("element_tables", "device")
+    def test_custom_op_zero_edges_clears_outputs(self, request):
+        """A nonempty zero-edge CSR graph clears caller-owned outputs."""
+        element_tables = request.getfixturevalue("element_tables")
+        device = request.getfixturevalue("device")
+        covalent_radii, r4r2, c6_reference, coord_num_ref = _d3_parameter_tensors(
+            element_tables, device
+        )
+        energy = torch.full((1,), 17.0, dtype=torch.float32, device=device)
+        forces = torch.full((1, 3), 17.0, dtype=torch.float32, device=device)
+        coord_num = torch.full((1,), 17.0, dtype=torch.float32, device=device)
+        virial = torch.full((1, 3, 3), 17.0, dtype=torch.float32, device=device)
+
+        _dftd3_op(
+            positions=torch.zeros((1, 3), dtype=torch.float32, device=device),
+            numbers=torch.ones(1, dtype=torch.int32, device=device),
+            idx_j=torch.empty((0,), dtype=torch.int32, device=device),
+            neighbor_ptr=torch.zeros((2,), dtype=torch.int32, device=device),
+            covalent_radii=covalent_radii,
+            r4r2=r4r2,
+            c6_reference=c6_reference,
+            coord_num_ref=coord_num_ref,
+            a1=0.4,
+            a2=4.0,
+            s8=0.8,
+            energy=energy,
+            forces=forces,
+            coord_num=coord_num,
+            virial=virial,
+            device=device,
+        )
+
+        for output in (energy, forces, coord_num, virial):
+            assert torch.count_nonzero(output) == 0
+
+    @pytest.mark.usefixtures("element_tables", "device")
+    def test_custom_op_pbc_zero_edges_clears_outputs(self, request):
+        """PBC CSR custom ops clear sentinels before a zero-edge return."""
+        element_tables = request.getfixturevalue("element_tables")
+        device = request.getfixturevalue("device")
+        covalent_radii, r4r2, c6_reference, coord_num_ref = _d3_parameter_tensors(
+            element_tables, device
+        )
+        positions = torch.zeros((1, 3), dtype=torch.float32, device=device)
+        numbers = torch.ones(1, dtype=torch.int32, device=device)
+        energy = torch.full((1,), 17.0, dtype=torch.float32, device=device)
+        forces = torch.full((1, 3), 17.0, dtype=torch.float32, device=device)
+        coord_num = torch.full((1,), 17.0, dtype=torch.float32, device=device)
+        virial = torch.full((1, 3, 3), 17.0, dtype=torch.float32, device=device)
+
+        _dftd3_pbc_op(
+            positions=positions,
+            numbers=numbers,
+            idx_j=torch.zeros(0, dtype=torch.int32, device=device),
+            neighbor_ptr=torch.zeros(2, dtype=torch.int32, device=device),
+            cell=torch.eye(3, dtype=torch.float32, device=device).unsqueeze(0),
+            unit_shifts=torch.zeros((0, 3), dtype=torch.int32, device=device),
+            covalent_radii=covalent_radii,
+            r4r2=r4r2,
+            c6_reference=c6_reference,
+            coord_num_ref=coord_num_ref,
+            a1=0.4,
+            a2=4.0,
+            s8=0.8,
+            energy=energy,
+            forces=forces,
+            coord_num=coord_num,
+            virial=virial,
+            device=device,
+        )
+
+        assert torch.count_nonzero(energy) == 0
+        assert torch.count_nonzero(forces) == 0
+        assert torch.count_nonzero(coord_num) == 0
+        assert torch.count_nonzero(virial) == 0
+
+
+@pytest.mark.parametrize(
+    "op, neighbor_parameter",
+    [
+        (_dftd3_matrix_op, "neighbor_matrix"),
+        (_dftd3_matrix_pbc_op, "neighbor_matrix"),
+        (_dftd3_op, "idx_j"),
+        (_dftd3_pbc_op, "idx_j"),
+    ],
+)
+def test_custom_ops_expose_implementation_metadata(op, neighbor_parameter):
+    """Custom-op introspection exposes the decorated implementation contract."""
+    signature = inspect.signature(op)
+
+    assert signature == inspect.signature(op.__wrapped__)
+    assert "positions" in signature.parameters
+    assert "numbers" in signature.parameters
+    assert neighbor_parameter in signature.parameters
+    assert inspect.getdoc(op).startswith("Internal custom op for DFT-D3(BJ)")
 
 
 # ==============================================================================
@@ -619,6 +765,47 @@ class TestDtypeHandling:
 
 class TestTorchCompile:
     """Test torch.compile compatibility."""
+
+    @pytest.mark.parametrize("compute_virial", [False, True])
+    @pytest.mark.usefixtures("element_tables", "device")
+    def test_wrapper_compile_zero_edges(self, request, compute_virial):
+        """Compiled CSR zero-edge calls match eager zero outputs."""
+        element_tables = request.getfixturevalue("element_tables")
+        device = request.getfixturevalue("device")
+        positions = torch.zeros((2, 3), dtype=torch.float32, device=device)
+        numbers = torch.ones(2, dtype=torch.int32, device=device)
+        neighbor_list = torch.empty((2, 0), dtype=torch.int32, device=device)
+        neighbor_ptr = torch.zeros(3, dtype=torch.int32, device=device)
+        periodic_kwargs = (
+            {
+                "cell": torch.eye(3, dtype=torch.float32, device=device).unsqueeze(0),
+                "unit_shifts": torch.empty((0, 3), dtype=torch.int32, device=device),
+            }
+            if compute_virial
+            else {}
+        )
+        kwargs = {
+            "positions": positions,
+            "numbers": numbers,
+            "neighbor_list": neighbor_list,
+            "neighbor_ptr": neighbor_ptr,
+            "d3_params": _d3_parameters(element_tables, device),
+            "a1": 0.4,
+            "a2": 4.0,
+            "s8": 0.8,
+            "compute_virial": compute_virial,
+            "device": device,
+            **periodic_kwargs,
+        }
+
+        eager = dftd3(**kwargs)
+        compiled = torch.compile(dftd3)(**kwargs)
+
+        assert len(compiled) == len(eager)
+        for compiled_output, eager_output in zip(compiled, eager):
+            assert compiled_output.shape == eager_output.shape
+            assert torch.count_nonzero(compiled_output) == 0
+            torch.testing.assert_close(compiled_output, eager_output)
 
     @pytest.mark.usefixtures("element_tables", "device")
     def test_wrapper_compile(self, request):

--- a/test/neighbors/bindings/jax/test_batch_cluster_tile.py
+++ b/test/neighbors/bindings/jax/test_batch_cluster_tile.py
@@ -654,6 +654,9 @@ class TestJaxBatchClusterTileAutograd:
         batch_ptr = jnp.array([0, n_per, 2 * n_per], dtype=jnp.int32)
         cell_batch = jnp.tile(jnp.eye(3, dtype=jnp.float32)[None] * 20.0, (2, 1, 1))
 
+        # Drain asynchronous input construction before Warp starts CUDA graph capture.
+        jax.block_until_ready((pos, cell_batch, batch_ptr))
+
         def loss(p):
             *_, d, _ = batch_cluster_tile_neighbor_list(
                 p,

--- a/test/neighbors/bindings/jax/test_cluster_tile.py
+++ b/test/neighbors/bindings/jax/test_cluster_tile.py
@@ -515,6 +515,9 @@ class TestJaxClusterTileAutograd:
         pos = jax.random.normal(key, (32, 3), dtype=jnp.float32) * 0.15
         cell = jnp.eye(3, dtype=jnp.float32) * 20.0
 
+        # Drain asynchronous input construction before Warp starts CUDA graph capture.
+        jax.block_until_ready((pos, cell))
+
         def loss(p):
             *_, d, _ = cluster_tile_neighbor_list(
                 p,


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Fix DFT-D3 empty-system and zero-edge CSR handling so output buffers and per-atom result shapes remain valid for reuse and compiled execution.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- Clear Torch DFT-D3 custom-op output buffers before empty-system and zero-edge returns.
- Preserve JAX per-atom force and coordination-number shapes for nonempty zero-edge CSR graphs.
- Add Torch and JAX regression coverage for empty, zero-edge, and compiled calls.

## Testing

- [ ] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
