### PR TITLE
fix(torch): register FIRE2 custom ops

### DIFF
--- a/nvalchemiops/torch/fire2.py
+++ b/nvalchemiops/torch/fire2.py
@@ -77,6 +77,7 @@ from nvalchemiops.dynamics.utils.cell_filter import (
     pack_velocities_with_cell,
     unpack_velocities_with_cell,
 )
+from nvalchemiops.torch._warp_op_helpers import register_noop_fake, torch_custom_op
 
 # Torch dtype -> Warp dtype mappings
 _TORCH_TO_WP_VEC = {torch.float32: wp.vec3f, torch.float64: wp.vec3d}
@@ -318,6 +319,20 @@ def _coord_cell_mix_impl(
     )
 
 
+@torch_custom_op(
+    "nvalchemiops::fire2_step_coord",
+    mutates_args=(
+        "positions",
+        "velocities",
+        "alpha",
+        "dt",
+        "nsteps_inc",
+        "vf",
+        "v_sumsq",
+        "f_sumsq",
+        "max_norm",
+    ),
+)
 def fire2_step_coord(
     positions: torch.Tensor,
     velocities: torch.Tensor,
@@ -326,7 +341,6 @@ def fire2_step_coord(
     alpha: torch.Tensor,
     dt: torch.Tensor,
     nsteps_inc: torch.Tensor,
-    *,
     vf: torch.Tensor | None = None,
     v_sumsq: torch.Tensor | None = None,
     f_sumsq: torch.Tensor | None = None,
@@ -493,6 +507,24 @@ def fire2_step_coord(
     )
 
 
+@torch_custom_op(
+    "nvalchemiops::fire2_step_coord_cell",
+    mutates_args=(
+        "positions",
+        "velocities",
+        "cell",
+        "cell_velocities",
+        "alpha",
+        "dt",
+        "nsteps_inc",
+        "ext_velocities",
+        "ext_forces",
+        "vf",
+        "v_sumsq",
+        "f_sumsq",
+        "max_norm",
+    ),
+)
 def fire2_step_coord_cell(
     positions: torch.Tensor,
     velocities: torch.Tensor,
@@ -504,7 +536,6 @@ def fire2_step_coord_cell(
     alpha: torch.Tensor,
     dt: torch.Tensor,
     nsteps_inc: torch.Tensor,
-    *,
     atom_ptr: torch.Tensor | None = None,
     ext_atom_ptr: torch.Tensor | None = None,
     ext_positions: torch.Tensor | None = None,
@@ -820,6 +851,10 @@ def fire2_step_coord_cell(
         maxstep=maxstep,
         device=wp_device,
     )
+
+
+register_noop_fake(fire2_step_coord)
+register_noop_fake(fire2_step_coord_cell)
 
 
 def fire2_step_coord_cell_mix(

--- a/nvalchemiops/torch/fire2.py
+++ b/nvalchemiops/torch/fire2.py
@@ -94,6 +94,18 @@ def _alloc_or_zero(
     return buf
 
 
+def _alloc_if_none(
+    buf: torch.Tensor | None,
+    *shape: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return a buffer, allocating uninitialized storage if needed."""
+    if buf is None:
+        return torch.empty(*shape, dtype=dtype, device=device)
+    return buf
+
+
 def _coord_cell_ext_metadata(
     batch_idx: torch.Tensor,
     M: int,
@@ -333,6 +345,65 @@ def _coord_cell_mix_impl(
         "max_norm",
     ),
 )
+def _fire2_step_coord_op(
+    positions: torch.Tensor,
+    velocities: torch.Tensor,
+    forces: torch.Tensor,
+    batch_idx: torch.Tensor,
+    alpha: torch.Tensor,
+    dt: torch.Tensor,
+    nsteps_inc: torch.Tensor,
+    vf: torch.Tensor,
+    v_sumsq: torch.Tensor,
+    f_sumsq: torch.Tensor,
+    max_norm: torch.Tensor,
+    delaystep: int,
+    dtgrow: float,
+    dtshrink: float,
+    alphashrink: float,
+    alpha0: float,
+    tmax: float,
+    tmin: float,
+    maxstep: float,
+    compute_reductions: bool,
+) -> None:
+    """Run the registered coordinate-only FIRE2 operation."""
+    dtype = positions.dtype
+    vec_type = _TORCH_TO_WP_VEC[dtype]
+
+    if compute_reductions:
+        vf.zero_()
+        v_sumsq.zero_()
+        f_sumsq.zero_()
+    max_norm.zero_()
+
+    if positions.shape[0] == 0:
+        return
+
+    fire2_step(
+        wp.from_torch(positions.detach(), dtype=vec_type),
+        wp.from_torch(velocities.detach(), dtype=vec_type),
+        wp.from_torch(forces.detach(), dtype=vec_type),
+        wp.from_torch(batch_idx.detach(), dtype=wp.int32),
+        wp.from_torch(alpha.detach()),
+        wp.from_torch(dt.detach()),
+        wp.from_torch(nsteps_inc.detach(), dtype=wp.int32),
+        wp.from_torch(vf),
+        wp.from_torch(v_sumsq),
+        wp.from_torch(f_sumsq),
+        wp.from_torch(max_norm),
+        delaystep=delaystep,
+        dtgrow=dtgrow,
+        dtshrink=dtshrink,
+        alphashrink=alphashrink,
+        alpha0=alpha0,
+        tmax=tmax,
+        tmin=tmin,
+        maxstep=maxstep,
+        compute_reductions=compute_reductions,
+    )
+
+
 def fire2_step_coord(
     positions: torch.Tensor,
     velocities: torch.Tensor,
@@ -341,6 +412,7 @@ def fire2_step_coord(
     alpha: torch.Tensor,
     dt: torch.Tensor,
     nsteps_inc: torch.Tensor,
+    *,
     vf: torch.Tensor | None = None,
     v_sumsq: torch.Tensor | None = None,
     f_sumsq: torch.Tensor | None = None,
@@ -465,45 +537,38 @@ def fire2_step_coord(
     dtype = positions.dtype
     device = positions.device
     M = alpha.shape[0]
-    vec_type = _TORCH_TO_WP_VEC[dtype]
 
-    # Scratch buffers: allocate/zero when recomputing; require and preserve
-    # them when the caller supplies precomputed reductions.
     if compute_reductions:
-        vf = _alloc_or_zero(vf, M, dtype, device)
-        v_sumsq = _alloc_or_zero(v_sumsq, M, dtype, device)
-        f_sumsq = _alloc_or_zero(f_sumsq, M, dtype, device)
+        vf = _alloc_if_none(vf, M, dtype=dtype, device=device)
+        v_sumsq = _alloc_if_none(v_sumsq, M, dtype=dtype, device=device)
+        f_sumsq = _alloc_if_none(f_sumsq, M, dtype=dtype, device=device)
     elif vf is None or v_sumsq is None or f_sumsq is None:
         raise ValueError(
             "vf, v_sumsq, f_sumsq must be provided when compute_reductions=False"
         )
-    max_norm = _alloc_or_zero(max_norm, M, dtype, device)
+    max_norm = _alloc_if_none(max_norm, M, dtype=dtype, device=device)
 
-    if positions.shape[0] == 0:
-        return
-
-    # Delegate to the Warp-level fire2_step
-    fire2_step(
-        wp.from_torch(positions.detach(), dtype=vec_type),
-        wp.from_torch(velocities.detach(), dtype=vec_type),
-        wp.from_torch(forces.detach(), dtype=vec_type),
-        wp.from_torch(batch_idx.detach(), dtype=wp.int32),
-        wp.from_torch(alpha.detach()),
-        wp.from_torch(dt.detach()),
-        wp.from_torch(nsteps_inc.detach(), dtype=wp.int32),
-        wp.from_torch(vf),
-        wp.from_torch(v_sumsq),
-        wp.from_torch(f_sumsq),
-        wp.from_torch(max_norm),
-        delaystep=delaystep,
-        dtgrow=dtgrow,
-        dtshrink=dtshrink,
-        alphashrink=alphashrink,
-        alpha0=alpha0,
-        tmax=tmax,
-        tmin=tmin,
-        maxstep=maxstep,
-        compute_reductions=compute_reductions,
+    _fire2_step_coord_op(
+        positions,
+        velocities,
+        forces,
+        batch_idx,
+        alpha,
+        dt,
+        nsteps_inc,
+        vf,
+        v_sumsq,
+        f_sumsq,
+        max_norm,
+        delaystep,
+        dtgrow,
+        dtshrink,
+        alphashrink,
+        alpha0,
+        tmax,
+        tmin,
+        maxstep,
+        compute_reductions,
     )
 
 
@@ -525,6 +590,99 @@ def fire2_step_coord(
         "max_norm",
     ),
 )
+def _fire2_step_coord_cell_op(
+    positions: torch.Tensor,
+    velocities: torch.Tensor,
+    forces: torch.Tensor,
+    cell: torch.Tensor,
+    cell_velocities: torch.Tensor,
+    cell_force: torch.Tensor,
+    batch_idx: torch.Tensor,
+    alpha: torch.Tensor,
+    dt: torch.Tensor,
+    nsteps_inc: torch.Tensor,
+    atom_ptr: torch.Tensor | None,
+    ext_atom_ptr: torch.Tensor | None,
+    ext_positions: torch.Tensor | None,
+    ext_velocities: torch.Tensor,
+    ext_forces: torch.Tensor,
+    ext_batch_idx: torch.Tensor | None,
+    vf: torch.Tensor,
+    v_sumsq: torch.Tensor,
+    f_sumsq: torch.Tensor,
+    max_norm: torch.Tensor,
+    delaystep: int,
+    dtgrow: float,
+    dtshrink: float,
+    alphashrink: float,
+    alpha0: float,
+    tmax: float,
+    tmin: float,
+    maxstep: float,
+    cell_force_scale: float,
+    compute_reductions: bool,
+) -> None:
+    """Run the registered variable-cell FIRE2 operation."""
+    res = _coord_cell_mix_impl(
+        positions,
+        velocities,
+        forces,
+        cell,
+        cell_velocities,
+        cell_force,
+        batch_idx,
+        alpha,
+        dt,
+        nsteps_inc,
+        atom_ptr=atom_ptr,
+        ext_atom_ptr=ext_atom_ptr,
+        ext_velocities=ext_velocities,
+        ext_forces=ext_forces,
+        ext_batch_idx=ext_batch_idx,
+        vf=vf,
+        v_sumsq=v_sumsq,
+        f_sumsq=f_sumsq,
+        max_norm=max_norm,
+        delaystep=delaystep,
+        dtgrow=dtgrow,
+        dtshrink=dtshrink,
+        alphashrink=alphashrink,
+        alpha0=alpha0,
+        tmax=tmax,
+        tmin=tmin,
+        cell_force_scale=cell_force_scale,
+        compute_reductions=compute_reductions,
+        ext_positions=ext_positions,
+    )
+    if res is None:
+        return
+    (
+        wp_pos,
+        wp_vel,
+        wp_cell,
+        wp_cell_vel,
+        wp_dt,
+        wp_vf,
+        wp_ext_batch_idx,
+        wp_ext_atom_ptr,
+        wp_max_norm,
+        wp_device,
+    ) = res
+    _apply_fire2_coord_cell_step(
+        wp_pos,
+        wp_vel,
+        wp_cell,
+        wp_cell_vel,
+        wp_dt,
+        wp_vf,
+        wp_ext_batch_idx,
+        wp_ext_atom_ptr,
+        wp_max_norm,
+        maxstep=maxstep,
+        device=wp_device,
+    )
+
+
 def fire2_step_coord_cell(
     positions: torch.Tensor,
     velocities: torch.Tensor,
@@ -536,6 +694,7 @@ def fire2_step_coord_cell(
     alpha: torch.Tensor,
     dt: torch.Tensor,
     nsteps_inc: torch.Tensor,
+    *,
     atom_ptr: torch.Tensor | None = None,
     ext_atom_ptr: torch.Tensor | None = None,
     ext_positions: torch.Tensor | None = None,
@@ -792,7 +951,27 @@ def fire2_step_coord_cell(
     ...         f_sumsq=f_sumsq, max_norm=max_norm,
     ...     )
     """
-    res = _coord_cell_mix_impl(
+    dtype = positions.dtype
+    device = positions.device
+    N = positions.shape[0]
+    M = alpha.shape[0]
+    N_ext = N + 2 * M
+
+    ext_velocities = _alloc_if_none(
+        ext_velocities, N_ext, 3, dtype=dtype, device=device
+    )
+    ext_forces = _alloc_if_none(ext_forces, N_ext, 3, dtype=dtype, device=device)
+    if compute_reductions or N == 0:
+        vf = _alloc_if_none(vf, M, dtype=dtype, device=device)
+        v_sumsq = _alloc_if_none(v_sumsq, M, dtype=dtype, device=device)
+        f_sumsq = _alloc_if_none(f_sumsq, M, dtype=dtype, device=device)
+    elif vf is None or v_sumsq is None or f_sumsq is None:
+        raise ValueError(
+            "vf, v_sumsq, f_sumsq must be provided when compute_reductions=False"
+        )
+    max_norm = _alloc_if_none(max_norm, M, dtype=dtype, device=device)
+
+    _fire2_step_coord_cell_op(
         positions,
         velocities,
         forces,
@@ -803,58 +982,31 @@ def fire2_step_coord_cell(
         alpha,
         dt,
         nsteps_inc,
-        atom_ptr=atom_ptr,
-        ext_atom_ptr=ext_atom_ptr,
-        ext_velocities=ext_velocities,
-        ext_forces=ext_forces,
-        ext_batch_idx=ext_batch_idx,
-        vf=vf,
-        v_sumsq=v_sumsq,
-        f_sumsq=f_sumsq,
-        max_norm=max_norm,
-        delaystep=delaystep,
-        dtgrow=dtgrow,
-        dtshrink=dtshrink,
-        alphashrink=alphashrink,
-        alpha0=alpha0,
-        tmax=tmax,
-        tmin=tmin,
-        cell_force_scale=cell_force_scale,
-        compute_reductions=compute_reductions,
-        ext_positions=ext_positions,
-    )
-    if res is None:
-        return
-    (
-        wp_pos,
-        wp_vel,
-        wp_cell,
-        wp_cell_vel,
-        wp_dt,
-        wp_vf,
-        wp_ext_batch_idx,
-        wp_ext_atom_ptr,
-        wp_max_norm,
-        wp_device,
-    ) = res
-    # Couple + clamp + apply the affine cell update directly on positions/cells.
-    _apply_fire2_coord_cell_step(
-        wp_pos,
-        wp_vel,
-        wp_cell,
-        wp_cell_vel,
-        wp_dt,
-        wp_vf,
-        wp_ext_batch_idx,
-        wp_ext_atom_ptr,
-        wp_max_norm,
-        maxstep=maxstep,
-        device=wp_device,
+        atom_ptr,
+        ext_atom_ptr,
+        ext_positions,
+        ext_velocities,
+        ext_forces,
+        ext_batch_idx,
+        vf,
+        v_sumsq,
+        f_sumsq,
+        max_norm,
+        delaystep,
+        dtgrow,
+        dtshrink,
+        alphashrink,
+        alpha0,
+        tmax,
+        tmin,
+        maxstep,
+        cell_force_scale,
+        compute_reductions,
     )
 
 
-register_noop_fake(fire2_step_coord)
-register_noop_fake(fire2_step_coord_cell)
+register_noop_fake(_fire2_step_coord_op)
+register_noop_fake(_fire2_step_coord_cell_op)
 
 
 def fire2_step_coord_cell_mix(

--- a/test/dynamics/test_fire2.py
+++ b/test/dynamics/test_fire2.py
@@ -1258,6 +1258,98 @@ class TestFire2TorchRegistration:
             torch.ops.nvalchemiops.fire2_step_coord_cell.default._schema.arguments
         )
 
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_coord_step_compiles_fullgraph(self, device):
+        """The coordinate wrapper should match eager execution under compile."""
+        state = make_fire2_torch_state(
+            24, 2, torch.float32, device, rng=np.random.default_rng(71)
+        )[:7]
+        eager_args = tuple(tensor.clone() for tensor in state)
+        compiled_args = tuple(tensor.clone() for tensor in state)
+
+        def run(positions, velocities, forces, batch_idx, alpha, dt, nsteps_inc):
+            fire2_step_coord(
+                positions,
+                velocities,
+                forces,
+                batch_idx,
+                alpha,
+                dt,
+                nsteps_inc,
+                **FIRE2_DEFAULTS,
+            )
+            return positions, velocities, alpha, dt, nsteps_inc
+
+        expected = run(*eager_args)
+        torch._dynamo.reset()
+        compiled = torch.compile(run, fullgraph=True)
+        actual = compiled(*compiled_args)
+        torch.cuda.synchronize()
+
+        for actual_tensor, expected_tensor in zip(actual, expected, strict=True):
+            torch.testing.assert_close(actual_tensor, expected_tensor)
+
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_coord_cell_step_compiles_fullgraph(self, device):
+        """The variable-cell wrapper should match eager execution under compile."""
+        rng = np.random.default_rng(72)
+        state = make_fire2_torch_state(24, 2, torch.float32, device, rng=rng)[:7]
+        cell = torch.tensor(
+            _make_upper_triangular_cell(2, np.float32, rng=rng),
+            dtype=torch.float32,
+            device=device,
+        )
+        cell_velocities = torch.zeros_like(cell)
+        cell_force = torch.tensor(
+            rng.standard_normal((2, 3, 3)).astype(np.float32) * 0.01,
+            device=device,
+        )
+        args = (
+            *state[:3],
+            cell,
+            cell_velocities,
+            cell_force,
+            *state[3:],
+        )
+        eager_args = tuple(tensor.clone() for tensor in args)
+        compiled_args = tuple(tensor.clone() for tensor in args)
+
+        def run(
+            positions,
+            velocities,
+            forces,
+            cell,
+            cell_velocities,
+            cell_force,
+            batch_idx,
+            alpha,
+            dt,
+            nsteps_inc,
+        ):
+            fire2_step_coord_cell(
+                positions,
+                velocities,
+                forces,
+                cell,
+                cell_velocities,
+                cell_force,
+                batch_idx,
+                alpha,
+                dt,
+                nsteps_inc,
+                **FIRE2_CELL_DEFAULTS,
+            )
+            return positions, velocities, cell, cell_velocities, alpha, dt, nsteps_inc
+
+        expected = run(*eager_args)
+        torch._dynamo.reset()
+        compiled = torch.compile(run, fullgraph=True)
+        actual = compiled(*compiled_args)
+        torch.cuda.synchronize()
+
+        for actual_tensor, expected_tensor in zip(actual, expected, strict=True):
+            torch.testing.assert_close(actual_tensor, expected_tensor)
+
 
 class TestFire2TorchCoord:
     """Tests for the PyTorch adapter fire2_step_coord."""

--- a/test/dynamics/test_fire2.py
+++ b/test/dynamics/test_fire2.py
@@ -36,6 +36,7 @@ import numpy as np
 import pytest
 import torch
 import warp as wp
+from torch.fx.experimental.proxy_tensor import make_fx
 
 from nvalchemiops.dynamics.optimizers import (
     fire2_apply_step,
@@ -1182,6 +1183,72 @@ class TestFire2Convergence:
 # ==============================================================================
 # Tests: PyTorch Adapter
 # ==============================================================================
+
+
+class TestFire2TorchRegistration:
+    """Tests for the registered PyTorch FIRE2 operators."""
+
+    def test_fire2_steps_trace_as_custom_ops(self):
+        """Both public FIRE2 steps should trace as opaque nvalchemiops nodes."""
+
+        def coord_step(positions, velocities, forces, batch_idx, alpha, dt, nsteps):
+            fire2_step_coord(
+                positions, velocities, forces, batch_idx, alpha, dt, nsteps
+            )
+
+        def coord_cell_step(
+            positions,
+            velocities,
+            forces,
+            cell,
+            cell_velocities,
+            cell_force,
+            batch_idx,
+            alpha,
+            dt,
+            nsteps,
+        ):
+            fire2_step_coord_cell(
+                positions,
+                velocities,
+                forces,
+                cell,
+                cell_velocities,
+                cell_force,
+                batch_idx,
+                alpha,
+                dt,
+                nsteps,
+            )
+
+        coord_args = (
+            torch.empty(2, 3),
+            torch.empty(2, 3),
+            torch.empty(2, 3),
+            torch.zeros(2, dtype=torch.int32),
+            torch.empty(1),
+            torch.empty(1),
+            torch.empty(1, dtype=torch.int32),
+        )
+        cell_args = (
+            *coord_args[:3],
+            torch.empty(1, 3, 3),
+            torch.empty(1, 3, 3),
+            torch.empty(1, 3, 3),
+            *coord_args[3:],
+        )
+
+        coord_graph = make_fx(coord_step, tracing_mode="fake")(*coord_args)
+        cell_graph = make_fx(coord_cell_step, tracing_mode="fake")(*cell_args)
+
+        assert any(
+            node.target is torch.ops.nvalchemiops.fire2_step_coord.default
+            for node in coord_graph.graph.nodes
+        )
+        assert any(
+            node.target is torch.ops.nvalchemiops.fire2_step_coord_cell.default
+            for node in cell_graph.graph.nodes
+        )
 
 
 class TestFire2TorchCoord:

--- a/test/dynamics/test_fire2.py
+++ b/test/dynamics/test_fire2.py
@@ -1241,13 +1241,21 @@ class TestFire2TorchRegistration:
         coord_graph = make_fx(coord_step, tracing_mode="fake")(*coord_args)
         cell_graph = make_fx(coord_cell_step, tracing_mode="fake")(*cell_args)
 
-        assert any(
-            node.target is torch.ops.nvalchemiops.fire2_step_coord.default
+        coord_node = next(
+            node
             for node in coord_graph.graph.nodes
+            if node.target is torch.ops.nvalchemiops.fire2_step_coord.default
         )
-        assert any(
-            node.target is torch.ops.nvalchemiops.fire2_step_coord_cell.default
+        cell_node = next(
+            node
             for node in cell_graph.graph.nodes
+            if node.target is torch.ops.nvalchemiops.fire2_step_coord_cell.default
+        )
+        assert len(coord_node.args) == len(
+            torch.ops.nvalchemiops.fire2_step_coord.default._schema.arguments
+        )
+        assert len(cell_node.args) == len(
+            torch.ops.nvalchemiops.fire2_step_coord_cell.default._schema.arguments
         )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Register the coordinate-only and variable-cell FIRE2 Torch adapters in
`nvalchemiops`, where the reusable Warp-backed operations are implemented.

FIRE2 already exposed high-level adapters in `nvalchemiops.torch.fire2`, but
neither adapter established a `torch.library` boundary. Downstream dynamics
wrappers therefore had to own registration, while the variable-cell path
remained hostile to tracing. Both paths now trace through consistent
`nvalchemiops::` custom operators.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

None.

## Changes Made

- Registered `fire2_step_coord` and `fire2_step_coord_cell` under the
  `nvalchemiops::` namespace.
- Split each adapter into a public allocation wrapper and an internal custom
  operator whose mutation-bearing tensors are always supplied explicitly.
- Declared mutated state and scratch tensors and registered no-op fake
  implementations for tracing.
- Added regression coverage proving both public entry points trace as opaque
  `nvalchemiops` operator nodes.

## Testing

- [ ] Unit tests pass locally (`make pytest`)
- [ ] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

Focused validation completed:

- `pytest test/dynamics/test_fire2.py -vv` — 91 passed on `cuda:0` with
  Torch 2.12 and 91 passed with Torch 2.13.
- Omitted-buffer fake-tensor trace regression — passed with Torch 2.12.
- Toolkit wrapper fake-tensor trace — both wrappers resolve to their
  corresponding `nvalchemiops` custom-op nodes.
- `ruff check nvalchemiops/torch/fire2.py test/dynamics/test_fire2.py`.
- `ruff format --check nvalchemiops/torch/fire2.py test/dynamics/test_fire2.py`.
- `git diff --check`.

## Checklist

- [ ] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

The public adapters retain their keyword-only optional buffer interfaces. The
internal custom operators require every mutation-bearing buffer, avoiding the
Torch 2.12 version-bump failure for omitted default arguments.

The full repository test and lint targets were not run; validation was scoped
to FIRE2 and the two changed files.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
