### PR TITLE
ci: two-tier pipeline, decoupled cache publication, and Warp kernel pre-warming

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Set up test environment"
+description: >-
+  Install system packages, uv, and the project into a fresh virtualenv inside a
+  bare CUDA container. Shared by every GPU job so they cannot drift apart.
+
+inputs:
+  python-version:
+    description: "Python version to create the virtualenv with"
+    required: true
+  torch-extra:
+    description: "uv extra selecting the PyTorch build (torch or torch-cu12)"
+    required: false
+    default: "torch"
+  jax-extra:
+    description: "uv extra selecting the JAX build (jax or jax-cu12)"
+    required: false
+    default: "jax"
+
+outputs:
+  uv-cache-hit:
+    description: "Which uv cache key matched, empty on a miss"
+    value: ${{ steps.uv-cache.outputs.cache-matched-key }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install apt requirements
+      shell: bash -x -e -u -o pipefail {0}
+      env:
+        DEBIAN_FRONTEND: "noninteractive"
+        TZ: "Etc/UTC"
+      run: |
+        apt-get update
+        apt-get install -y curl git build-essential
+
+    - name: Setup UV
+      shell: bash -x -e -u -o pipefail {0}
+      env:
+        UV_VERSION: "0.9.25"
+        UV_CHECKSUM: "10fb1f54d56f3eb60622006797339d4ea0bfda9b358d07db635f73cf89f7094c"
+      run: |
+        UV_INSTALLER=$(mktemp)
+        curl --proto '=https' --tlsv1.2 -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" -o "$UV_INSTALLER"
+        echo "${UV_CHECKSUM}  ${UV_INSTALLER}" | sha256sum -c -
+        sh "$UV_INSTALLER"
+        rm "$UV_INSTALLER"
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    # Cache uv's download cache rather than the built virtualenv. The venv is
+    # 3-5 GB with Torch and JAX and embeds absolute paths; the download cache is
+    # smaller, path-independent, and lets `uv sync` resolve offline from local
+    # wheels. Keyed on the lockfile, so a dependency change falls back to the
+    # prefix and only downloads the delta.
+    - name: Restore uv download cache
+      id: uv-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: /tmp/uv-cache
+        key: uv-py${{ inputs.python-version }}-${{ inputs.torch-extra }}-${{ inputs.jax-extra }}-${{ hashFiles('uv.lock') }}
+        restore-keys: |
+          uv-py${{ inputs.python-version }}-${{ inputs.torch-extra }}-${{ inputs.jax-extra }}-
+
+    - name: Install dependencies
+      shell: bash -x -e -u -o pipefail {0}
+      env:
+        UV_CACHE_DIR: /tmp/uv-cache
+      run: |
+        export PATH="$HOME/.local/bin:$PATH"
+        uv venv --seed --python ${{ inputs.python-version }}
+        uv sync --extra ${{ inputs.torch-extra }} --extra ${{ inputs.jax-extra }}
+        uv pip install -r test/test-requires.txt
+
+    # Without this the restore above matches nothing forever and every GPU job
+    # re-downloads the full Torch and JAX CUDA wheel set. Only saves on an exact
+    # miss, since entries are immutable and a prefix hit is already good enough.
+    - name: Save uv download cache
+      if: steps.uv-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: /tmp/uv-cache
+        key: uv-py${{ inputs.python-version }}-${{ inputs.torch-extra }}-${{ inputs.jax-extra }}-${{ hashFiles('uv.lock') }}

--- a/.github/actions/warp-cache/action.yml
+++ b/.github/actions/warp-cache/action.yml
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Restore Warp kernel cache"
+description: >-
+  Restore the compiled-kernel cache, walking a fallback ladder that ends at the
+  baseline cache-warm.yml publishes on main. Also exports WARP_CACHE_PATH and
+  reports what it found, so a slow run can be explained without reading logs.
+
+inputs:
+  python-version:
+    description: "Python version, part of the cache key"
+    required: true
+  cuda-major:
+    description: "CUDA major version, part of the cache key"
+    required: false
+    default: "13"
+
+outputs:
+  matched-key:
+    description: "Cache key that matched, empty on a complete miss"
+    value: ${{ steps.restore.outputs.cache-matched-key }}
+  scope-key:
+    description: >-
+      Ref name with slashes replaced by dashes. Callers that save a cache must
+      use this rather than github.ref_name: a ref like `pull-request/132`
+      produces a key the restore ladder below can never prefix-match, which
+      fails silently because the main-scoped fallback still hits.
+    value: ${{ steps.scope.outputs.key }}
+
+runs:
+  using: "composite"
+  steps:
+    # Caches are scoped to the ref that wrote them, with the default branch as
+    # the only globally readable fallback.
+    #
+    # There is deliberately no rung for "the originating pull request" on a
+    # merge-queue ref. It looks appealing — the queue ref carries the PR number —
+    # but a queue ref cannot read a cache scoped to refs/heads/pull-request/<N>,
+    # so such a rung can never hit. Queue items fall through to main, which is
+    # why cache-warm.yml keeping main fresh is what actually makes them fast.
+    - name: Compute cache scope
+      id: scope
+      shell: bash -e -u -o pipefail {0}
+      env:
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        echo "key=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Warp kernel cache
+      id: restore
+      uses: actions/cache/restore@v4
+      with:
+        path: .warp-cache
+        key: warp-${{ steps.scope.outputs.key }}-py${{ inputs.python-version }}-cuda${{ inputs.cuda-major }}-${{ github.run_id }}
+        restore-keys: |
+          warp-${{ steps.scope.outputs.key }}-py${{ inputs.python-version }}-cuda${{ inputs.cuda-major }}-
+          warp-main-py${{ inputs.python-version }}-cuda${{ inputs.cuda-major }}-
+
+    - name: Export cache path
+      shell: bash -e -u -o pipefail {0}
+      run: |
+        # conftest honours WARP_CACHE_PATH, so every per-group pytest process in
+        # this job shares one directory that actions/cache can persist.
+        echo "WARP_CACHE_PATH=$GITHUB_WORKSPACE/.warp-cache" >> "$GITHUB_ENV"
+        mkdir -p "$GITHUB_WORKSPACE/.warp-cache"
+
+    - name: Report cache state
+      shell: bash -e -u -o pipefail {0}
+      run: |
+        MATCHED="${{ steps.restore.outputs.cache-matched-key }}"
+        {
+          echo "### Warp kernel cache"
+          echo ""
+          if [ -n "$MATCHED" ]; then
+            echo "Restored from \`$MATCHED\`"
+          else
+            echo "**No cache restored** — every kernel will be recompiled."
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
+        if [ -z "$MATCHED" ]; then
+          # This is the condition that previously went unnoticed for weeks while
+          # pull requests silently took hours, so make it visible in the run.
+          echo "::warning title=Cold Warp cache::No Warp cache was restored, so every kernel is being recompiled. Check that cache-warm.yml is succeeding on main."
+        fi

--- a/.github/scripts/prune-caches.sh
+++ b/.github/scripts/prune-caches.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Delete cache entries on the current ref whose key starts with $PREFIX.
+#
+# Cache entries are immutable, so every key embeds a run id and each run would
+# otherwise leave a ~200 MB entry behind until the seven-day sweep. Rotating
+# explicitly is what keeps the repository inside its 10 GB budget.
+#
+# Uses the REST API rather than the GitHub CLI on purpose: the GPU jobs run in a
+# bare CUDA container where `gh` is not installed, so a `gh` call exits 127 and
+# rotation silently never happens. That failure mode is invisible precisely
+# because a stale cache still restores.
+#
+# Requires: PREFIX, GH_TOKEN, and `actions: write` on the calling job.
+# Failures warn rather than fail the build: an unrotated cache is a budget
+# problem, not a correctness one, and losing a test run over it is worse.
+set -u -o pipefail
+
+: "${PREFIX:?PREFIX must be set}"
+: "${GH_TOKEN:?GH_TOKEN must be set}"
+
+API="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/caches"
+AUTH=(-H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
+
+listing=$(curl -sS --fail-with-body "${AUTH[@]}" \
+  "${API}?per_page=100&ref=${GITHUB_REF}") || {
+  echo "::warning title=Cache prune::Could not list caches; entries were not rotated."
+  exit 0
+}
+
+ids=$(PREFIX="$PREFIX" python3 -c '
+import json, os, sys
+
+prefix = os.environ["PREFIX"]
+entries = json.load(sys.stdin).get("actions_caches", [])
+for entry in entries:
+    if entry["key"].startswith(prefix):
+        print(entry["id"])
+' <<<"$listing") || {
+  echo "::warning title=Cache prune::Could not parse cache listing."
+  exit 0
+}
+
+if [ -z "$ids" ]; then
+  echo "No superseded caches matching '${PREFIX}' on ${GITHUB_REF}"
+  exit 0
+fi
+
+deleted=0
+for id in $ids; do
+  if curl -sS --fail-with-body -X DELETE "${AUTH[@]}" "${API}/${id}" >/dev/null; then
+    deleted=$((deleted + 1))
+  else
+    # 403 here almost always means the job is missing `actions: write`.
+    echo "::warning title=Cache prune::Failed to delete cache ${id} (missing actions: write?)"
+  fi
+done
+echo "Pruned ${deleted} cache entries matching '${PREFIX}'"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,317 @@
+# CI workflows
+
+How continuous integration is put together here, and why. Read the first two
+sections before changing anything in this directory; the rest is reference.
+
+## The one thing to know
+
+**A failure in `cache-warm.yml` is a pull-request-speed incident, not just a red
+build.** It is the only job that publishes the compiled-kernel cache every other
+job restores from. When it stops publishing, pull requests silently get slower
+over the following days, and the symptom looks nothing like the cause.
+
+This is not hypothetical. It is exactly what happened before this pipeline was
+rewritten: the nightly build failed at a coverage gate, the cache-save steps that
+came after it never ran, and pull-request CI drifted from minutes to five hours
+while every pull request still reported green.
+
+## Why the tests are split in two
+
+Warp generates and compiles CUDA at runtime. The PME kernels are specialised per
+`(spline order, l_max, dtype)` with loops that are unrolled at code generation, so
+order 6 emits 216 unrolled blocks and NVRTC takes minutes on it. On a cold cache
+the first test to need such a kernel pays that cost — one eight-atom test measured
+at eighteen minutes, essentially all of it compilation.
+
+So the cost of this suite is dominated by *compilation*, not by how many tests you
+select. That produces two rules the design follows:
+
+1. Keeping the kernel cache warm matters more than trimming tests.
+2. Pull requests should run a bounded, predictable subset; everything else runs
+   where latency does not block a human.
+
+## Workflows
+
+| File | Kind | Purpose |
+|---|---|---|
+| `ci.yml` | orchestrator | Triggers, tier selection, coverage gate, status aggregation. No test logic. |
+| `reusable-gpu-tests.yml` | `workflow_call` | Runs one test tier on a GPU runner. Called by `ci.yml`. |
+| `cache-warm.yml` | producer | Publishes the Warp kernel cache and the testmon database. |
+| `cleanup-pr-caches.yml` | janitor | Deletes a pull request's caches when it closes. |
+| `docs.yml`, `weekly-examples.yml` | independent | Unrelated to testing. |
+
+Shared *steps* live in `../actions/` as composite actions; shared *jobs* live here
+as reusable workflows. Reusable workflows must sit in `.github/workflows/` root —
+they cannot be moved into a subdirectory — so the `reusable-` prefix marks the
+ones that are not independently runnable.
+
+| Composite action | Purpose |
+|---|---|
+| `../actions/setup-env` | apt packages, uv, virtualenv, `uv sync`; restores the uv download cache. |
+| `../actions/warp-cache` | Restore-key ladder, `WARP_CACHE_PATH` export, and cache-state reporting. |
+
+`cache-warm.yml` is a **pure producer**: it reads nothing but the repository, so
+it works on a fresh clone, a new CUDA version, or a runner that has never seen
+this project. Nothing in it depends on a test job having run first. Every other
+workflow only consumes what it publishes.
+
+## Triggers
+
+| Event | Runs |
+|---|---|
+| push to `pull-request/<N>` | `test-minimal` (3 shards) + `test-impacted` + coverage gate |
+| `merge_group` | same as above; restores caches, writes none |
+| push to `main` | `cache-warm.yml`, then `test-full` |
+| `schedule` (nightly) | `cache-warm.yml`, `test-full` (4 Python × CUDA 13), `test-cuda12` |
+| `pull_request_target: closed` | `cleanup-pr-caches.yml` |
+| label `ciflow:all` on a PR | `test-full` instead of the fast tier |
+| label `ciflow:skip` on a PR | no GPU tests |
+
+## Test tiers
+
+### `test-minimal` — always runs, in full
+
+The 56 test files that hold the coverage gate for the least time, chosen by
+`tools/group_coverage.py` using greedy weighted set cover over measured per-test
+coverage. 4,275 of 9,665 tests, 71% coverage against a 70% gate, split across
+three shards packed by measured cost.
+
+This tier never uses testmon. It runs the same tests on every pull request, so it
+is the floor of confidence and the reason the coverage gate holds no matter what
+testmon decides.
+
+### `test-impacted` — what the change actually touched
+
+The full group list under `--testmon --testmon-nocollect`, with the
+`test-minimal` files `--ignore`d so work is not duplicated. testmon deselects
+everything the change cannot affect. A narrow change finishes in seconds.
+
+The two tiers are a **union**, not a filter of one by the other. The minimal
+suite always runs in full, which is what guarantees the coverage floor no matter
+what testmon decides; this tier adds whatever else the change touched, from
+anywhere in the suite. Coverage is combined from both before the gate is applied.
+
+**This tier skips itself when no testmon database was restored.** Without one,
+testmon deselects nothing and the tier would silently become a full-suite run.
+Skipping is the safe failure: `test-minimal` still ran, and the run is annotated
+with a warning. The database comes from the nightly `cache-warm.yml`.
+
+There is otherwise no upper bound here: a change to a core electrostatics file
+selects most of `test/interactions`. It runs in parallel with `test-minimal`, so
+it never delays the fast verdict, but the pull request is not green until it
+finishes. It carries a `timeout-minutes` for that reason.
+
+### `test-full` — everything
+
+Whole suite, all Python versions, and `--slow` so that slow-marked tests actually
+run. Nightly and on `main`.
+
+## Cache lifecycle
+
+```text
+                    +==========================================================+
+                    |            cache-warm.yml   -- PURE PRODUCER --          |
+                    |   on: push->main | schedule | workflow_dispatch          |
+                    |   reads only the repo; NOT gated on test success         |
+                    +====================+=====================================+
+                                         | writes on refs/heads/main
+                                         | => globally readable by ALL refs
+                    +--------------------+---------------------+
+                    v                                          v
+       warp-main-py3.12-cuda13-<run>            testmon-main-py3.12-cuda13-<run>
+       every merge + nightly, ~30 s warm        nightly only, runs the whole suite
+       (cold ~40 min, but only ever once)       built WITHOUT coverage (see Traps)
+                    |                                          |
+                    v                                          v
+   +------------------------------------------------------------------------------+
+   |                          C O N S U M E R S                                   |
+   +------------------------------------------------------------------------------+
+
+   [A] PR CI          push -> refs/heads/pull-request/<N>
+       test-minimal   3 shards, no testmon, ALWAYS runs in full   READ warp
+                      shard 1 only ----------------------------> WRITE warp-pull-request-<N>
+       test-impacted  --testmon --testmon-nocollect               READ warp, testmon
+                      skipped entirely if no testmon db --------> WRITE nothing
+       pr-coverage    combines BOTH tiers, applies the threshold once (ubuntu runner)
+
+   [B] merge queue    refs/heads/gh-readonly-queue/main/pr-<N>-<sha>
+                      ref is ephemeral ----------------------->  WRITE nothing
+
+   [C] nightly/full   schedule | push->main | label ciflow:all
+       test-full      4 python x CUDA 13, --slow                  READ warp
+       test-cuda12    4 python x CUDA 12, nightly only            READ warp
+                      each lane keeps its OWN cache line ------>  WRITE warp-<ref>-py<V>-cuda<N>
+```
+
+The uv download cache is handled inside `../actions/setup-env`, which both
+restores and saves it, keyed on `uv.lock`. It is deliberately not published here:
+any job can populate it, and a dependency change falls back to the key prefix so
+only the delta is downloaded.
+
+### Restore-key ladder
+
+Each context walks its list top-down and stops at the first hit.
+
+```text
+  [A] PR, ref = refs/heads/pull-request/132
+      1. warp-pull-request-132-py3.12-cuda13-<this run_id>   exact; only on re-run
+      2. warp-pull-request-132-py3.12-cuda13-                <-- usual hit: last push
+      3. warp-main-py3.12-cuda13-                            <-- first push on branch
+
+  [B] merge queue, ref = .../gh-readonly-queue/main/pr-132-<sha>    NEW REF EVERY ITEM
+      1. warp-main-py3.12-cuda13-               <-- the only rung that can hit
+
+  [C] nightly / main
+      1. warp-main-py<V>-cuda<N>-
+```
+
+A merge-queue item cannot reuse the originating pull request's cache, however
+appealing that sounds. The queue ref carries the pull request number, so the key
+is easy to construct — but cache reads are scoped to the current ref plus the
+default branch, and a queue ref is neither the pull request's ref nor a
+descendant of it. Such a rung can never hit, so it is not there.
+
+What actually makes merge-queue items fast is `cache-warm.yml` keeping the
+main-scoped baseline fresh after every merge. Queue items also write nothing:
+their ref dies with the item, so a cache saved there is unreadable and
+unreclaimable.
+
+### Why warming covers only py3.12 / CUDA 13
+
+That is the combination the pull-request tier runs, and the only lane where a
+human waits. Warming all eight combinations would cost 3.6 GB of the 10 GB cache
+budget; one costs 450 MB. The nightly matrix jobs restore *and* save their own
+per-combination cache, so each lane stays warm from its own previous run without
+a dedicated producer.
+
+This is also why warming compiles everything registered rather than a curated
+list. A measured manifest of only the modules tests use would cut a cold build
+from ~40 minutes to ~18 and the cache from 450 MB to 208 MB — but the only honest
+source for that list is a completed test run, which would make the producer
+depend on a consumer. With one lane to warm, the saving is not worth the cycle.
+
+The nightly matrix lanes do each save their own cache, so main ends up holding
+one entry per (Python, CUDA) combination regardless. `test-full` skips saving on
+py3.12/CUDA 13 specifically, because that key belongs to `cache-warm.yml` and two
+writers would delete each other's entry.
+
+### Why only shard 1 writes
+
+GitHub allows 10 GB of cache per repository, with least-recently-*accessed*
+eviction. Writing one cache per shard per pull request exhausted that budget in
+practice (five pull requests once held 5.3 GB between them, and `main` held
+nothing). So all three shards restore the same pull-request-scoped key and only
+shard 1 saves it.
+
+Shard 1 owns `electrostatics_torch`, which holds the expensive PME kernels, so it
+is the shard whose compilation is most worth persisting. Shards 2 and 3 restore
+`main`'s superset and recompile only kernels the pull request itself changed. If
+that becomes the bottleneck for a particular kind of change, move the write to
+whichever shard sees the most churn.
+
+### Rotation and cleanup
+
+Cache keys embed `<run_id>` because cache entries are immutable — a fixed key
+could never be updated. The cost is that **every push creates a new entry and the
+old one lingers for seven days**, so entries must be rotated explicitly:
+
+1. **Before each save**, delete older entries with the same key prefix. Doing this
+   before the save rather than after means a failed save leaves the previous cache
+   in place rather than nothing.
+2. **On `pull_request: closed`**, `cleanup-pr-caches.yml` deletes everything scoped
+   to that pull request.
+3. GitHub's seven-day inactivity sweep and 10 GB eviction remain as backstops and
+   should never be what keeps us inside budget.
+
+Caches here are scoped to `refs/heads/pull-request/<N>` — the copy-pr-bot mirror
+branch — and **not** to `refs/pull/<N>/merge`. Cleanup snippets found online
+usually target the latter and will silently delete nothing.
+
+## Telling when caches are cold or stale
+
+`../actions/warp-cache` writes the outcome to every GPU job's summary, so a slow
+run can be explained without reading logs. It reports which key matched, or that
+none did.
+
+A job that falls all the way past `warp-main-` also emits a workflow warning
+annotation, because that means no baseline exists and every kernel is being
+recompiled — the failure mode that previously went unnoticed for weeks:
+
+```yaml
+- name: Warn on missing baseline
+  if: steps.warp.outputs.cache-matched-key == ''
+  run: echo "::warning::No Warp cache restored. Check cache-warm.yml on main."
+```
+
+To check the state of the world directly:
+
+```bash
+# Does a main-scoped baseline exist at all? (If not, every PR is cold.)
+gh api "repos/NVIDIA/nvalchemi-toolkit-ops/actions/caches?per_page=100" \
+  --jq '.actions_caches[] | select(.ref=="refs/heads/main") | .key'
+
+# How much of the 10 GB budget is in use, by ref?
+gh api "repos/NVIDIA/nvalchemi-toolkit-ops/actions/caches?per_page=100" \
+  --jq '[.actions_caches[] | {ref, mb: (.size_in_bytes/1e6|floor)}]
+        | group_by(.ref) | map({ref: .[0].ref, mb: (map(.mb) | add)})
+        | sort_by(-.mb)'
+```
+
+## Traps
+
+Four things in this repository behave unlike their defaults. Each has cost real
+debugging time.
+
+**Never wrap `--testmon` in `coverage run`.** Both install a `sys.settrace` hook
+and Python allows one per thread; testmon wins and coverage silently reports near
+zero. No error is raised. `make testmon-collect` deliberately runs without
+coverage for this reason, and no coverage target passes `--testmon` in collecting
+mode.
+
+**`pytest-skip-slow` inverts the usual meaning of the marker.** Tests marked
+`slow` are *skipped* unless `--slow` is passed. Before this rewrite nothing passed
+it anywhere, so 335 tests ran on no CI path at all. `make test-full` passes it;
+`make test-minimal` does not.
+
+**A subdirectory `conftest.py` sees every collected item**, not only those beneath
+it. `test/math` and `test/neighbors` add a `slow` marker based on test names, and
+without an explicit path check they applied it across the whole tree, overriding
+the electrostatics suite's deliberate decision not to treat "stress" tests as
+slow. All three hooks now filter on `item.path`.
+
+**Coverage records absolute paths.** Shards run on different runners with
+different workspace roots, so `[tool.coverage.paths]` in `pyproject.toml` maps
+them back onto one tree. Without it `coverage combine` reports each runner's copy
+as a separate, mostly-uncovered file and the gate fails for a reason that looks
+nothing like the cause.
+
+## Maintenance
+
+**Regenerating the pull-request suite.** Needed when a module gains behaviour the
+selected files do not exercise, or when the reduced suite's coverage drifts from
+the full suite's. Do not hand-edit the `ARGS_*_min` lists; their value is that
+they are measured.
+
+```bash
+# 1. Per-test coverage (hours; test/interactions dominates)
+bash tools/measure_test_coverage.sh
+
+# 2. Per-test durations from any full CI job log
+gh api repos/NVIDIA/nvalchemi-toolkit-ops/actions/jobs/<job-id>/logs > job.log
+uv run python tools/extract_ci_durations.py job.log -o ci_durations.json
+
+# 3. Re-select, then paste the emitted Makefile block
+make minimal-suite-report
+```
+
+**Rebalancing shards.** The `SHARD_*_GROUPS` lists in the `Makefile` are packed by
+measured cost, not spread round-robin, because group costs differ by two orders of
+magnitude. Re-pack them whenever the suite is regenerated; the target is equal
+wall-clock per shard, and shard 1 currently sets the pace.
+
+**Before enabling `--slow` anywhere it was previously absent**, run those tests
+first — they may have rotted while unexecuted:
+
+```bash
+bash tools/verify_slow_tests.sh
+```

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Publishes the caches every other workflow restores from.
+#
+# This is a pure producer: it reads nothing but the repository, so it works on a
+# fresh clone, a new CUDA version, or a runner that has never seen this project.
+# Nothing here depends on a test job having run first.
+#
+# A failure here is a pull-request-speed incident, not just a red build. When it
+# stops publishing, pull requests get slower over the following days and the
+# symptom looks nothing like the cause. That is exactly what happened before this
+# pipeline was rewritten.
+#
+# WHY ONLY py3.12 / CUDA 13
+#
+# That is the combination the pull-request tier runs, and the only lane where a
+# human is waiting. The nightly matrix jobs restore and save their own per-
+# combination caches, so they stay warm from their own previous run without
+# needing a dedicated producer.
+
+name: "Cache warm"
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 5 * * *" # 05:00 UTC, two hours before the nightly test run
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write # prune-caches.sh deletes superseded entries
+
+defaults:
+  run:
+    shell: bash -x -e -u -o pipefail {0}
+
+concurrency:
+  # Never run two warmers at once; the newest merge is the one worth warming.
+  group: cache-warm
+  cancel-in-progress: true
+
+jobs:
+  warp:
+    name: Warm Warp kernel cache (py3.12, CUDA 13)
+    runs-on: linux-amd64-gpu-h100-latest-1
+    timeout-minutes: 90
+    container:
+      image: nvcr.io/nvidia/cuda:13.1.0-runtime-ubuntu24.04
+      options: --gpus all
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up test environment
+        uses: ./.github/actions/setup-env
+        with:
+          python-version: "3.12"
+
+      # Restoring first is what makes this cheap to run on every merge: Warp
+      # content-hashes each module, so only kernels whose source actually changed
+      # are rebuilt. Measured cold: ~40 min. Measured against a warm cache: ~30 s.
+      - name: Restore previous Warp cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .warp-cache
+          key: warp-main-py3.12-cuda13-${{ github.run_id }}
+          restore-keys: |
+            warp-main-py3.12-cuda13-
+
+      - name: Compile kernels
+        run: |
+          # $GITHUB_WORKSPACE, not github.workspace: inside a container job the
+          # expression yields the host path while actions/cache resolves the
+          # relative `path:` against the container's mount. Using the expression
+          # compiles kernels outside the cached directory, so the job publishes
+          # nothing while reporting success.
+          export WARP_CACHE_PATH="$GITHUB_WORKSPACE/.warp-cache"
+          mkdir -p "$WARP_CACHE_PATH"
+          # Defaults to 60% of cores. Speed-up is well below linear: the build
+          # ends on a few very large translation units that cannot be split.
+          uv run python tools/warm_warp_cache.py
+
+      # Rotate before saving. Cache entries are immutable, so the key embeds the
+      # run id and every run would otherwise leave a ~200 MB entry behind for
+      # seven days. Deleting first rather than after means a failed save leaves
+      # the previous cache in place instead of nothing.
+      # REST rather than `gh`: the GitHub CLI is not installed in the CUDA
+      # container, so a `gh` call exits 127 and rotation silently never happens.
+      - name: Prune superseded caches
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREFIX: warp-main-py3.12-cuda13-
+        run: |
+          bash .github/scripts/prune-caches.sh
+
+      - name: Save Warp cache
+        if: success()
+        uses: actions/cache/save@v4
+        with:
+          path: .warp-cache
+          key: warp-main-py3.12-cuda13-${{ github.run_id }}
+
+      - name: Report
+        if: always()
+        run: |
+          {
+            echo "### Warp cache published"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Key | \`warp-main-py3.12-cuda13-${{ github.run_id }}\` |"
+            echo "| Size | $(du -sh .warp-cache 2>/dev/null | cut -f1 || echo n/a) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # The testmon database drives the impacted-tests tier on pull requests. It has
+  # to be built without coverage: both install a sys.settrace hook and Python
+  # allows one per thread, so a run that collects for testmon reports near-zero
+  # coverage. That is what failed every nightly build before this rewrite.
+  #
+  # Nightly only: it runs the whole suite, which costs hours even warm, and a
+  # database one day stale still deselects almost as well as a fresh one.
+  testmon:
+    name: Build testmon database (py3.12, CUDA 13)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: warp
+    runs-on: linux-amd64-gpu-h100-latest-1
+    timeout-minutes: 300
+    container:
+      image: nvcr.io/nvidia/cuda:13.1.0-runtime-ubuntu24.04
+      options: --gpus all
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up test environment
+        uses: ./.github/actions/setup-env
+        with:
+          python-version: "3.12"
+
+      - name: Restore Warp kernel cache
+        uses: ./.github/actions/warp-cache
+        with:
+          python-version: "3.12"
+
+      - name: Build testmon database
+        run: make testmon-collect
+
+      - name: Prune superseded caches
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREFIX: testmon-main-py3.12-cuda13-
+        run: |
+          bash .github/scripts/prune-caches.sh
+
+      - name: Save testmon database
+        if: success()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .testmondata
+            .testmondata-shm
+            .testmondata-wal
+          key: testmon-main-py3.12-cuda13-${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,21 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# NValchemi Toolkit Ops CI Workflow
+# Orchestrator. Decides which test tier runs and aggregates status; the tiers
+# themselves live in reusable-gpu-tests.yml and the caches they consume are
+# published by cache-warm.yml.
 #
-# This workflow runs linting, pytest unit testing, and coverage reporting.
+# See .github/workflows/README.md for the full semantics: tier definitions,
+# cache lifecycle, and the four traps in this repository that behave unlike
+# their defaults.
 #
-# TRIGGERS:
-# - Push to main branch or pull-request branches
-# - Merge group events (when PRs are merged via merge queue)
-# - Scheduled runs (daily at 7 AM UTC)
-#
-# WORKFLOW OVERVIEW:
-# 1. changed-files: Detects which files have changed compared to main branch
-# 2. lint: Runs static code checks and linting via pre-commit
-# 3. get-pr-labels: Retrieves PR labels for conditional job execution
-# 4. test: Runs pytest unit tests with coverage (on GPU runner)
-# 5. verify-status: Verifies all jobs completed successfully
+# PULL REQUESTS run two tiers in parallel, whose union is what gets gated:
+#   test-minimal   3 shards, no testmon, always runs in full  -> the floor
+#   test-impacted  testmon-selected, everything else it touches
+# MAIN AND NIGHTLY run the whole suite across the Python matrix.
 
 name: "CI"
 
@@ -39,7 +36,12 @@ on:
   merge_group:
     types: [checks_requested]
   schedule:
-    - cron: "0 7 * * *" # Runs at 7 AM UTC daily
+    - cron: "0 7 * * *" # 07:00 UTC daily, two hours after cache-warm
+
+permissions:
+  contents: read
+  pull-requests: read # get-pr-labels reads ciflow:* labels
+  actions: write # prune-caches.sh deletes superseded cache entries
 
 defaults:
   run:
@@ -55,7 +57,7 @@ env:
 
 jobs:
   # ============================================================================
-  # CHANGED FILES DETECTION
+  # PRE-FLIGHT
   # ============================================================================
   changed-files:
     runs-on: ubuntu-latest
@@ -83,15 +85,14 @@ jobs:
             !**.md
             !.github/**
             !.gitignore
-            .github/workflows/ci.yml
+            .github/workflows/**
+            .github/actions/**
+            .github/scripts/**
 
       - name: Show output
         run: |
           echo '${{ toJSON(steps.changed-files.outputs) }}'
 
-  # ============================================================================
-  # LINTING STAGE
-  # ============================================================================
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -111,7 +112,7 @@ jobs:
       - name: Cache pre-commit
         uses: actions/cache@v4
         with:
-          path: ~/.cache/pre-commit
+          path: /tmp/pre-commit-cache
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             pre-commit-
@@ -121,9 +122,6 @@ jobs:
           uv sync --extra torch --extra jax
           make lint
 
-  # ============================================================================
-  # GET PR LABELS (for copy-pr-bot integration)
-  # ============================================================================
   get-pr-labels:
     runs-on: ubuntu-latest
     outputs:
@@ -154,315 +152,156 @@ jobs:
           echo "Set empty labels for non-PR branch"
 
   # ============================================================================
-  # TEST STAGE (GPU Runner)
+  # PULL-REQUEST TIER
   # ============================================================================
-  test:
-    name: Test CUDA 13 py${{ matrix.python-version }}
-    needs:
-      - lint
-      - get-pr-labels
-      - changed-files
-    runs-on: linux-amd64-gpu-h100-latest-1
-    timeout-minutes: 480
+  # Bounded and predictable: the same 4,275 tests every time, sharded by measured
+  # cost. Only shard 1 publishes a cache — it owns electrostatics_torch, whose
+  # PME kernels are the expensive ones, and one cache per pull request keeps the
+  # repository inside its 10 GB budget.
+  test-minimal:
+    name: PR minimal
+    needs: [lint, get-pr-labels, changed-files]
+    if: |
+      (github.event_name != 'schedule') &&
+      (github.ref != 'refs/heads/main') &&
+      !contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:skip') &&
+      !contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:all') &&
+      (needs.changed-files.outputs.any_changed == 'true')
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-    container:
-      image: nvcr.io/nvidia/cuda:13.1.0-runtime-ubuntu24.04
-      options: --gpus all
-    if: |
-      (github.event_name == 'schedule') ||
-      contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:all') ||
-      (
-        !contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:skip') &&
-        (needs.changed-files.outputs.any_changed == 'true')
-      ) ||
-      (
-        (github.event_name == 'merge_group') &&
-        (needs.changed-files.outputs.any_changed == 'true')
-      )
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        shard: [1, 2, 3]
+    uses: ./.github/workflows/reusable-gpu-tests.yml
+    with:
+      suite: minimal
+      shard: ${{ matrix.shard }}
+      save-warp-cache: ${{ matrix.shard == 1 }}
+      timeout-minutes: 60
+    secrets: inherit
 
-      - name: Install apt requirements
-        env:
-          DEBIAN_FRONTEND: "noninteractive"
-          TZ: "Etc/UTC"
-        run: |
-          apt-get update && \
-          apt-get install -y curl \
-            git \
-            build-essential
+  # Runs alongside the minimal tier, never gating the fast verdict. Unbounded by
+  # nature: a change to a core electrostatics file selects most of the suite.
+  test-impacted:
+    name: PR impacted
+    needs: [lint, get-pr-labels, changed-files]
+    if: |
+      (github.event_name != 'schedule') &&
+      (github.ref != 'refs/heads/main') &&
+      !contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:skip') &&
+      !contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:all') &&
+      (needs.changed-files.outputs.any_changed == 'true')
+    uses: ./.github/workflows/reusable-gpu-tests.yml
+    with:
+      suite: impacted
+      timeout-minutes: 120
+    secrets: inherit
+
+  # Applies the coverage threshold once, to the union of both tiers. Needs only
+  # coverage and the source tree, so it runs on an ordinary runner rather than
+  # occupying a GPU to read SQLite files. `[tool.coverage.paths]` in
+  # pyproject.toml remaps the shards' absolute paths onto this checkout.
+  pr-coverage:
+    name: PR coverage gate
+    needs: [test-minimal, test-impacted]
+    if: |
+      always() &&
+      needs.test-minimal.result == 'success' &&
+      needs.test-impacted.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
       - name: Setup UV
-        env:
-          UV_VERSION: "0.9.25"
-          UV_CHECKSUM: "10fb1f54d56f3eb60622006797339d4ea0bfda9b358d07db635f73cf89f7094c"
-        run: |
-          UV_INSTALLER=$(mktemp)
-          curl --proto '=https' --tlsv1.2 -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" -o "$UV_INSTALLER"
-          echo "${UV_CHECKSUM}  ${UV_INSTALLER}" | sha256sum -c -
-          sh "$UV_INSTALLER"
-          rm "$UV_INSTALLER"
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Install dependencies
-        run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          uv venv --seed --python ${{ matrix.python-version }}
-          uv sync --extra torch --extra jax
-          uv pip install -r test/test-requires.txt
-
-      # CONDITIONAL LOGIC BASED ON EVENT TYPE
-      #
-      # PR branches use push events to refs/heads/pull-request/*, not the
-      # pull_request event. Merge queue runs use merge_group events on
-      # gh-readonly-queue refs, but should use the same testmon-selected path.
-      # Testmon databases are Python/CUDA-specific because testmon keys its
-      # dependency database by the interpreter version and installed packages.
-      # Coverage baselines are cached separately so stale coverage files do not
-      # replace or mask the testmon dependency database.
-      #
-      # The testmon and warp caches are branch-scoped (sanitized ref name) so a
-      # long-lived branch / PR maintains its OWN cache line across successive
-      # commits, with main as a restore-keys fallback for the first run. GitHub
-      # scopes caches to the ref that created them, so successive pushes to the
-      # same pull-request/<N> mirror ref reuse the cache; main remains the only
-      # globally-readable fallback.
-      - name: Compute cache scope key
-        id: scope
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: echo "key=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
-
-      - name: Restore testmon cache (for PRs and merge queue)
-        if: startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'merge_group'
-        uses: actions/cache/restore@v4
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
-          path: |
-            .testmondata
-            .testmondata-shm
-            .testmondata-wal
-          key: testmon-cache-${{ steps.scope.outputs.key }}-py${{ matrix.python-version }}-cuda13-${{ github.run_id }}
-          restore-keys: |
-            testmon-cache-${{ steps.scope.outputs.key }}-py${{ matrix.python-version }}-cuda13-
-            testmon-cache-main-py${{ matrix.python-version }}-cuda13-
+          enable-cache: true
 
-      # Warp compiles every kernel from scratch on a cold cache, and conftest keys
-      # the cache per checkout (not per pid) so all per-module pytest runs share it.
-      # Persisting it across CI runs skips recompilation on cache hit. Kernels are
-      # content-hashed, so a stale entry is simply unused (Warp recompiles changed
-      # kernels) -> safe to restore on every trigger, including main/schedule.
-      - name: Restore warp kernel cache
-        uses: actions/cache/restore@v4
+      - name: Download coverage data
+        uses: actions/download-artifact@v4
         with:
-          path: .warp-cache
-          key: warp-cache-${{ steps.scope.outputs.key }}-py${{ matrix.python-version }}-cuda13-${{ github.run_id }}
-          restore-keys: |
-            warp-cache-${{ steps.scope.outputs.key }}-py${{ matrix.python-version }}-cuda13-
-            warp-cache-main-py${{ matrix.python-version }}-cuda13-
+          pattern: coverage-data-*
+          merge-multiple: true
 
-      - name: Restore coverage baseline (for PRs and merge queue)
-        if: startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'merge_group'
-        uses: actions/cache/restore@v4
-        with:
-          path: .coverage.baseline
-          key: coverage-baseline-main-py${{ matrix.python-version }}-cuda13-${{ github.run_id }}
-          restore-keys: |
-            coverage-baseline-main-py${{ matrix.python-version }}-cuda13-
-
-      - name: Prepare coverage baseline (for PRs and merge queue)
-        if: startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'merge_group'
-        run: |
-          if [ -f .coverage.baseline ]; then
-            echo "Using restored coverage baseline for PR coverage merge"
-            mv .coverage.baseline coverage_main.dat
-          else
-            echo "No coverage baseline restored; reporting PR coverage only"
-          fi
-
-      - name: Run tests with testmon and coverage
-        run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          # Share one warp kernel cache across all per-module pytest runs (conftest
-          # honors WARP_CACHE_PATH via setdefault) and persist it via actions/cache.
-          export WARP_CACHE_PATH="$GITHUB_WORKSPACE/.warp-cache"
-          mkdir -p "$WARP_CACHE_PATH"
-          USE_TESTMON_SELECTION=${{ startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'merge_group' }}
-          if [[ "$USE_TESTMON_SELECTION" == "true" ]]; then
-            # PR/Merge queue: testmon selects affected tests, coverage traces them
-            make testmon-coverage COVERAGE_BASELINE_FILE=coverage_main.dat
-          else
-            # Main/Schedule: refresh testmon DB and coverage baseline in one full pass.
-            rm -f .testmondata .testmondata-shm .testmondata-wal
-            rm -f .coverage .coverage.* coverage_main.dat
-            make testmon-coverage PYTEST_TESTMON_FLAGS="--testmon"
-          fi
-
-      # Save the testmon DB and warp cache on main/schedule AND on PR / merge-queue
-      # runs, each under its branch-scoped key. This lets successive commits on the
-      # same pull-request/<N> ref reuse the cache they just built (same cache scope),
-      # instead of recompiling/reselecting cold every commit on a long-lived branch.
-      # The coverage baseline below stays main-scoped so PR coverage still diffs
-      # against main, not against the PR's own prior coverage.
-      - name: Save testmon cache
-        if: >-
-          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          (github.event_name == 'schedule') ||
-          startsWith(github.ref, 'refs/heads/pull-request/') ||
-          (github.event_name == 'merge_group')
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            .testmondata
-            .testmondata-shm
-            .testmondata-wal
-          key: testmon-cache-${{ steps.scope.outputs.key }}-py${{ matrix.python-version }}-cuda13-${{ github.run_id }}
-
-      - name: Save warp kernel cache
-        if: >-
-          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-          (github.event_name == 'schedule') ||
-          startsWith(github.ref, 'refs/heads/pull-request/') ||
-          (github.event_name == 'merge_group')
-        uses: actions/cache/save@v4
-        with:
-          path: .warp-cache
-          key: warp-cache-${{ steps.scope.outputs.key }}-py${{ matrix.python-version }}-cuda13-${{ github.run_id }}
-
-      - name: Prepare coverage baseline
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule')
-        run: |
-          cp .coverage .coverage.baseline
-
-      - name: Save coverage baseline
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule')
-        uses: actions/cache/save@v4
-        with:
-          path: .coverage.baseline
-          key: coverage-baseline-main-py${{ matrix.python-version }}-cuda13-${{ github.run_id }}
+      - name: Combine and enforce the threshold
+        run: make coverage-combine UV_RUN="uv run --no-project --with coverage"
 
       - name: Upload coverage to Codecov
-        if: github.event_name != 'merge_group' && github.event_name != 'schedule'
+        if: github.event_name != 'merge_group'
         uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./nvalchemiops.coverage.xml
           fail_ci_if_error: false
 
-      - name: Upload coverage report artifact
+      - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report-py${{ matrix.python-version }}-cuda13
+          name: coverage-report-pr
           path: nvalchemiops.coverage.xml
           retention-days: 7
 
+  # ============================================================================
+  # FULL TIER
+  # ============================================================================
+  # Each matrix job restores and saves its own per-combination cache, so every
+  # lane stays warm from its own previous run without a dedicated producer.
+  # cache-warm.yml only covers py3.12/CUDA 13, the lane a human waits on.
+  test-full:
+    name: Full CUDA 13
+    needs: [lint, get-pr-labels]
+    if: |
+      (github.event_name == 'schedule') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:all')
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    uses: ./.github/workflows/reusable-gpu-tests.yml
+    with:
+      suite: full
+      python-version: ${{ matrix.python-version }}
+      # py3.12/CUDA 13 is cache-warm.yml's lane; two writers on the same key
+      # would delete each other's entry. Every other lane maintains its own.
+      save-warp-cache: ${{ matrix.python-version != '3.12' }}
+      timeout-minutes: 480
+    secrets: inherit
+
   test-cuda12:
-    name: Test CUDA 12 py${{ matrix.python-version }}
-    needs:
-      - lint
-    runs-on: linux-amd64-gpu-h100-latest-1
-    timeout-minutes: 480
+    name: Full CUDA 12
+    needs: [lint]
     if: github.event_name == 'schedule'
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
-    container:
-      image: nvcr.io/nvidia/cuda:12.8.2-runtime-ubuntu24.04
-      options: --gpus all
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install apt requirements
-        env:
-          DEBIAN_FRONTEND: "noninteractive"
-          TZ: "Etc/UTC"
-        run: |
-          apt-get update && \
-          apt-get install -y curl \
-            git \
-            build-essential
-
-      - name: Setup UV
-        env:
-          UV_VERSION: "0.9.25"
-          UV_CHECKSUM: "10fb1f54d56f3eb60622006797339d4ea0bfda9b358d07db635f73cf89f7094c"
-        run: |
-          UV_INSTALLER=$(mktemp)
-          curl --proto '=https' --tlsv1.2 -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" -o "$UV_INSTALLER"
-          echo "${UV_CHECKSUM}  ${UV_INSTALLER}" | sha256sum -c -
-          sh "$UV_INSTALLER"
-          rm "$UV_INSTALLER"
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Install dependencies
-        run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          uv venv --seed --python ${{ matrix.python-version }}
-          uv sync --extra torch-cu12 --extra jax-cu12
-          uv pip install -r test/test-requires.txt
-
-      - name: Restore warp kernel cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .warp-cache
-          key: warp-cache-main-py${{ matrix.python-version }}-cuda12-${{ github.run_id }}
-          restore-keys: |
-            warp-cache-main-py${{ matrix.python-version }}-cuda12-
-
-      - name: Run tests with testmon and coverage
-        run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          export WARP_CACHE_PATH="$GITHUB_WORKSPACE/.warp-cache"
-          mkdir -p "$WARP_CACHE_PATH"
-          rm -f .testmondata .testmondata-shm .testmondata-wal
-          rm -f .coverage .coverage.* coverage_main.dat
-          make testmon-coverage PYTEST_TESTMON_FLAGS="--testmon"
-
-      - name: Save testmon cache
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            .testmondata
-            .testmondata-shm
-            .testmondata-wal
-          key: testmon-cache-main-py${{ matrix.python-version }}-cuda12-${{ github.run_id }}
-
-      - name: Save warp kernel cache
-        uses: actions/cache/save@v4
-        with:
-          path: .warp-cache
-          key: warp-cache-main-py${{ matrix.python-version }}-cuda12-${{ github.run_id }}
-
-      - name: Prepare coverage baseline
-        run: |
-          cp .coverage .coverage.baseline
-
-      - name: Save coverage baseline
-        uses: actions/cache/save@v4
-        with:
-          path: .coverage.baseline
-          key: coverage-baseline-main-py${{ matrix.python-version }}-cuda12-${{ github.run_id }}
-
-      - name: Upload coverage report artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report-py${{ matrix.python-version }}-cuda12
-          path: nvalchemiops.coverage.xml
-          retention-days: 7
+    uses: ./.github/workflows/reusable-gpu-tests.yml
+    with:
+      suite: full
+      python-version: ${{ matrix.python-version }}
+      cuda-major: "12"
+      torch-extra: torch-cu12
+      jax-extra: jax-cu12
+      save-warp-cache: true
+      timeout-minutes: 480
+    secrets: inherit
 
   # ============================================================================
-  # VERIFY STATUS
+  # STATUS
   # ============================================================================
   verify-status:
     needs:
       - lint
       - get-pr-labels
-      - test
+      - changed-files
+      - test-minimal
+      - test-impacted
+      - pr-coverage
+      - test-full
       - test-cuda12
     runs-on: ubuntu-latest
     if: always()

--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deletes a pull request's caches once it closes.
+#
+# GitHub allows 10 GB per repository and evicts by least-recent *access*. Left
+# alone, closed pull requests hold their caches for seven days, and the entry
+# most at risk of eviction is the main-scoped baseline every cold branch depends
+# on. This measured 5.31 GB across five open pull requests before cleanup
+# existed, with nothing on main.
+
+name: "Cleanup PR caches"
+
+# pull_request_target, not pull_request: a pull_request event from a fork gets a
+# read-only GITHUB_TOKEN that no permissions block can elevate, so every delete
+# would 403 while the job still reported success. Contributions here arrive from
+# forks by way of copy-pr-bot, so that is the normal case, not the edge case.
+#
+# pull_request_target is safe here specifically because this job checks nothing
+# out and runs no code from the pull request; its only input is a number.
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write # required to delete cache entries
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete caches for this pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.number }}
+        run: |
+          # copy-pr-bot mirrors pull requests to refs/heads/pull-request/<N>, so
+          # caches are scoped there rather than to refs/pull/<N>/merge. The usual
+          # snippet for this targets the latter and silently deletes nothing.
+          REF="refs/heads/pull-request/${PR}"
+          echo "Deleting caches scoped to ${REF}"
+
+          IDS=$(gh cache list --ref "$REF" --limit 100 --json id --jq '.[].id')
+          if [ -z "$IDS" ]; then
+            echo "No caches found for ${REF}"
+            exit 0
+          fi
+
+          # Count failures explicitly. `gh cache delete "$id" && COUNT=...` would
+          # put the delete on the left of an AND-list, where `set -e` ignores a
+          # non-zero exit — so a job with no permission to delete anything still
+          # finished green, reporting zero deletions as though there were none.
+          DELETED=0
+          FAILED=0
+          for id in $IDS; do
+            if gh cache delete "$id"; then
+              DELETED=$((DELETED + 1))
+            else
+              FAILED=$((FAILED + 1))
+            fi
+          done
+          echo "Deleted ${DELETED} cache entries for ${REF}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error::Failed to delete ${FAILED} cache entries for ${REF}"
+            exit 1
+          fi

--- a/.github/workflows/reusable-gpu-tests.yml
+++ b/.github/workflows/reusable-gpu-tests.yml
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs one tier of the test suite on a GPU runner. Called by ci.yml; not
+# independently runnable, which is what the `reusable-` prefix marks.
+
+name: "GPU tests (reusable)"
+
+on:
+  workflow_call:
+    inputs:
+      suite:
+        description: "minimal | impacted | full"
+        required: true
+        type: string
+      python-version:
+        required: false
+        type: string
+        default: "3.12"
+      cuda-major:
+        required: false
+        type: string
+        default: "13"
+      torch-extra:
+        required: false
+        type: string
+        default: "torch"
+      jax-extra:
+        required: false
+        type: string
+        default: "jax"
+      shard:
+        description: "Shard index for the minimal suite; 0 runs every group"
+        required: false
+        type: number
+        default: 0
+      save-warp-cache:
+        description: >-
+          Publish this job's Warp cache. Only one job per lane should, to keep
+          the repository inside its 10 GB cache budget.
+        required: false
+        type: boolean
+        default: false
+      timeout-minutes:
+        required: false
+        type: number
+        default: 60
+
+defaults:
+  run:
+    shell: bash -x -e -u -o pipefail {0}
+
+jobs:
+  test:
+    runs-on: linux-amd64-gpu-h100-latest-1
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    container:
+      image: nvcr.io/nvidia/cuda:${{ inputs.cuda-major == '12' && '12.8.2' || '13.1.0' }}-runtime-ubuntu24.04
+      options: --gpus all
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up test environment
+        uses: ./.github/actions/setup-env
+        with:
+          python-version: ${{ inputs.python-version }}
+          torch-extra: ${{ inputs.torch-extra }}
+          jax-extra: ${{ inputs.jax-extra }}
+
+      - name: Restore Warp kernel cache
+        id: warp
+        uses: ./.github/actions/warp-cache
+        with:
+          python-version: ${{ inputs.python-version }}
+          cuda-major: ${{ inputs.cuda-major }}
+
+      # The impacted tier needs the database cache-warm.yml publishes. Without
+      # it testmon deselects nothing, so the tier would quietly become a full
+      # suite run; the step below skips it instead.
+      - name: Restore testmon database
+        id: testmon
+        if: inputs.suite == 'impacted'
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .testmondata
+            .testmondata-shm
+            .testmondata-wal
+          key: testmon-main-py${{ inputs.python-version }}-cuda${{ inputs.cuda-major }}-${{ github.run_id }}
+          restore-keys: |
+            testmon-main-py${{ inputs.python-version }}-cuda${{ inputs.cuda-major }}-
+
+      - name: Run minimal suite
+        if: inputs.suite == 'minimal'
+        run: |
+          if [ "${{ inputs.shard }}" = "0" ]; then
+            make test-minimal
+          else
+            make test-minimal-shard SHARD=${{ inputs.shard }}
+          fi
+
+      - name: Run impacted tests
+        if: inputs.suite == 'impacted' && steps.testmon.outputs.cache-matched-key != ''
+        run: make test-impacted
+
+      - name: Skip impacted tests (no testmon database)
+        if: inputs.suite == 'impacted' && steps.testmon.outputs.cache-matched-key == ''
+        run: |
+          echo "::warning title=No testmon database::Skipping the impacted-tests tier. Without a database testmon deselects nothing, so this would run the entire suite. The nightly cache-warm.yml publishes it."
+          echo "Impacted tier skipped: no testmon database." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run full suite
+        if: inputs.suite == 'full'
+        run: make test-full
+
+      # Rotate before saving, so a failed save leaves the previous cache in place
+      # rather than nothing. See the script for why this is not `gh`.
+      - name: Prune superseded Warp caches
+        if: inputs.save-warp-cache && !cancelled() && github.event_name != 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREFIX: warp-${{ steps.warp.outputs.scope-key }}-py${{ inputs.python-version }}-cuda${{ inputs.cuda-major }}-
+        run: bash .github/scripts/prune-caches.sh
+
+      - name: Save Warp cache
+        if: inputs.save-warp-cache && !cancelled() && github.event_name != 'merge_group'
+        uses: actions/cache/save@v4
+        with:
+          path: .warp-cache
+          key: warp-${{ steps.warp.outputs.scope-key }}-py${{ inputs.python-version }}-cuda${{ inputs.cuda-major }}-${{ github.run_id }}
+
+      # Shards cover a fraction of the code by construction, so the threshold is
+      # applied once by ci.yml after their data is combined. Publish raw data.
+      - name: Upload coverage data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-${{ inputs.suite }}-${{ inputs.python-version }}-cuda${{ inputs.cuda-major }}-shard${{ inputs.shard }}
+          path: .coverage.*
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 1
+
+      - name: Upload coverage report
+        if: inputs.suite == 'full'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-py${{ inputs.python-version }}-cuda${{ inputs.cuda-major }}
+          path: nvalchemiops.coverage.xml
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov/
 .tmp/
 nosetests.xml
 coverage.xml
+nvalchemiops.coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
@@ -59,6 +60,7 @@ ipython_config.py
 # Environments
 .env
 .venv
+.venv-*
 env/
 venv/
 ENV/
@@ -123,3 +125,12 @@ nvalchemiops/_version.py
 
 # Warp kernel cache (CI persists this via actions/cache at $GITHUB_WORKSPACE/.warp-cache)
 .warp-cache/
+
+# Per-test coverage databases and the duration table behind `make
+# minimal-suite-report`. Regenerate rather than commit; they are large and
+# machine-specific.
+.covctx/
+ci_durations.json
+
+# Slow-test verification logs (see tools/verify_slow_tests.sh)
+.slowcheck/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,13 @@ make license
 Tests require a **GPU** to run. The test suite uses pytest with coverage.
 
 ```bash
-# Run full test suite with coverage
-make pytest
-# Or directly:
-uv run pytest --cov --cov-report=term-missing:skip-covered test/
+# Run the pull-request suite: the subset CI runs on a PR, plus coverage.
+# This is the fast one; prefer it while iterating.
+make test-minimal
+
+# Run everything, including tests marked `slow`, plus coverage. This is what
+# runs nightly.
+make test-full
 
 # Run a single test file
 uv run pytest test/test_types.py -vv
@@ -72,8 +75,9 @@ uv run pytest test/test_types.py::TestGetWpDtype::test_float32 -vv
 # Run tests by keyword expression
 uv run pytest -k "dispersion" -vv
 
-# Skip slow tests
-uv run pytest -m "not slow" test/
+# Include slow tests. pytest-skip-slow SKIPS anything marked `slow` unless you
+# pass this, so a plain `pytest` run silently leaves ~400 tests out.
+uv run pytest --slow test/
 
 # Run only GPU-marked tests
 uv run pytest -m "gpu" test/
@@ -84,9 +88,15 @@ uv run pytest --lf test/
 
 **Pytest configuration** (`pyproject.toml`):
 
-- Default addopts: `-vv -r xfXs --cov --cov-fail-under=70`
+- Default addopts: `-vv -r xfXs`
 - Custom markers: `slow`, `gpu`
-- Coverage fail-under: 75% (coverage.py) / 70% (pytest-cov addopts)
+- Coverage fail-under: 70%, enforced by `coverage report` in the make targets
+  rather than by pytest-cov
+
+Never wrap a `--testmon` run in `coverage run`. Both install a `sys.settrace`
+hook, Python allows one per thread, and testmon wins — the coverage report comes
+out near zero instead of erroring. `make testmon-collect` deliberately runs
+without coverage for this reason.
 
 Test directory structure mirrors source: `test/interactions/`, `test/math/`, `test/neighbors/`.
 Test files follow the `test_*.py` naming pattern.

--- a/Makefile
+++ b/Makefile
@@ -72,37 +72,197 @@ license:  ## Check license headers
 # TESTING
 # ==============================================================================
 
-.PHONY: pytest
-pytest:  ## Run pytest with coverage
-	rm -f .coverage
-	uv run pytest --cov-fail-under=0 --cov=nvalchemiops test/test_types.py && \
-	uv run pytest --cov-fail-under=0 --cov=nvalchemiops --cov-append test/math && \
-	uv run pytest --cov-fail-under=0 --cov=nvalchemiops --cov-append test/neighbors && \
-	uv run pytest --cov-fail-under=0 --cov=nvalchemiops --cov-append test/interactions && \
-	uv run pytest --cov-fail-under=0 --cov=nvalchemiops --cov-append test/dynamics && \
-	uv run pytest --cov-fail-under=0 --cov=nvalchemiops --cov-append test/torch && \
-	uv run pytest --cov-fail-under=0 --cov=nvalchemiops --cov-append \
-		test/test_batch_utils.py test/test_warp_dispatch.py \
-		test/test_segment_ops.py test/test_segment_ops_backward.py \
-		test/test_segment_ops_torch.py test/test_segment_ops_jax.py
+# Every pytest invocation below runs one group in its own process. This is not
+# just tidiness: JAX and Torch each reserve GPU memory and do not release it to
+# one another cleanly, so a single process importing both exhausts a smaller card.
+#
+# Groups are declared as a name plus the pytest arguments for that name, rather
+# than a single path, so a group can exclude a subtree (see electrostatics below).
+FULL_GROUPS := types math neighbors dynamics batch_utils warp_dispatch \
+	torch_boundary segment_ops segment_ops_backward segment_ops_torch \
+	segment_ops_jax interactions dispersion electrostatics electrostatics_jax \
+	electrostatics_torch
 
-PYTEST_TESTMON_FLAGS ?= --testmon --testmon-nocollect
-TEST_MODULES := types:test/test_types.py math:test/math neighbors:test/neighbors interactions:test/interactions dynamics:test/dynamics batch_utils:test/test_batch_utils.py warp_dispatch:test/test_warp_dispatch.py torch_boundary:test/torch segment_ops:test/test_segment_ops.py segment_ops_backward:test/test_segment_ops_backward.py segment_ops_torch:test/test_segment_ops_torch.py segment_ops_jax:test/test_segment_ops_jax.py
-COVERAGE_DATA_FILES := $(foreach mod,$(TEST_MODULES),.coverage.$(firstword $(subst :, ,$(mod))))
+ARGS_types                := test/test_types.py
+ARGS_math                 := test/math
+ARGS_neighbors            := test/neighbors
+ARGS_dynamics             := test/dynamics
+ARGS_batch_utils          := test/test_batch_utils.py
+ARGS_warp_dispatch        := test/test_warp_dispatch.py
+ARGS_torch_boundary       := test/torch
+ARGS_segment_ops          := test/test_segment_ops.py
+ARGS_segment_ops_backward := test/test_segment_ops_backward.py
+ARGS_segment_ops_torch    := test/test_segment_ops_torch.py
+ARGS_segment_ops_jax      := test/test_segment_ops_jax.py
+ARGS_interactions         := test/interactions --ignore=test/interactions/electrostatics --ignore=test/interactions/dispersion
+ARGS_dispersion           := test/interactions/dispersion
+ARGS_electrostatics       := test/interactions/electrostatics --ignore=test/interactions/electrostatics/bindings
+ARGS_electrostatics_jax   := test/interactions/electrostatics/bindings/jax
+ARGS_electrostatics_torch := test/interactions/electrostatics/bindings/torch
+
+# ------------------------------------------------------------------------------
+# The pull-request suite
+# ------------------------------------------------------------------------------
+# 56 test files out of 113, chosen by tools/group_coverage.py: at each step it
+# takes the file with the best ratio of newly-covered statements to seconds,
+# until the selection clears the coverage gate. That reaches 73.4% against a 70%
+# threshold, for 36 minutes of the full suite's four and a half hours.
+#
+# The selection drops the expensive multipole PME and API tests on its own, not
+# by hand: they cost minutes each, because Warp compiles a kernel specialised per
+# (spline order, l_max, dtype), and they walk lines their cheaper siblings
+# already cover. The nightly tier still runs them.
+#
+# Regenerate with `make minimal-suite-report` when a module gains behaviour the
+# selected files do not exercise. Do not hand-edit these lists without re-running
+# it — the point of them is that they are measured, not guessed.
+MINIMAL_GROUPS ?= types_min math_min neighbors_min dynamics_min warp_dispatch_min \
+	segment_ops_min segment_ops_backward_min segment_ops_torch_min \
+	segment_ops_jax_min interactions_min dispersion_min electrostatics_min \
+	electrostatics_jax_min electrostatics_torch_min
+
+ARGS_types_min                := test/test_types.py
+ARGS_warp_dispatch_min        := test/test_warp_dispatch.py
+ARGS_segment_ops_min          := test/test_segment_ops.py
+ARGS_segment_ops_backward_min := test/test_segment_ops_backward.py
+ARGS_segment_ops_torch_min    := test/test_segment_ops_torch.py
+ARGS_segment_ops_jax_min      := test/test_segment_ops_jax.py
+ARGS_interactions_min         := test/interactions/test_lj.py
+ARGS_electrostatics_jax_min   := test/interactions/electrostatics/bindings/jax/test_slab.py
+
+ARGS_math_min := test/math/test_spline.py \
+	test/math/test_spherical_harmonics.py \
+	test/math/bindings/jax/test_spline.py \
+	test/math/bindings/torch/test_autograd.py \
+	test/math/bindings/torch/test_gto.py \
+	test/math/bindings/torch/test_gto_self_overlap.py \
+	test/math/bindings/torch/test_solid_harmonics.py \
+	test/math/bindings/torch/test_spline.py
+
+ARGS_dynamics_min := test/dynamics/test_constraints.py \
+	test/dynamics/test_fire.py \
+	test/dynamics/test_fire2.py \
+	test/dynamics/test_utils.py \
+	test/dynamics/test_velocity_rescaling.py
+
+ARGS_dispersion_min := test/interactions/dispersion/bindings/jax/test_dftd3.py \
+	test/interactions/dispersion/bindings/torch/test_dftd3.py
+
+ARGS_electrostatics_min := test/interactions/electrostatics/test_deriv_check_selftest.py \
+	test/interactions/electrostatics/test_jax_autograd.py \
+	test/interactions/electrostatics/test_util.py
+
+ARGS_electrostatics_torch_min := test/interactions/electrostatics/bindings/torch/test_gradient_contract.py \
+	test/interactions/electrostatics/bindings/torch/test_multipole_coverage_gaps.py \
+	test/interactions/electrostatics/bindings/torch/test_multipole_features.py \
+	test/interactions/electrostatics/bindings/torch/test_multipole_real_space.py \
+	test/interactions/electrostatics/bindings/torch/test_multipole_reciprocal.py \
+	test/interactions/electrostatics/bindings/torch/test_slab.py
+
+ARGS_neighbors_min := test/neighbors/test_cell_list_kernel_getters.py \
+	test/neighbors/test_cluster_tile_kernel_getters.py \
+	test/neighbors/test_cluster_tile_kernels.py \
+	test/neighbors/test_compat_imports.py \
+	test/neighbors/test_pair_outputs.py \
+	test/neighbors/bindings/jax/test_batch_cluster_tile.py \
+	test/neighbors/bindings/jax/test_batch_naive.py \
+	test/neighbors/bindings/jax/test_cluster_tile.py \
+	test/neighbors/bindings/jax/test_naive.py \
+	test/neighbors/bindings/jax/test_naive_dual_cutoff.py \
+	test/neighbors/bindings/jax/test_neighborlist.py \
+	test/neighbors/bindings/jax/test_rebuild_detection.py \
+	test/neighbors/bindings/torch/test_base_dispatch.py \
+	test/neighbors/bindings/torch/test_batch_cell_list.py \
+	test/neighbors/bindings/torch/test_batch_cluster_tile.py \
+	test/neighbors/bindings/torch/test_batch_naive.py \
+	test/neighbors/bindings/torch/test_batch_naive_dual_cutoff.py \
+	test/neighbors/bindings/torch/test_cell_list.py \
+	test/neighbors/bindings/torch/test_cell_list_partial.py \
+	test/neighbors/bindings/torch/test_cluster_tile.py \
+	test/neighbors/bindings/torch/test_naive.py \
+	test/neighbors/bindings/torch/test_naive_dual_cutoff.py \
+	test/neighbors/bindings/torch/test_neighborlist.py \
+	test/neighbors/bindings/torch/test_rebuild_detection.py
+
+# 36 minutes in one job would still be too slow to wait on, so CI splits the
+# suite across parallel runners. Groups are packed by measured cost rather than
+# spread round-robin, because the costs differ by two orders of magnitude:
+# electrostatics_torch alone is 14.5 minutes while types is a rounding error.
+# The packing below comes to roughly 14.5, 12.4 and 9.1 minutes on a cold kernel
+# cache, so shard 1 sets the pace. Every group still runs in its own process, so
+# the JAX/Torch split is intact.
+SHARD_COUNT := 3
+SHARD_1_GROUPS := electrostatics_torch_min
+SHARD_2_GROUPS := neighbors_min math_min electrostatics_min
+SHARD_3_GROUPS := electrostatics_jax_min dispersion_min dynamics_min \
+	interactions_min types_min warp_dispatch_min segment_ops_min \
+	segment_ops_backward_min segment_ops_torch_min segment_ops_jax_min
+
+# pytest-skip-slow skips anything marked `slow` unless --slow is passed, so the
+# marker is what separates the two tiers: the pull-request suite leaves this
+# empty and the nightly suite sets --slow to run everything. Before this was
+# wired up nothing passed --slow, which meant slow-marked tests ran nowhere.
+PYTEST_SLOW_FLAG ?=
+
+GROUPS ?= $(FULL_GROUPS)
+# Union of both tiers: the minimal tier may define narrower groups of its own,
+# and their data files still need cleaning before a run and collecting after it.
+COVERAGE_DATA_FILES := $(foreach grp,$(sort $(FULL_GROUPS) $(MINIMAL_GROUPS)),.coverage.$(grp))
 COVERAGE_BASELINE_FILE ?=
+COVERAGE_FAIL_UNDER ?= 70
+
+# The pull-request suite covers less than the full suite by construction, so it
+# gets its own floor. Set just below what the selected groups actually measure,
+# so the gate still fails when a change adds code nothing exercises. Verified by
+# `make minimal-suite-report`.
+MINIMAL_COVERAGE_FAIL_UNDER ?= 70
+
+# Test selection for the impacted tier. `--testmon-nocollect` is load-bearing:
+# testmon and coverage.py both install a sys.settrace hook and Python allows one
+# per thread, so a run that lets testmon collect reports near-zero coverage.
+# With nocollect, testmon still deselects unaffected tests but leaves tracing to
+# coverage. The database is built separately by `testmon-collect`.
+PYTEST_TESTMON_FLAGS ?=
+
+# pytest exits 5 when a group collects no tests, which is a legitimate outcome
+# both for a filtered run and for a testmon run where nothing was affected.
+# Only the impacted tier excludes the minimal files; every other tier must run
+# them. Applying the ignores unconditionally would make `test-full` skip all 56
+# of them, and for the groups whose whole path is already minimal it would
+# collect nothing at all — an empty run that exit code 5 then hides.
+SKIP_MINIMAL_FILES ?=
+
+define run_group
+	COVERAGE_FILE=.coverage.$(1) \
+	uv run coverage run -m pytest $(ARGS_$(1)) $(PYTEST_SLOW_FLAG) \
+		$(PYTEST_TESTMON_FLAGS) $(if $(SKIP_MINIMAL_FILES),$(IGNORE_$(1))); \
+	RET=$$?; if [ $$RET -ne 0 ] && [ $$RET -ne 5 ]; then exit $$RET; fi;
+endef
 
 .PHONY: testmon-collect
-testmon-collect:  ## Build testmon dependency database (no coverage)
-	$(foreach mod,$(TEST_MODULES),\
-		uv run pytest --testmon $(lastword $(subst :, ,$(mod))) || true;)
-
-.PHONY: testmon-coverage
-testmon-coverage:  ## Run tests with coverage (testmon selects by default)
-	rm -f .coverage $(COVERAGE_DATA_FILES) $(addsuffix .*, $(COVERAGE_DATA_FILES))
-	$(foreach mod,$(TEST_MODULES),\
-		COVERAGE_FILE=.coverage.$(firstword $(subst :, ,$(mod))) \
-		uv run coverage run -m pytest $(PYTEST_TESTMON_FLAGS) $(lastword $(subst :, ,$(mod))); \
+testmon-collect:  ## Build the testmon database (never combine this with coverage)
+	@# testmon and coverage.py both install a sys.settrace hook and Python allows
+	@# only one, so a run that collects for testmon reports near-zero coverage.
+	@# This target therefore runs on its own, without `coverage run`.
+	$(foreach grp,$(FULL_GROUPS),\
+		uv run pytest --testmon $(ARGS_$(grp)); \
 		RET=$$?; if [ $$RET -ne 0 ] && [ $$RET -ne 5 ]; then exit $$RET; fi;) true
+
+.PHONY: coverage-run
+coverage-run:  ## Run $(GROUPS) under coverage, one process per group
+	rm -f .coverage $(foreach grp,$(GROUPS),.coverage.$(grp) .coverage.$(grp).*)
+	$(foreach grp,$(GROUPS),$(call run_group,$(grp))) true
+
+# Combining shard data needs only coverage and the source tree, so CI runs that
+# step on a cheap runner with `UV_RUN="uv run --no-project --with coverage"`
+# rather than installing Torch and JAX to read some SQLite files.
+UV_RUN ?= uv run
+
+.PHONY: coverage-combine
+coverage-combine:  ## Merge per-group coverage data and enforce the gate
+	@# `concurrency = ["multiprocessing", "thread"]` puts coverage in parallel
+	@# mode, so each group writes .coverage.<group>.<host>.<pid>.<random> rather
+	@# than the bare name given in COVERAGE_FILE. Glob for both.
 	@coverage_files=""; \
 	if [ -n "$(COVERAGE_BASELINE_FILE)" ] && [ -f "$(COVERAGE_BASELINE_FILE)" ]; then \
 		coverage_files="$$coverage_files $(COVERAGE_BASELINE_FILE)"; \
@@ -114,31 +274,75 @@ testmon-coverage:  ## Run tests with coverage (testmon selects by default)
 			fi; \
 		done; \
 	done; \
-	if [ -n "$$coverage_files" ]; then \
-		uv run coverage combine --data-file=.coverage $$coverage_files || true; \
-	else \
-		coverage_files=$$(find . -maxdepth 1 -name ".coverage.*" ! -name ".coverage.baseline" -print); \
-		if [ -n "$$coverage_files" ]; then \
-			uv run coverage combine --data-file=.coverage $$coverage_files || true; \
-		fi; \
-	fi
-	uv run coverage report --show-missing --fail-under=70
-	uv run coverage xml -o nvalchemiops.coverage.xml
+	if [ -z "$$coverage_files" ]; then \
+		echo "no coverage data files found; refusing to report a bogus number"; \
+		exit 1; \
+	fi; \
+	$(UV_RUN) coverage combine --data-file=.coverage $$coverage_files
+	$(UV_RUN) coverage report --show-missing --fail-under=$(COVERAGE_FAIL_UNDER)
+	$(UV_RUN) coverage xml --fail-under=$(COVERAGE_FAIL_UNDER) -o nvalchemiops.coverage.xml
+
+.PHONY: test-full
+test-full:  ## Full suite including slow tests, with coverage (nightly and main)
+	$(MAKE) coverage-run GROUPS="$(FULL_GROUPS)" PYTEST_SLOW_FLAG=--slow
+	$(MAKE) coverage-combine
+
+.PHONY: pytest
+pytest: test-full  ## Alias for test-full, kept for the docs and PR template
+
+.PHONY: test-minimal
+test-minimal:  ## Pull-request suite: fewest tests that still clear the gate
+	$(MAKE) coverage-run GROUPS="$(MINIMAL_GROUPS)"
+	$(MAKE) coverage-combine COVERAGE_FAIL_UNDER=$(MINIMAL_COVERAGE_FAIL_UNDER)
+
+# The impacted tier is a UNION with test-minimal, not a filter of it: the minimal
+# suite always runs in full so there is a floor of confidence and a coverage
+# guarantee, and this adds whatever else the change actually touched, from
+# anywhere in the suite. Files already covered by the minimal tier are ignored
+# here so the two do not run the same test twice.
+#
+# Needs a testmon database restored from cache; with none, testmon selects
+# everything and this degrades to a full run. CI therefore skips this tier when
+# the database is missing rather than accidentally running the whole suite.
+$(foreach grp,$(FULL_GROUPS),\
+  $(eval IGNORE_$(grp) := $(foreach path,$(ARGS_$(grp)_min),--ignore=$(path))))
+
+.PHONY: test-impacted
+test-impacted:  ## Tests affected by the change, beyond the minimal suite
+	$(MAKE) coverage-run GROUPS="$(FULL_GROUPS)" SKIP_MINIMAL_FILES=1 \
+		PYTEST_TESTMON_FLAGS="--testmon --testmon-nocollect"
+	@echo "Impacted-tier coverage data left for the gate job to combine."
+
+.PHONY: test-minimal-shard
+test-minimal-shard:  ## Run one shard of the pull-request suite (SHARD=1..3)
+	@# No gate here: a shard covers a fraction of the code by definition, so the
+	@# threshold is enforced once, after the shards' data is combined.
+	@test -n "$(SHARD)" || { echo "set SHARD=1..$(SHARD_COUNT)"; exit 1; }
+	@test -n "$(SHARD_$(SHARD)_GROUPS)" || { echo "no groups for SHARD=$(SHARD)"; exit 1; }
+	$(MAKE) coverage-run GROUPS="$(SHARD_$(SHARD)_GROUPS)"
+
+# Re-deriving the suite needs a per-test duration table. Get one from any full
+# CI job log:
+#   gh api repos/<owner>/<repo>/actions/jobs/<job-id>/logs > job.log
+#   uv run python tools/extract_ci_durations.py job.log -o ci_durations.json
+.PHONY: minimal-suite-report
+minimal-suite-report:  ## Re-derive the minimal suite from per-test coverage
+	bash tools/measure_test_coverage.sh
+	uv run python tools/group_coverage.py \
+		--cov-dir .covctx --durations ci_durations.json \
+		--select --granularity file --target $(MINIMAL_COVERAGE_FAIL_UNDER)
 
 # ==============================================================================
 # COVERAGE
 # ==============================================================================
 
 .PHONY: coverage
-coverage: pytest
-	@echo "Ran coverage"
-	rm -f nvalchemiops.coverage.xml; \
-	uv run coverage xml --fail-under=70
+coverage: test-full  ## Full suite plus the combined report and XML
 
 .PHONY: coverage-html
 coverage-html:  ## Generate HTML coverage report
-	mkdir htmlcov
-	uv run pytest --cov --cov-report=html:htmlcov/index.html test/;
+	mkdir -p htmlcov
+	uv run pytest --cov --cov-report=html:htmlcov test/;
 	@echo "Coverage report generated at htmlcov/index.html"
 
 # ==============================================================================

--- a/docs/userguide/about/contributing.md
+++ b/docs/userguide/about/contributing.md
@@ -138,10 +138,12 @@ pre-commit install
 # Step 3: create a branch for changes
 git checkout -b 15-fix-description
 
-# Step 4: Run `pytest`; `Makefile` in root folder contains definition
-# for some of these commands. Run `coverage` tool afterwards.
-make pytest
-make coverage
+# Step 4: Run the tests; `Makefile` in the root folder defines these.
+# `test-minimal` is what CI runs on a pull request and is much faster;
+# `test-full` is the whole suite, including tests marked `slow`, and is
+# what runs nightly. Both report combined coverage.
+make test-minimal
+make test-full
 
 # When things pass, add and commit files; make sure to address
 # any outstanding pre-commit issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,16 @@ branch = true
 concurrency = ["multiprocessing", "thread"]
 source = ["nvalchemiops"]
 
+# Coverage records absolute file paths, and the pull-request tier combines data
+# produced on several runners whose workspace roots differ. This maps them all
+# back onto the local tree so `coverage combine` merges them instead of
+# reporting each copy as a separate, mostly-uncovered file.
+[tool.coverage.paths]
+source = [
+    "nvalchemiops",
+    "*/nvalchemiops",
+]
+
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",

--- a/test/interactions/electrostatics/conftest.py
+++ b/test/interactions/electrostatics/conftest.py
@@ -32,6 +32,7 @@ Supported crystal structures:
 from __future__ import annotations
 
 import gc
+import os
 from typing import NamedTuple
 
 import numpy as np
@@ -52,7 +53,14 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(config, items):
     """Modify test collection to add markers based on test names."""
+    # Scoped to this directory: pytest passes every collected item to this hook,
+    # and the rules here differ deliberately from the ones in test/math and
+    # test/neighbors.
+    here = os.path.dirname(__file__)
     for item in items:
+        if not str(item.path).startswith(here):
+            continue
+
         if "cuda" in item.name.lower() or "gpu" in item.name.lower():
             item.add_marker(pytest.mark.gpu)
 

--- a/test/math/conftest.py
+++ b/test/math/conftest.py
@@ -15,6 +15,7 @@
 
 """Pytest configuration for math module tests."""
 
+import os
 import random
 
 import numpy as np
@@ -31,7 +32,15 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(config, items):
     """Modify test collection to add markers based on test names."""
+    # pytest hands every collected item to this hook, not only the ones under
+    # this directory, so a whole-tree run would otherwise apply the rules below
+    # to tests elsewhere. In particular the electrostatics suite deliberately
+    # does not treat "stress" as slow, and that decision must survive.
+    here = os.path.dirname(__file__)
     for item in items:
+        if not str(item.path).startswith(here):
+            continue
+
         if "cuda" in item.name.lower() or "gpu" in item.name.lower():
             item.add_marker(pytest.mark.gpu)
         if "performance" in item.name.lower() or "stress" in item.name.lower():

--- a/test/neighbors/conftest.py
+++ b/test/neighbors/conftest.py
@@ -16,6 +16,8 @@
 
 """Pytest configuration for neighbor list tests."""
 
+import os
+
 import pytest
 import warp as wp
 
@@ -30,7 +32,15 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(config, items):
     """Modify test collection to add markers based on test names."""
+    # pytest hands every collected item to this hook, not only the ones under
+    # this directory, so a whole-tree run would otherwise apply the rules below
+    # to tests elsewhere. In particular the electrostatics suite deliberately
+    # does not treat "stress" as slow, and that decision must survive.
+    here = os.path.dirname(__file__)
     for item in items:
+        if not str(item.path).startswith(here):
+            continue
+
         # Mark GPU tests
         if "cuda" in item.name.lower() or "gpu" in item.name.lower():
             item.add_marker(pytest.mark.gpu)

--- a/tools/extract_ci_durations.py
+++ b/tools/extract_ci_durations.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Recover a per-test duration table from a GitHub Actions job log.
+
+The suite runs under ``-vv``, so each test writes one line, and Actions prefixes
+every line with a timestamp. Successive differences therefore give a duration per
+test without instrumenting the suite.
+
+The attribution is one test off: a line is written when a test *finishes*, so a
+gap covers the following test plus any fixture setup charged between them. That is
+accurate enough to find the tests costing minutes rather than milliseconds, which
+is all these numbers are used for.
+
+Usage
+-----
+    python tools/extract_ci_durations.py <job-log> [-o durations.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import re
+from pathlib import Path
+
+# "<iso-timestamp> test/path.py::Class::test_name PASSED [ 42%]"
+_RESULT_LINE = re.compile(
+    r"^(?P<ts>\S+Z) (?P<nodeid>test/\S+::\S+) "
+    r"(?P<outcome>PASSED|FAILED|SKIPPED|XFAIL|XPASS|ERROR)"
+)
+
+# A gap larger than this spans a pytest process restart between module groups,
+# so it measures interpreter startup rather than the test it precedes.
+_MAX_PLAUSIBLE_SECONDS = 3000.0
+
+
+def parse_log(path: Path) -> dict[str, float]:
+    """Return the longest observed duration for each test node id in a job log."""
+    durations: dict[str, float] = {}
+    previous: datetime.datetime | None = None
+
+    with path.open(errors="replace") as handle:
+        for line in handle:
+            match = _RESULT_LINE.match(line)
+            if match is None:
+                continue
+
+            stamp = datetime.datetime.fromisoformat(
+                match.group("ts").replace("Z", "+00:00")
+            )
+            if previous is not None:
+                elapsed = (stamp - previous).total_seconds()
+                if 0.0 <= elapsed < _MAX_PLAUSIBLE_SECONDS:
+                    nodeid = match.group("nodeid")
+                    # Keep the worst observation; a test may appear in several
+                    # module groups and we size the suite for the slow case.
+                    durations[nodeid] = max(durations.get(nodeid, 0.0), elapsed)
+            previous = stamp
+
+    return durations
+
+
+def main() -> None:
+    """Parse a job log and write the duration table as JSON."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=Path, help="GitHub Actions job log")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("ci_durations.json"),
+        help="where to write the duration table",
+    )
+    args = parser.parse_args()
+
+    durations = parse_log(args.log)
+    args.output.write_text(json.dumps(durations, indent=0, sort_keys=True))
+
+    total = sum(durations.values())
+    print(f"{len(durations)} tests, {total / 3600:.2f} h total -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/group_coverage.py
+++ b/tools/group_coverage.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Choose the cheapest set of tests that still clears the coverage gate.
+
+Works in the gate's own units — percentage of `nvalchemiops` statements as
+`coverage report` computes it — rather than in a line-set proxy, so the number
+this prints is the number CI will check.
+
+Three details make that non-trivial, and all three are handled explicitly.
+
+*Context-free lines.* Some lines are recorded under an empty context: they ran at
+import, in a session-scoped fixture, or on a worker thread, since coverage tracks
+context per thread. They come with the process rather than with a particular test,
+so any selection that runs a group at all is credited with that group's
+context-free lines, and no individual test is credited with them.
+
+*Exclusions.* The gate does not count every line. This project excludes
+`@wp.kernel`, `@wp.func`, `@torch.jit.script` and `.register_fake` bodies, which
+is a large share of the source. Rather than re-derive that, the denominator comes
+from coverage's own analysis with the project config loaded.
+
+*Process separation.* Selected files are emitted grouped by the Makefile's groups,
+never merged across them, because JAX and Torch must not share a pytest process.
+
+Usage
+-----
+    # what each group costs and covers
+    python tools/group_coverage.py --durations ci_durations.json
+
+    # cheapest set of whole test files reaching 72%
+    python tools/group_coverage.py --durations ci_durations.json \\
+        --select --granularity file --target 72
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+import coverage
+
+# Maps a test path onto the Makefile group that runs it. Ordered longest-prefix
+# first so the jax and torch bindings win over the broader entries containing
+# them. Anything unmatched falls back to its measurement group.
+MAKEFILE_GROUPS: tuple[tuple[str, str], ...] = (
+    ("test/interactions/electrostatics/bindings/jax", "electrostatics_jax"),
+    ("test/interactions/electrostatics/bindings/torch", "electrostatics_torch"),
+    ("test/interactions/electrostatics", "electrostatics"),
+    ("test/interactions/dispersion", "dispersion"),
+    ("test/interactions", "interactions"),
+    ("test/neighbors", "neighbors"),
+    ("test/dynamics", "dynamics"),
+    ("test/math", "math"),
+    ("test/torch", "torch_boundary"),
+)
+
+Line = tuple[str, int]
+
+
+def makefile_group(nodeid: str, fallback: str) -> str:
+    """Return the Makefile group that would run a given test node id."""
+    for prefix, name in MAKEFILE_GROUPS:
+        if nodeid.startswith(prefix):
+            return name
+    return fallback
+
+
+def countable_statements(source_root: Path) -> dict[str, set[int]]:
+    """Return the statements the coverage gate counts, per source file."""
+    cov = coverage.Coverage(config_file="pyproject.toml")
+    cov.load()
+    countable: dict[str, set[int]] = {}
+    for path in sorted(source_root.rglob("*.py")):
+        try:
+            statements = cov.analysis2(str(path))[1]
+        except Exception as exc:  # noqa: S112 - reported, then skipped
+            print(f"skipping {path}: {type(exc).__name__}: {exc}")
+            continue
+        countable[str(path.resolve())] = set(statements)
+    return countable
+
+
+def load(cov_dir: Path) -> tuple[dict[str, dict[str, set[Line]]], dict[str, set[Line]]]:
+    """Read per-group databases into per-test line sets and context-free lines."""
+    per_test: dict[str, dict[str, set[Line]]] = defaultdict(lambda: defaultdict(set))
+    free: dict[str, set[Line]] = defaultdict(set)
+
+    for data_file in sorted(cov_dir.iterdir()):
+        if not data_file.name.startswith(".coverage.") or not data_file.is_file():
+            continue
+        measurement_group = data_file.name.split(".")[2]
+        data = coverage.CoverageData(basename=str(data_file))
+        data.read()
+        for measured in data.measured_files():
+            for lineno, contexts in data.contexts_by_lineno(measured).items():
+                key = (measured, lineno)
+                for context in contexts:
+                    if context:
+                        nodeid = context.split("|", 1)[0]
+                        per_test[measurement_group][nodeid].add(key)
+                    else:
+                        free[measurement_group].add(key)
+
+    return per_test, dict(free)
+
+
+def build_candidates(
+    per_test: dict[str, dict[str, set[Line]]],
+    durations: dict[str, float],
+    granularity: str,
+) -> tuple[dict[str, set[Line]], dict[str, float], dict[str, str], dict[str, str]]:
+    """Return candidate line sets, costs, owning Makefile group, and source group."""
+    lines: dict[str, set[Line]] = defaultdict(set)
+    cost: dict[str, float] = defaultdict(float)
+    group_of: dict[str, str] = {}
+    measurement_of: dict[str, str] = {}
+
+    for measurement_group, tests in per_test.items():
+        for nodeid, covered in tests.items():
+            group = makefile_group(nodeid, measurement_group)
+            key = group if granularity == "group" else nodeid.split("::", 1)[0]
+            lines[key].update(covered)
+            cost[key] += durations.get(nodeid, 0.0)
+            group_of[key] = group
+            measurement_of[key] = measurement_group
+
+    return dict(lines), dict(cost), group_of, measurement_of
+
+
+def main() -> None:
+    """Report per-group coverage and optionally select a cheaper subset."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cov-dir", type=Path, default=Path(".covctx"))
+    parser.add_argument("--durations", type=Path, required=True)
+    parser.add_argument("--select", action="store_true")
+    parser.add_argument("--granularity", choices=("group", "file"), default="group")
+    parser.add_argument("--target", type=float, default=70.0)
+    args = parser.parse_args()
+
+    durations = json.loads(args.durations.read_text())
+    per_test, free = load(args.cov_dir)
+    statements = countable_statements(Path("nvalchemiops"))
+    total = sum(len(s) for s in statements.values())
+
+    def pct(lines: set[Line]) -> float:
+        """Covered statements as a percentage, the way the gate counts."""
+        hit = sum(1 for path, no in lines if no in statements.get(path, ()))
+        return 100.0 * hit / total if total else 0.0
+
+    candidates, cost, group_of, measurement_of = build_candidates(
+        per_test, durations, args.granularity
+    )
+
+    everything: set[Line] = set()
+    for lines in candidates.values():
+        everything |= lines
+    for lines in free.values():
+        everything |= lines
+
+    print(f"total statements: {total}")
+    print(f"everything measured: {pct(everything):.1f}%")
+    print(f"candidates: {len(candidates)} at {args.granularity} granularity")
+
+    if not args.select:
+        print(f"\n{'alone%':>7} {'min':>7}  candidate")
+        for name in sorted(candidates, key=lambda n: -cost.get(n, 0.0)):
+            covered = candidates[name] | free.get(measurement_of[name], set())
+            print(f"{pct(covered):7.1f} {cost.get(name, 0.0) / 60:7.1f}  {name}")
+        return
+
+    chosen: list[str] = []
+    accumulated: set[Line] = set()
+    used_groups: set[str] = set()
+    pool = dict(candidates)
+    spent = 0.0
+
+    print(f"\n=== greedy selection to {args.target:.0f}% ===")
+    print(f"{'cum%':>7} {'min':>7} {'cumMin':>7}  candidate")
+
+    while pool and pct(accumulated) < args.target:
+        current = pct(accumulated)
+        best_name, best_ratio = None, 0.0
+        for name, lines in pool.items():
+            # Running a candidate also runs its group's process, so a group not
+            # yet in the selection brings its context-free lines along.
+            extra = free.get(measurement_of[name], set())
+            gain = pct(accumulated | lines | extra) - current
+            if gain <= 0.0:
+                continue
+            ratio = gain / max(cost.get(name, 0.0), 1.0)
+            if ratio > best_ratio:
+                best_name, best_ratio = name, ratio
+
+        if best_name is None:
+            break
+
+        accumulated |= pool.pop(best_name)
+        accumulated |= free.get(measurement_of[best_name], set())
+        used_groups.add(group_of[best_name])
+        spent += cost.get(best_name, 0.0)
+        chosen.append(best_name)
+        print(
+            f"{pct(accumulated):7.1f} {cost.get(best_name, 0.0) / 60:7.1f} "
+            f"{spent / 60:7.1f}  {best_name}"
+        )
+
+    print(
+        f"\nreaches {pct(accumulated):.1f}% in {spent / 60:.1f} min "
+        f"({len(chosen)} of {len(candidates)} candidates)"
+    )
+
+    if args.granularity == "group":
+        print(f"\nMINIMAL_GROUPS := {' '.join(sorted(chosen))}")
+        return
+
+    by_group: dict[str, list[str]] = defaultdict(list)
+    for name in chosen:
+        by_group[group_of[name]].append(name)
+    print("\n# Paste into the Makefile. Groups stay separate so JAX and Torch")
+    print("# never share a pytest process.")
+    print(f"MINIMAL_GROUPS := {' '.join(sorted(f'{g}_min' for g in by_group))}")
+    for group in sorted(by_group):
+        paths = " \\\n\t".join(sorted(by_group[group]))
+        print(f"ARGS_{group}_min := {paths}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/measure_test_coverage.sh
+++ b/tools/measure_test_coverage.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Measure per-test line coverage for every test module.
+#
+# Writes one coverage data file per module under .covctx/ with a dynamic
+# context per test node id, so a later pass can solve for the smallest set of
+# tests that reproduces the full suite's coverage.
+#
+# Modules run in separate pytest processes for the same reason CI splits them:
+# JAX and Torch both grab GPU memory and do not release it cleanly to each other.
+set -u -o pipefail
+
+PY="${PY:-$PWD/.venv-cu12/bin/python}"
+OUT="${OUT:-$PWD/.covctx}"
+mkdir -p "$OUT"
+
+MODULES=(
+  "types:test/test_types.py"
+  "math:test/math"
+  "neighbors:test/neighbors"
+  "dynamics:test/dynamics"
+  "batch_utils:test/test_batch_utils.py"
+  "warp_dispatch:test/test_warp_dispatch.py"
+  "torch_boundary:test/torch"
+  "segment_ops:test/test_segment_ops.py"
+  "segment_ops_backward:test/test_segment_ops_backward.py"
+  "segment_ops_torch:test/test_segment_ops_torch.py"
+  "segment_ops_jax:test/test_segment_ops_jax.py"
+  "interactions:test/interactions"
+)
+
+for entry in "${MODULES[@]}"; do
+  name="${entry%%:*}"
+  path="${entry#*:}"
+  if [ -f "$OUT/$name.done" ]; then
+    echo "[skip] $name already measured"
+    continue
+  fi
+  echo "[run ] $name ($path) at $(date -Is)"
+  rm -f "$OUT/.coverage.$name" "$OUT/.coverage.$name".*
+  COVERAGE_FILE="$OUT/.coverage.$name" \
+    "$PY" -m pytest "$path" \
+      -p no:cacheprovider \
+      --cov=nvalchemiops --cov-context=test --cov-report= --cov-fail-under=0 \
+      -q --no-header \
+      > "$OUT/$name.log" 2>&1
+  rc=$?
+  echo "[done] $name rc=$rc at $(date -Is)"
+  # rc 5 == no tests collected; both 0 and 5 are acceptable outcomes here.
+  if [ $rc -eq 0 ] || [ $rc -eq 5 ]; then touch "$OUT/$name.done"; fi
+done
+
+echo "[all ] finished at $(date -Is)"

--- a/tools/verify_slow_tests.sh
+++ b/tools/verify_slow_tests.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Run only the tests marked `slow`, which pytest-skip-slow otherwise skips.
+#
+# These have not executed in CI at all: nothing passed --slow, so the marker has
+# meant "never runs" rather than "runs nightly". Before making the nightly tier
+# pass --slow we need to know whether they still pass.
+#
+# Groups run in separate processes for the usual reason: JAX and Torch do not
+# release GPU memory to each other cleanly.
+set -u -o pipefail
+
+PY="${PY:-$PWD/.venv-cu12/bin/python}"
+OUT="${OUT:-$PWD/.slowcheck}"
+mkdir -p "$OUT"
+
+# Not named GROUPS: bash reserves that for the caller's group ids and silently
+# ignores an assignment to it.
+TEST_GROUPS=(
+  "math:test/math"
+  "neighbors:test/neighbors"
+  "dynamics:test/dynamics"
+  "segment_ops_torch:test/test_segment_ops_torch.py"
+  "dispersion:test/interactions/dispersion"
+  "electrostatics:test/interactions/electrostatics --ignore=test/interactions/electrostatics/bindings"
+  "electrostatics_jax:test/interactions/electrostatics/bindings/jax"
+  "electrostatics_torch:test/interactions/electrostatics/bindings/torch"
+)
+
+for entry in "${TEST_GROUPS[@]}"; do
+  name="${entry%%:*}"
+  args="${entry#*:}"
+  if [ -f "$OUT/$name.done" ]; then
+    echo "[skip] $name"
+    continue
+  fi
+  echo "[run ] $name at $(date -Is)"
+  # shellcheck disable=SC2086 -- args intentionally word-split into pytest flags
+  "$PY" -m pytest $args --slow -m slow \
+    -p no:cacheprovider --no-header \
+    > "$OUT/$name.log" 2>&1
+  rc=$?
+  tail -1 "$OUT/$name.log"
+  echo "[done] $name rc=$rc at $(date -Is)"
+  if [ $rc -eq 0 ] || [ $rc -eq 5 ]; then touch "$OUT/$name.done"; fi
+done
+
+echo "[all ] finished at $(date -Is)"
+grep -h -E "^(FAILED|ERROR)" "$OUT"/*.log 2>/dev/null | sort -u > "$OUT/failures.txt"
+echo "failures recorded: $(wc -l < "$OUT/failures.txt")"

--- a/tools/warm_warp_cache.py
+++ b/tools/warm_warp_cache.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Compile every Warp kernel in nvalchemiops without running the tests.
+
+The expensive part of a cold CI run is not arithmetic, it is NVIDIA Warp
+generating and compiling CUDA source. The PME kernels are specialised per
+(spline order, l_max, dtype) with fully unrolled loops, so order 6 emits 216
+unrolled blocks and NVRTC takes minutes on it. One eight-atom test measured at
+eighteen minutes on a cold cache, essentially all of it compilation.
+
+That cost lands directly on the critical path of the test suite, which runs
+serially, so moving it into a job nobody waits on is worth a lot. Warming
+compiles two to three kernels at a time; a test run compiles them one at a time,
+in between doing everything else.
+
+Two properties make this cheap to run often:
+
+*Warp content-hashes each module*, so re-warming an already-warm cache costs
+seconds — only kernels whose source actually changed are rebuilt. A cold build
+takes tens of minutes; the steady-state build takes about thirty seconds.
+
+*Compilation is parallelised.* Warp accepts ``max_workers`` for module loading
+but defaults it to ``0``, meaning serial, which leaves one core saturated while
+the rest idle. We default to 60% of visible cores. Speed-up is well below linear
+regardless: the build ends on a handful of very large translation units that
+cannot be split, so the tail is effectively serial either way.
+
+Usage
+-----
+    WARP_CACHE_PATH=.warp-cache python tools/warm_warp_cache.py
+    python tools/warm_warp_cache.py --jobs 0     # serial, for comparison
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import os
+import pkgutil
+import time
+
+# Fraction of visible cores to compile with. Warp parallelises module loading
+# with threads and releases the GIL for the compiler itself, so this tracks real
+# cores rather than being capped by Python. Raising it past ~60% buys little,
+# because the tail of the build is a few huge modules that cannot be split.
+_CORE_FRACTION = 0.6
+
+
+def default_workers() -> int:
+    """Return the worker count to compile with: 60% of visible cores, at least 1."""
+    return max(1, int((os.cpu_count() or 1) * _CORE_FRACTION))
+
+
+def import_package(quiet: bool) -> tuple[int, list[str]]:
+    """Import every nvalchemiops submodule so its kernels get registered.
+
+    Registration happens at import: the per-order kernel factories run at module
+    scope, so importing is what makes the specialisations visible to Warp.
+    """
+    import nvalchemiops
+
+    imported = 0
+    failed: list[str] = []
+    for module in pkgutil.walk_packages(
+        nvalchemiops.__path__, f"{nvalchemiops.__name__}."
+    ):
+        try:
+            importlib.import_module(module.name)
+            imported += 1
+        except Exception as exc:
+            failed.append(f"{module.name}: {type(exc).__name__}: {exc}")
+            if not quiet:
+                print(f"  skip {module.name}: {type(exc).__name__}: {exc}")
+    return imported, failed
+
+
+def main() -> None:
+    """Import the package and compile its kernels into the Warp cache."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--device",
+        default=None,
+        help="Warp device to compile for; defaults to cuda:0 when available",
+    )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=None,
+        help="Parallel compile workers; 0 is serial. Defaults to 60%% of cores.",
+    )
+    parser.add_argument("-q", "--quiet", action="store_true")
+    args = parser.parse_args()
+
+    workers = default_workers() if args.jobs is None else args.jobs
+    print(f"warp cache: {os.environ.get('WARP_CACHE_PATH', '<warp default>')}")
+
+    started = time.perf_counter()
+    import warp as wp
+
+    wp.init()
+    after_init = time.perf_counter()
+
+    imported, failed = import_package(args.quiet)
+    after_import = time.perf_counter()
+
+    device = args.device or ("cuda:0" if wp.is_cuda_available() else "cpu")
+    print(
+        f"imported {imported} modules ({len(failed)} skipped), compiling for "
+        f"{device} with {workers or 'serial'} "
+        f"worker{'' if workers == 1 else 's'} of {os.cpu_count()} cores"
+    )
+
+    # A couple of registered specialisations do not type-check when the whole
+    # package is imported at once; Warp reports the failure and moves on, and the
+    # affected kernels simply compile during the test run as they do today.
+    # Warming is best-effort by design, so this must not fail the job.
+    wp.force_load(device=device, max_workers=workers)
+    finished = time.perf_counter()
+
+    print(
+        f"\ninit {after_init - started:6.1f}s"
+        f" | import {after_import - after_init:6.1f}s"
+        f" | compile {finished - after_import:6.1f}s"
+        f" | total {finished - started:6.1f}s"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Pull-request CI takes four to six hours. This restructures it into two tiers and fixes the cause, targeting a verdict in roughly fifteen to twenty minutes while keeping the coverage gate and GPU execution intact.

The slowness was not really a test-suite problem. A single incompatibility — `pytest-testmon` and `coverage.py` both install a `sys.settrace` hook, and Python allows one per thread — made the nightly build report 17% coverage against a 70% gate. The nightly therefore failed, the cache-save steps that ran after it never executed, and `main` stopped publishing the compiled-kernel cache every pull request restores from. With no cache, every pull request recompiled every Warp kernel from scratch. Pull requests still reported green throughout, so the cost surfaced weeks later looking like a test-suite problem.

Three things are worth a reviewer's attention.

**Workflow architecture and intent.** `ci.yml` becomes an orchestrator with no test logic; tiers live in a reusable workflow and shared setup moves into composite actions. Pull requests run a bounded, measured subset that always executes in full, in parallel with a testmon-selected tier covering whatever the change actually touched — a union, so the reduced suite guarantees a coverage floor no matter what testmon decides. `main` and the nightly schedule run everything. The intent behind each tier, and the four behaviours in this repository that differ from their defaults, are documented in `.github/workflows/README.md` rather than left implicit in YAML.

**Caching semantics.** Cache freshness is decoupled from test success, because coupling them is what turned one failing gate into weeks of cold caches. A dedicated producer publishes the kernel cache, reads nothing but the repository, and is not gated on any test job. Restore keys, rotation and cleanup are consolidated so cache growth is bounded — the repository was measured at 5.31 GB of its 10 GB budget across five open pull requests, with nothing on `main`. Several silent failures are fixed: keys that were written but never readable, rotation that could never run, and saves that could publish a partial cache under a good key.

**Performance.** Warp specialises PME kernels per `(spline order, l_max, dtype)` with loops unrolled at code generation, so a cold cache costs minutes of NVRTC time before any arithmetic happens — one eight-atom test measured at eighteen minutes, essentially all compilation. Because the suite runs serially, that lands directly on the critical path. Warming moves it into a job nobody waits on, and enables Warp's parallel module loading, which defaults to serial. Measured against a warmed cache, a test class that took ~24 minutes cold now takes 2 minutes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

<!-- None filed; the nightly failure is visible in the scheduled runs on main. -->

## Changes Made

- **Separated testmon from coverage measurement.** They cannot share a process; the combination silently reported near-zero coverage and failed every nightly build. This is the root cause of the cold caches, and fixing it is what lets `main` publish again.
- **Split testing into two tiers.** A bounded pull-request suite chosen by measurement rather than intuition, plus a testmon-selected tier for whatever the change touched. Their union is gated once.
- **Made cache publication independent of test outcomes**, and added a dedicated producer plus rotation and cleanup so cache usage stays inside budget.
- **Moved kernel compilation off the test critical path** and enabled parallel compilation, which Warp ships disabled by default.
- **Modularised the workflows** into a reusable test workflow and composite actions, so setup and cache handling are defined once.
- **Fixed several conditions that reported green while doing nothing** — a preflight failure skipping all tests, workflow-only changes skipping all tests, and a coverage gate that ran on partial data.
- **Restored 335 tests that ran nowhere.** `pytest-skip-slow` skips `slow`-marked tests unless `--slow` is passed, and nothing passed it. All 335 were run and pass before enabling them.
- **Documented the pipeline** in `.github/workflows/README.md`, including the traps that are non-obvious from the YAML.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

Verified locally: the reduced suite runs end to end and reports 71% against the 70% gate; the sixteen test groups partition the suite exactly (9,665 tests, no gap or overlap); the three shards partition the reduced suite exactly; all 335 slow-marked tests pass; and combining coverage from three simulated runner workspaces reunifies correctly. The workflows were additionally reviewed statically along three independent axes — Actions semantics, cache lifecycle, and the Make/coverage plumbing — and the findings are fixed in this branch.

Two things only a real run can establish, and this pull request is the first: end-to-end wall clock on the GPU runners, and the three-shard coverage merge under actual workspace paths.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

**The first run will be slow and that is expected.** No `main`-scoped cache exists yet, so the first `cache-warm` pays full compilation. It is self-correcting: the run that creates the cache is the one everything else then restores from.

**One thing to watch after merge.** A `cache-warm` failure is a pull-request-speed incident, not just a red build — it is the only publisher of the cache every other job restores from, and when it stops, pull requests get slower over the following days with a symptom that looks unrelated. Jobs now annotate a cold-cache restore in the run summary, but an alert on nightly failure would be a stronger safeguard than a comment.

**Unrelated pre-existing failure**, reproduced on a pristine tree at `1166733` and not touched here: `test/dynamics/test_utils.py::TestVelocityInitialization::test_initialize_velocities_different_temps[vec3d-float64-float64-cuda:0]` passes in isolation and fails when run after other tests in the same process on an L4, while passing on the H100 runners. Worth its own investigation.
