### PR TITLE
CI examples dependencies fix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -83,7 +83,9 @@ jobs:
           enable-cache: true
 
       - name: Install documentation dependencies
-        run: uv sync --extra torch --extra jax
+        run: |
+          uv sync --extra torch --extra jax
+          make docs-install-examples
 
       - name: Install historical Warp versions
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,14 +66,14 @@ jobs:
       SMV_SITE_PACKAGES_0_3_1_RC: /tmp/docs-deps/warp-1.11.0
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           # Site-wide tooling always comes from main. The fetched tags and RC
           # branches remain available to sphinx-multiversion as content refs.
           ref: main
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -81,6 +81,7 @@ jobs:
         uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           enable-cache: true
+          version: "0.12.1"
 
       - name: Install documentation dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ BENCHMARK_PLOT_JOBS ?= auto
 .PHONY: docs-install-examples
 docs-install-examples:  ## Install example dependencies
 	@echo "Installing example dependencies..."
-	@for req in examples/*/*-requires.txt; do \
+	@for req in examples/*-requires.txt examples/*/*-requires.txt; do \
 		if [ -f "$$req" ]; then \
 			echo "Installing dependencies from $$req"; \
 			uv pip install -r "$$req"; \

--- a/docs/_gallery_worker.py
+++ b/docs/_gallery_worker.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Entry points for the isolated processes that execute gallery examples.
+
+The private module name is deliberately absent from historical documentation
+trees. Spawned processes unpickle functions by module path, so a generic name
+such as ``sphinxext`` can resolve to an older ref's incompatible helper module.
+"""
+
+
+def run_example(*args, **kwargs):
+    """Render one gallery example in its dedicated process.
+
+    This seems roundabout, but the main issue is to try and get around
+    `sphinx` needing to serialize functions for multiprocessing.
+    """
+    from sphinx_gallery.gen_rst import generate_file_rst
+
+    return generate_file_rst(*args, **kwargs)
+
+
+def reset_seeds(gallery_conf, fname):
+    """Seed NumPy and Torch so example output is stable across rebuilds."""
+    import numpy
+    import torch
+
+    numpy.random.seed(42)
+    torch.manual_seed(0)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(0)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,7 @@ if version_site_packages:
 source_root = pathlib.Path(os.getenv("SPHINX_MULTIVERSION_SOURCEDIR", root))
 sys.path.insert(0, source_root.parent.as_posix())
 
-# Sphinx does not make its own conf directory importable, and sphinxext.py next
+# Sphinx does not make its own conf directory importable, and _gallery_worker.py next
 # to this file holds both the gallery reset hook and the entry point for the
 # processes that run examples, each reached by import path. Appended rather than
 # inserted so that ``docs/benchmarks`` cannot shadow the repository's top-level
@@ -157,6 +157,7 @@ intersphinx_mapping = {
     "torch": ("https://pytorch.org/docs/stable", None),
     "warp": ("https://nvidia.github.io/warp/latest", None),
 }
+intersphinx_timeout = 30
 
 source_suffix = [".rst", ".md"]
 myst_enable_extensions = ["colon_fence", "dollarmath"]
@@ -247,8 +248,8 @@ def isolate_gallery_examples() -> None:
     tag built by sphinx-multiversion would import the installed package rather
     than the tree being rendered.
     """
+    from _gallery_worker import run_example
     from sphinx_gallery import gen_rst
-    from sphinxext import run_example
 
     spawn = multiprocessing.get_context("spawn")
     worker_path = os.pathsep.join(
@@ -300,10 +301,10 @@ sphinx_gallery_conf = {
     "backreferences_dir": "modules/backreferences",
     "doc_module": ("nvalchemiops",),
     # Named by import path, not passed as a function: ``gallery_conf`` is
-    # pickled to the process each example runs in. See docs/sphinxext.py.
+    # pickled to the process each example runs in. See docs/_gallery_worker.py.
     "reset_modules": (
         "matplotlib",
-        "sphinxext.reset_seeds",
+        "_gallery_worker.reset_seeds",
     ),
     "reset_modules_order": "both",
     "show_memory": False,

--- a/docs/sphinxext.py
+++ b/docs/sphinxext.py
@@ -12,45 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Sphinx-Gallery hooks, and the entry point for the process an example runs in.
+"""Compatibility imports for the Sphinx-Gallery worker hooks."""
 
-Everything here is reached by import path rather than by passing an object,
-because each example runs in a spawned process and what crosses that boundary
-has to pickle. ``conf.py`` names the reset hook as ``"sphinxext.reset_seeds"``
-for that reason, and submits ``run_example`` rather than the Sphinx-Gallery
-function it wraps -- that one is monkeypatched in the parent, so pickling it by
-reference fails its own identity check.
+from _gallery_worker import reset_seeds, run_example
 
-The module is addressed as top-level ``sphinxext``, not ``docs.sphinxext``. That
-resolves it out of the Sphinx conf directory, which sphinx-multiversion takes
-from the branch driving the build. ``docs.sphinxext`` would instead resolve
-against whichever ref is being rendered, so the historical tags would silently
-run their own copy of this file.
-"""
-
-
-def run_example(*args, **kwargs):
-    """Render one gallery example, in the process created to hold it.
-
-    Imports Sphinx-Gallery here rather than at module scope: this runs in a
-    fresh interpreter, where the function is the unpatched original.
-    """
-    from sphinx_gallery.gen_rst import generate_file_rst
-
-    return generate_file_rst(*args, **kwargs)
-
-
-def reset_seeds(gallery_conf, fname):
-    """Seed NumPy and Torch so example output is stable across rebuilds.
-
-    Every example gets a fresh interpreter, so each one would otherwise start
-    from OS entropy and the examples that draw random numbers would rewrite
-    their own output on every build.
-    """
-    import numpy
-    import torch
-
-    numpy.random.seed(42)
-    torch.manual_seed(0)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(0)
+__all__ = ["reset_seeds", "run_example"]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

This PR fixes the issue where the CI docs build process omits example dependencies. The fix is to simply add a `make docs-install-examples` step to the set up.

Some additional changes were added to make sure that multi-version builds would also use the right documentation trees, which are (hopefully) preemptive fixes.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

-
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [ ] New tests added for new functionality meets coverage expectations?

## Checklist

- [ ] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
