### PR TITLE
fix(torch): preserve symbolic compiled shapes

### DIFF
--- a/nvalchemiops/torch/_warnings.py
+++ b/nvalchemiops/torch/_warnings.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared warning helpers for PyTorch bindings."""
+
+from __future__ import annotations
+
+import warnings
+
+import torch
+
+__all__: list[str] = []
+
+
+def _warn_compile_missing_argument_inference(
+    missing: str,
+    inference: str,
+    *,
+    stacklevel: int = 3,
+) -> None:
+    """Warn when compiled execution falls back to host-side inference.
+
+    Examples
+    --------
+    Warn when ``max_atoms_per_system`` is inferred from ``batch_ptr``:
+
+    >>> _warn_compile_missing_argument_inference(
+    ...     missing="`max_atoms_per_system`",
+    ...     inference="inferring it from `batch_ptr`",
+    ... )
+    """
+    if torch.compiler.is_compiling():
+        warnings.warn(
+            f"Missing {missing}; {inference} introduces a graph break under "
+            "torch.compile. This will become an error in a future release.",
+            FutureWarning,
+            stacklevel=stacklevel,
+        )

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
@@ -54,6 +54,8 @@ forward inputs); the detached caches are first-order value only.
 
 from __future__ import annotations
 
+import warnings
+
 import torch
 import warp as wp
 
@@ -213,6 +215,14 @@ def _resolve_max_atoms_per_system(
     value = int(max_atoms_per_system_bound)
     if value > 0:
         return value
+    if torch.compiler.is_compiling():
+        warnings.warn(
+            "Missing `max_atoms_per_system`; inferring it from `atom_start` and "
+            "`atom_end` introduces a graph break under torch.compile. This will "
+            "become an error in a future release.",
+            FutureWarning,
+            stacklevel=2,
+        )
     return int((atom_end - atom_start).max().item())
 
 

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
@@ -54,8 +54,6 @@ forward inputs); the detached caches are first-order value only.
 
 from __future__ import annotations
 
-import warnings
-
 import torch
 import warp as wp
 
@@ -80,6 +78,7 @@ from nvalchemiops.interactions.electrostatics.ewald_recip_factory import (
     get_ewald_recip_component_kernel,
     get_ewald_recip_kernel,
 )
+from nvalchemiops.torch._warnings import _warn_compile_missing_argument_inference
 from nvalchemiops.torch._warp_op_helpers import (
     register_warp_op_chain,
 )
@@ -215,14 +214,10 @@ def _resolve_max_atoms_per_system(
     value = int(max_atoms_per_system_bound)
     if value > 0:
         return value
-    if torch.compiler.is_compiling():
-        warnings.warn(
-            "Missing `max_atoms_per_system`; inferring it from `atom_start` and "
-            "`atom_end` introduces a graph break under torch.compile. This will "
-            "become an error in a future release.",
-            FutureWarning,
-            stacklevel=2,
-        )
+    _warn_compile_missing_argument_inference(
+        missing="`max_atoms_per_system`",
+        inference="inferring it from `atom_start` and `atom_end`",
+    )
     return int((atom_end - atom_start).max().item())
 
 

--- a/nvalchemiops/torch/interactions/electrostatics/_util.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_util.py
@@ -58,7 +58,7 @@ def _validate_energy_reduction(energy_reduction: str) -> str:
 def _reduce_atom_energy(
     energy: torch.Tensor,
     batch_idx: torch.Tensor | None,
-    num_systems: torch.SymInt,
+    num_systems: int | torch.SymInt,
 ) -> torch.Tensor:
     """Sum an atom-major energy tensor into an explicit system-major layout."""
     flat = energy.reshape(-1)
@@ -72,7 +72,7 @@ def _reduce_atom_energy(
 def _system_cotangent_to_atoms(
     grad_system: torch.Tensor,
     batch_idx: torch.Tensor | None,
-    num_atoms: torch.SymInt,
+    num_atoms: int | torch.SymInt,
 ) -> torch.Tensor:
     """Broadcast an explicit system cotangent to atom-major layout."""
     grad = grad_system.reshape(-1)
@@ -356,7 +356,7 @@ def _is_static_single_system(num_systems: int | torch.SymInt) -> bool:
 def _sum_atom_values_by_system(
     values: torch.Tensor,
     batch_idx: torch.Tensor | None,
-    num_systems: torch.SymInt,
+    num_systems: int | torch.SymInt,
 ) -> torch.Tensor:
     """Reduce atom-major values to per-system sums."""
     if _is_static_single_system(num_systems):
@@ -371,7 +371,7 @@ def _sum_atom_values_by_system(
 def _mean_atom_values_by_system(
     values: torch.Tensor,
     batch_idx: torch.Tensor | None,
-    num_systems: torch.SymInt,
+    num_systems: int | torch.SymInt,
 ) -> torch.Tensor:
     """Reduce atom-major values to guarded per-system means."""
     if _is_static_single_system(num_systems):
@@ -394,8 +394,8 @@ def _mean_atom_values_by_system(
 def _broadcast_system_values_to_atoms(
     per_system: torch.Tensor,
     batch_idx: torch.Tensor | None,
-    num_systems: torch.SymInt,
-    num_atoms: torch.SymInt,
+    num_systems: int | torch.SymInt,
+    num_atoms: int | torch.SymInt,
 ) -> torch.Tensor:
     """Broadcast per-system values to atom-major values."""
     if _is_static_single_system(num_systems):

--- a/nvalchemiops/torch/interactions/electrostatics/_util.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_util.py
@@ -58,13 +58,11 @@ def _validate_energy_reduction(energy_reduction: str) -> str:
 def _reduce_atom_energy(
     energy: torch.Tensor,
     batch_idx: torch.Tensor | None,
-    num_systems: int,
+    num_systems: torch.SymInt,
 ) -> torch.Tensor:
     """Sum an atom-major energy tensor into an explicit system-major layout."""
     flat = energy.reshape(-1)
     result = flat.new_zeros((num_systems,))
-    if flat.numel() == 0 or num_systems == 0:
-        return result
     if batch_idx is None:
         result[0] = flat.sum()
         return result
@@ -74,12 +72,10 @@ def _reduce_atom_energy(
 def _system_cotangent_to_atoms(
     grad_system: torch.Tensor,
     batch_idx: torch.Tensor | None,
-    num_atoms: int,
+    num_atoms: torch.SymInt,
 ) -> torch.Tensor:
     """Broadcast an explicit system cotangent to atom-major layout."""
     grad = grad_system.reshape(-1)
-    if num_atoms == 0:
-        return grad.new_zeros((0,))
     if batch_idx is None:
         return grad[0].expand(num_atoms)
     return grad.index_select(0, batch_idx.to(device=grad.device, dtype=torch.long))
@@ -352,17 +348,21 @@ def _component_direct_output_deprecation_msg(fn: str, flags: tuple[str, ...]) ->
     )
 
 
+def _is_static_single_system(num_systems: int | torch.SymInt) -> bool:
+    """Return whether a system count is the concrete single-system value."""
+    return type(num_systems) is int and num_systems == 1
+
+
 def _sum_atom_values_by_system(
     values: torch.Tensor,
     batch_idx: torch.Tensor | None,
-    num_systems: int,
+    num_systems: torch.SymInt,
 ) -> torch.Tensor:
     """Reduce atom-major values to per-system sums."""
-    if num_systems == 1:
+    if _is_static_single_system(num_systems):
         return values.sum(dim=0, keepdim=True)
-
     if batch_idx is None:
-        raise RuntimeError("batch_idx is required for multi-system atom reduction")
+        return values.sum(dim=0, keepdim=True)
 
     result = values.new_zeros((num_systems, *values.shape[1:]))
     return result.index_add(0, batch_idx, values)
@@ -371,12 +371,14 @@ def _sum_atom_values_by_system(
 def _mean_atom_values_by_system(
     values: torch.Tensor,
     batch_idx: torch.Tensor | None,
-    num_systems: int,
+    num_systems: torch.SymInt,
 ) -> torch.Tensor:
     """Reduce atom-major values to guarded per-system means."""
-    if values.shape[0] == 0:
-        return values.new_zeros((num_systems, *values.shape[1:]))
-    if num_systems == 1:
+    if _is_static_single_system(num_systems):
+        sums = values.sum(dim=0, keepdim=True)
+        counts = values.new_ones((values.shape[0],)).sum().clamp_min(1)
+        return sums / counts
+    if batch_idx is None:
         return values.mean(dim=0, keepdim=True)
 
     sums = _sum_atom_values_by_system(values, batch_idx, num_systems)
@@ -392,17 +394,14 @@ def _mean_atom_values_by_system(
 def _broadcast_system_values_to_atoms(
     per_system: torch.Tensor,
     batch_idx: torch.Tensor | None,
-    num_systems: int,
-    num_atoms: int,
+    num_systems: torch.SymInt,
+    num_atoms: torch.SymInt,
 ) -> torch.Tensor:
     """Broadcast per-system values to atom-major values."""
-    if num_atoms == 0:
-        return per_system.new_empty((0, *per_system.shape[1:]))
-    if num_systems == 1:
+    if _is_static_single_system(num_systems):
         return per_system[0].expand((num_atoms, *per_system.shape[1:]))
-
     if batch_idx is None:
-        raise RuntimeError("batch_idx is required for multi-system atom broadcast")
+        return per_system[0].expand((num_atoms, *per_system.shape[1:]))
 
     return per_system.index_select(0, batch_idx)
 
@@ -569,7 +568,7 @@ class _InjectCachedEvalGrad(torch.autograd.Function):
     ):
         """Return energy in the requested public layout."""
         if energy_reduction == "system":
-            count = int(cell.shape[0]) if num_systems is None else int(num_systems)
+            count = cell.shape[0] if num_systems is None else num_systems
             return _reduce_atom_energy(energy, batch_idx, count)
         return energy
 
@@ -593,12 +592,12 @@ class _InjectCachedEvalGrad(torch.autograd.Function):
             cell_grad_state,
             batch_idx,
         )
-        ctx.num_atoms = int(positions.shape[0])
+        ctx.num_atoms = positions.shape[0]
         ctx.energy_reduction = inputs[8] if len(inputs) > 8 else "atom"
         ctx.num_systems = (
-            int(inputs[9])
+            inputs[9]
             if len(inputs) > 9 and inputs[9] is not None
-            else (int(cell.shape[0]) if cell.dim() == 3 else 1)
+            else (cell.shape[0] if cell.dim() == 3 else 1)
         )
         ctx.num_inputs = len(inputs)
 
@@ -696,7 +695,7 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
     ):
         """Return energy in the requested public layout."""
         if energy_reduction == "system":
-            count = int(cell.shape[0]) if num_systems is None else int(num_systems)
+            count = cell.shape[0] if num_systems is None else num_systems
             return _reduce_atom_energy(energy, batch_idx, count)
         return energy
 
@@ -728,12 +727,12 @@ class _InjectCachedEvalGradWithFallback(torch.autograd.Function):
         )
         ctx.fallback_fn = fallback_fn
         ctx.num_fallback_tensor_args = len(fallback_tensor_args)
-        ctx.num_atoms = int(positions.shape[0]) if positions.ndim else 1
+        ctx.num_atoms = positions.shape[0] if positions.ndim else 1
         ctx.energy_reduction = inputs[9] if len(inputs) > 9 else "atom"
         ctx.num_systems = (
-            int(inputs[10])
+            inputs[10]
             if len(inputs) > 10 and inputs[10] is not None
-            else (int(cell.shape[0]) if cell.dim() == 3 else 1)
+            else (cell.shape[0] if cell.dim() == 3 else 1)
         )
         ctx.force_fallback = bool(inputs[11]) if len(inputs) > 11 else False
         ctx.fallback_returns_system = bool(inputs[12]) if len(inputs) > 12 else False
@@ -920,9 +919,9 @@ class _InjectChargeGrad(torch.autograd.Function):
             else "atom"
         )
         if len(inputs) > 5 and inputs[5] is not None:
-            ctx.num_systems = int(inputs[5])
+            ctx.num_systems = inputs[5]
         elif ctx.energy_is_system:
-            ctx.num_systems = int(_energy.numel())
+            ctx.num_systems = _energy.numel()
         elif batch_idx is not None and batch_idx.numel() > 0:
             ctx.num_systems = int(batch_idx.max().item()) + 1
         else:
@@ -933,7 +932,7 @@ class _InjectChargeGrad(torch.autograd.Function):
     def backward(ctx, grad_energy):
         """Scale analytical ``dE/dq`` by the energy cotangent."""
         (charge_grad_state,) = ctx.saved_tensors
-        num_atoms = int(charge_grad_state.shape[0])
+        num_atoms = charge_grad_state.shape[0]
 
         if ctx.output_layout == "system":
             grad_system, atom_grad = _energy_cotangents(

--- a/nvalchemiops/torch/interactions/electrostatics/dsf.py
+++ b/nvalchemiops/torch/interactions/electrostatics/dsf.py
@@ -67,8 +67,6 @@ Examples
 
 from __future__ import annotations
 
-import warnings
-
 import torch
 import warp as wp
 
@@ -78,6 +76,7 @@ from nvalchemiops.interactions.electrostatics.dsf import (
 from nvalchemiops.interactions.electrostatics.dsf import (
     dsf_matrix as wp_dsf_matrix,
 )
+from nvalchemiops.torch._warnings import _warn_compile_missing_argument_inference
 from nvalchemiops.torch.interactions.electrostatics._util import _InjectChargeGrad
 from nvalchemiops.torch.types import get_wp_dtype, get_wp_mat_dtype, get_wp_vec_dtype
 
@@ -541,14 +540,10 @@ def dsf_coulomb(
         elif cell is not None:
             num_systems = cell.size(0)
         else:
-            if torch.compiler.is_compiling():
-                warnings.warn(
-                    "Missing `num_systems`; inferring it from `batch_idx` "
-                    "introduces a graph break under torch.compile. This will "
-                    "become an error in a future release.",
-                    FutureWarning,
-                    stacklevel=2,
-                )
+            _warn_compile_missing_argument_inference(
+                missing="`num_systems`",
+                inference="inferring it from `batch_idx`",
+            )
             num_systems = int(batch_idx.max().item()) + 1
 
     # Ensure cell matches input dtype

--- a/nvalchemiops/torch/interactions/electrostatics/dsf.py
+++ b/nvalchemiops/torch/interactions/electrostatics/dsf.py
@@ -67,6 +67,8 @@ Examples
 
 from __future__ import annotations
 
+import warnings
+
 import torch
 import warp as wp
 
@@ -424,7 +426,9 @@ def dsf_coulomb(
     compute_virial : bool, default False
         Whether to compute virial tensor (requires PBC and compute_forces).
     num_systems : int, optional
-        Number of systems. Inferred from batch_idx or cell if not given.
+        Number of systems. Inferred from batch_idx or cell if not given. When
+        compiling without a cell, pass this explicitly; inference emits a
+        ``FutureWarning`` and will become an error in a future release.
     device : str, optional
         Warp device string. Inferred from positions if not given.
 
@@ -537,6 +541,14 @@ def dsf_coulomb(
         elif cell is not None:
             num_systems = cell.size(0)
         else:
+            if torch.compiler.is_compiling():
+                warnings.warn(
+                    "Missing `num_systems`; inferring it from `batch_idx` "
+                    "introduces a graph break under torch.compile. This will "
+                    "become an error in a future release.",
+                    FutureWarning,
+                    stacklevel=2,
+                )
             num_systems = int(batch_idx.max().item()) + 1
 
     # Ensure cell matches input dtype

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -116,6 +116,7 @@ from nvalchemiops.torch.interactions.electrostatics._util import (
     _InjectCachedEvalGrad,
     _InjectCachedEvalGradWithFallback,
     _InjectChargeGrad,
+    _is_static_single_system,
     _reduce_atom_energy,
     _unpack_electrostatic_outputs,
     _validate_energy_reduction,
@@ -183,7 +184,7 @@ def _prepare_alpha(
         raise TypeError(f"alpha must be float or torch.Tensor, got {type(alpha)}")
 
 
-def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, int]:
+def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, torch.SymInt]:
     """Ensure cell is 3D (B, 3, 3) and return number of systems.
 
     Parameters
@@ -195,7 +196,7 @@ def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, int]:
     -------
     cell : torch.Tensor, shape (B, 3, 3)
         Cell with batch dimension.
-    num_systems : int
+    num_systems : torch.SymInt
         Number of systems (B).
     """
     if cell.dim() == 2:
@@ -230,7 +231,7 @@ def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, int]:
 
 
 def _atom_ranges(
-    batch_idx: torch.Tensor, num_systems: int
+    batch_idx: torch.Tensor, num_systems: torch.SymInt
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Per-system [start, end) atom index ranges from a sorted ``batch_idx``.
 
@@ -238,14 +239,9 @@ def _atom_ranges(
     (the existing batched-Ewald contract); ``atom_start``/``atom_end`` are int32.
     """
     device = batch_idx.device
-    if num_systems == 1:
+    if _is_static_single_system(num_systems):
         starts = torch.zeros((1,), dtype=torch.int32, device=device)
-        ends = torch.full(
-            (1,),
-            batch_idx.shape[0],
-            dtype=torch.int32,
-            device=device,
-        )
+        ends = torch.full((1,), batch_idx.shape[0], dtype=torch.int32, device=device)
         return starts, ends
 
     counts = torch.zeros(num_systems, dtype=torch.long, device=device)
@@ -878,7 +874,7 @@ def ewald_real_space(
 
     """
     _validate_energy_reduction(energy_reduction)
-    num_systems = int(cell.shape[0]) if cell.dim() == 3 else 1
+    num_systems = cell.shape[0] if cell.dim() == 3 else 1
 
     def _select_energy(energy):
         if energy_reduction == "system":
@@ -1407,7 +1403,7 @@ def _ewald_reciprocal_space(
             k_vectors_2d = k_vectors[:1]
         else:
             k_vectors_2d = k_vectors.unsqueeze(0)
-    num_systems = int(k_vectors_2d.shape[0])
+    num_systems = k_vectors_2d.shape[0]
 
     def _select_energy(energy):
         if energy_reduction == "system":

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -184,7 +184,7 @@ def _prepare_alpha(
         raise TypeError(f"alpha must be float or torch.Tensor, got {type(alpha)}")
 
 
-def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, torch.SymInt]:
+def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, int | torch.SymInt]:
     """Ensure cell is 3D (B, 3, 3) and return number of systems.
 
     Parameters
@@ -196,7 +196,7 @@ def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, torch.SymInt]:
     -------
     cell : torch.Tensor, shape (B, 3, 3)
         Cell with batch dimension.
-    num_systems : torch.SymInt
+    num_systems : int or torch.SymInt
         Number of systems (B).
     """
     if cell.dim() == 2:
@@ -231,7 +231,7 @@ def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, torch.SymInt]:
 
 
 def _atom_ranges(
-    batch_idx: torch.Tensor, num_systems: torch.SymInt
+    batch_idx: torch.Tensor, num_systems: int | torch.SymInt
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Per-system [start, end) atom index ranges from a sorted ``batch_idx``.
 

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -286,7 +286,7 @@ def _prepare_alpha(
         raise TypeError(f"alpha must be float or torch.Tensor, got {type(alpha)}")
 
 
-def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, int]:
+def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, torch.SymInt]:
     """Ensure cell is 3D (B, 3, 3) and return number of systems.
 
     Parameters
@@ -298,7 +298,7 @@ def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, int]:
     -------
     cell : torch.Tensor, shape (B, 3, 3)
         Cell with batch dimension.
-    num_systems : int
+    num_systems : torch.SymInt
         Number of systems (B).
     """
     if cell.dim() == 2:
@@ -1584,14 +1584,10 @@ def pme_energy_corrections(
         else:
             volumes = volume.to(input_dtype)
 
-        # Compute total charge per system
-        if num_systems == 1:
-            total_charges = charges.to(input_dtype).sum().reshape(1)
-        else:
-            total_charges = torch.zeros(
-                num_systems, dtype=input_dtype, device=raw_energies.device
-            )
-            total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
+        total_charges = torch.zeros(
+            num_systems, dtype=input_dtype, device=raw_energies.device
+        )
+        total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
 
         result = _batch_pme_energy_corrections(
             raw_energies,
@@ -1680,14 +1676,10 @@ def pme_energy_corrections_with_charge_grad(
         else:
             volumes = volume.to(input_dtype)
 
-        # Compute total charge per system
-        if num_systems == 1:
-            total_charges = charges.to(input_dtype).sum().reshape(1)
-        else:
-            total_charges = torch.zeros(
-                num_systems, dtype=input_dtype, device=raw_energies.device
-            )
-            total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
+        total_charges = torch.zeros(
+            num_systems, dtype=input_dtype, device=raw_energies.device
+        )
+        total_charges.scatter_add_(0, batch_idx, charges.to(input_dtype))
 
         return _batch_pme_energy_corrections_with_charge_grad(
             raw_energies,
@@ -2253,7 +2245,7 @@ class _PMEReciprocalCachedFirstGrad(torch.autograd.Function):
         ctx.need_charge = bool(need_charge)
         ctx.need_cell = bool(need_cell)
         ctx.energy_reduction = energy_reduction
-        ctx.num_systems = int(num_systems)
+        ctx.num_systems = num_systems
         if energy_reduction == "system":
             return _reduce_atom_energy(energies, batch_idx, ctx.num_systems)
         return energies
@@ -2963,7 +2955,8 @@ def pme_reciprocal_space(
         Target mesh spacing in same units as cell. Mesh dimensions computed as
         ceil(cell_length / mesh_spacing). Typical value: ~1 Å. This setup path
         reads cell lengths into Python integers; pass explicit
-        ``mesh_dimensions`` when cell-dependent mesh sizing is not desired.
+        ``mesh_dimensions`` when compiling; implicit sizing emits a
+        ``FutureWarning`` and will become an error in a future release.
     spline_order : int, default=4
         B-spline interpolation order. Higher orders are more accurate but slower.
         - 4: Cubic B-splines (good balance, most common)
@@ -3151,6 +3144,14 @@ def pme_reciprocal_space(
     if mesh_dimensions is None:
         if mesh_spacing is None:
             raise ValueError("Either mesh_dimensions or mesh_spacing must be provided")
+        if torch.compiler.is_compiling():
+            warnings.warn(
+                "Missing `mesh_dimensions`; inferring it from `mesh_spacing` and "
+                "`cell` introduces a graph break under torch.compile. This will "
+                "become an error in a future release.",
+                FutureWarning,
+                stacklevel=2,
+            )
         cell_lengths = torch.norm(cell[0], dim=1)
         mesh_dimensions = tuple(
             int(torch.ceil(length / mesh_spacing).item()) for length in cell_lengths

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -183,6 +183,7 @@ from nvalchemiops.interactions.electrostatics.pme_kernels import (
 from nvalchemiops.interactions.electrostatics.pme_kernels import (
     pme_virial_bg_correction_backward as _pme_virial_bg_correction_backward_warp,
 )
+from nvalchemiops.torch._warnings import _warn_compile_missing_argument_inference
 from nvalchemiops.torch._warp_op_helpers import (
     attach_simple_backward,
     register_warp_op_chain,
@@ -3144,14 +3145,10 @@ def pme_reciprocal_space(
     if mesh_dimensions is None:
         if mesh_spacing is None:
             raise ValueError("Either mesh_dimensions or mesh_spacing must be provided")
-        if torch.compiler.is_compiling():
-            warnings.warn(
-                "Missing `mesh_dimensions`; inferring it from `mesh_spacing` and "
-                "`cell` introduces a graph break under torch.compile. This will "
-                "become an error in a future release.",
-                FutureWarning,
-                stacklevel=2,
-            )
+        _warn_compile_missing_argument_inference(
+            missing="`mesh_dimensions`",
+            inference="inferring it from `mesh_spacing` and `cell`",
+        )
         cell_lengths = torch.norm(cell[0], dim=1)
         mesh_dimensions = tuple(
             int(torch.ceil(length / mesh_spacing).item()) for length in cell_lengths

--- a/nvalchemiops/torch/interactions/electrostatics/pme.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme.py
@@ -286,7 +286,7 @@ def _prepare_alpha(
         raise TypeError(f"alpha must be float or torch.Tensor, got {type(alpha)}")
 
 
-def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, torch.SymInt]:
+def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, int | torch.SymInt]:
     """Ensure cell is 3D (B, 3, 3) and return number of systems.
 
     Parameters
@@ -298,7 +298,7 @@ def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, torch.SymInt]:
     -------
     cell : torch.Tensor, shape (B, 3, 3)
         Cell with batch dimension.
-    num_systems : torch.SymInt
+    num_systems : int or torch.SymInt
         Number of systems (B).
     """
     if cell.dim() == 2:

--- a/nvalchemiops/torch/interactions/electrostatics/pme_multipole.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme_multipole.py
@@ -33,6 +33,7 @@ Design:
 from __future__ import annotations
 
 import math
+import warnings
 from contextlib import nullcontext
 
 import torch
@@ -4346,6 +4347,10 @@ def multipole_pme_energy_corrections(
         where :math:`|Q_i|_F^2 = \sum_{\alpha\beta} Q_{i,\alpha\beta}^2` is
         the squared Frobenius norm; matches the direct-k
         ``_multipole_ewald_self_energy_per_atom`` convention.
+    n_systems : int, optional
+        Number of batched systems. When ``batch_idx`` is provided, pass this
+        explicitly when compiling; inference emits a ``FutureWarning`` and
+        will become an error in a future release.
 
     Returns
     -------
@@ -4410,8 +4415,14 @@ def multipole_pme_energy_corrections(
 
     # Batched: per-system total charge + per-system volume (B,).
     if n_systems is None:
-        # Eager fallback only; the batched composite passes n_systems to
-        # avoid this device sync (a torch.compile graph break) on the hot path.
+        if torch.compiler.is_compiling():
+            warnings.warn(
+                "Missing `n_systems`; inferring it from `batch_idx` introduces a "
+                "graph break under torch.compile. This will become an error in a "
+                "future release.",
+                FutureWarning,
+                stacklevel=2,
+            )
         n_systems = int(batch_idx.max().item()) + 1
     total_charge = torch.zeros(n_systems, dtype=torch.float64, device=device)
     total_charge.scatter_add_(0, batch_idx, charges_f64)
@@ -4504,6 +4515,14 @@ def multipole_pme_energy_corrections_per_atom(
         bg = inv_v * charges_f64 * total_charge
     else:
         if n_systems is None:
+            if torch.compiler.is_compiling():
+                warnings.warn(
+                    "Missing `n_systems`; inferring it from `batch_idx` introduces "
+                    "a graph break under torch.compile. This will become an error "
+                    "in a future release.",
+                    FutureWarning,
+                    stacklevel=2,
+                )
             n_systems = int(batch_idx.max().item()) + 1
         total_charge = torch.zeros(
             n_systems, dtype=torch.float64, device=charges.device

--- a/nvalchemiops/torch/interactions/electrostatics/pme_multipole.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme_multipole.py
@@ -33,7 +33,6 @@ Design:
 from __future__ import annotations
 
 import math
-import warnings
 from contextlib import nullcontext
 
 import torch
@@ -92,6 +91,7 @@ from nvalchemiops.math.spline import (
     spline_gather,
     spline_gather_gradient,
 )
+from nvalchemiops.torch._warnings import _warn_compile_missing_argument_inference
 from nvalchemiops.torch._warp_op_helpers import (
     register_warp_op_chain,
 )
@@ -4415,14 +4415,10 @@ def multipole_pme_energy_corrections(
 
     # Batched: per-system total charge + per-system volume (B,).
     if n_systems is None:
-        if torch.compiler.is_compiling():
-            warnings.warn(
-                "Missing `n_systems`; inferring it from `batch_idx` introduces a "
-                "graph break under torch.compile. This will become an error in a "
-                "future release.",
-                FutureWarning,
-                stacklevel=2,
-            )
+        _warn_compile_missing_argument_inference(
+            missing="`n_systems`",
+            inference="inferring it from `batch_idx`",
+        )
         n_systems = int(batch_idx.max().item()) + 1
     total_charge = torch.zeros(n_systems, dtype=torch.float64, device=device)
     total_charge.scatter_add_(0, batch_idx, charges_f64)
@@ -4515,14 +4511,10 @@ def multipole_pme_energy_corrections_per_atom(
         bg = inv_v * charges_f64 * total_charge
     else:
         if n_systems is None:
-            if torch.compiler.is_compiling():
-                warnings.warn(
-                    "Missing `n_systems`; inferring it from `batch_idx` introduces "
-                    "a graph break under torch.compile. This will become an error "
-                    "in a future release.",
-                    FutureWarning,
-                    stacklevel=2,
-                )
+            _warn_compile_missing_argument_inference(
+                missing="`n_systems`",
+                inference="inferring it from `batch_idx`",
+            )
             n_systems = int(batch_idx.max().item()) + 1
         total_charge = torch.zeros(
             n_systems, dtype=torch.float64, device=charges.device

--- a/nvalchemiops/torch/neighbors/batch_cell_list.py
+++ b/nvalchemiops/torch/neighbors/batch_cell_list.py
@@ -587,6 +587,15 @@ def _batch_query_cell_list_op(
     n_outer = None
     R_max = None
     if use_pair_centric:
+        if torch.compiler.is_compiling():
+            warnings.warn(
+                'Missing `strategy="atom_centric"`; inferring total-cell '
+                "allocation from `cells_per_system` introduces a graph break "
+                "under torch.compile. This will become an error in a future "
+                "release.",
+                FutureWarning,
+                stacklevel=2,
+            )
         total_cells = int(cells_per_system.sum().item())
         R_max = _max_radius_tuple(neighbor_search_radius)
         n_outer = compute_batch_pair_centric_n_outer(R_max, bool(half_fill))
@@ -1534,6 +1543,15 @@ def _batch_query_cell_list_optional(
     n_outer = None
     R_max = None
     if use_pair_centric:
+        if torch.compiler.is_compiling():
+            warnings.warn(
+                'Missing `strategy="atom_centric"`; inferring total-cell '
+                "allocation from `cells_per_system` introduces a graph break "
+                "under torch.compile. This will become an error in a future "
+                "release.",
+                FutureWarning,
+                stacklevel=2,
+            )
         total_cells = int(cells_per_system.sum().item())
         R_max = _max_radius_tuple(neighbor_search_radius)
         n_outer = compute_batch_pair_centric_n_outer(R_max, bool(half_fill))
@@ -1726,6 +1744,9 @@ def batch_cell_list(
         Pre-allocated tensor for start indices.
     cell_atom_list : torch.Tensor, shape (total_atoms,), dtype=int32, optional
         Pre-allocated tensor for atom list.
+        When compiling, provide this and the other cell-list cache buffers
+        explicitly. Implicit cache allocation emits a ``FutureWarning`` and
+        will become an error in a future release.
     cell_offsets : torch.Tensor, shape (num_systems,), dtype=int32, optional
         Accepted for API compatibility; computed internally and not used from
         this argument.
@@ -1899,6 +1920,15 @@ def batch_cell_list(
     )
     cell_list_min_cells = 1 if strategy == "atom_centric" else 4
     if allocated_cell_list:
+        if torch.compiler.is_compiling():
+            warnings.warn(
+                "Missing `cells_per_dimension` and related cache buffers; "
+                "inferring their allocation from `cell` and `pbc` introduces a "
+                "graph break under torch.compile. This will become an error in "
+                "a future release.",
+                FutureWarning,
+                stacklevel=2,
+            )
         max_total_cells, neighbor_search_radius = estimate_batch_cell_list_sizes(
             cell,
             pbc,

--- a/nvalchemiops/torch/neighbors/batch_cell_list.py
+++ b/nvalchemiops/torch/neighbors/batch_cell_list.py
@@ -60,6 +60,7 @@ from nvalchemiops.neighbors.neighbor_utils import (
 from nvalchemiops.neighbors.output_args import (
     _has_partial_or_pair_outputs,
 )
+from nvalchemiops.torch._warnings import _warn_compile_missing_argument_inference
 from nvalchemiops.torch._warp_op_helpers import register_noop_fake
 from nvalchemiops.torch.neighbors._autograd import (
     _flatten_active_pairs,
@@ -587,15 +588,10 @@ def _batch_query_cell_list_op(
     n_outer = None
     R_max = None
     if use_pair_centric:
-        if torch.compiler.is_compiling():
-            warnings.warn(
-                'Missing `strategy="atom_centric"`; inferring total-cell '
-                "allocation from `cells_per_system` introduces a graph break "
-                "under torch.compile. This will become an error in a future "
-                "release.",
-                FutureWarning,
-                stacklevel=2,
-            )
+        _warn_compile_missing_argument_inference(
+            missing='`strategy="atom_centric"`',
+            inference="inferring total-cell allocation from `cells_per_system`",
+        )
         total_cells = int(cells_per_system.sum().item())
         R_max = _max_radius_tuple(neighbor_search_radius)
         n_outer = compute_batch_pair_centric_n_outer(R_max, bool(half_fill))
@@ -1543,15 +1539,10 @@ def _batch_query_cell_list_optional(
     n_outer = None
     R_max = None
     if use_pair_centric:
-        if torch.compiler.is_compiling():
-            warnings.warn(
-                'Missing `strategy="atom_centric"`; inferring total-cell '
-                "allocation from `cells_per_system` introduces a graph break "
-                "under torch.compile. This will become an error in a future "
-                "release.",
-                FutureWarning,
-                stacklevel=2,
-            )
+        _warn_compile_missing_argument_inference(
+            missing='`strategy="atom_centric"`',
+            inference="inferring total-cell allocation from `cells_per_system`",
+        )
         total_cells = int(cells_per_system.sum().item())
         R_max = _max_radius_tuple(neighbor_search_radius)
         n_outer = compute_batch_pair_centric_n_outer(R_max, bool(half_fill))
@@ -1920,15 +1911,10 @@ def batch_cell_list(
     )
     cell_list_min_cells = 1 if strategy == "atom_centric" else 4
     if allocated_cell_list:
-        if torch.compiler.is_compiling():
-            warnings.warn(
-                "Missing `cells_per_dimension` and related cache buffers; "
-                "inferring their allocation from `cell` and `pbc` introduces a "
-                "graph break under torch.compile. This will become an error in "
-                "a future release.",
-                FutureWarning,
-                stacklevel=2,
-            )
+        _warn_compile_missing_argument_inference(
+            missing="`cells_per_dimension` and related cache buffers",
+            inference="inferring their allocation from `cell` and `pbc`",
+        )
         max_total_cells, neighbor_search_radius = estimate_batch_cell_list_sizes(
             cell,
             pbc,

--- a/nvalchemiops/torch/neighbors/batch_naive.py
+++ b/nvalchemiops/torch/neighbors/batch_naive.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import torch
 import warp as wp
 
@@ -252,6 +254,14 @@ def _batch_naive_neighbor_matrix_pbc(
     )
 
     if max_atoms_per_system is None:
+        if torch.compiler.is_compiling():
+            warnings.warn(
+                "Missing `max_atoms_per_system`; inferring it from `batch_ptr` "
+                "introduces a graph break under torch.compile. This will become "
+                "an error in a future release.",
+                FutureWarning,
+                stacklevel=2,
+            )
         max_atoms_per_system = (batch_ptr[1:] - batch_ptr[:-1]).max().item()
 
     wp_rebuild_flags = None
@@ -1626,9 +1636,14 @@ def batch_naive_neighbor_list(
                 device=positions.device,
             )
         if pbc is not None and max_atoms_per_system is None:
-            # ``.item()`` is a CPU sync; it works in eager but triggers a
-            # graph break under ``torch.compile``.  Pass max_atoms_per_system
-            # explicitly to keep the autograd path graph-clean under compile.
+            if torch.compiler.is_compiling():
+                warnings.warn(
+                    "Missing `max_atoms_per_system`; inferring it from `batch_ptr` "
+                    "introduces a graph break under torch.compile. This will "
+                    "become an error in a future release.",
+                    FutureWarning,
+                    stacklevel=2,
+                )
             max_atoms_per_system = int((batch_ptr[1:] - batch_ptr[:-1]).max().item())
         forward_kwargs = {
             "cutoff": cutoff,
@@ -1719,6 +1734,14 @@ def batch_naive_neighbor_list(
         else:
             return neighbor_matrix, num_neighbors
     else:
+        if max_atoms_per_system is None and torch.compiler.is_compiling():
+            warnings.warn(
+                "Missing `max_atoms_per_system`; inferring it from `batch_ptr` "
+                "introduces a graph break under torch.compile. This will become "
+                "an error in a future release.",
+                FutureWarning,
+                stacklevel=2,
+            )
         _batch_naive_neighbor_matrix_pbc(
             positions=positions,
             cell=cell,

--- a/nvalchemiops/torch/neighbors/batch_naive.py
+++ b/nvalchemiops/torch/neighbors/batch_naive.py
@@ -17,8 +17,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 import torch
 import warp as wp
 
@@ -29,6 +27,7 @@ from nvalchemiops.neighbors.naive import (
 from nvalchemiops.neighbors.neighbor_utils import (
     estimate_max_neighbors,
 )
+from nvalchemiops.torch._warnings import _warn_compile_missing_argument_inference
 from nvalchemiops.torch._warp_op_helpers import register_noop_fake
 from nvalchemiops.torch.neighbors._autograd import (
     _flatten_active_pairs,
@@ -254,14 +253,10 @@ def _batch_naive_neighbor_matrix_pbc(
     )
 
     if max_atoms_per_system is None:
-        if torch.compiler.is_compiling():
-            warnings.warn(
-                "Missing `max_atoms_per_system`; inferring it from `batch_ptr` "
-                "introduces a graph break under torch.compile. This will become "
-                "an error in a future release.",
-                FutureWarning,
-                stacklevel=2,
-            )
+        _warn_compile_missing_argument_inference(
+            missing="`max_atoms_per_system`",
+            inference="inferring it from `batch_ptr`",
+        )
         max_atoms_per_system = (batch_ptr[1:] - batch_ptr[:-1]).max().item()
 
     wp_rebuild_flags = None
@@ -1636,14 +1631,10 @@ def batch_naive_neighbor_list(
                 device=positions.device,
             )
         if pbc is not None and max_atoms_per_system is None:
-            if torch.compiler.is_compiling():
-                warnings.warn(
-                    "Missing `max_atoms_per_system`; inferring it from `batch_ptr` "
-                    "introduces a graph break under torch.compile. This will "
-                    "become an error in a future release.",
-                    FutureWarning,
-                    stacklevel=2,
-                )
+            _warn_compile_missing_argument_inference(
+                missing="`max_atoms_per_system`",
+                inference="inferring it from `batch_ptr`",
+            )
             max_atoms_per_system = int((batch_ptr[1:] - batch_ptr[:-1]).max().item())
         forward_kwargs = {
             "cutoff": cutoff,
@@ -1734,13 +1725,10 @@ def batch_naive_neighbor_list(
         else:
             return neighbor_matrix, num_neighbors
     else:
-        if max_atoms_per_system is None and torch.compiler.is_compiling():
-            warnings.warn(
-                "Missing `max_atoms_per_system`; inferring it from `batch_ptr` "
-                "introduces a graph break under torch.compile. This will become "
-                "an error in a future release.",
-                FutureWarning,
-                stacklevel=2,
+        if max_atoms_per_system is None:
+            _warn_compile_missing_argument_inference(
+                missing="`max_atoms_per_system`",
+                inference="inferring it from `batch_ptr`",
             )
         _batch_naive_neighbor_matrix_pbc(
             positions=positions,

--- a/nvalchemiops/torch/neighbors/batch_naive_dual_cutoff.py
+++ b/nvalchemiops/torch/neighbors/batch_naive_dual_cutoff.py
@@ -17,8 +17,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 import torch
 import warp as wp
 
@@ -29,6 +27,7 @@ from nvalchemiops.neighbors.naive import (
 from nvalchemiops.neighbors.neighbor_utils import (
     estimate_max_neighbors,
 )
+from nvalchemiops.torch._warnings import _warn_compile_missing_argument_inference
 from nvalchemiops.torch._warp_op_helpers import register_noop_fake
 from nvalchemiops.torch.neighbors.neighbor_utils import (
     compute_naive_num_shifts,
@@ -203,14 +202,10 @@ def _batch_naive_neighbor_matrix_pbc_dual_cutoff(
     )
 
     if max_atoms_per_system is None:
-        if torch.compiler.is_compiling():
-            warnings.warn(
-                "Missing `max_atoms_per_system`; inferring it from `batch_ptr` "
-                "introduces a graph break under torch.compile. This will become "
-                "an error in a future release.",
-                FutureWarning,
-                stacklevel=2,
-            )
+        _warn_compile_missing_argument_inference(
+            missing="`max_atoms_per_system`",
+            inference="inferring it from `batch_ptr`",
+        )
         max_atoms_per_system = (batch_ptr[1:] - batch_ptr[:-1]).max().item()
 
     wp_positions_wrapped = (
@@ -472,14 +467,10 @@ def _batch_naive_neighbor_matrix_pbc_dual_cutoff_selective(
     )
 
     if max_atoms_per_system is None:
-        if torch.compiler.is_compiling():
-            warnings.warn(
-                "Missing `max_atoms_per_system`; inferring it from `batch_ptr` "
-                "introduces a graph break under torch.compile. This will become "
-                "an error in a future release.",
-                FutureWarning,
-                stacklevel=2,
-            )
+        _warn_compile_missing_argument_inference(
+            missing="`max_atoms_per_system`",
+            inference="inferring it from `batch_ptr`",
+        )
         max_atoms_per_system = (batch_ptr[1:] - batch_ptr[:-1]).max().item()
 
     batch_naive_neighbor_matrix_pbc_dual_cutoff(
@@ -875,13 +866,10 @@ def batch_naive_neighbor_list_dual_cutoff(
                 num_neighbors2,
             )
     else:
-        if max_atoms_per_system is None and torch.compiler.is_compiling():
-            warnings.warn(
-                "Missing `max_atoms_per_system`; inferring it from `batch_ptr` "
-                "introduces a graph break under torch.compile. This will become "
-                "an error in a future release.",
-                FutureWarning,
-                stacklevel=2,
+        if max_atoms_per_system is None:
+            _warn_compile_missing_argument_inference(
+                missing="`max_atoms_per_system`",
+                inference="inferring it from `batch_ptr`",
             )
         if rebuild_flags is not None:
             _batch_naive_neighbor_matrix_pbc_dual_cutoff_selective(

--- a/nvalchemiops/torch/neighbors/batch_naive_dual_cutoff.py
+++ b/nvalchemiops/torch/neighbors/batch_naive_dual_cutoff.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import torch
 import warp as wp
 
@@ -201,6 +203,14 @@ def _batch_naive_neighbor_matrix_pbc_dual_cutoff(
     )
 
     if max_atoms_per_system is None:
+        if torch.compiler.is_compiling():
+            warnings.warn(
+                "Missing `max_atoms_per_system`; inferring it from `batch_ptr` "
+                "introduces a graph break under torch.compile. This will become "
+                "an error in a future release.",
+                FutureWarning,
+                stacklevel=2,
+            )
         max_atoms_per_system = (batch_ptr[1:] - batch_ptr[:-1]).max().item()
 
     wp_positions_wrapped = (
@@ -462,6 +472,14 @@ def _batch_naive_neighbor_matrix_pbc_dual_cutoff_selective(
     )
 
     if max_atoms_per_system is None:
+        if torch.compiler.is_compiling():
+            warnings.warn(
+                "Missing `max_atoms_per_system`; inferring it from `batch_ptr` "
+                "introduces a graph break under torch.compile. This will become "
+                "an error in a future release.",
+                FutureWarning,
+                stacklevel=2,
+            )
         max_atoms_per_system = (batch_ptr[1:] - batch_ptr[:-1]).max().item()
 
     batch_naive_neighbor_matrix_pbc_dual_cutoff(
@@ -857,6 +875,14 @@ def batch_naive_neighbor_list_dual_cutoff(
                 num_neighbors2,
             )
     else:
+        if max_atoms_per_system is None and torch.compiler.is_compiling():
+            warnings.warn(
+                "Missing `max_atoms_per_system`; inferring it from `batch_ptr` "
+                "introduces a graph break under torch.compile. This will become "
+                "an error in a future release.",
+                FutureWarning,
+                stacklevel=2,
+            )
         if rebuild_flags is not None:
             _batch_naive_neighbor_matrix_pbc_dual_cutoff_selective(
                 positions=positions,

--- a/nvalchemiops/torch/spline.py
+++ b/nvalchemiops/torch/spline.py
@@ -1155,7 +1155,7 @@ def _batch_spread_forward_launch(
     values: torch.Tensor,
     batch_idx: torch.Tensor,
     cell_inv_t: torch.Tensor,
-    num_systems: int,
+    num_systems: torch.SymInt,
     mesh_dims: tuple[int, int, int],
     spline_order: int,
 ) -> torch.Tensor:
@@ -1538,11 +1538,15 @@ def _batch_cell_inv_t_grad_from_force(
 
 # Batched spread + gather — same adjoint pattern as single-system, with
 # ``batch_idx`` (non-differentiable) at position 2. The batched spread
-# additionally carries an explicit ``num_systems: int`` arg at position 4
+# additionally carries an explicit ``num_systems: SymInt`` arg at position 4
 # (used to size the output mesh).
 register_warp_op_chain(
     name="nvalchemiops::batch_spline_spread",
     forward=_batch_spread_forward_launch,
+    forward_schema=(
+        "(Tensor positions, Tensor values, Tensor batch_idx, Tensor cell_inv_t, "
+        "SymInt num_systems, int[3] mesh_dims, int spline_order) -> Tensor"
+    ),
     forward_fake=lambda positions,
     values,
     batch_idx,
@@ -1709,7 +1713,7 @@ def _batch_spline_spread(
     values: torch.Tensor,
     batch_idx: torch.Tensor,
     cell: torch.Tensor,
-    num_systems: int,
+    num_systems: torch.SymInt,
     mesh_nx: int,
     mesh_ny: int,
     mesh_nz: int,

--- a/nvalchemiops/torch/spline.py
+++ b/nvalchemiops/torch/spline.py
@@ -1155,7 +1155,7 @@ def _batch_spread_forward_launch(
     values: torch.Tensor,
     batch_idx: torch.Tensor,
     cell_inv_t: torch.Tensor,
-    num_systems: torch.SymInt,
+    num_systems: int | torch.SymInt,
     mesh_dims: tuple[int, int, int],
     spline_order: int,
 ) -> torch.Tensor:
@@ -1713,7 +1713,7 @@ def _batch_spline_spread(
     values: torch.Tensor,
     batch_idx: torch.Tensor,
     cell: torch.Tensor,
-    num_systems: torch.SymInt,
+    num_systems: int | torch.SymInt,
     mesh_nx: int,
     mesh_ny: int,
     mesh_nz: int,

--- a/test/interactions/electrostatics/bindings/torch/test_dsf.py
+++ b/test/interactions/electrostatics/bindings/torch/test_dsf.py
@@ -35,6 +35,8 @@ Tests cover:
 
 from __future__ import annotations
 
+import warnings
+
 import pytest
 import torch
 
@@ -2196,6 +2198,39 @@ class TestTorchCompile:
         torch.testing.assert_close(energy_compiled, energy_eager, atol=1e-10, rtol=0.0)
         torch.testing.assert_close(forces_compiled, forces_eager, atol=1e-10, rtol=0.0)
         torch.testing.assert_close(cg_compiled, cg_eager, atol=1e-10, rtol=0.0)
+
+    def test_compiled_batch_system_inference_warns(self, device):
+        """Compiled batch-index system inference warns without changing values."""
+        positions = torch.tensor(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [4.0, 0.0, 0.0], [5.0, 0.0, 0.0]],
+            dtype=torch.float64,
+            device=device,
+        )
+        charges = torch.tensor(
+            [1.0, -1.0, 1.0, -1.0], dtype=torch.float64, device=device
+        )
+        batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=device)
+        neighbor_matrix = torch.tensor(
+            [[1], [0], [3], [2]], dtype=torch.int32, device=device
+        )
+        common = {
+            "cutoff": 2.0,
+            "alpha": 0.2,
+            "neighbor_matrix": neighbor_matrix,
+            "batch_idx": batch_idx,
+            "compute_forces": False,
+        }
+
+        eager = dsf_coulomb(positions, charges, **common)
+        compiled = torch.compile(dsf_coulomb)
+        with pytest.warns(FutureWarning, match="num_systems"):
+            inferred = compiled(positions, charges, **common)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            explicit = compiled(positions, charges, num_systems=2, **common)
+
+        torch.testing.assert_close(inferred[0], eager[0])
+        torch.testing.assert_close(explicit[0], eager[0])
 
 
 # ==============================================================================

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -40,6 +40,7 @@ import numpy as np
 import pytest
 import torch
 import warp as wp
+from torch.fx.experimental.proxy_tensor import make_fx
 from torchpme.lib.kvectors import _generate_kvectors as _generate_kvectors_torchpme
 
 from nvalchemiops.interactions.electrostatics._factory_common import _DerivState
@@ -47,6 +48,7 @@ from nvalchemiops.torch.interactions.electrostatics import (
     _ewald_real_chain,
     _ewald_recip_chain,
 )
+from nvalchemiops.torch.interactions.electrostatics import ewald as _ewald_module
 from nvalchemiops.torch.interactions.electrostatics.ewald import (
     ewald_real_space,
     ewald_reciprocal_space,
@@ -104,6 +106,17 @@ from test.interactions.electrostatics.conftest import (
 # Tolerances
 TIGHT_TOL = 1e-6
 LOOSE_TOL = 1e-4
+
+
+def test_compiled_single_system_atom_ranges_have_no_atomic_scatter():
+    """Concrete B=1 atom-range setup avoids segmented reduction in compiled graphs."""
+    batch_idx = torch.zeros(3, dtype=torch.long)
+    graph = make_fx(lambda indices: _ewald_module._atom_ranges(indices, 1))(batch_idx)
+
+    assert "index_add" not in graph.code
+    starts, ends = graph(batch_idx)
+    assert torch.equal(starts, torch.tensor([0], dtype=torch.int32))
+    assert torch.equal(ends, torch.tensor([3], dtype=torch.int32))
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
@@ -10783,6 +10796,59 @@ class TestMaxAtomsPerSystem:
             positions, charges, cell, k_vectors, alpha, batch_idx=batch_idx
         )
         assert inference_calls >= 1
+
+    def test_compiling_inference_warns_and_explicit_bound_does_not(self):
+        """Only the compiled launch-bound fallback emits its migration warning."""
+        atom_start = torch.tensor([0, 1], dtype=torch.int32)
+        atom_end = torch.tensor([1, 4], dtype=torch.int32)
+        compiled = torch.compile(_ewald_recip_chain._resolve_max_atoms_per_system)
+
+        with pytest.warns(FutureWarning, match="max_atoms_per_system"):
+            assert compiled(0, atom_start, atom_end, 4) == 3
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            assert compiled(3, atom_start, atom_end, 4) == 3
+
+
+class TestReciprocalSymbolicMakeFx:
+    """Symbolic tracing coverage for batched reciprocal Ewald."""
+
+    @staticmethod
+    def _inputs(batch_size: int) -> tuple[torch.Tensor, ...]:
+        positions = torch.arange(batch_size * 6, dtype=torch.float64).reshape(-1, 3)
+        positions = positions.mul(0.01).add(0.1)
+        charges = torch.linspace(-0.4, 0.4, batch_size * 2, dtype=torch.float64)
+        cell = torch.eye(3, dtype=torch.float64).expand(batch_size, -1, -1).clone()
+        batch_idx = torch.arange(batch_size, dtype=torch.int32).repeat_interleave(2)
+        alpha = torch.full((batch_size,), 0.35, dtype=torch.float64)
+        k_vectors = torch.tensor([[[1.0, 0.0, 0.0]]], dtype=torch.float64).expand(
+            batch_size, -1, -1
+        )
+        return positions, charges, cell, batch_idx, alpha, k_vectors
+
+    @pytest.mark.parametrize("energy_reduction", ["atom", "system"])
+    def test_symbolic_make_fx_is_batch_size_independent(self, energy_reduction):
+        """Symbolic reciprocal graphs are independent of the concrete batch size."""
+
+        def reciprocal(positions, charges, cell, batch_idx, alpha, k_vectors):
+            return ewald_reciprocal_space(
+                positions,
+                charges,
+                cell,
+                k_vectors,
+                alpha,
+                batch_idx=batch_idx,
+                max_atoms_per_system=2,
+                energy_reduction=energy_reduction,
+            )
+
+        args4 = self._inputs(4)
+        args5 = self._inputs(5)
+        traced4 = make_fx(reciprocal, tracing_mode="symbolic")(*args4)
+        traced5 = make_fx(reciprocal, tracing_mode="symbolic")(*args5)
+
+        assert traced4.code == traced5.code
+        torch.testing.assert_close(traced4(*args5), reciprocal(*args5))
 
 
 if __name__ == "__main__":

--- a/test/interactions/electrostatics/bindings/torch/test_multipole_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_multipole_pme.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import math
+import warnings
 
 import numpy as np
 import pytest
@@ -897,6 +898,50 @@ class TestEnergyCorrections:
             sf_b = _path_a_pack_source_feats(charges[mask], dipoles[mask])
             expected_b = _multipole_ewald_self_energy_per_atom(sf_b, sigma, alpha).sum()
             torch.testing.assert_close(per_sys[b], expected_b, rtol=1e-15, atol=1e-15)
+
+    def test_compiled_batched_system_inference_warns(self):
+        """Compiled correction fallbacks warn and explicit counts remain silent."""
+        td = (
+            torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
+        )
+        charges = torch.tensor([0.4, -0.1, 0.2, -0.3], dtype=torch.float64, device=td)
+        batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=td)
+        volume = torch.tensor([500.0, 600.0], dtype=torch.float64, device=td)
+        common = {
+            "dipoles": None,
+            "sigma": 1.0,
+            "alpha": 0.4,
+            "volume": volume,
+            "batch_idx": batch_idx,
+        }
+
+        eager = multipole_pme_energy_corrections(charges, **common)
+        eager_per_atom = multipole_pme_energy_corrections_per_atom(
+            charges, None, 1.0, 0.4, volume, batch_idx=batch_idx
+        )
+        compiled = torch.compile(multipole_pme_energy_corrections)
+        with pytest.warns(FutureWarning, match="n_systems"):
+            inferred = compiled(charges, **common)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            explicit = compiled(charges, n_systems=2, **common)
+
+        torch.testing.assert_close(inferred, eager)
+        torch.testing.assert_close(explicit, eager)
+
+        compiled_per_atom = torch.compile(multipole_pme_energy_corrections_per_atom)
+        with pytest.warns(FutureWarning, match="n_systems"):
+            inferred_per_atom = compiled_per_atom(
+                charges, None, 1.0, 0.4, volume, batch_idx=batch_idx
+            )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            explicit_per_atom = compiled_per_atom(
+                charges, None, 1.0, 0.4, volume, batch_idx=batch_idx, n_systems=2
+            )
+
+        torch.testing.assert_close(inferred_per_atom, eager_per_atom)
+        torch.testing.assert_close(explicit_per_atom, eager_per_atom)
 
 
 class TestEnergyCorrectionsPerAtom:

--- a/test/interactions/electrostatics/bindings/torch/test_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_pme.py
@@ -35,6 +35,7 @@ from importlib import import_module
 import pytest
 import torch
 import warp as wp
+from torch.fx.experimental.proxy_tensor import make_fx
 
 from nvalchemiops.torch.interactions.electrostatics import (
     compute_bspline_moduli_1d,
@@ -7492,6 +7493,68 @@ class TestDirectOutputDeprecation:
 
         energy = result[0] if isinstance(result, tuple) else result
         assert torch.isfinite(energy).all()
+
+
+class TestPMEReciprocalSymbolicMakeFx:
+    """Symbolic tracing coverage for batched reciprocal PME."""
+
+    @staticmethod
+    def _inputs(batch_size: int) -> tuple[torch.Tensor, ...]:
+        positions = torch.arange(batch_size * 6, dtype=torch.float64).reshape(-1, 3)
+        positions = positions.mul(0.01).add(0.1)
+        charges = torch.linspace(-0.4, 0.4, batch_size * 2, dtype=torch.float64)
+        cell = torch.eye(3, dtype=torch.float64).expand(batch_size, -1, -1).clone()
+        batch_idx = torch.arange(batch_size, dtype=torch.int32).repeat_interleave(2)
+        alpha = torch.full((batch_size,), 0.35, dtype=torch.float64)
+        return positions, charges, cell, batch_idx, alpha
+
+    @pytest.mark.parametrize("energy_reduction", ["atom", "system"])
+    def test_symbolic_make_fx_is_batch_size_independent(self, energy_reduction):
+        """Explicit mesh dimensions make symbolic PME traces shape-polymorphic."""
+
+        def reciprocal(positions, charges, cell, batch_idx, alpha):
+            return pme_reciprocal_space(
+                positions,
+                charges,
+                cell,
+                alpha,
+                mesh_dimensions=(4, 4, 4),
+                batch_idx=batch_idx,
+                energy_reduction=energy_reduction,
+            )
+
+        args4 = self._inputs(4)
+        args5 = self._inputs(5)
+        traced4 = make_fx(reciprocal, tracing_mode="symbolic")(*args4)
+        traced5 = make_fx(reciprocal, tracing_mode="symbolic")(*args5)
+
+        assert traced4.code == traced5.code
+        torch.testing.assert_close(traced4(*args5), reciprocal(*args5))
+
+    def test_compiling_mesh_spacing_warning(self):
+        """Compiled mesh-spacing setup warns while explicit dimensions do not."""
+        positions, charges, cell = create_simple_system(
+            torch.device("cpu"), num_atoms=4
+        )
+        compiled = torch.compile(pme_reciprocal_space)
+
+        with pytest.warns(FutureWarning, match="mesh_dimensions"):
+            compiled(
+                positions,
+                charges,
+                cell,
+                alpha=0.3,
+                mesh_spacing=2.0,
+            )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            compiled(
+                positions,
+                charges,
+                cell,
+                alpha=0.3,
+                mesh_dimensions=(4, 4, 4),
+            )
 
 
 if __name__ == "__main__":

--- a/test/neighbors/bindings/torch/test_batch_naive.py
+++ b/test/neighbors/bindings/torch/test_batch_naive.py
@@ -15,6 +15,7 @@
 
 """Tests for PyTorch bindings of batched naive neighbor list methods."""
 
+import warnings
 from unittest import mock
 
 import pytest
@@ -1454,7 +1455,77 @@ class TestBatchNaiveCompile:
             )
 
         eager = run(positions, *alloc_outputs())
-        compiled = torch.compile(run)(positions, *alloc_outputs())
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            compiled = torch.compile(run)(positions, *alloc_outputs())
+
+        compiled_matrix, compiled_counts, compiled_shifts = compiled
+        eager_matrix, eager_counts, eager_shifts = eager
+        assert torch.equal(compiled_counts, eager_counts)
+        for atom_index in range(fill_value):
+            assert _active_neighbor_shift_rows(
+                compiled_matrix,
+                compiled_shifts,
+                compiled_counts,
+                atom_index,
+            ) == _active_neighbor_shift_rows(
+                eager_matrix,
+                eager_shifts,
+                eager_counts,
+                atom_index,
+            )
+
+    @pytest.mark.slow
+    def test_compile_pbc_implicit_max_atoms_warns_and_matches_eager(
+        self, device, dtype
+    ):
+        """Compiled PBC fallback warns while retaining eager neighbor output."""
+        atoms_per_system = [5, 6]
+        positions, cell, pbc, _ = create_batch_systems(
+            num_systems=2, atoms_per_system=atoms_per_system, dtype=dtype, device=device
+        )
+        batch_idx, batch_ptr = create_batch_idx_and_ptr(atoms_per_system, device)
+        cutoff = 1.5
+        fill_value = positions.shape[0]
+        max_neighbors = 30
+        shift_range, num_shifts, max_shifts = compute_naive_num_shifts(
+            cell, cutoff, pbc
+        )
+
+        def alloc_outputs():
+            return (
+                torch.full(
+                    (fill_value, max_neighbors),
+                    fill_value,
+                    dtype=torch.int32,
+                    device=device,
+                ),
+                torch.zeros(fill_value, dtype=torch.int32, device=device),
+                torch.zeros(
+                    (fill_value, max_neighbors, 3), dtype=torch.int32, device=device
+                ),
+            )
+
+        def run(pos, neighbor_matrix, num_neighbors, neighbor_matrix_shifts):
+            return batch_naive_neighbor_list(
+                pos,
+                cutoff,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                pbc=pbc,
+                cell=cell,
+                fill_value=fill_value,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+                num_neighbors=num_neighbors,
+                shift_range_per_dimension=shift_range,
+                num_shifts_per_system=num_shifts,
+                max_shifts_per_system=max_shifts,
+            )
+
+        eager = run(positions, *alloc_outputs())
+        with pytest.warns(FutureWarning, match="max_atoms_per_system"):
+            compiled = torch.compile(run)(positions, *alloc_outputs())
 
         compiled_matrix, compiled_counts, compiled_shifts = compiled
         eager_matrix, eager_counts, eager_shifts = eager

--- a/test/neighbors/bindings/torch/test_batch_naive_dual_cutoff.py
+++ b/test/neighbors/bindings/torch/test_batch_naive_dual_cutoff.py
@@ -15,6 +15,8 @@
 
 """Tests for PyTorch bindings of batched naive dual cutoff neighbor list methods."""
 
+import warnings
+
 import pytest
 import torch
 
@@ -1230,7 +1232,9 @@ class TestBatchNaiveDualCutoffCompile:
             )
 
         eager = run(positions, *alloc_outputs())
-        compiled = torch.compile(run)(positions, *alloc_outputs())
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            compiled = torch.compile(run)(positions, *alloc_outputs())
 
         (
             compiled_nm1,
@@ -1265,4 +1269,95 @@ class TestBatchNaiveDualCutoffCompile:
                 eager_shifts2,
                 eager_nn2,
                 atom_index,
+            )
+
+    @pytest.mark.slow
+    def test_compile_pbc_implicit_max_atoms_warns_and_matches_eager(
+        self, device, dtype
+    ):
+        """Compiled dual-cutoff PBC fallback warns while retaining eager output."""
+        atoms_per_system = [5, 6]
+        positions, cell, pbc, _ = create_batch_systems(
+            num_systems=2, atoms_per_system=atoms_per_system, dtype=dtype, device=device
+        )
+        batch_idx, batch_ptr = create_batch_idx_and_ptr(atoms_per_system, device)
+        cutoff1 = 1.0
+        cutoff2 = 1.5
+        fill_value = positions.shape[0]
+        max_neighbors1 = 20
+        max_neighbors2 = 30
+        shift_range, num_shifts, max_shifts = compute_naive_num_shifts(
+            cell, cutoff2, pbc
+        )
+
+        def alloc_outputs():
+            return (
+                torch.full(
+                    (fill_value, max_neighbors1),
+                    fill_value,
+                    dtype=torch.int32,
+                    device=device,
+                ),
+                torch.zeros(fill_value, dtype=torch.int32, device=device),
+                torch.zeros(
+                    (fill_value, max_neighbors1, 3), dtype=torch.int32, device=device
+                ),
+                torch.full(
+                    (fill_value, max_neighbors2),
+                    fill_value,
+                    dtype=torch.int32,
+                    device=device,
+                ),
+                torch.zeros(fill_value, dtype=torch.int32, device=device),
+                torch.zeros(
+                    (fill_value, max_neighbors2, 3), dtype=torch.int32, device=device
+                ),
+            )
+
+        def run(pos, nm1, nn1, shifts1, nm2, nn2, shifts2):
+            return batch_naive_neighbor_list_dual_cutoff(
+                pos,
+                cutoff1,
+                cutoff2,
+                batch_idx=batch_idx,
+                batch_ptr=batch_ptr,
+                pbc=pbc,
+                cell=cell,
+                fill_value=fill_value,
+                neighbor_matrix1=nm1,
+                num_neighbors1=nn1,
+                neighbor_matrix_shifts1=shifts1,
+                neighbor_matrix2=nm2,
+                num_neighbors2=nn2,
+                neighbor_matrix_shifts2=shifts2,
+                shift_range_per_dimension=shift_range,
+                num_shifts_per_system=num_shifts,
+                max_shifts_per_system=max_shifts,
+            )
+
+        eager = run(positions, *alloc_outputs())
+        with pytest.warns(FutureWarning, match="max_atoms_per_system"):
+            compiled = torch.compile(run)(positions, *alloc_outputs())
+
+        (
+            compiled_nm1,
+            compiled_nn1,
+            compiled_shifts1,
+            compiled_nm2,
+            compiled_nn2,
+            compiled_shifts2,
+        ) = compiled
+        eager_nm1, eager_nn1, eager_shifts1, eager_nm2, eager_nn2, eager_shifts2 = eager
+        assert torch.equal(compiled_nn1, eager_nn1)
+        assert torch.equal(compiled_nn2, eager_nn2)
+        for atom_index in range(fill_value):
+            assert _active_neighbor_shift_rows(
+                compiled_nm1, compiled_shifts1, compiled_nn1, atom_index
+            ) == _active_neighbor_shift_rows(
+                eager_nm1, eager_shifts1, eager_nn1, atom_index
+            )
+            assert _active_neighbor_shift_rows(
+                compiled_nm2, compiled_shifts2, compiled_nn2, atom_index
+            ) == _active_neighbor_shift_rows(
+                eager_nm2, eager_shifts2, eager_nn2, atom_index
             )

--- a/test/neighbors/bindings/torch/test_cell_list.py
+++ b/test/neighbors/bindings/torch/test_cell_list.py
@@ -19,6 +19,7 @@ import pytest
 import torch
 
 from nvalchemiops.neighbors.neighbor_utils import estimate_max_neighbors
+from nvalchemiops.torch.neighbors.batch_cell_list import batch_cell_list
 from nvalchemiops.torch.neighbors.cell_list import (
     build_cell_list,
     cell_list,
@@ -897,6 +898,33 @@ class TestCellListAtomCentricPathEquivalence:
 
 class TestCellListCompile:
     """Tests for torch.compile compatibility."""
+
+    def test_missing_cache_compilation_warning(self, device, dtype):
+        """Implicit cell-list cache allocation warns only during compilation."""
+        if not str(device).startswith("cuda"):
+            pytest.skip("Pair-centric batch cell-list routing is CUDA-only")
+        positions = torch.tensor(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [0.0, 0.5, 0.0], [0.5, 0.5, 0.0]],
+            dtype=dtype,
+            device=device,
+        )
+        cell = torch.eye(3, dtype=dtype, device=device).expand(2, -1, -1).clone() * 4.0
+        pbc = torch.ones((2, 3), dtype=torch.bool, device=device)
+        batch_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=device)
+        common = {
+            "cutoff": 1.0,
+            "cell": cell,
+            "pbc": pbc,
+            "batch_idx": batch_idx,
+            "max_neighbors": 8,
+        }
+
+        eager = batch_cell_list(positions, strategy="pair_centric", **common)
+        compiled = torch.compile(batch_cell_list)
+        with pytest.warns(FutureWarning, match="cells_per_dimension"):
+            inferred = compiled(positions, strategy="pair_centric", **common)
+
+        torch.testing.assert_close(inferred[1], eager[1])
 
     @pytest.mark.slow
     def test_build_cell_list_compile(self, device, dtype):


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Under `torch.compile`, several batched operations were converting symbolic batch and atom counts into Python integers, while omitted sizing metadata could fall back to `.item()`, causing graph breaks and sometimes synchronizing the device. The patch carries these counts as `torch.SymInt` values through Ewald and PME, including multipole electrostatics, the shared electrostatics/autograd helpers, and the custom spline Warp operator. The patch also emits targeted `FutureWarning`s when DSF, PME mesh setup, reciprocal Ewald, or batched naive, dual-cutoff, and cell-list neighbor construction must infer missing system counts, mesh dimensions, maximum atom counts, or cache and allocation metadata in Python. Callers can supply the named metadata to keep compiled execution graph-safe before the compatibility fallbacks become errors.

Concrete single-system reduction, broadcast, and Ewald atom-range fast paths remain in place, and empty single-system means still return zeros.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #145.

## Changes Made

- Preserve symbolic system and atom counts through reciprocal Ewald, PME, spline, and shared electrostatics helpers.
- Warn during compilation when compatibility metadata is missing and Python inference introduces a graph break; the fallback will become an error in a future release.
- Preserve the concrete single-system reduction, broadcast, and atom-range fast paths, including zero-valued means for empty single-system inputs.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the documentation (if applicable)

## Additional Notes

The warning paths are compatibility fallbacks. Supplying the relevant explicit metadata keeps compiled execution graph-safe.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
