### PR TITLE
Fixing documentation build chain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,17 +15,9 @@
 
 name: "Docs"
 
-# On demand, and after the test suite passes on main. ``workflow_run`` is what
-# gets the second one without a workflow of its own: it fires when "CI" finishes
-# on main, and the build job below refuses to run unless that finish was a
-# success, so a red main never publishes.
-#
-# Watching "CI" alone is the whole gate, not a shortcut. The GPU suites run
-# inside it through ``workflow_call`` and report as part of its conclusion
-# rather than as workflows of their own, and its ``verify-status`` job fails the
-# run if any of them did. Listing more workflows here would not tighten
-# anything either: several entries fire when any one of them completes, not when
-# all of them have passed.
+# runs on demand as well as after a successful CI run on main branch
+# this means we only try and build docs if and only if changes to main
+# aren't going to poison them
 on:
   workflow_dispatch:
   workflow_run:
@@ -39,12 +31,6 @@ defaults:
   run:
     shell: bash -x -e -u -o pipefail {0}
 
-# Concurrency is declared per job rather than here, because the two jobs want
-# opposite things. A workflow-level group would force one policy on both: keep
-# ``cancel-in-progress: false`` and merges that land together queue up whole
-# eight-hour GPU builds behind each other, set it true and a deployment can be
-# killed half-written.
-
 env:
   UV_CACHE_DIR: /tmp/uv-cache
   WARP_CACHE_PATH: /tmp/warp-cache
@@ -56,16 +42,13 @@ env:
 jobs:
   build:
     name: Build versioned documentation
-    # ``workflow_run`` fires on completion whatever the conclusion, so the
-    # success check belongs here. A manual run carries no workflow_run context
-    # and is always allowed. ``deploy`` needs this job, so it skips with it.
+    # ``workflow_run`` fires on completion whatever the conclusion
     if: >-
-      github.event_name == 'workflow_dispatch'
-      || github.event.workflow_run.conclusion == 'success'
-    # When several merges land close together their CI runs finish close
-    # together too, and every resulting build would checkout the same ``main``
-    # and produce the same site. Cancelling the superseded one hands the GPU
-    # runner back instead of leaving it building a site nobody will publish.
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    # cancel-in-progress makes it so that newer PRs that land around the same time
+    # in main will supercede older ones, so we don't redundantly
+    # try and build docs
     concurrency:
       group: ${{ github.workflow }}-build
       cancel-in-progress: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,17 +15,35 @@
 
 name: "Docs"
 
-# Manual only for now.
+# On demand, and after the test suite passes on main. ``workflow_run`` is what
+# gets the second one without a workflow of its own: it fires when "CI" finishes
+# on main, and the build job below refuses to run unless that finish was a
+# success, so a red main never publishes.
+#
+# Watching "CI" alone is the whole gate, not a shortcut. The GPU suites run
+# inside it through ``workflow_call`` and report as part of its conclusion
+# rather than as workflows of their own, and its ``verify-status`` job fails the
+# run if any of them did. Listing more workflows here would not tighten
+# anything either: several entries fire when any one of them completes, not when
+# all of them have passed.
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    # The head branch of the triggering run. CI also runs on the copy-pr-bot's
+    # ``pull-request/*`` branches and in the merge queue; neither should publish.
+    branches: [main]
 
 defaults:
   run:
     shell: bash -x -e -u -o pipefail {0}
 
-concurrency:
-  group: github-pages
-  cancel-in-progress: false
+# Concurrency is declared per job rather than here, because the two jobs want
+# opposite things. A workflow-level group would force one policy on both: keep
+# ``cancel-in-progress: false`` and merges that land together queue up whole
+# eight-hour GPU builds behind each other, set it true and a deployment can be
+# killed half-written.
 
 env:
   UV_CACHE_DIR: /tmp/uv-cache
@@ -38,6 +56,19 @@ env:
 jobs:
   build:
     name: Build versioned documentation
+    # ``workflow_run`` fires on completion whatever the conclusion, so the
+    # success check belongs here. A manual run carries no workflow_run context
+    # and is always allowed. ``deploy`` needs this job, so it skips with it.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.workflow_run.conclusion == 'success'
+    # When several merges land close together their CI runs finish close
+    # together too, and every resulting build would checkout the same ``main``
+    # and produce the same site. Cancelling the superseded one hands the GPU
+    # runner back instead of leaving it building a site nobody will publish.
+    concurrency:
+      group: ${{ github.workflow }}-build
+      cancel-in-progress: true
     runs-on: linux-amd64-gpu-h100-latest-1
     timeout-minutes: 480
     permissions:
@@ -96,6 +127,12 @@ jobs:
   deploy:
     name: Deploy GitHub Pages
     needs: build
+    # The opposite policy to the build: a deployment that is cancelled part way
+    # through leaves the published site in whatever state it had reached, so
+    # these queue instead of superseding each other.
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,20 @@ from sphinx_gallery.sorting import FileNameSortKey
 # Defaults build API docs, execute examples, and generate benchmark plots.
 dotenv.load_dotenv()
 os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+# JAX's default GPU client preallocates a fraction of total device memory on its
+# first use and holds it for the life of the process: measured at 93.8 GiB of a
+# GB10's 121.7 GiB, which is unified with host RAM. The platform allocator drops
+# the pool entirely -- JAX allocates and frees through the driver per buffer, so
+# Torch's caching allocator is the only one holding memory and the whole gallery
+# peaks near 350 MiB. ``test/conftest.py`` does the same for pytest.
+#
+# Assigned rather than ``setdefault``: a preallocating value inherited from the
+# shell is exactly the failure this prevents, so the environment does not get a
+# vote. sphinx-multiversion passes this conf directory to every ref it builds,
+# so setting it here covers the historical tags too.
+os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
+os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
 doc_version = os.getenv(
     "SPHINX_MULTIVERSION_NAME",
     os.getenv("DOC_VERSION", "main"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -225,7 +225,9 @@ def isolate_gallery_examples() -> None:
     allocator setting, survives unloading all Warp modules, and no pair of
     examples triggers it on its own -- it takes the accumulated state of a
     dozen. Reordering the gallery therefore only changes which example dies.
-    ``tools/repro_d3_torch_then_jax.py`` has a short version.
+    To see it, run the examples of a gallery in one interpreter rather than
+    letting Sphinx-Gallery do it; the Torch DFT-D3 example followed by the JAX
+    one is the shortest case.
 
     A process per example is already how the rest of the repository runs this
     code: ``weekly-examples.yml`` forks per script and the Makefile forks per

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,11 +17,15 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
+
 import logging
+import multiprocessing
 import os
 import pathlib
 import re
 import sys
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from importlib.metadata import version
 from inspect import signature
 
@@ -34,10 +38,11 @@ from sphinx_gallery.sorting import FileNameSortKey
 dotenv.load_dotenv()
 os.environ.setdefault("JAX_ENABLE_X64", "1")
 
-# JAX's default GPU client preallocates a fraction of total device memory on its
-# first use and holds it for the life of the process: measured at 93.8 GiB of a
-# GB10's 121.7 GiB, which is unified with host RAM. The platform allocator drops
-# the pool entirely -- JAX allocates and frees through the driver per buffer, so
+# Examples run one per process (see ``isolate_gallery_examples``), but a single
+# JAX example still preallocates a fraction of total device memory on its first
+# use and holds it for that process's life: measured at 93.8 GiB of a GB10's
+# 121.7 GiB, which is unified with host RAM. The platform allocator drops the
+# pool entirely -- JAX allocates and frees through the driver per buffer, so
 # Torch's caching allocator is the only one holding memory and the whole gallery
 # peaks near 350 MiB. ``test/conftest.py`` does the same for pytest.
 #
@@ -91,6 +96,13 @@ if version_site_packages:
 # launched the build.
 source_root = pathlib.Path(os.getenv("SPHINX_MULTIVERSION_SOURCEDIR", root))
 sys.path.insert(0, source_root.parent.as_posix())
+
+# Sphinx does not make its own conf directory importable, and sphinxext.py next
+# to this file holds both the gallery reset hook and the entry point for the
+# processes that run examples, each reached by import path. Appended rather than
+# inserted so that ``docs/benchmarks`` cannot shadow the repository's top-level
+# ``benchmarks`` package.
+sys.path.append(root.as_posix())
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -201,6 +213,76 @@ html_theme_options = {
 }
 favicons = ["favicon.ico"]
 
+
+# -- Gallery example isolation -------------------------------------------------
+def isolate_gallery_examples() -> None:
+    """Run each gallery example in a process of its own.
+
+    Sphinx-Gallery executes examples in the Sphinx process, so every example
+    shares one CUDA context. Mixing the Torch and JAX examples in that context
+    corrupts it: a clean build dies part way through with
+    ``CUDA_ERROR_ILLEGAL_ADDRESS``. The fault reproduces under every XLA
+    allocator setting, survives unloading all Warp modules, and no pair of
+    examples triggers it on its own -- it takes the accumulated state of a
+    dozen. Reordering the gallery therefore only changes which example dies.
+    ``tools/repro_d3_torch_then_jax.py`` has a short version.
+
+    A process per example is already how the rest of the repository runs this
+    code: ``weekly-examples.yml`` forks per script and the Makefile forks per
+    test group, both citing the same Torch/JAX interaction. It is also the only
+    arrangement that does not depend on which examples happen to coexist.
+
+    A pool of one, rebuilt per example, is what makes each call a new
+    interpreter rather than a reused worker. ``spawn`` keeps that interpreter
+    free of whatever the Sphinx process has already loaded, at the price of
+    everything crossing the boundary having to pickle -- which is why
+    ``reset_modules`` names its hook by import path instead of passing the
+    function.
+
+    A spawned interpreter starts from a bare ``sys.path``, so the entries this
+    file adds are handed over as ``PYTHONPATH``. Without the conf directory
+    there the hook would not import; without the source root, examples from a
+    tag built by sphinx-multiversion would import the installed package rather
+    than the tree being rendered.
+    """
+    from sphinx_gallery import gen_rst
+    from sphinxext import run_example
+
+    spawn = multiprocessing.get_context("spawn")
+    worker_path = os.pathsep.join(
+        entry
+        for entry in (
+            version_site_packages,
+            source_root.parent.as_posix(),
+            root.as_posix(),
+            os.environ.get("PYTHONPATH"),
+        )
+        if entry
+    )
+
+    def generate_file_rst_isolated(fname, *args, **kwargs):
+        original_path = os.environ.get("PYTHONPATH")
+        os.environ["PYTHONPATH"] = worker_path
+        try:
+            with ProcessPoolExecutor(max_workers=1, mp_context=spawn) as executor:
+                return executor.submit(run_example, fname, *args, **kwargs).result()
+        except BrokenProcessPool as exc:
+            # A CUDA abort kills the interpreter outright, so there is no
+            # traceback to fold into the example page. Name the example instead
+            # of letting a bare pool error reach the user.
+            raise RuntimeError(
+                f"example {fname} crashed the worker process running it; "
+                f"run it directly to see the fault ({exc})"
+            ) from exc
+        finally:
+            if original_path is None:
+                del os.environ["PYTHONPATH"]
+            else:
+                os.environ["PYTHONPATH"] = original_path
+
+    gen_rst.generate_file_rst = generate_file_rst_isolated
+
+
 # https://sphinx-gallery.github.io/stable/configuration.html
 # Multiple galleries: examples and benchmarks
 sphinx_gallery_conf = {
@@ -215,9 +297,11 @@ sphinx_gallery_conf = {
     "run_stale_examples": run_stale_examples,
     "backreferences_dir": "modules/backreferences",
     "doc_module": ("nvalchemiops",),
+    # Named by import path, not passed as a function: ``gallery_conf`` is
+    # pickled to the process each example runs in. See docs/sphinxext.py.
     "reset_modules": (
         "matplotlib",
-        "docs.sphinxext.reset_torch",
+        "sphinxext.reset_seeds",
     ),
     "reset_modules_order": "both",
     "show_memory": False,
@@ -277,6 +361,9 @@ def set_figure_alt_text(app, doctree, docname):  # noqa: ARG001
 
 def setup(app):
     """Sphinx setup hook to register event handlers."""
+    if run_examples:
+        # Before ``builder-inited``, which is when the gallery starts executing.
+        isolate_gallery_examples()
     app.connect("config-inited", set_multiversion_release, priority=999)
     app.connect("builder-inited", generate_benchmark_plots)
     app.connect("doctree-resolved", set_figure_alt_text)

--- a/docs/sphinxext.py
+++ b/docs/sphinxext.py
@@ -12,18 +12,44 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Sphinx-Gallery hooks, and the entry point for the process an example runs in.
+
+Everything here is reached by import path rather than by passing an object,
+because each example runs in a spawned process and what crosses that boundary
+has to pickle. ``conf.py`` names the reset hook as ``"sphinxext.reset_seeds"``
+for that reason, and submits ``run_example`` rather than the Sphinx-Gallery
+function it wraps -- that one is monkeypatched in the parent, so pickling it by
+reference fails its own identity check.
+
+The module is addressed as top-level ``sphinxext``, not ``docs.sphinxext``. That
+resolves it out of the Sphinx conf directory, which sphinx-multiversion takes
+from the branch driving the build. ``docs.sphinxext`` would instead resolve
+against whichever ref is being rendered, so the historical tags would silently
+run their own copy of this file.
+"""
 
 
-def reset_torch(gallery_conf, fname):
-    """Reset PyTorch's state between examples."""
+def run_example(*args, **kwargs):
+    """Render one gallery example, in the process created to hold it.
+
+    Imports Sphinx-Gallery here rather than at module scope: this runs in a
+    fresh interpreter, where the function is the unpatched original.
+    """
+    from sphinx_gallery.gen_rst import generate_file_rst
+
+    return generate_file_rst(*args, **kwargs)
+
+
+def reset_seeds(gallery_conf, fname):
+    """Seed NumPy and Torch so example output is stable across rebuilds.
+
+    Every example gets a fresh interpreter, so each one would otherwise start
+    from OS entropy and the examples that draw random numbers would rewrite
+    their own output on every build.
+    """
     import numpy
     import torch
 
-    # Clear CUDA memory
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
-        torch.cuda.reset_peak_memory_stats()
-    # Reset random seeds
     numpy.random.seed(42)
     torch.manual_seed(0)
     if torch.cuda.is_available():


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

A clean documentation build was broken in two independent ways, and enabling it
in CI was blocked on both. Sphinx-Gallery executes every example inside the
Sphinx process, so all 33 share one CUDA context. That context is where the
first JAX example preallocated most of the device for the rest of the build, and
where mixing the Torch and JAX examples eventually corrupted memory outright.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

None filed. The underlying Torch/JAX corruption described below is unfixed and
deserves its own issue — see "Additional Notes".

## Changes Made

- **`docs/conf.py`** — set `XLA_PYTHON_CLIENT_ALLOCATOR=platform` and
  `XLA_PYTHON_CLIENT_PREALLOCATE=false`. Only `JAX_ENABLE_X64` was set before, so
  the first JAX example preallocated 75% of the device — measured at 93.8 GiB of
  a GB10's 121.7 GiB, which is unified with host RAM — and held it for the whole
  build. `test/conftest.py` has set these same two variables since #83.
- **`docs/conf.py`** — run each gallery example in a spawned process, by wrapping
  `sphinx_gallery.gen_rst.generate_file_rst`. Stdlib `ProcessPoolExecutor` only;
  no new dependency.
- **`docs/sphinxext.py`** — `reset_torch` becomes `reset_seeds` (releasing caches
  is redundant once each example gets its own process), plus a `run_example`
  entry point for the spawned worker. Both are reached by import path, because
  `gallery_conf` has to pickle to cross the process boundary.
- **`.github/workflows/docs.yml`** — add a `workflow_run` trigger on the `CI`
  workflow gated on success, alongside the existing manual dispatch. Concurrency
  moves from the workflow to the jobs so superseded builds are cancelled while
  deployments still queue.

## Testing

- [ ] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes
