### PR TITLE
0.4.1 Bug Fixes Release

### DIFF
--- a/.github/scripts/prune-caches.sh
+++ b/.github/scripts/prune-caches.sh
@@ -55,7 +55,7 @@ for entry in entries:
   exit 0
 }
 
-if [ -z "$ids" ]; then
+if [[ -z "$ids" ]]; then
   echo "No superseded caches matching '${PREFIX}' on ${GITHUB_REF}"
   exit 0
 fi

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -40,9 +40,8 @@ on:
     - cron: "0 5 * * *" # 05:00 UTC, two hours before the nightly test run
   workflow_dispatch:
 
-permissions:
-  contents: read
-  actions: write # prune-caches.sh deletes superseded entries
+# Declared per job rather than here: both jobs need the same scopes today, but
+# a job-level grant cannot silently widen when a new job is added.
 
 defaults:
   run:
@@ -57,6 +56,9 @@ jobs:
   warp:
     name: Warm Warp kernel cache (py3.12, CUDA 13)
     runs-on: linux-amd64-gpu-h100-latest-1
+    permissions:
+      contents: read
+      actions: write # prune-caches.sh deletes superseded entries
     timeout-minutes: 90
     container:
       image: nvcr.io/nvidia/cuda:13.1.0-runtime-ubuntu24.04
@@ -139,6 +141,9 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: warp
     runs-on: linux-amd64-gpu-h100-latest-1
+    permissions:
+      contents: read
+      actions: write # prune-caches.sh deletes superseded entries
     timeout-minutes: 300
     container:
       image: nvcr.io/nvidia/cuda:13.1.0-runtime-ubuntu24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,9 @@ on:
   schedule:
     - cron: "0 7 * * *" # 07:00 UTC daily, two hours after cache-warm
 
-permissions:
-  contents: read
-  pull-requests: read # get-pr-labels reads ciflow:* labels
-  actions: write # prune-caches.sh deletes superseded cache entries
+# Permissions are declared per job rather than here, so a job only ever holds
+# the scopes it actually uses: `pull-requests: read` exists for get-pr-labels
+# alone, and `actions: write` for the jobs whose runs call prune-caches.sh.
 
 defaults:
   run:
@@ -61,6 +60,8 @@ jobs:
   # ============================================================================
   changed-files:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       any_changed: ${{ steps.changed-files.outputs.any_changed }}
     steps:
@@ -95,6 +96,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -124,6 +127,9 @@ jobs:
 
   get-pr-labels:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # reads ciflow:* labels off the pull request
     outputs:
       labels: ${{ steps.get-labels.outputs.labels || steps.get-labels-empty.outputs.labels }}
     steps:
@@ -171,13 +177,15 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2, 3]
+    permissions:
+      contents: read
+      actions: write # prune-caches.sh deletes superseded cache entries
     uses: ./.github/workflows/reusable-gpu-tests.yml
     with:
       suite: minimal
       shard: ${{ matrix.shard }}
       save-warp-cache: ${{ matrix.shard == 1 }}
       timeout-minutes: 60
-    secrets: inherit
 
   # Runs alongside the minimal tier, never gating the fast verdict. Unbounded by
   # nature: a change to a core electrostatics file selects most of the suite.
@@ -190,11 +198,13 @@ jobs:
       !contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:skip') &&
       !contains(fromJSON(needs.get-pr-labels.outputs.labels || '[]'), 'ciflow:all') &&
       (needs.changed-files.outputs.any_changed == 'true')
+    permissions:
+      contents: read
+      actions: write # prune-caches.sh deletes superseded cache entries
     uses: ./.github/workflows/reusable-gpu-tests.yml
     with:
       suite: impacted
       timeout-minutes: 120
-    secrets: inherit
 
   # Applies the coverage threshold once, to the union of both tiers. Needs only
   # coverage and the source tree, so it runs on an ordinary runner rather than
@@ -208,6 +218,9 @@ jobs:
       needs.test-minimal.result == 'success' &&
       needs.test-impacted.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # download-artifact reads this run's artifacts
     steps:
       - uses: actions/checkout@v4
 
@@ -261,6 +274,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
+    permissions:
+      contents: read
+      actions: write # prune-caches.sh deletes superseded cache entries
     uses: ./.github/workflows/reusable-gpu-tests.yml
     with:
       suite: full
@@ -269,7 +285,6 @@ jobs:
       # would delete each other's entry. Every other lane maintains its own.
       save-warp-cache: ${{ matrix.python-version != '3.12' }}
       timeout-minutes: 480
-    secrets: inherit
 
   test-cuda12:
     name: Full CUDA 12
@@ -279,6 +294,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
+    permissions:
+      contents: read
+      actions: write # prune-caches.sh deletes superseded cache entries
     uses: ./.github/workflows/reusable-gpu-tests.yml
     with:
       suite: full
@@ -288,7 +306,6 @@ jobs:
       jax-extra: jax-cu12
       save-warp-cache: true
       timeout-minutes: 480
-    secrets: inherit
 
   # ============================================================================
   # STATUS
@@ -304,6 +321,8 @@ jobs:
       - test-full
       - test-cuda12
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: always()
     steps:
       - name: Check job statuses

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
           python-version: "3.12"
 
       - name: Setup UV
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           enable-cache: true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,13 +15,8 @@
 
 name: "Docs"
 
+# Manual only for now.
 on:
-  push:
-    branches:
-      - main
-      - "*.*.*-rc*"
-    tags:
-      - "v*.*.*"
   workflow_dispatch:
 
 defaults:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.1 - 2026-08-03
 
 ### Added
 
@@ -24,6 +24,7 @@
   direct single-system fixed-state route instead.
 - JAX cluster-tile empty selective rebuilds now preserve false-flag state and
   clear true-flag pair and tile counts while retaining fixed-capacity storage.
+
 ### Changed (neighbors)
 
 - Improved JAX neighbor-list import performance by deferring dtype-specific

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.4.1 - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,49 @@
 
 ### Added
 
+- Monopole Torch and JAX Ewald, PME, and slab entry points accept keyword-only
+  `energy_reduction="atom" | "system"` (default `"atom"`). `"atom"` returns
+  per-atom energies `(N,)`; `"system"` returns per-system totals `(B,)`.
+  Direct-output fields (forces, charge gradients, virials) keep their existing
+  shapes. Torch eager atom mode may synchronize once per participating component
+  when a materialized uniform cotangent is proven by value inspection; system
+  mode is structurally sync-free for arbitrary `(B,)` loss weights. JAX adds
+  API/layout parity only; underlying Warp kernels remain atom-buffer-oriented.
 - PyTorch cluster-tile selective calls can append caller-owned tile state with
   `return_state=True`, without changing the default neighbor-list return arity.
 
+### Changed
+
+- Improved JAX neighbor-list import performance by deferring dtype-specific
+  direct naive and cell-list Warp wrapper registration until first use.
+  Cluster-tile graph callbacks now use bundled callback/preload registrations
+  with lazy direct kernels for naive and cell-list paths. Public behavior is
+  unchanged.
+
 ### Fixed
 
+- Fixed Torch PME and Ewald energy gradients for connected charge, position, and
+  cell inputs. Non-uniform or weighted energy losses and `create_graph=True`
+  higher-order derivatives no longer double-count upstream chain-rule terms.
+- Torch `ewald_reciprocal_space` now preserves graph-connected reciprocal
+  vectors for cell/strain autograd, restoring the physical reciprocal Ewald
+  virial when vectors are regenerated from the differentiable cell.
+- Torch Ewald, PME, and slab backward paths now compile when an explicit
+  single-system batch (`batch_idx=zeros(N)`) is supplied. Reciprocal PME
+  compiled gradients are also correct when a compiled function is reused across
+  mesh sizes.
+- Torch DFT-D3 custom operators now zero caller-owned energy, forces,
+  coordination-number, and virial buffers before empty-system or zero-edge
+  early returns, so reused output tensors cannot retain stale values.
+- JAX DFT-D3 CSR calls with atoms but no edges return zero-filled per-atom
+  forces and coordination numbers with shapes `(N, 3)` and `(N,)`, matching
+  the neighbor-matrix contract and preserving per-system energy and virial axes.
+- JAX cell-list builds now derive search radii from their realized grids,
+  preventing missed neighbors when static capacity changes the constructed
+  grid. Batched `capacity_strategy="geometry"` preserves promoted grids for
+  all non-empty systems by reserving an equal per-system capacity; volume-based
+  sizing remains the default. Fused Warp graph calls with explicit
+  `max_total_cells` now require an explicit `neighbor_search_radius`.
 - Unbatched JAX naive dual-cutoff PBC neighbor lists now populate both cutoff
   outputs when using the default `wrap_positions=True`. Previously this path
   wrapped positions but skipped the fill kernel, leaving zero counts and padded
@@ -26,52 +64,6 @@
   direct single-system fixed-state route instead.
 - JAX cluster-tile empty selective rebuilds now preserve false-flag state and
   clear true-flag pair and tile counts while retaining fixed-capacity storage.
-
-### Changed (neighbors)
-
-- Improved JAX neighbor-list import performance by deferring dtype-specific
-  direct naive and cell-list Warp wrapper registration until first use.
-  Cluster-tile graph callbacks now use bundled callback/preload registrations
-  with lazy direct kernels for naive and cell-list paths. Public behavior is
-  unchanged.
-
-### Added
-
-- Monopole Torch and JAX Ewald, PME, and slab entry points accept keyword-only
-  `energy_reduction="atom" | "system"` (default `"atom"`). `"atom"` returns
-  per-atom energies `(N,)`; `"system"` returns per-system totals `(B,)`.
-  Direct-output fields (forces, charge gradients, virials) keep their existing
-  shapes. Torch eager atom mode may synchronize once per participating component
-  when a materialized uniform cotangent is proven by value inspection; system
-  mode is structurally sync-free for arbitrary `(B,)` loss weights. JAX adds
-  API/layout parity only; underlying Warp kernels remain atom-buffer-oriented.
-
-### Fixed
-
-- Torch DFT-D3 custom operators now zero caller-owned energy, forces,
-  coordination-number, and virial buffers before empty-system or zero-edge
-  early returns, so reused output tensors cannot retain stale values.
-- JAX DFT-D3 CSR calls with atoms but no edges return zero-filled per-atom
-  forces and coordination numbers with shapes ``(N, 3)`` and ``(N,)``, matching
-  the neighbor-matrix contract and preserving per-system energy and virial axes.
-- JAX cell-list builds now derive search radii from their realized grids,
-  preventing missed neighbors when static capacity changes the constructed
-  grid. Batched `capacity_strategy="geometry"` preserves promoted grids for
-  all non-empty systems by reserving an equal per-system capacity; volume-based
-  sizing remains the default. Fused Warp graph calls with explicit
-  `max_total_cells` now require an explicit `neighbor_search_radius`.
-- Torch Ewald, PME, and slab backward paths now compile when an explicit
-  single-system batch (`batch_idx=zeros(N)`) is supplied. Reciprocal PME
-  compiled gradients are also correct when a compiled function is reused across
-  mesh sizes.
-
-- Fixed Torch PME and Ewald energy gradients for connected charge, position, and
-  cell inputs. Non-uniform or weighted energy losses and `create_graph=True`
-  higher-order derivatives no longer double-count upstream chain-rule terms.
-
-- Torch `ewald_reciprocal_space` now preserves graph-connected reciprocal
-  vectors for cell/strain autograd, restoring the physical reciprocal Ewald
-  virial when vectors are regenerated from the differentiable cell.
 
 ## 0.4.0 - 2026-07-13
 

--- a/benchmarks/nh3/generate_pbc_pdbs.sh
+++ b/benchmarks/nh3/generate_pbc_pdbs.sh
@@ -146,10 +146,14 @@ progress_bar() {
     local percent=$((current * 100 / total))
     local filled=$((current * width / total))
 
-    # Build the bar
-    local bar=""
-    for ((i=0; i<filled; i++)); do bar+="█"; done
-    for ((i=0; i<width-filled; i++)); do bar+="░"; done
+    # Build the bar from a blank canvas sliced at `filled`, rather than appending
+    # one character at a time. The leading run becomes solid glyphs, whatever
+    # spaces remain become the empty ones.
+    local canvas
+    printf -v canvas "%*s" "$width" ""
+    local bar="${canvas:0:filled}"
+    bar="${bar// /█}${canvas:filled}"
+    bar="${bar// /░}"
 
     printf "\r${prefix}: [${bar}] %3d%% (%d/%d)" "$percent" "$current" "$total"
     return 0

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2,6 +2,69 @@
 
 # Change Log
 
+## v0.4.1 - 2026-08-03
+
+### Added
+
+- Monopole Torch and JAX Ewald, PME, and slab entry points accept keyword-only
+  `energy_reduction="atom" | "system"` (default `"atom"`). `"atom"` returns
+  per-atom energies `(N,)`; `"system"` returns per-system totals `(B,)`.
+  Direct-output fields (forces, charge gradients, virials) keep their existing
+  shapes. Torch eager atom mode may synchronize once per participating component
+  when a materialized uniform cotangent is proven by value inspection; system
+  mode is structurally sync-free for arbitrary `(B,)` loss weights. JAX adds
+  API/layout parity only; underlying Warp kernels remain atom-buffer-oriented.
+- PyTorch cluster-tile selective calls can append caller-owned tile state with
+  `return_state=True`, without changing the default neighbor-list return arity.
+
+### Changed
+
+- Improved JAX neighbor-list import performance by deferring dtype-specific
+  direct naive and cell-list Warp wrapper registration until first use.
+  Cluster-tile graph callbacks now use bundled callback/preload registrations
+  with lazy direct kernels for naive and cell-list paths. Public behavior is
+  unchanged.
+
+### Fixed
+
+- Fixed Torch PME and Ewald energy gradients for connected charge, position, and
+  cell inputs. Non-uniform or weighted energy losses and `create_graph=True`
+  higher-order derivatives no longer double-count upstream chain-rule terms.
+- Torch `ewald_reciprocal_space` now preserves graph-connected reciprocal
+  vectors for cell/strain autograd, restoring the physical reciprocal Ewald
+  virial when vectors are regenerated from the differentiable cell.
+- Torch Ewald, PME, and slab backward paths now compile when an explicit
+  single-system batch (`batch_idx=zeros(N)`) is supplied. Reciprocal PME
+  compiled gradients are also correct when a compiled function is reused across
+  mesh sizes.
+- Torch DFT-D3 custom operators now zero caller-owned energy, forces,
+  coordination-number, and virial buffers before empty-system or zero-edge
+  early returns, so reused output tensors cannot retain stale values.
+- JAX DFT-D3 CSR calls with atoms but no edges return zero-filled per-atom
+  forces and coordination numbers with shapes `(N, 3)` and `(N,)`, matching
+  the neighbor-matrix contract and preserving per-system energy and virial axes.
+- JAX cell-list builds now derive search radii from their realized grids,
+  preventing missed neighbors when static capacity changes the constructed
+  grid. Batched `capacity_strategy="geometry"` preserves promoted grids for
+  all non-empty systems by reserving an equal per-system capacity; volume-based
+  sizing remains the default. Fused Warp graph calls with explicit
+  `max_total_cells` now require an explicit `neighbor_search_radius`.
+- Unbatched JAX naive dual-cutoff PBC neighbor lists now populate both cutoff
+  outputs when using the default `wrap_positions=True`. Previously this path
+  wrapped positions but skipped the fill kernel, leaving zero counts and padded
+  matrices.
+- Batched PyTorch cluster-tile segmented COO validates fixed topology, offsets,
+  counts, and tile-state capacities before launching Warp kernels.
+- Single-system Torch and JAX segmented cluster-tile COO now require one exact
+  physical interval, bound writes by output capacity, fail closed for malformed
+  offsets, and cap compiled/JIT active counts to writable capacity. Batched
+  per-system physical subsegments remain supported.
+- Compiled unified PyTorch cluster-tile dispatch now rejects tensor-valued PBC
+  rather than treating it as fully periodic. Eagerly validate PBC and compile the
+  direct single-system fixed-state route instead.
+- JAX cluster-tile empty selective rebuilds now preserve false-flag state and
+  clear true-flag pair and tile counts while retaining fixed-capacity storage.
+
 ## v0.4.0 - 2026-07-13
 
 ### Added

--- a/docs/pages-index.html
+++ b/docs/pages-index.html
@@ -5,10 +5,15 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="refresh" content="0; url=./main/">
     <title>ALCHEMI Toolkit-Ops Documentation</title>
   </head>
   <body>
     <p><a href="./main/">Continue to the latest development documentation.</a></p>
+    <!-- Redirect in script rather than a meta refresh: a meta refresh cannot be
+         cancelled by the reader, and the link above is the no-script fallback.
+         replace() rather than assign() so Back does not bounce off this page. -->
+    <script>
+      globalThis.location.replace("./main/");
+    </script>
   </body>
 </html>

--- a/docs/templates/version-switcher.html
+++ b/docs/templates/version-switcher.html
@@ -9,7 +9,7 @@
     type="button"
     class="version-switcher__button btn btn-sm navbar-btn dropdown-toggle"
     data-bs-toggle="dropdown"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-controls="{{ dropdown_id }}"
     aria-label="Select documentation version; current version is {{ current_version.name }}">
     {{ current_version.name }}
@@ -17,19 +17,18 @@
   </button>
   <div id="{{ dropdown_id }}"
     class="version-switcher__menu dropdown-menu list-group-flush py-0"
-    role="listbox"
     aria-labelledby="{{ button_id }}">
     {% for item in versions.branches %}
     {%- set is_current = item.name == current_version.name -%}
     <a class="dropdown-item list-group-item list-group-item-action py-1{% if is_current %} active{% endif %}"
-      href="{{ item.url }}" role="option" aria-selected="{{ 'true' if is_current else 'false' }}"{% if is_current %} aria-current="page"{% endif %}>
+      href="{{ item.url }}"{% if is_current %} aria-current="page"{% endif %}>
       {{ item.name }}{% if item.name == "main" %} (development){% else %} (preview){% endif %}
     </a>
     {% endfor %}
     {% for item in versions.tags | reverse %}
     {%- set is_current = item.name == current_version.name -%}
     <a class="dropdown-item list-group-item list-group-item-action py-1{% if is_current %} active{% endif %}"
-      href="{{ item.url }}" role="option" aria-selected="{{ 'true' if is_current else 'false' }}"{% if is_current %} aria-current="page"{% endif %}>
+      href="{{ item.url }}"{% if is_current %} aria-current="page"{% endif %}>
       {{ item.name }}
     </a>
     {% endfor %}

--- a/docs/userguide/about/migration.md
+++ b/docs/userguide/about/migration.md
@@ -8,6 +8,8 @@ This guide lists user-visible migrations by release.
 
 ## Unreleased
 
+## v0.4.1: Energy Output Layout
+
 ### Energy Output Layout (`energy_reduction`)
 
 Monopole Torch and JAX Ewald, PME, and slab entry points accept keyword-only

--- a/nvalchemiops/__init__.py
+++ b/nvalchemiops/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 import warp as wp
 

--- a/tools/measure_test_coverage.sh
+++ b/tools/measure_test_coverage.sh
@@ -45,7 +45,7 @@ MODULES=(
 for entry in "${MODULES[@]}"; do
   name="${entry%%:*}"
   path="${entry#*:}"
-  if [ -f "$OUT/$name.done" ]; then
+  if [[ -f "$OUT/$name.done" ]]; then
     echo "[skip] $name already measured"
     continue
   fi
@@ -60,7 +60,7 @@ for entry in "${MODULES[@]}"; do
   rc=$?
   echo "[done] $name rc=$rc at $(date -Is)"
   # rc 5 == no tests collected; both 0 and 5 are acceptable outcomes here.
-  if [ $rc -eq 0 ] || [ $rc -eq 5 ]; then touch "$OUT/$name.done"; fi
+  if [[ $rc -eq 0 || $rc -eq 5 ]]; then touch "$OUT/$name.done"; fi
 done
 
 echo "[all ] finished at $(date -Is)"

--- a/tools/verify_slow_tests.sh
+++ b/tools/verify_slow_tests.sh
@@ -43,7 +43,7 @@ TEST_GROUPS=(
 for entry in "${TEST_GROUPS[@]}"; do
   name="${entry%%:*}"
   args="${entry#*:}"
-  if [ -f "$OUT/$name.done" ]; then
+  if [[ -f "$OUT/$name.done" ]]; then
     echo "[skip] $name"
     continue
   fi
@@ -55,7 +55,7 @@ for entry in "${TEST_GROUPS[@]}"; do
   rc=$?
   tail -1 "$OUT/$name.log"
   echo "[done] $name rc=$rc at $(date -Is)"
-  if [ $rc -eq 0 ] || [ $rc -eq 5 ]; then touch "$OUT/$name.done"; fi
+  if [[ $rc -eq 0 || $rc -eq 5 ]]; then touch "$OUT/$name.done"; fi
 done
 
 echo "[all ] finished at $(date -Is)"


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Release preparation for the 0.4.1 hotfix. Bumps the package version, cuts the
changelog, and adds the published-docs changelog entry along with some small
bug fixes.

The behavioural fixes that make up 0.4.1 (#131, #133, #137, #138, #140, #141)
already landed on `main` individually. This PR carries only the release
metadata and the static-analysis cleanup.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

Rolls up the fixes released as 0.4.1: #131, #133, #137, #138, #140, #141.

## Changes Made

- Bump `__version__` to 0.4.1 and cut `CHANGELOG.md`; add the matching
  `v0.4.1 - 2026-08-03` section to `docs/changes.md`, which had gone stale at v0.4.0.
- Scope GitHub Actions permissions per job in `ci.yml` and `cache-warm.yml`,
  replacing the workflow-level grants. `pull-requests: read` now exists only on
  `get-pr-labels`, and `actions: write` only on the jobs whose runs call
  `prune-caches.sh`.
- Drop `secrets: inherit` from the four `reusable-gpu-tests.yml` calls. That
  workflow declares no `secrets:` and references none, so this was passing every
  repository secret to it for nothing.
- Pin `astral-sh/setup-uv` to a full commit SHA in `docs.yml`, matching how
  `ci.yml` already pins it.
- Use `[[` over `[` in `prune-caches.sh`, `measure_test_coverage.sh`, and
  `verify_slow_tests.sh`.
- Build the `generate_pbc_pdbs.sh` progress bar from a sliced blank canvas
  instead of appending one character at a time. Output is byte-identical —
  verified against the previous implementation for filled = 0, 1, 7, 13, 20, 39, 40.
- Replace the `pages-index.html` meta refresh with a scripted redirect, keeping
  the existing link as the no-script fallback.
- Drop the `listbox`/`option` ARIA roles from `version-switcher.html`, leaving
  standard Bootstrap dropdown link semantics with `aria-current="page"` — this
  matches upstream pydata-sphinx-theme's own switcher markup.
- Add `sonar-install` / `sonar` targets to the Makefile for running the scan locally.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

No new tests: this PR adds no functionality. Nothing under `nvalchemiops/` is
modified, so the coverage figure above applies unchanged.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
