### PR TITLE
fix(electrostatics): retain Ewald Miller topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### Added
+
+- Torch and JAX Ewald now expose caller-retained reciprocal Miller topology via
+  `generate_ewald_miller_indices(...)` and
+  `k_vectors_from_miller_indices(...)`. Full `ewald_summation(...)` accepts
+  keyword-only `miller_indices=` and materializes Cartesian reciprocal vectors
+  from the current cell. Both backends provide
+  `ewald_reciprocal_space_from_miller_indices(...)` for the reciprocal
+  component. This avoids rebuilding the integer index grid while preserving
+  the reciprocal vectors' dependence on the current cell.
+
+### Fixed
+
+- Fixed JAX autodiff through `ewald_reciprocal_space(...)` when `k_vectors`
+  are derived from the differentiated cell. The custom JVP previously
+  discarded the `k_vectors` tangent and omitted the reciprocal-cell
+  contribution to the cell gradient. It now differentiates through the
+  supplied JAX graph, matching Torch. Cartesian vectors remain fixed only when
+  they have zero tangent in the active JAX transformation, for example when
+  precomputed from a reference cell or passed through
+  `jax.lax.stop_gradient(k_vectors)`. Full
+  `ewald_summation(k_vectors=...)` semantics are unchanged.
+
 ## 0.4.1 - 2026-08-03
 
 ### Added

--- a/docs/modules/jax/electrostatics.rst
+++ b/docs/modules/jax/electrostatics.rst
@@ -20,17 +20,28 @@ estimated from traced inputs. ``miller_bounds`` is also a static shape control:
 under ``jax.jit``, pass it as a concrete tuple or build ``k_vectors`` outside
 the compiled function.
 Energy derivatives are defined for positions, charges, and cell. Setup values
-such as ``alpha`` and mesh controls are constants; precomputed reciprocal
-metadata such as ``k_vectors``, ``k_squared``, ``volume``, and ``cell_inv_t`` is
-accepted for cell-differentiated calls as static metadata that is assumed to
-correspond to the current ``cell``; cache-generation derivatives are not
-recovered. Energy-returning Ewald, PME, and slab paths support atom-weighted
+such as ``alpha`` and mesh controls are constants. The lower-level
+``ewald_reciprocal_space`` component follows the tangent carried by its
+``k_vectors`` argument. Vectors constructed from ``cell`` in the traced
+computation therefore contribute their reciprocal-cell derivative. A
+precomputed array, or one passed through ``jax.lax.stop_gradient``, has zero
+tangent and is fixed for that differentiation. Full
+``ewald_summation(k_vectors=...)`` and PME precomputed metadata treat explicit
+vectors as static metadata. Use ``ewald_reciprocal_space_from_miller_indices``
+or ``ewald_summation(miller_indices=...)`` for retained topology materialized
+from the live cell. Energy-returning Ewald, PME, and slab paths support atom-weighted
 losses such as ``(weights * energies).sum()`` for positions, charges, and
 supported cell derivatives. Monopole entry points provide the keyword-only
 ``energy_reduction`` option. The default, ``"atom"``, returns one energy per
 atom with shape ``(N,)``. Set it to ``"system"`` to sum energies within each
 system and return shape ``(B,)``. Other requested outputs keep their existing
 shapes.
+For changing-cell full Ewald, retain signed Miller indices with
+``generate_ewald_miller_indices`` and pass them through ``ewald_summation``;
+the full-Ewald custom-JVP then includes the reciprocal-cell tangent. A retained
+topology must cover all intended cells. Enlarging it changes ``K`` and can
+trigger JIT recompilation. The legacy ``generate_miller_indices`` remains the
+batched bounds helper for static-shape JIT generation.
 JAX PME supports first-order cell/strain gradients,
 but PME cell/strain HVPs, including full PME with ``slab_correction=True``, are
 explicitly unsupported until a native transposable PME cell-HVP path is
@@ -57,6 +68,7 @@ Individual components of the Ewald summation method.
 
 .. autofunction:: ewald_real_space
 .. autofunction:: ewald_reciprocal_space
+.. autofunction:: ewald_reciprocal_space_from_miller_indices
 
 PME Components
 --------------
@@ -82,6 +94,8 @@ K-Vector Generation
 
 .. autofunction:: generate_miller_indices
 .. autofunction:: generate_k_vectors_ewald_summation
+.. autofunction:: generate_ewald_miller_indices
+.. autofunction:: k_vectors_from_miller_indices
 .. autofunction:: generate_k_vectors_pme
 
 Parameter Estimation

--- a/docs/modules/torch/electrostatics.rst
+++ b/docs/modules/torch/electrostatics.rst
@@ -11,13 +11,14 @@ DSF supports charge gradients via autograd; forces and virials are computed anal
 Setup parameters such as ``alpha``, cutoffs, mesh controls, batch metadata, and
 neighbor topology are treated as constants. On the full ``ewald_summation`` and
 ``particle_mesh_ewald`` APIs, cell-derived caches such as ``k_vectors``,
-``k_squared``, ``volume``, and ``cell_inv_t`` are accepted when
-``cell.requires_grad`` is true, but they are static metadata assumed to
-correspond to the current ``cell``; cache-generation derivatives are not
-recovered. The lower-level ``ewald_reciprocal_space`` component preserves a
-supplied ``k_vectors`` autograd graph when the cell also requires gradients;
-physical strain derivatives require vectors generated from the same
-differentiable cell. Energy-returning Ewald, PME, and slab paths support
+``k_squared``, ``volume``, and ``cell_inv_t`` are static metadata assumed to
+correspond to the current ``cell``. The lower-level
+``ewald_reciprocal_space`` component follows a ``k_vectors`` autograd edge
+from ``cell`` when one exists. For reusable changing-cell Ewald topology,
+retain signed Miller indices with ``generate_ewald_miller_indices`` and use
+``ewald_reciprocal_space_from_miller_indices`` or
+``ewald_summation(miller_indices=...)``. Energy-returning
+Ewald, PME, and slab paths support
 atom-weighted losses such as ``(weights * energies).sum()`` for positions,
 charges, and supported cell derivatives.
 
@@ -81,6 +82,7 @@ Individual components of the Ewald summation method.
 
 .. autofunction:: ewald_real_space
 .. autofunction:: ewald_reciprocal_space
+.. autofunction:: ewald_reciprocal_space_from_miller_indices
 
 PME Components
 --------------
@@ -94,6 +96,8 @@ K-Vector Generation
 -------------------
 
 .. autofunction:: generate_k_vectors_ewald_summation
+.. autofunction:: generate_ewald_miller_indices
+.. autofunction:: k_vectors_from_miller_indices
 .. autofunction:: generate_k_vectors_pme
 
 Parameter Estimation

--- a/docs/userguide/about/migration.md
+++ b/docs/userguide/about/migration.md
@@ -8,6 +8,44 @@ This guide lists user-visible migrations by release.
 
 ## Unreleased
 
+### Retained Ewald Miller Topology
+
+Torch and JAX can now retain integer Miller topology separately from Cartesian
+reciprocal vectors:
+
+```python
+miller_indices = generate_ewald_miller_indices(reference_cell, k_cutoff=8.0)
+energy = ewald_summation(
+    ...,
+    cell=current_cell,
+    alpha=alpha,
+    miller_indices=miller_indices,
+)
+```
+
+The generator returns positive-half-space integer rows inside conservative
+rectangular Miller bounds. It does not filter individual Cartesian-vector
+magnitudes. The caller owns the topology and must choose bounds that cover all
+intended cell states. Changing its size changes `K` and may recompile JAX.
+
+Both Torch and JAX backends also provide
+`ewald_reciprocal_space_from_miller_indices(...)`. It materializes Cartesian
+vectors from the supplied cell, then calls the reciprocal component. Torch
+retains its component-only `hybrid_forces` option; JAX does not expose it.
+
+JAX `ewald_reciprocal_space(...)` now follows the tangent carried by
+`k_vectors`. Earlier releases dropped that tangent even when vectors were
+constructed from the differentiated cell, so the cell gradient omitted the
+reciprocal-vector contribution. This is fixed. A vector is fixed only when it
+has zero tangent in the active transformation, for example when it was
+precomputed from a reference cell or passed through
+`jax.lax.stop_gradient(k_vectors)`. Matching numerical values alone do not
+create a dependency. Full `ewald_summation(k_vectors=...)` still treats
+explicit vectors as fixed metadata.
+
+A reciprocal-component cell derivative holds positions fixed. For a
+homogeneous-strain derivative, deform positions and cell together.
+
 ## v0.4.1: Energy Output Layout
 
 ### Energy Output Layout (`energy_reduction`)

--- a/nvalchemiops/jax/interactions/electrostatics/__init__.py
+++ b/nvalchemiops/jax/interactions/electrostatics/__init__.py
@@ -38,12 +38,15 @@ from nvalchemiops.jax.interactions.electrostatics.coulomb import (
 from nvalchemiops.jax.interactions.electrostatics.ewald import (
     ewald_real_space,
     ewald_reciprocal_space,
+    ewald_reciprocal_space_from_miller_indices,
     ewald_summation,
 )
 from nvalchemiops.jax.interactions.electrostatics.k_vectors import (
+    generate_ewald_miller_indices,
     generate_k_vectors_ewald_summation,
     generate_k_vectors_pme,
     generate_miller_indices,
+    k_vectors_from_miller_indices,
 )
 from nvalchemiops.jax.interactions.electrostatics.parameters import (
     EwaldParameters,
@@ -222,6 +225,7 @@ __all__ = [
     # Ewald
     "ewald_real_space",
     "ewald_reciprocal_space",
+    "ewald_reciprocal_space_from_miller_indices",
     "ewald_summation",
     # PME
     "particle_mesh_ewald",
@@ -231,9 +235,11 @@ __all__ = [
     "pme_energy_corrections_with_charge_grad",
     "compute_bspline_moduli_1d",
     # K-vectors
+    "generate_ewald_miller_indices",
     "generate_k_vectors_ewald_summation",
     "generate_k_vectors_pme",
     "generate_miller_indices",
+    "k_vectors_from_miller_indices",
     # Parameters
     "EwaldParameters",
     "PMEParameters",

--- a/nvalchemiops/jax/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/jax/interactions/electrostatics/ewald.py
@@ -75,6 +75,7 @@ from nvalchemiops.jax.interactions.electrostatics._utils import (
 )
 from nvalchemiops.jax.interactions.electrostatics.k_vectors import (
     generate_k_vectors_ewald_summation,
+    k_vectors_from_miller_indices,
 )
 from nvalchemiops.jax.interactions.electrostatics.parameters import (
     estimate_ewald_parameters,
@@ -90,6 +91,7 @@ from nvalchemiops.jax.interactions.electrostatics.slab import (
 __all__ = [
     "ewald_real_space",
     "ewald_reciprocal_space",
+    "ewald_reciprocal_space_from_miller_indices",
     "ewald_summation",
 ]
 
@@ -1106,6 +1108,49 @@ def _ewald_reciprocal_space_impl(
         num_k = k_vectors_cast.shape[0]
         num_systems = 1
 
+    if num_k == 0:
+        atom_system = (
+            jnp.zeros((num_atoms,), dtype=jnp.int32)
+            if batch_idx is None
+            else batch_idx.astype(jnp.int32)
+        )
+        energies = _reciprocal_space_energy_reference(
+            positions_cast,
+            charges_cast,
+            cell_cast,
+            k_vectors_cast,
+            alpha_arr,
+            batch_idx,
+        )
+        forces = jnp.zeros((num_atoms, 3), dtype=dtype) if compute_forces else None
+        charge_grads = None
+        if compute_charge_gradients:
+            atom_alpha = alpha_arr[atom_system]
+            charge_grads = -(
+                2.0 * atom_alpha * charges_cast / jnp.sqrt(PI)
+                + PI * total_charge_over_volume[atom_system] / (atom_alpha * atom_alpha)
+            )
+
+        virial = None
+        if compute_virial:
+            alpha_v = alpha_arr.astype(dtype)
+            e_bg = (
+                PI
+                * total_charge.astype(dtype) ** 2
+                / (2.0 * alpha_v**2 * volumes_for_background.astype(dtype))
+            )
+            virial = -e_bg[:, jnp.newaxis, jnp.newaxis] * jnp.eye(3, dtype=dtype)
+
+        return _build_electrostatic_result(
+            energies,
+            forces,
+            charge_grads,
+            virial,
+            compute_forces,
+            compute_charge_gradients,
+            compute_virial,
+        )
+
     # Allocate intermediate arrays for structure factors (always float64)
     if is_batched:
         cos_k_dot_r = jnp.zeros((num_k, num_atoms), dtype=jnp.float64)
@@ -1442,10 +1487,13 @@ def ewald_reciprocal_space(
     cell : jax.Array, shape (3, 3) or (B, 3, 3)
         Unit cell matrices. A 2-D input is promoted to (1, 3, 3) internally.
     k_vectors : jax.Array, shape (K, 3) or (B, K, 3)
-        Reciprocal-space lattice vectors. Gradients are stopped internally
-        so this argument must not depend on ``cell`` outside this function.
-        Use :func:`nvalchemiops.jax.interactions.electrostatics.ewald.ewald_summation`
-        for cell-differentiable k-vectors.
+        Reciprocal-space lattice vectors. Energy autodiff uses the tangent
+        carried by this argument. Vectors constructed from the differentiated
+        ``cell`` in the traced computation contribute their reciprocal-cell
+        derivative. A precomputed array, or one passed through
+        ``jax.lax.stop_gradient``, has zero tangent and is fixed with respect
+        to that differentiation. Matching values alone do not create a
+        dependency.
     alpha : float or jax.Array
         Ewald splitting parameter. A scalar float or array of shape (1,) or (B,).
     batch_idx : jax.Array or None, shape (N,), optional
@@ -1509,8 +1557,6 @@ def ewald_reciprocal_space(
             stacklevel=2,
         )
 
-    k_vectors = jax.lax.stop_gradient(k_vectors)
-
     if compute_forces or compute_charge_gradients or compute_virial:
         result = _ewald_reciprocal_space_impl(
             positions=positions,
@@ -1536,6 +1582,55 @@ def ewald_reciprocal_space(
         max_atoms_per_system,
     )
     return _apply_energy_reduction(result, energy_reduction, batch_idx, cell)
+
+
+def ewald_reciprocal_space_from_miller_indices(
+    positions: jax.Array,
+    charges: jax.Array,
+    cell: jax.Array,
+    miller_indices: jax.Array,
+    alpha: float | jax.Array,
+    batch_idx: jax.Array | None = None,
+    max_atoms_per_system: int | None = None,
+    compute_forces: bool = False,
+    compute_charge_gradients: bool = False,
+    compute_virial: bool = False,
+    *,
+    energy_reduction: Literal["atom", "system"] = "atom",
+) -> jax.Array | tuple[jax.Array, ...]:
+    """Compute the reciprocal component from retained Miller indices.
+
+    Materializes Cartesian vectors from the supplied ``cell``, then delegates
+    to :func:`ewald_reciprocal_space`. Direct outputs, return order, warnings,
+    and energy reduction match that component.
+
+    Parameters
+    ----------
+    positions, charges, cell, alpha, batch_idx, max_atoms_per_system,
+    compute_forces, compute_charge_gradients, compute_virial, energy_reduction
+        Match :func:`ewald_reciprocal_space`.
+    miller_indices : jax.Array, shape (K, 3)
+        Caller-retained signed integer topology. See
+        :func:`k_vectors_from_miller_indices` for its preconditions.
+
+    Returns
+    -------
+    jax.Array or tuple[jax.Array, ...]
+        Same result contract as :func:`ewald_reciprocal_space`.
+    """
+    return ewald_reciprocal_space(
+        positions=positions,
+        charges=charges,
+        cell=cell,
+        k_vectors=k_vectors_from_miller_indices(cell, miller_indices),
+        alpha=alpha,
+        batch_idx=batch_idx,
+        max_atoms_per_system=max_atoms_per_system,
+        compute_forces=compute_forces,
+        compute_charge_gradients=compute_charge_gradients,
+        compute_virial=compute_virial,
+        energy_reduction=energy_reduction,
+    )
 
 
 def _tangent_or_zeros(tangent, primal: jax.Array, dtype=None) -> jax.Array:
@@ -2556,7 +2651,7 @@ def _ewald_reciprocal_space_energy_jvp_rule(
         t_positions,
         t_charges,
         t_cell,
-        _t_k_vectors,
+        t_k_vectors,
         _t_alpha,
         _t_batch_idx,
     ) = tangents
@@ -2573,7 +2668,7 @@ def _ewald_reciprocal_space_energy_jvp_rule(
     tpos = _tangent_or_zeros(t_positions, positions, dtype=positions.dtype)
     tq = _tangent_or_zeros(t_charges, charges, dtype=charges.dtype)
     tcell = _tangent_or_zeros(t_cell, cell, dtype=cell.dtype)
-    tk = jnp.zeros_like(k_vectors)
+    tk = _tangent_or_zeros(t_k_vectors, k_vectors, dtype=k_vectors.dtype)
     charges_ref = charges.astype(jnp.float64)
     tq_ref = tq.astype(jnp.float64)
     _reference_out, tangent_out = jax.jvp(
@@ -2736,6 +2831,27 @@ _ewald_summation_energy_jvp.defjvp(
 )
 
 
+def _validate_ewald_topology_inputs(
+    k_vectors: jax.Array | None,
+    k_cutoff: float | jax.Array | None,
+    miller_bounds: tuple[int, int, int] | None,
+    miller_indices: jax.Array | None,
+) -> None:
+    """Validate that full Ewald receives one reciprocal-topology source."""
+    if k_vectors is not None and miller_indices is not None:
+        raise ValueError("k_vectors cannot be combined with miller_indices")
+    if miller_indices is not None:
+        if k_cutoff is not None or miller_bounds is not None or k_vectors is not None:
+            raise ValueError(
+                "miller_indices cannot be combined with k_vectors, k_cutoff, or "
+                "miller_bounds"
+            )
+        if miller_indices.ndim != 2 or miller_indices.shape[-1] != 3:
+            raise ValueError("miller_indices must have shape (K, 3)")
+        if not jnp.issubdtype(miller_indices.dtype, jnp.signedinteger):
+            raise ValueError("miller_indices must have a signed integer dtype")
+
+
 def _resolve_ewald_summation_parameters(
     positions: jax.Array,
     charges: jax.Array,
@@ -2744,11 +2860,13 @@ def _resolve_ewald_summation_parameters(
     k_vectors: jax.Array | None,
     k_cutoff: float | jax.Array | None,
     miller_bounds: tuple[int, int, int] | None,
+    miller_indices: jax.Array | None,
     batch_idx: jax.Array | None,
     accuracy: float,
 ) -> tuple[float | jax.Array, jax.Array]:
     """Resolve Ewald ``alpha`` and ``k_vectors`` once for forward/backward reuse."""
-    if alpha is None or k_cutoff is None:
+    needs_generated_vectors = k_vectors is None and miller_indices is None
+    if alpha is None or (needs_generated_vectors and k_cutoff is None):
         cell_3d = cell if cell.ndim == 3 else cell[jnp.newaxis, :, :]
         params = estimate_ewald_parameters(
             positions=positions,
@@ -2758,10 +2876,12 @@ def _resolve_ewald_summation_parameters(
         )
         if alpha is None:
             alpha = params.alpha
-        if k_cutoff is None:
+        if k_cutoff is None and needs_generated_vectors:
             k_cutoff = params.reciprocal_space_cutoff
 
-    if k_vectors is None:
+    if miller_indices is not None:
+        k_vectors = k_vectors_from_miller_indices(cell, miller_indices)
+    elif k_vectors is None:
         cell_3d = cell if cell.ndim == 3 else cell[jnp.newaxis, :, :]
         if k_cutoff is None:
             raise ValueError("k_cutoff must be provided if k_vectors is None")
@@ -2782,6 +2902,7 @@ def _ewald_summation_impl(
     k_vectors: jax.Array | None = None,
     k_cutoff: float | jax.Array | None = None,
     miller_bounds: tuple[int, int, int] | None = None,
+    miller_indices: jax.Array | None = None,
     batch_idx: jax.Array | None = None,
     max_atoms_per_system: int | None = None,
     neighbor_list: jax.Array | None = None,
@@ -2903,6 +3024,7 @@ def _ewald_summation_impl(
         k_vectors=k_vectors,
         k_cutoff=k_cutoff,
         miller_bounds=miller_bounds,
+        miller_indices=miller_indices,
         batch_idx=batch_idx,
         accuracy=accuracy,
     )
@@ -3061,9 +3183,14 @@ def ewald_summation(
     slab_correction: bool = False,
     *,
     miller_bounds: tuple[int, int, int] | None = None,
+    miller_indices: jax.Array | None = None,
     energy_reduction: Literal["atom", "system"] = "atom",
 ) -> jax.Array | tuple[jax.Array, ...]:
     """Compute complete Ewald summation.
+
+    Supply explicit ``k_vectors`` as fixed metadata, retained
+    ``miller_indices`` to materialize vectors from the current cell, or neither
+    to generate vectors from ``k_cutoff`` and optional ``miller_bounds``.
 
     Parameters
     ----------
@@ -3076,11 +3203,18 @@ def ewald_summation(
     alpha : float, jax.Array, or None, default=None
         Ewald splitting parameter. If ``None``, estimated automatically.
     k_vectors : jax.Array or None, default=None
-        Reciprocal lattice vectors. Generated from ``cell`` when omitted.
+        Explicit reciprocal vectors, treated as fixed metadata. When omitted,
+        vectors are generated from ``k_cutoff`` or materialized from
+        ``miller_indices``.
     k_cutoff : float, jax.Array, or None, default=None
-        K-space cutoff used when generating ``k_vectors``.
+        Reciprocal cutoff used only when generating vectors internally.
     miller_bounds : tuple[int, int, int] or None, default=None, keyword-only
-        Static Miller-index bounds for JIT-compatible k-vector generation.
+        Static Miller-index bounds used with internally generated vectors.
+        Ignored when explicit ``k_vectors`` are supplied for compatibility.
+    miller_indices : jax.Array or None, default=None, keyword-only
+        Caller-retained signed integer topology of shape ``(K, 3)``. Full
+        Ewald materializes vectors from the current cell. Do not combine it
+        with ``k_vectors``, ``k_cutoff``, or ``miller_bounds``.
     batch_idx : jax.Array or None, default=None
         System index for each atom. When provided, atoms must be grouped by
         system: ``batch_idx`` must be contiguous, nondecreasing, and use system
@@ -3143,6 +3277,12 @@ def ewald_summation(
     :func:`nvalchemiops.jax.interactions.electrostatics.k_vectors.generate_k_vectors_ewald_summation` : Generates k-vectors from cell and cutoff.
     """
     _validate_energy_reduction(energy_reduction)
+    _validate_ewald_topology_inputs(
+        k_vectors,
+        k_cutoff,
+        miller_bounds,
+        miller_indices,
+    )
     if compute_forces or compute_virial or compute_charge_gradients or hybrid_forces:
         warnings.warn(
             _direct_output_deprecation_msg("ewald_summation"),
@@ -3164,6 +3304,7 @@ def ewald_summation(
             k_vectors=k_vectors,
             k_cutoff=k_cutoff,
             miller_bounds=miller_bounds,
+            miller_indices=miller_indices,
             batch_idx=batch_idx,
             accuracy=accuracy,
         )
@@ -3206,6 +3347,7 @@ def ewald_summation(
             k_vectors=k_vectors,
             k_cutoff=k_cutoff,
             miller_bounds=miller_bounds,
+            miller_indices=miller_indices,
             batch_idx=batch_idx,
             max_atoms_per_system=max_atoms_per_system,
             neighbor_list=neighbor_list,
@@ -3233,6 +3375,7 @@ def ewald_summation(
         k_vectors=k_vectors,
         k_cutoff=k_cutoff,
         miller_bounds=miller_bounds,
+        miller_indices=miller_indices,
         batch_idx=batch_idx,
         accuracy=accuracy,
     )

--- a/nvalchemiops/jax/interactions/electrostatics/k_vectors.py
+++ b/nvalchemiops/jax/interactions/electrostatics/k_vectors.py
@@ -22,9 +22,11 @@ PI = math.pi
 TWOPI = 2.0 * PI
 
 __all__ = [
+    "generate_ewald_miller_indices",
     "generate_k_vectors_ewald_summation",
     "generate_k_vectors_pme",
     "generate_miller_indices",
+    "k_vectors_from_miller_indices",
 ]
 
 
@@ -75,16 +77,18 @@ def generate_miller_indices(
 _generate_miller_indices = generate_miller_indices
 
 
-def generate_k_vectors_ewald_summation(
+def generate_ewald_miller_indices(
     cell: jax.Array,
     k_cutoff: float | jax.Array,
     miller_bounds: tuple[int, int, int] | None = None,
 ) -> jax.Array:
-    r"""Generate reciprocal lattice vectors for Ewald summation (half-space).
+    r"""Generate the positive-half-space Miller topology for Ewald summation.
 
-    Creates k-vectors within the specified cutoff for the reciprocal space
-    summation in the Ewald method. Uses half-space optimization to reduce
-    computational cost by approximately 2x.
+    Derives conservative rectangular Miller bounds from ``k_cutoff`` for the
+    reciprocal-space Ewald sum. Supplying ``miller_bounds`` instead enumerates
+    that rectangle directly; neither mode applies a per-vector magnitude
+    filter. Uses half-space optimization to reduce computational cost by
+    approximately 2x.
 
     Half-Space Optimization
     -----------------------
@@ -127,33 +131,28 @@ def generate_k_vectors_ewald_summation(
         Unit cell matrix with lattice vectors as rows.
         Shape (3, 3) for single system or (B, 3, 3) for batch.
     k_cutoff : float or jax.Array
-        Maximum magnitude of k-vectors to include (:math:`|\mathbf{k}| \leq k_{\text{cutoff}}`).
-        Typical values: 8-12 :math:`\text{\AA}^{-1}` for molecular systems.
-        Higher values increase accuracy but also computational cost.
+        Reciprocal cutoff used to derive conservative per-axis Miller bounds.
+        The resulting rectangular topology can contain vectors whose magnitude
+        exceeds this value.
     miller_bounds : tuple[int, int, int] | None, optional
-        Precomputed maximum Miller indices (M_h, M_k, M_l) for each lattice
-        direction. When provided, the function skips the internal computation
-        of bounds from ``cell`` and ``k_cutoff``, making it compatible with
-        ``jax.jit`` (which requires static array shapes).
-        Use :func:`generate_miller_indices` to compute these bounds eagerly
-        before entering a JIT context. When ``None`` (default), bounds are
-        computed automatically from ``cell`` and ``k_cutoff``.
+        Explicit Miller half-bounds ``(M_h, M_k, M_l)``. When supplied, their
+        rectangle is enumerated directly and ``k_cutoff`` does not select
+        individual rows. Use the legacy :func:`generate_miller_indices` bounds
+        helper before ``jax.jit``; it returns bounds, not full index rows.
 
     Returns
     -------
     jax.Array
-        Reciprocal lattice vectors within the cutoff.
-        Shape (K, 3) for single system or (B, K, 3) for batch.
-        Excludes k=0 and includes only half-space vectors.
+        Signed integer Miller indices of shape ``(K, 3)``. The rows are
+        nonzero, unique, and in the positive half-space.
 
     Examples
     --------
     Single system with explicit k_cutoff::
 
         >>> cell = jnp.eye(3, dtype=jnp.float64) * 10.0
-        >>> k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=8.0)
-        >>> k_vectors.shape
-        (...)  # Number depends on cell size and cutoff
+        >>> indices = generate_ewald_miller_indices(cell, k_cutoff=8.0)
+        >>> k_vectors = k_vectors_from_miller_indices(cell, indices)
 
     With automatic parameter estimation::
 
@@ -182,16 +181,11 @@ def generate_k_vectors_ewald_summation(
       as a concrete ``tuple[int, int, int]``. The bounds determine array shapes
       (via ``jnp.arange``), which must be statically known at trace time.
 
-    See Also
-    --------
-    ewald_reciprocal_space : Uses these k-vectors for reciprocal space energy.
-    estimate_ewald_parameters : Automatic parameter estimation including k_cutoff.
-    generate_miller_indices : Compute Miller bounds for JIT-compatible usage.
+    A retained topology must conservatively cover every cell state in which it
+    will be used. Enlarging it changes ``K`` and can recompile ``jax.jit``.
     """
     if cell.ndim == 2:
         cell = cell[None, ...]
-    dtype = cell.dtype
-
     # Get max Miller indices per direction: M_h, M_k, M_l
     if miller_bounds is not None:
         M_h, M_k, M_l = miller_bounds
@@ -203,21 +197,21 @@ def generate_k_vectors_ewald_summation(
 
     # Build half-space Miller indices directly (no boolean masking)
     # Block 1: h in [1, M_h], k in [-M_k, M_k], l in [-M_l, M_l]
-    h1 = jnp.arange(1, M_h + 1, dtype=dtype)
-    k1 = jnp.arange(-M_k, M_k + 1, dtype=dtype)
-    l1 = jnp.arange(-M_l, M_l + 1, dtype=dtype)
+    h1 = jnp.arange(1, M_h + 1, dtype=jnp.int32)
+    k1 = jnp.arange(-M_k, M_k + 1, dtype=jnp.int32)
+    l1 = jnp.arange(-M_l, M_l + 1, dtype=jnp.int32)
     h1_grid, k1_grid, l1_grid = jnp.meshgrid(h1, k1, l1, indexing="ij")
     block1 = jnp.stack(
         [h1_grid.reshape(-1), k1_grid.reshape(-1), l1_grid.reshape(-1)], axis=1
     )
 
     # Block 2: h = 0, k in [1, M_k], l in [-M_l, M_l]
-    k2 = jnp.arange(1, M_k + 1, dtype=dtype)
-    l2 = jnp.arange(-M_l, M_l + 1, dtype=dtype)
+    k2 = jnp.arange(1, M_k + 1, dtype=jnp.int32)
+    l2 = jnp.arange(-M_l, M_l + 1, dtype=jnp.int32)
     k2_grid, l2_grid = jnp.meshgrid(k2, l2, indexing="ij")
     block2 = jnp.stack(
         [
-            jnp.zeros(k2_grid.size, dtype=dtype),
+            jnp.zeros(k2_grid.size, dtype=jnp.int32),
             k2_grid.reshape(-1),
             l2_grid.reshape(-1),
         ],
@@ -225,23 +219,53 @@ def generate_k_vectors_ewald_summation(
     )
 
     # Block 3: h = 0, k = 0, l in [1, M_l]
-    l3 = jnp.arange(1, M_l + 1, dtype=dtype)
+    l3 = jnp.arange(1, M_l + 1, dtype=jnp.int32)
     block3 = jnp.stack(
-        [jnp.zeros(l3.size, dtype=dtype), jnp.zeros(l3.size, dtype=dtype), l3],
+        [jnp.zeros(l3.size, dtype=jnp.int32), jnp.zeros(l3.size, dtype=jnp.int32), l3],
         axis=1,
     )
 
-    # Concatenate all blocks
-    miller_indices = jnp.concatenate([block1, block2, block3], axis=0)
+    return jnp.concatenate([block1, block2, block3], axis=0)
 
-    # Compute reciprocal lattice vectors (2π times reciprocal of direct lattice)
-    reciprocal_cell = TWOPI * jnp.linalg.inv(
-        jnp.swapaxes(cell, -2, -1)
-    )  # Transpose for column vectors
+
+def k_vectors_from_miller_indices(
+    cell: jax.Array,
+    miller_indices: jax.Array,
+) -> jax.Array:
+    """Materialize reciprocal vectors from caller-retained Miller indices.
+
+    The supplied ``cell`` defines the live reciprocal transform. ``miller_indices``
+    must be a signed integer array of shape ``(K, 3)``; ``(0, 3)`` is valid.
+    Duplicate rows, zero rows, and half-space membership are caller
+    preconditions and are not checked. :func:`generate_ewald_miller_indices`
+    produces valid topology. The result has shape ``(K, 3)`` for one cell or
+    ``(B, K, 3)`` for a batch.
+    """
+    if cell.ndim not in (2, 3) or cell.shape[-2:] != (3, 3):
+        raise ValueError("cell must have shape (3, 3) or (B, 3, 3)")
+    if miller_indices.ndim != 2 or miller_indices.shape[-1] != 3:
+        raise ValueError("miller_indices must have shape (K, 3)")
+    if not jnp.issubdtype(miller_indices.dtype, jnp.signedinteger):
+        raise ValueError("miller_indices must have a signed integer dtype")
+    if cell.ndim == 2:
+        cell = cell[None, ...]
+    reciprocal_cell = TWOPI * jnp.linalg.inv(jnp.swapaxes(cell, -2, -1))
     k_vectors = miller_indices.astype(reciprocal_cell.dtype) @ reciprocal_cell
     if k_vectors.shape[0] == 1:
         return jnp.squeeze(k_vectors, axis=0)
     return k_vectors
+
+
+def generate_k_vectors_ewald_summation(
+    cell: jax.Array,
+    k_cutoff: float | jax.Array,
+    miller_bounds: tuple[int, int, int] | None = None,
+) -> jax.Array:
+    """Generate reciprocal lattice vectors for Ewald summation (half-space)."""
+    return k_vectors_from_miller_indices(
+        cell,
+        generate_ewald_miller_indices(cell, k_cutoff, miller_bounds),
+    )
 
 
 def generate_k_vectors_pme(

--- a/nvalchemiops/torch/interactions/electrostatics/__init__.py
+++ b/nvalchemiops/torch/interactions/electrostatics/__init__.py
@@ -39,11 +39,14 @@ from nvalchemiops.torch.interactions.electrostatics.dsf import (
 from nvalchemiops.torch.interactions.electrostatics.ewald import (
     ewald_real_space,
     ewald_reciprocal_space,
+    ewald_reciprocal_space_from_miller_indices,
     ewald_summation,
 )
 from nvalchemiops.torch.interactions.electrostatics.k_vectors import (
+    generate_ewald_miller_indices,
     generate_k_vectors_ewald_summation,
     generate_k_vectors_pme,
+    k_vectors_from_miller_indices,
 )
 from nvalchemiops.torch.interactions.electrostatics.multipole_electrostatics import (
     multipole_electrostatic_energy,
@@ -167,6 +170,7 @@ __all__ = [
     # Ewald
     "ewald_real_space",
     "ewald_reciprocal_space",
+    "ewald_reciprocal_space_from_miller_indices",
     "ewald_summation",
     # Slab correction (Yeh-Berkowitz / Ballenegger Eq. 29)
     "compute_slab_correction",
@@ -178,8 +182,10 @@ __all__ = [
     "pme_green_structure_factor",
     "compute_bspline_moduli_1d",
     # K-vectors
+    "generate_ewald_miller_indices",
     "generate_k_vectors_ewald_summation",
     "generate_k_vectors_pme",
+    "k_vectors_from_miller_indices",
     # Multipole moments packing (e3nn <-> Cartesian)
     "pack_multipole_moments",
     "infer_l_max",

--- a/nvalchemiops/torch/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/ewald.py
@@ -122,6 +122,7 @@ from nvalchemiops.torch.interactions.electrostatics._util import (
 )
 from nvalchemiops.torch.interactions.electrostatics.k_vectors import (
     generate_k_vectors_ewald_summation,
+    k_vectors_from_miller_indices,
 )
 from nvalchemiops.torch.interactions.electrostatics.parameters import (
     estimate_ewald_parameters,
@@ -133,6 +134,7 @@ from nvalchemiops.torch.interactions.electrostatics.slab import (
 __all__ = [
     "ewald_real_space",
     "ewald_reciprocal_space",
+    "ewald_reciprocal_space_from_miller_indices",
     "ewald_summation",
 ]
 
@@ -201,6 +203,35 @@ def _prepare_cell(cell: torch.Tensor) -> tuple[torch.Tensor, int]:
     if cell.dim() == 2:
         cell = cell.unsqueeze(0)
     return cell, cell.shape[0]
+
+
+def _validate_ewald_topology_inputs(
+    cell: torch.Tensor,
+    k_vectors: torch.Tensor | None,
+    k_cutoff: float | None,
+    miller_bounds: tuple[int, int, int] | torch.Tensor | None,
+    miller_indices: torch.Tensor | None,
+) -> None:
+    """Validate that full Ewald receives one reciprocal-topology source."""
+    if k_vectors is not None and miller_indices is not None:
+        raise ValueError("k_vectors cannot be combined with miller_indices")
+    if miller_indices is not None:
+        if k_cutoff is not None or miller_bounds is not None or k_vectors is not None:
+            raise ValueError(
+                "miller_indices cannot be combined with k_vectors, k_cutoff, or "
+                "miller_bounds"
+            )
+        if miller_indices.ndim != 2 or miller_indices.shape[-1] != 3:
+            raise ValueError("miller_indices must have shape (K, 3)")
+        if miller_indices.dtype not in {
+            torch.int8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+        }:
+            raise ValueError("miller_indices must have a signed integer dtype")
+        if cell.device != miller_indices.device:
+            raise ValueError("cell and miller_indices must be on the same device")
 
 
 ###########################################################################################
@@ -1243,11 +1274,10 @@ def ewald_reciprocal_space(
         Unit cell matrices.
     k_vectors : torch.Tensor
         Reciprocal lattice vectors. Shape (K, 3) for single system, (B, K, 3) for batch.
-        When both ``cell`` and ``k_vectors`` require gradients, the supplied
-        k-vector graph is preserved. Physical strain derivatives require vectors
-        generated from the same differentiable cell. Non-differentiable vectors,
-        and grad-bearing leaf vectors without a cell edge, are fixed Cartesian
-        metadata for cell derivatives.
+        If these vectors are computed from the differentiated ``cell`` without
+        detaching them, autograd follows that graph edge. A precomputed or
+        detached tensor has no cell edge and is fixed with respect to the cell
+        derivative.
     alpha : torch.Tensor, shape (1,) or (B,)
         Ewald splitting parameter(s).
     batch_idx : torch.Tensor, shape (N,), optional
@@ -1300,10 +1330,10 @@ def ewald_reciprocal_space(
     Energies are always float64 for numerical stability during accumulation.
     Forces, virial, and charge gradients match the input dtype (float32 or float64).
     For eager execution, a differentiable ``cell`` paired with fixed Cartesian
-    ``k_vectors`` emits a warning because its cell derivative is not the physical
-    Ewald strain virial. This advisory warning is suppressed under
-    ``torch.compile``. Generate vectors from the differentiable cell with fixed
-    Miller bounds for physical strain derivatives.
+    ``k_vectors`` emits a warning because its cell derivative omits the
+    reciprocal-vector dependence. This advisory warning is suppressed under
+    ``torch.compile``. A component cell derivative holds positions fixed; for a
+    homogeneous-strain derivative, deform positions and cell together.
 
     When ``charges`` is a non-leaf tensor that may depend on ``positions``
     (:math:`q = q(R)`), ordinary first-order losses may use cached partial
@@ -1347,6 +1377,43 @@ def ewald_reciprocal_space(
         hybrid_forces=hybrid_forces,
         allow_cell_grad_with_k_vectors=allow_cell_grad_with_k_vectors,
         preserve_k_vector_grad=allow_cell_grad_with_k_vectors,
+        max_atoms_per_system=max_atoms_per_system,
+        energy_reduction=energy_reduction,
+    )
+
+
+def ewald_reciprocal_space_from_miller_indices(
+    positions: torch.Tensor,
+    charges: torch.Tensor,
+    cell: torch.Tensor,
+    miller_indices: torch.Tensor,
+    alpha: torch.Tensor,
+    batch_idx: torch.Tensor | None = None,
+    compute_forces: bool = False,
+    compute_charge_gradients: bool = False,
+    compute_virial: bool = False,
+    hybrid_forces: bool = False,
+    *,
+    max_atoms_per_system: int | None = None,
+    energy_reduction: Literal["atom", "system"] = "atom",
+) -> torch.Tensor | tuple[torch.Tensor, ...]:
+    """Compute the reciprocal component from retained Miller indices.
+
+    Materializes Cartesian vectors from the supplied ``cell``, then delegates
+    to :func:`ewald_reciprocal_space`. Direct outputs, return order,
+    deprecation behavior, and energy reduction match that component.
+    """
+    return ewald_reciprocal_space(
+        positions=positions,
+        charges=charges,
+        cell=cell,
+        k_vectors=k_vectors_from_miller_indices(cell, miller_indices),
+        alpha=alpha,
+        batch_idx=batch_idx,
+        compute_forces=compute_forces,
+        compute_charge_gradients=compute_charge_gradients,
+        compute_virial=compute_virial,
+        hybrid_forces=hybrid_forces,
         max_atoms_per_system=max_atoms_per_system,
         energy_reduction=energy_reduction,
     )
@@ -1707,6 +1774,7 @@ def ewald_summation(
     slab_correction: bool = False,
     *,
     miller_bounds: tuple[int, int, int] | torch.Tensor | None = None,
+    miller_indices: torch.Tensor | None = None,
     max_atoms_per_system: int | None = None,
     energy_reduction: Literal["atom", "system"] = "atom",
 ) -> tuple[torch.Tensor, ...] | torch.Tensor:
@@ -1714,6 +1782,9 @@ def ewald_summation(
 
     Computes total Coulomb energy by combining real-space and reciprocal-space
     contributions with self-energy and background corrections.
+    Supply explicit ``k_vectors`` as fixed metadata, retained
+    ``miller_indices`` to materialize vectors from the current cell, or neither
+    to generate vectors from ``k_cutoff`` and optional ``miller_bounds``.
 
     Parameters
     ----------
@@ -1726,17 +1797,18 @@ def ewald_summation(
     alpha : float, torch.Tensor, or None, default=None
         Ewald splitting parameter. Auto-estimated if None.
     k_vectors : torch.Tensor, optional
-        Pre-computed reciprocal lattice vectors for fixed-cell reuse.
-        Caller-supplied vectors are static metadata assumed to correspond to the
-        current ``cell``; cache-generation derivatives are not recovered. For
-        physical cell/strain derivatives, omit ``k_vectors`` so vectors are
-        regenerated from the differentiable ``cell``.
+        Explicit reciprocal vectors, treated as fixed metadata. When omitted,
+        vectors are generated from ``k_cutoff`` or materialized from
+        ``miller_indices``.
     k_cutoff : float, optional
-        K-space cutoff for generating k_vectors.
+        Reciprocal cutoff used only when generating vectors internally.
     miller_bounds : tuple[int, int, int] or torch.Tensor, optional, keyword-only
-        Precomputed Miller-index half-bounds used when ``k_vectors`` is not
-        supplied. Passing Python integer bounds avoids deriving range sizes from
-        device tensors inside regenerated-k-vector loops.
+        Miller half-bounds used with internally generated vectors. Ignored when
+        explicit ``k_vectors`` are supplied for compatibility.
+    miller_indices : torch.Tensor, optional, keyword-only
+        Caller-retained signed integer topology of shape ``(K, 3)``. Full Ewald
+        materializes vectors from the current ``cell``. Do not combine it with
+        ``k_vectors``, ``k_cutoff``, or ``miller_bounds``.
     max_atoms_per_system : int, optional, keyword-only
         Maximum number of atoms in any single system when ``batch_idx`` is
         provided. See :func:`ewald_reciprocal_space` for the sync-free launch
@@ -1858,6 +1930,13 @@ def ewald_summation(
         ... )
     """
     _validate_energy_reduction(energy_reduction)
+    _validate_ewald_topology_inputs(
+        cell,
+        k_vectors,
+        k_cutoff,
+        miller_bounds,
+        miller_indices,
+    )
     if compute_forces or compute_virial or compute_charge_gradients or hybrid_forces:
         if torch.compiler.is_compiling():
             _compiled_direct_output_deprecation_signal("ewald_summation")
@@ -1874,11 +1953,13 @@ def ewald_summation(
 
     cell, num_systems = _prepare_cell(cell)
 
-    if alpha is None or (k_cutoff is None and k_vectors is None):
+    if alpha is None or (
+        k_cutoff is None and k_vectors is None and miller_indices is None
+    ):
         params = estimate_ewald_parameters(positions, cell, batch_idx, accuracy)
         if alpha is None:
             alpha = params.alpha
-        if k_cutoff is None:
+        if k_cutoff is None and miller_indices is None:
             k_cutoff = params.reciprocal_space_cutoff
 
     alpha_tensor = _detach_setup_tensor(
@@ -1886,7 +1967,9 @@ def ewald_summation(
     )
 
     generated_k_vectors = k_vectors is None
-    if k_vectors is None:
+    if miller_indices is not None:
+        k_vectors = k_vectors_from_miller_indices(cell, miller_indices)
+    elif k_vectors is None:
         k_vectors = generate_k_vectors_ewald_summation(
             cell, k_cutoff, miller_bounds=miller_bounds
         )

--- a/nvalchemiops/torch/interactions/electrostatics/k_vectors.py
+++ b/nvalchemiops/torch/interactions/electrostatics/k_vectors.py
@@ -20,6 +20,13 @@ import torch
 PI = math.pi
 TWOPI = 2.0 * PI
 
+__all__ = [
+    "generate_ewald_miller_indices",
+    "generate_k_vectors_ewald_summation",
+    "generate_k_vectors_pme",
+    "k_vectors_from_miller_indices",
+]
+
 
 def _prepare_k_cutoff(
     cell: torch.Tensor,
@@ -58,16 +65,51 @@ def _generate_miller_indices(
     return torch.ceil(shared_k_cutoff * cell_lengths).long()
 
 
-def generate_k_vectors_ewald_summation(
+def _ewald_miller_grid(
+    cell: torch.Tensor,
+    k_cutoff: float | torch.Tensor,
+    miller_bounds: tuple[int, int, int] | torch.Tensor | None,
+) -> torch.Tensor:
+    """Build the legacy floating-point FFT-grid Miller representation."""
+    if cell.ndim == 2:
+        cell = cell.unsqueeze(0)
+    device = cell.device
+    dtype = cell.dtype
+    if miller_bounds is None:
+        max_h, max_k, max_l = 2 * _generate_miller_indices(cell, k_cutoff) + 1
+    else:
+        if isinstance(miller_bounds, torch.Tensor):
+            if miller_bounds.numel() != 3:
+                raise ValueError("miller_bounds tensor must contain exactly 3 values")
+            bounds = tuple(int(v) for v in miller_bounds.reshape(3).tolist())
+        else:
+            if len(miller_bounds) != 3:
+                raise ValueError("miller_bounds must contain exactly 3 values")
+            bounds = tuple(int(v) for v in miller_bounds)
+        max_h, max_k, max_l = (2 * bounds[0] + 1, 2 * bounds[1] + 1, 2 * bounds[2] + 1)
+
+    h_range = torch.fft.fftfreq(max_h, device=device, dtype=dtype) * max_h
+    k_range = torch.fft.fftfreq(max_k, device=device, dtype=dtype) * max_k
+    l_range = torch.fft.fftfreq(max_l, device=device, dtype=dtype) * max_l
+    h_grid, k_grid, l_grid = torch.meshgrid(h_range, k_range, l_range, indexing="ij")
+    miller_grid = torch.stack(
+        [h_grid.flatten(), k_grid.flatten(), l_grid.flatten()], dim=1
+    )
+    h, k, m = miller_grid.unbind(dim=1)
+    halfspace_mask = (h > 0) | ((h == 0) & (k > 0)) | ((h == 0) & (k == 0) & (m > 0))
+    return miller_grid[halfspace_mask]
+
+
+def generate_ewald_miller_indices(
     cell: torch.Tensor,
     k_cutoff: float | torch.Tensor,
     miller_bounds: tuple[int, int, int] | torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Generate reciprocal lattice vectors for Ewald summation (half-space).
+    """Generate the positive-half-space Miller topology for Ewald summation.
 
-    Creates k-vectors within the specified cutoff for the reciprocal space
-    summation in the Ewald method. Uses half-space optimization to reduce
-    computational cost by approximately 2x.
+    The returned signed integer rows are caller-owned topology. They can be
+    retained across cell updates and transformed with
+    :func:`k_vectors_from_miller_indices`.
 
     Half-Space Optimization
     -----------------------
@@ -110,32 +152,28 @@ def generate_k_vectors_ewald_summation(
         Unit cell matrix with lattice vectors as rows.
         Shape (3, 3) for single system or (B, 3, 3) for batch.
     k_cutoff : float or torch.Tensor
-        Maximum magnitude of k-vectors to include (:math:`|\\mathbf{k}| \\leq k_{\\text{cutoff}}`).
-        Typical values: 8-12 :math:`\\text{\\AA}^{-1}` for molecular systems.
-        Higher values increase accuracy but also computational cost.
+        Reciprocal cutoff used to derive conservative per-axis Miller bounds.
+        The resulting rectangular topology can contain vectors whose magnitude
+        exceeds this value.
     miller_bounds : tuple[int, int, int] or torch.Tensor, optional
-        Precomputed Miller-index half-bounds as returned by
-        :func:`_generate_miller_indices`. Supplying Python integer bounds skips
-        the device-to-host synchronization needed to derive FFT range sizes from
-        ``cell`` and ``k_cutoff`` inside tight regenerated-k-vector loops. Tensor
-        bounds are accepted for convenience but are read back to Python integers
-        during setup.
+        Explicit Miller half-bounds ``(M_h, M_k, M_l)``. When supplied, their
+        rectangle is enumerated directly and ``k_cutoff`` does not select
+        individual rows. Python integer bounds avoid deriving range sizes from
+        device tensors; tensor bounds are accepted for convenience.
 
     Returns
     -------
     torch.Tensor
-        Reciprocal lattice vectors within the cutoff.
-        Shape (K, 3) for single system or (B, K, 3) for batch.
-        Excludes k=0 and includes only half-space vectors.
+        Signed integer Miller indices of shape ``(K, 3)``. The rows are
+        nonzero, unique, and in the positive half-space.
 
     Examples
     --------
     Single system with explicit k_cutoff::
 
         >>> cell = torch.eye(3, dtype=torch.float64) * 10.0
-        >>> k_vectors = generate_k_vectors_ewald_summation(cell, k_cutoff=8.0)
-        >>> k_vectors.shape
-        torch.Size([...])  # Number depends on cell size and cutoff
+        >>> indices = generate_ewald_miller_indices(cell, k_cutoff=8.0)
+        >>> k_vectors = k_vectors_from_miller_indices(cell, indices)
 
     With automatic parameter estimation::
 
@@ -145,62 +183,80 @@ def generate_k_vectors_ewald_summation(
 
     Notes
     -----
-    - The k=0 vector is always excluded (causes division by zero in Green's function).
-    - For batch mode, the same set of Miller indices is used for all systems but
-      transformed using each system's reciprocal cell. If ``k_cutoff`` is given
-      per system, the maximum cutoff across the batch determines the shared
-      Miller bounds.
-    - The number of k-vectors K scales as O(k_cutoff^3 * V) where V is the cell volume.
+    For batch mode, the maximum cutoff across the batch determines shared
+    bounds. A retained topology must conservatively cover every cell state in
+    which it will be used.
 
     See Also
     --------
-    ewald_reciprocal_space : Uses these k-vectors for reciprocal space energy.
+    k_vectors_from_miller_indices : Transform retained indices for a live cell.
     estimate_ewald_parameters : Automatic parameter estimation including k_cutoff.
+    """
+    return torch.round(_ewald_miller_grid(cell, k_cutoff, miller_bounds)).to(
+        torch.int64
+    )
+
+
+def k_vectors_from_miller_indices(
+    cell: torch.Tensor,
+    miller_indices: torch.Tensor,
+) -> torch.Tensor:
+    """Materialize reciprocal vectors from caller-retained Miller indices.
+
+    The supplied ``cell`` defines the live reciprocal transform. Duplicate
+    rows, zero rows, and half-space membership are caller preconditions and are
+    not checked; :func:`generate_ewald_miller_indices` produces valid topology.
+
+    Parameters
+    ----------
+    cell : torch.Tensor
+        Unit cell of shape ``(3, 3)`` or ``(B, 3, 3)``.
+    miller_indices : torch.Tensor
+        Signed integer indices of shape ``(K, 3)`` on the same device as
+        ``cell``. ``(0, 3)`` is valid.
+
+    Returns
+    -------
+    torch.Tensor
+        Reciprocal vectors of shape ``(K, 3)`` or ``(B, K, 3)``.
+    """
+    if cell.ndim not in (2, 3) or cell.shape[-2:] != (3, 3):
+        raise ValueError("cell must have shape (3, 3) or (B, 3, 3)")
+    if miller_indices.ndim != 2 or miller_indices.shape[-1] != 3:
+        raise ValueError("miller_indices must have shape (K, 3)")
+    if miller_indices.dtype not in {
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+    }:
+        raise ValueError("miller_indices must have a signed integer dtype")
+    if cell.device != miller_indices.device:
+        raise ValueError("cell and miller_indices must be on the same device")
+
+    if cell.ndim == 2:
+        cell = cell.unsqueeze(0)
+    reciprocal_cell = TWOPI * torch.linalg.inv_ex(cell.transpose(1, 2))[0]
+    return (miller_indices.to(reciprocal_cell.dtype) @ reciprocal_cell).squeeze(0)
+
+
+def generate_k_vectors_ewald_summation(
+    cell: torch.Tensor,
+    k_cutoff: float | torch.Tensor,
+    miller_bounds: tuple[int, int, int] | torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Generate reciprocal lattice vectors for Ewald summation (half-space).
+
+    This compatibility wrapper preserves Torch's historical float32 FFT-grid
+    rounding. Use :func:`generate_ewald_miller_indices` and
+    :func:`k_vectors_from_miller_indices` for caller-retained topology.
     """
     if cell.ndim == 2:
         cell = cell.unsqueeze(0)
-    device = cell.device
-    dtype = cell.dtype
-
-    if miller_bounds is None:
-        max_h, max_k, max_l = 2 * _generate_miller_indices(cell, k_cutoff) + 1
-    else:
-        if isinstance(miller_bounds, torch.Tensor):
-            if miller_bounds.numel() != 3:
-                raise ValueError("miller_bounds tensor must contain exactly 3 values")
-            bounds = tuple(int(v) for v in miller_bounds.reshape(3).tolist())
-        else:
-            if len(miller_bounds) != 3:
-                raise ValueError("miller_bounds must contain exactly 3 values")
-            bounds = tuple(int(v) for v in miller_bounds)
-        max_h, max_k, max_l = (2 * bounds[0] + 1, 2 * bounds[1] + 1, 2 * bounds[2] + 1)
-
-    # Generate all combinations of Miller indices
-    h_range = torch.fft.fftfreq(max_h, device=device, dtype=dtype) * max_h
-    k_range = torch.fft.fftfreq(max_k, device=device, dtype=dtype) * max_k
-    l_range = torch.fft.fftfreq(max_l, device=device, dtype=dtype) * max_l
-
-    h_grid, k_grid, l_grid = torch.meshgrid(h_range, k_range, l_range, indexing="ij")
-    miller_indices = torch.stack(
-        [h_grid.flatten(), k_grid.flatten(), l_grid.flatten()], dim=1
-    )
-
-    # Apply half-space filter: keep only one of each +-k pair
-    # Condition: h > 0 OR (h == 0 AND k > 0) OR (h == 0 AND k == 0 AND l > 0)
-    h = miller_indices[:, 0]
-    k = miller_indices[:, 1]
-    m = miller_indices[:, 2]  # Using 'm' instead of 'l' to avoid E741 ambiguity
-
-    halfspace_mask = (h > 0) | ((h == 0) & (k > 0)) | ((h == 0) & (k == 0) & (m > 0))
-
-    miller_indices = miller_indices[halfspace_mask]
-
-    # Compute reciprocal lattice vectors (2π times reciprocal of direct lattice)
-    reciprocal_cell = (
-        TWOPI * torch.linalg.inv_ex(cell.transpose(1, 2))[0]
-    )  # Transpose for column vectors
-    k_vectors = miller_indices.to(reciprocal_cell.dtype) @ reciprocal_cell
-    return k_vectors.squeeze(0)
+    reciprocal_cell = TWOPI * torch.linalg.inv_ex(cell.transpose(1, 2))[0]
+    return (
+        _ewald_miller_grid(cell, k_cutoff, miller_bounds) @ reciprocal_cell
+    ).squeeze(0)
 
 
 def generate_k_vectors_pme(

--- a/test/interactions/electrostatics/bindings/jax/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/jax/test_ewald.py
@@ -47,10 +47,13 @@ import pytest
 from nvalchemiops.jax.interactions.electrostatics.ewald import (
     ewald_real_space,
     ewald_reciprocal_space,
+    ewald_reciprocal_space_from_miller_indices,
     ewald_summation,
 )
 from nvalchemiops.jax.interactions.electrostatics.k_vectors import (
+    generate_ewald_miller_indices,
     generate_k_vectors_ewald_summation,
+    k_vectors_from_miller_indices,
 )
 from nvalchemiops.jax.neighbors import batch_cell_list, cell_list
 from test.interactions.electrostatics.bindings.jax.conftest import (
@@ -682,6 +685,135 @@ class TestEwaldReciprocalSpaceAPI:
         assert jnp.all(jnp.isfinite(energies))
         assert jnp.all(jnp.isfinite(forces))
 
+    def test_retained_miller_component_matches_explicit_vectors(self, device):
+        """Retained component matches live explicit vectors and their gradients."""
+        positions, charges, cell = create_simple_system()
+        cell = cell[0]
+        alpha = jnp.array(0.3, dtype=jnp.float64)
+        indices = generate_ewald_miller_indices(cell, 4.0, (3, 3, 3))
+
+        def explicit(pos, q, lattice):
+            return ewald_reciprocal_space(
+                pos,
+                q,
+                lattice,
+                k_vectors_from_miller_indices(lattice, indices),
+                alpha,
+            )
+
+        def retained(pos, q, lattice, topology):
+            return ewald_reciprocal_space_from_miller_indices(
+                pos, q, lattice, topology, alpha
+            )
+
+        expected = explicit(positions, charges, cell)
+        actual = retained(positions, charges, cell, indices)
+        assert jnp.allclose(actual, expected, rtol=1e-12, atol=1e-12)
+        expected_grads = jax.grad(
+            lambda pos, q, lattice: explicit(pos, q, lattice).sum(), argnums=(0, 1, 2)
+        )(positions, charges, cell)
+        actual_grads = jax.grad(
+            lambda pos, q, lattice: retained(pos, q, lattice, indices).sum(),
+            argnums=(0, 1, 2),
+        )(positions, charges, cell)
+        for actual_grad, expected_grad in zip(
+            actual_grads, expected_grads, strict=True
+        ):
+            assert jnp.allclose(actual_grad, expected_grad, rtol=1e-8, atol=1e-9)
+
+        jitted = jax.jit(
+            lambda lattice, topology: retained(positions, charges, lattice, topology)
+        )
+        assert jnp.allclose(jitted(cell, indices), actual, rtol=1e-12, atol=1e-12)
+
+    def test_retained_miller_component_supports_jitted_shared_batch(self, device):
+        """A shared retained topology serves a jitted reciprocal-space batch."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [3.0, 0.0, 0.0], [0.0, 0.0, 0.0], [3.0, 0.0, 0.0]],
+            dtype=jnp.float64,
+        )
+        charges = jnp.array([1.0, -1.0, 0.8, -0.8], dtype=jnp.float64)
+        cell = jnp.stack(
+            [jnp.eye(3, dtype=jnp.float64) * 10.0, jnp.eye(3, dtype=jnp.float64) * 12.0]
+        )
+        alpha = jnp.array([0.3, 0.4], dtype=jnp.float64)
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        indices = generate_ewald_miller_indices(cell, 2.0, (3, 3, 3))
+
+        def explicit(lattice):
+            return ewald_reciprocal_space(
+                positions,
+                charges,
+                lattice,
+                k_vectors_from_miller_indices(lattice, indices),
+                alpha,
+                batch_idx=batch_idx,
+                max_atoms_per_system=2,
+                energy_reduction="system",
+            )
+
+        def retained(lattice, topology):
+            return ewald_reciprocal_space_from_miller_indices(
+                positions,
+                charges,
+                lattice,
+                topology,
+                alpha,
+                batch_idx=batch_idx,
+                max_atoms_per_system=2,
+                energy_reduction="system",
+            )
+
+        expected = explicit(cell)
+        actual = retained(cell, indices)
+        assert actual.shape == (2,)
+        assert jnp.allclose(actual, expected, rtol=1e-12, atol=1e-12)
+        assert jnp.allclose(
+            jax.jit(retained)(cell, indices), actual, rtol=1e-12, atol=1e-12
+        )
+
+    def test_retained_miller_component_direct_outputs_match_explicit_vectors(
+        self, device
+    ):
+        """Retained component preserves direct-output warnings and tuple fields."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+            dtype=jnp.float64,
+        )
+        charges = jnp.array([1.0, 0.5, -0.7, 0.2], dtype=jnp.float64)
+        cell = jnp.stack(
+            [jnp.eye(3, dtype=jnp.float64) * 10.0, jnp.eye(3, dtype=jnp.float64) * 12.0]
+        )
+        alpha = jnp.array([0.3, 0.4], dtype=jnp.float64)
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        indices = generate_ewald_miller_indices(cell, 2.0, (2, 2, 2))
+        kwargs = {
+            "batch_idx": batch_idx,
+            "max_atoms_per_system": 2,
+            "compute_forces": True,
+            "compute_charge_gradients": True,
+            "compute_virial": True,
+            "energy_reduction": "system",
+        }
+
+        with pytest.warns(DeprecationWarning):
+            expected = ewald_reciprocal_space(
+                positions,
+                charges,
+                cell,
+                k_vectors_from_miller_indices(cell, indices),
+                alpha,
+                **kwargs,
+            )
+        with pytest.warns(DeprecationWarning):
+            actual = ewald_reciprocal_space_from_miller_indices(
+                positions, charges, cell, indices, alpha, **kwargs
+            )
+
+        assert len(actual) == 4
+        for actual_field, expected_field in zip(actual, expected, strict=True):
+            assert jnp.allclose(actual_field, expected_field, rtol=1e-12, atol=1e-12)
+
 
 class TestEwaldSummationAPI:
     """Test full Ewald summation API."""
@@ -714,6 +846,323 @@ class TestEwaldSummationAPI:
         assert jnp.all(jnp.isfinite(energies))
         # Opposite charges should produce negative energy
         assert energies.sum() < 0
+
+    def test_retained_miller_indices_match_generated_energy_and_gradients(self, device):
+        """Full Ewald retained topology preserves the internal-vector JVP."""
+        (
+            positions,
+            charges,
+            cell,
+            neighbor_matrix,
+            _num_neighbors,
+            neighbor_matrix_shifts,
+        ) = create_dipole_system()
+        bounds = (8, 8, 8)
+        miller_indices = generate_ewald_miller_indices(cell, 8.0, bounds)
+
+        def retained(pos, q, c, indices):
+            return ewald_summation(
+                positions=pos,
+                charges=q,
+                cell=c,
+                alpha=None,
+                miller_indices=indices,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+            ).sum()
+
+        def generated(pos, q, c):
+            return ewald_summation(
+                positions=pos,
+                charges=q,
+                cell=c,
+                alpha=None,
+                k_cutoff=8.0,
+                miller_bounds=bounds,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+            ).sum()
+
+        assert jnp.allclose(
+            retained(positions, charges, cell, miller_indices),
+            generated(positions, charges, cell),
+            rtol=1e-12,
+            atol=1e-12,
+        )
+        retained_grads = jax.grad(retained, argnums=(0, 1, 2))(
+            positions, charges, cell, miller_indices
+        )
+        generated_grads = jax.grad(generated, argnums=(0, 1, 2))(
+            positions, charges, cell
+        )
+        for actual, expected in zip(retained_grads, generated_grads, strict=True):
+            assert jnp.allclose(actual, expected, rtol=1e-5, atol=1e-7)
+
+        cell_direction = jnp.array(
+            [[0.1, -0.2, 0.3], [0.2, 0.1, -0.1], [-0.1, 0.2, 0.1]],
+            dtype=cell.dtype,
+        )[None, ...]
+        retained_cell_grad = jax.grad(
+            lambda c: retained(positions, charges, c, miller_indices)
+        )
+        generated_cell_grad = jax.grad(lambda c: generated(positions, charges, c))
+        _, retained_hvp = jax.jvp(
+            retained_cell_grad,
+            (cell,),
+            (cell_direction,),
+        )
+        _, generated_hvp = jax.jvp(
+            generated_cell_grad,
+            (cell,),
+            (cell_direction,),
+        )
+        assert jnp.allclose(retained_hvp, generated_hvp, rtol=2e-3, atol=1e-6)
+
+        jitted = jax.jit(retained)
+        assert jnp.allclose(
+            jitted(positions, charges, cell, miller_indices),
+            retained(positions, charges, cell, miller_indices),
+            rtol=1e-12,
+            atol=1e-12,
+        )
+
+    def test_retained_miller_indices_reject_conflicting_topology_sources(self, device):
+        """Full Ewald rejects ambiguous reciprocal topology combinations."""
+        (
+            positions,
+            charges,
+            cell,
+            neighbor_matrix,
+            _num_neighbors,
+            neighbor_matrix_shifts,
+        ) = create_dipole_system()
+        indices = generate_ewald_miller_indices(cell, 8.0, (8, 8, 8))
+        k_vectors = generate_k_vectors_ewald_summation(cell, 8.0, (8, 8, 8))
+
+        with pytest.raises(ValueError, match="miller_indices"):
+            ewald_summation(
+                positions,
+                charges,
+                cell,
+                alpha=0.3,
+                miller_indices=indices,
+                k_cutoff=8.0,
+            )
+        with pytest.raises(ValueError, match="k_vectors"):
+            ewald_summation(
+                positions,
+                charges,
+                cell,
+                alpha=0.3,
+                k_vectors=k_vectors,
+                miller_indices=indices,
+            )
+
+        explicit = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_vectors=k_vectors,
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+        )
+        legacy_with_bounds = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_vectors=k_vectors,
+            miller_bounds=(1, 1, 1),
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+        )
+        assert jnp.array_equal(legacy_with_bounds, explicit)
+
+    def test_retained_miller_indices_support_jitted_shared_batch(self, device):
+        """One retained topology serves a jitted multi-system Ewald batch."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [3.0, 0.0, 0.0], [0.0, 0.0, 0.0], [3.0, 0.0, 0.0]],
+            dtype=jnp.float64,
+        )
+        charges = jnp.array([1.0, -1.0, 1.0, -1.0], dtype=jnp.float64)
+        cell = jnp.stack(
+            [jnp.eye(3, dtype=jnp.float64) * 10.0, jnp.eye(3, dtype=jnp.float64) * 12.0]
+        )
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        batch_ptr = jnp.array([0, 2, 4], dtype=jnp.int32)
+        pbc = jnp.array([[True, True, True], [True, True, True]])
+        neighbor_matrix, _num_neighbors, neighbor_matrix_shifts = batch_cell_list(
+            positions,
+            5.0,
+            cell,
+            pbc,
+            batch_idx=batch_idx,
+            batch_ptr=batch_ptr,
+            max_neighbors=32,
+        )
+        alpha = jnp.array([0.3, 0.3], dtype=jnp.float64)
+        bounds = (4, 4, 4)
+        miller_indices = generate_ewald_miller_indices(cell, 2.0, bounds)
+
+        def retained(lattice):
+            return ewald_summation(
+                positions,
+                charges,
+                lattice,
+                alpha=alpha,
+                miller_indices=miller_indices,
+                batch_idx=batch_idx,
+                max_atoms_per_system=2,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+            ).sum()
+
+        def generated(lattice):
+            return ewald_summation(
+                positions,
+                charges,
+                lattice,
+                alpha=alpha,
+                k_cutoff=2.0,
+                miller_bounds=bounds,
+                batch_idx=batch_idx,
+                max_atoms_per_system=2,
+                neighbor_matrix=neighbor_matrix,
+                neighbor_matrix_shifts=neighbor_matrix_shifts,
+            ).sum()
+
+        assert jnp.allclose(retained(cell), generated(cell), rtol=1e-12, atol=1e-12)
+        assert jnp.allclose(
+            jax.grad(retained)(cell),
+            jax.grad(generated)(cell),
+            rtol=1e-5,
+            atol=1e-7,
+        )
+        assert jnp.allclose(
+            jax.jit(retained)(cell), retained(cell), rtol=1e-12, atol=1e-12
+        )
+
+    def test_summation_accepts_empty_miller_topology(self, device):
+        """Full Ewald accepts an empty caller-owned reciprocal topology."""
+        (
+            positions,
+            charges,
+            cell,
+            neighbor_matrix,
+            _num_neighbors,
+            neighbor_matrix_shifts,
+        ) = create_dipole_system()
+        energy = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            miller_indices=jnp.empty((0, 3), dtype=jnp.int32),
+            neighbor_matrix=neighbor_matrix,
+            neighbor_matrix_shifts=neighbor_matrix_shifts,
+        )
+        assert jnp.all(jnp.isfinite(energy))
+
+    def test_empty_reciprocal_topology_direct_fields_match_analytic_terms(self, device):
+        """Zero-length reciprocal topology preserves analytic correction fields."""
+        positions = jnp.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+            dtype=jnp.float64,
+        )
+        charges = jnp.array([1.0, 0.5, -0.7, 0.2], dtype=jnp.float64)
+        cell = jnp.stack(
+            [jnp.eye(3, dtype=jnp.float64) * 10.0, jnp.eye(3, dtype=jnp.float64) * 12.0]
+        )
+        alpha = jnp.array([0.3, 0.4], dtype=jnp.float64)
+        batch_idx = jnp.array([0, 0, 1, 1], dtype=jnp.int32)
+        empty = jnp.empty((0, 3), dtype=jnp.float64)
+        total_charge = jnp.array([1.5, -0.5], dtype=jnp.float64)
+        volume = jnp.abs(jnp.linalg.det(cell))
+        atom_alpha = alpha[batch_idx]
+        atom_volume = volume[batch_idx]
+        atom_charge = total_charge[batch_idx]
+        expected_energy = -(
+            atom_alpha * charges**2 / jnp.sqrt(jnp.pi)
+            + jnp.pi * charges * atom_charge / (2.0 * atom_alpha**2 * atom_volume)
+        )
+        expected_charge_grads = -(
+            2.0 * atom_alpha * charges / jnp.sqrt(jnp.pi)
+            + jnp.pi * atom_charge / (atom_alpha**2 * atom_volume)
+        )
+        expected_virial = -(jnp.pi * total_charge**2 / (2.0 * alpha**2 * volume))[
+            :, None, None
+        ] * jnp.eye(3, dtype=jnp.float64)
+
+        with pytest.warns(DeprecationWarning):
+            energy, forces, charge_grads, virial = ewald_reciprocal_space(
+                positions,
+                charges,
+                cell,
+                empty,
+                alpha,
+                batch_idx=batch_idx,
+                max_atoms_per_system=2,
+                compute_forces=True,
+                compute_charge_gradients=True,
+                compute_virial=True,
+            )
+
+        assert jnp.allclose(energy, expected_energy, rtol=1e-12, atol=1e-12)
+        assert jnp.array_equal(forces, jnp.zeros_like(forces))
+        assert jnp.allclose(charge_grads, expected_charge_grads, rtol=1e-12, atol=1e-12)
+        assert jnp.allclose(virial, expected_virial, rtol=1e-12, atol=1e-12)
+
+        def energy_sum(q, lattice):
+            return ewald_reciprocal_space(
+                positions,
+                q,
+                lattice,
+                empty,
+                alpha,
+                batch_idx=batch_idx,
+                max_atoms_per_system=2,
+            ).sum()
+
+        assert jnp.allclose(
+            jax.grad(energy_sum, argnums=0)(charges, cell),
+            expected_charge_grads,
+            rtol=1e-12,
+            atol=1e-12,
+        )
+
+        def strain_energy(strain):
+            transform = jnp.eye(3, dtype=cell.dtype) + strain
+            return energy_sum(charges, cell @ transform)
+
+        strain_gradient = jax.grad(strain_energy)(jnp.zeros((3, 3), dtype=cell.dtype))
+        assert jnp.allclose(
+            -strain_gradient,
+            expected_virial.sum(axis=0),
+            rtol=1e-12,
+            atol=1e-12,
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            jitted = jax.jit(
+                lambda: ewald_reciprocal_space(
+                    positions,
+                    charges,
+                    cell,
+                    empty,
+                    alpha,
+                    batch_idx=batch_idx,
+                    max_atoms_per_system=2,
+                    compute_forces=True,
+                    compute_charge_gradients=True,
+                    compute_virial=True,
+                )
+            )()
+        for actual, expected in zip(
+            jitted, (energy, forces, charge_grads, virial), strict=True
+        ):
+            assert jnp.allclose(actual, expected, rtol=1e-12, atol=1e-12)
 
     def test_energy_grad_positions_matches_direct_forces(self, device):
         """Energy-derived position gradients match direct forces."""

--- a/test/interactions/electrostatics/bindings/jax/test_gradient_contract.py
+++ b/test/interactions/electrostatics/bindings/jax/test_gradient_contract.py
@@ -27,8 +27,10 @@ from nvalchemiops.jax.interactions.electrostatics import (
     ewald_real_space,
     ewald_reciprocal_space,
     ewald_summation,
+    generate_ewald_miller_indices,
     generate_k_vectors_ewald_summation,
     generate_k_vectors_pme,
+    k_vectors_from_miller_indices,
     particle_mesh_ewald,
     pme_reciprocal_space,
 )
@@ -248,10 +250,15 @@ def test_jax_pme_ignores_alpha_tangent(device) -> None:
 def test_jax_ewald_reciprocal_silently_accepts_cell_tangent_with_k_vectors(
     device,
 ) -> None:
-    """Public Ewald reciprocal k-vectors are static cell-JVP metadata."""
+    """Zero-tangent reciprocal vectors retain fixed-vector cell derivatives."""
     positions, charges, cell, alpha = _system(device)
     cell_static = jax.lax.stop_gradient(cell)
     k_vectors = generate_k_vectors_ewald_summation(cell_static, k_cutoff=5.0)
+    direction = jnp.array(
+        [[0.03, -0.02, 0.01], [0.01, 0.02, -0.01], [-0.02, 0.01, 0.03]],
+        dtype=cell.dtype,
+    )
+    epsilon = 1e-4
 
     def energy_cell(cell_arg):
         return ewald_reciprocal_space(
@@ -264,10 +271,56 @@ def test_jax_ewald_reciprocal_silently_accepts_cell_tangent_with_k_vectors(
 
     with warnings.catch_warnings(record=True) as records:
         warnings.simplefilter("always")
-        value, tangent = jax.jvp(energy_cell, (cell,), (jnp.ones_like(cell),))
+        value, tangent = jax.jvp(energy_cell, (cell,), (direction,))
+    finite_difference = (
+        energy_cell(cell + epsilon * direction)
+        - energy_cell(cell - epsilon * direction)
+    ) / (2.0 * epsilon)
     _assert_no_cache_warning(records)
     assert jnp.isfinite(value)
-    assert jnp.isfinite(tangent)
+    assert jnp.allclose(tangent, finite_difference, rtol=2e-4, atol=2e-6)
+
+
+def test_jax_ewald_reciprocal_preserves_graph_derived_k_vector_tangent(
+    device,
+) -> None:
+    """Graph-derived reciprocal vectors contribute partial cell derivatives."""
+    positions, charges, cell, alpha = _system(device)
+    indices = generate_ewald_miller_indices(cell, 5.0, (4, 4, 4))
+    direction = jnp.array(
+        [[0.03, -0.02, 0.01], [0.01, 0.02, -0.01], [-0.02, 0.01, 0.03]],
+        dtype=cell.dtype,
+    )
+    epsilon = 1e-4
+
+    def energy_cell(lattice):
+        return ewald_reciprocal_space(
+            positions,
+            charges,
+            lattice,
+            k_vectors_from_miller_indices(lattice, indices),
+            alpha,
+        ).sum()
+
+    value, tangent = jax.jvp(energy_cell, (cell,), (direction,))
+    gradient = jax.grad(energy_cell)(cell)
+    finite_difference = (
+        energy_cell(cell + epsilon * direction)
+        - energy_cell(cell - epsilon * direction)
+    ) / (2.0 * epsilon)
+    assert jnp.isfinite(value)
+    assert jnp.allclose(tangent, finite_difference, rtol=2e-4, atol=2e-6)
+    assert jnp.allclose(
+        jnp.vdot(gradient, direction), finite_difference, rtol=2e-4, atol=2e-6
+    )
+
+    cell_gradient = jax.grad(energy_cell)
+    _, hvp = jax.jvp(cell_gradient, (cell,), (direction,))
+    finite_difference_hvp = (
+        cell_gradient(cell + epsilon * direction)
+        - cell_gradient(cell - epsilon * direction)
+    ) / (2.0 * epsilon)
+    assert jnp.allclose(hvp, finite_difference_hvp, rtol=3e-3, atol=3e-5)
 
 
 @pytest.mark.parametrize(

--- a/test/interactions/electrostatics/bindings/jax/test_kvectors.py
+++ b/test/interactions/electrostatics/bindings/jax/test_kvectors.py
@@ -28,9 +28,56 @@ import jax.numpy as jnp
 import pytest
 
 from nvalchemiops.jax.interactions.electrostatics.k_vectors import (
+    generate_ewald_miller_indices,
     generate_k_vectors_ewald_summation,
     generate_k_vectors_pme,
+    generate_miller_indices,
+    k_vectors_from_miller_indices,
 )
+
+
+def _legacy_ewald_k_vectors(cell, k_cutoff, miller_bounds=None):
+    """Reproduce the pre-refactor Ewald vector enumeration exactly."""
+    if cell.ndim == 2:
+        cell = cell[None, ...]
+    if miller_bounds is None:
+        bounds = generate_miller_indices(cell, k_cutoff)
+        max_h, max_k, max_l = (int(bounds[0]), int(bounds[1]), int(bounds[2]))
+    else:
+        max_h, max_k, max_l = miller_bounds
+
+    h1 = jnp.arange(1, max_h + 1, dtype=cell.dtype)
+    k1 = jnp.arange(-max_k, max_k + 1, dtype=cell.dtype)
+    l1 = jnp.arange(-max_l, max_l + 1, dtype=cell.dtype)
+    h1_grid, k1_grid, l1_grid = jnp.meshgrid(h1, k1, l1, indexing="ij")
+    block1 = jnp.stack(
+        [h1_grid.reshape(-1), k1_grid.reshape(-1), l1_grid.reshape(-1)], axis=1
+    )
+    k2 = jnp.arange(1, max_k + 1, dtype=cell.dtype)
+    l2 = jnp.arange(-max_l, max_l + 1, dtype=cell.dtype)
+    k2_grid, l2_grid = jnp.meshgrid(k2, l2, indexing="ij")
+    block2 = jnp.stack(
+        [
+            jnp.zeros(k2_grid.size, dtype=cell.dtype),
+            k2_grid.reshape(-1),
+            l2_grid.reshape(-1),
+        ],
+        axis=1,
+    )
+    l3 = jnp.arange(1, max_l + 1, dtype=cell.dtype)
+    block3 = jnp.stack(
+        [
+            jnp.zeros(l3.size, dtype=cell.dtype),
+            jnp.zeros(l3.size, dtype=cell.dtype),
+            l3,
+        ],
+        axis=1,
+    )
+    miller_indices = jnp.concatenate([block1, block2, block3], axis=0)
+    reciprocal_cell = 2.0 * jnp.pi * jnp.linalg.inv(jnp.swapaxes(cell, -2, -1))
+    k_vectors = miller_indices @ reciprocal_cell
+    return jnp.squeeze(k_vectors, axis=0) if k_vectors.shape[0] == 1 else k_vectors
+
 
 ###########################################################################################
 ########################### Ewald K-Vector Tests ##########################################
@@ -49,6 +96,66 @@ class TestKVectorsEwald:
         assert k_vectors.ndim == 2
         assert k_vectors.shape[1] == 3
         assert k_vectors.shape[0] > 0
+
+    @pytest.mark.parametrize(
+        ("dtype", "batch_size", "miller_bounds"),
+        [
+            (jnp.float32, 0, None),
+            (jnp.float64, 1, (2, 3, 4)),
+            (jnp.float64, 2, None),
+        ],
+    )
+    def test_miller_topology_preserves_legacy_vectors(
+        self, dtype, batch_size, miller_bounds
+    ):
+        """Refactoring preserves historical values, order, and squeeze behavior."""
+        cell = jnp.array(
+            [[6.0, 0.0, 0.0], [0.5, 7.0, 0.0], [0.2, 0.1, 8.0]],
+            dtype=dtype,
+        )
+        if batch_size:
+            cell = jnp.stack(
+                [cell * (1.0 + 0.1 * index) for index in range(batch_size)]
+            )
+        k_cutoff = 2.0
+        indices = generate_ewald_miller_indices(cell, k_cutoff, miller_bounds)
+
+        actual = k_vectors_from_miller_indices(cell, indices)
+        expected = _legacy_ewald_k_vectors(cell, k_cutoff, miller_bounds)
+        public = generate_k_vectors_ewald_summation(cell, k_cutoff, miller_bounds)
+
+        assert indices.dtype == jnp.int32
+        assert jnp.array_equal(actual, expected)
+        assert jnp.array_equal(public, expected)
+        h, k, m = indices.T
+        assert jnp.all((h > 0) | ((h == 0) & (k > 0)) | ((h == 0) & (k == 0) & (m > 0)))
+        assert jnp.unique(indices, axis=0).shape[0] == indices.shape[0]
+
+    def test_miller_topology_empty_and_batched_materialization(self):
+        """Empty topology and shared batched topology retain public shapes."""
+        cell = jnp.stack([jnp.eye(3, dtype=jnp.float64) * side for side in (8.0, 9.0)])
+        indices = generate_ewald_miller_indices(cell, 1.0, (0, 0, 0))
+        assert indices.shape == (0, 3)
+        assert k_vectors_from_miller_indices(cell, indices).shape == (2, 0, 3)
+
+    @pytest.mark.parametrize(
+        "bad_indices",
+        [
+            jnp.zeros((3,), dtype=jnp.int32),
+            jnp.zeros((2, 2), dtype=jnp.int32),
+            jnp.zeros((2, 3), dtype=jnp.float64),
+        ],
+    )
+    def test_miller_materialization_rejects_invalid_structure(self, bad_indices):
+        """Materialization rejects unsupported index ranks, widths, and dtypes."""
+        cell = jnp.eye(3, dtype=jnp.float64)
+        with pytest.raises(ValueError, match="miller_indices"):
+            k_vectors_from_miller_indices(cell, bad_indices)
+
+    def test_legacy_generate_miller_indices_remains_batched_bounds(self):
+        """Legacy JIT-bounds helper remains a batched ``(3,)`` API."""
+        cell = jnp.eye(3, dtype=jnp.float64)[None, ...]
+        assert generate_miller_indices(cell, 8.0).shape == (3,)
 
     def test_output_shape_batch(self):
         """Test output shape for batch of systems."""

--- a/test/interactions/electrostatics/bindings/jax/test_public_api.py
+++ b/test/interactions/electrostatics/bindings/jax/test_public_api.py
@@ -67,6 +67,34 @@ def test_ewald_miller_bounds_is_keyword_only_after_legacy_slots() -> None:
     assert params[names.index("miller_bounds")].kind is inspect.Parameter.KEYWORD_ONLY
 
 
+def test_reciprocal_miller_component_matches_jax_public_argument_order() -> None:
+    """Retained-index reciprocal API keeps the established JAX optional order."""
+    params = list(
+        inspect.signature(
+            electrostatics.ewald_reciprocal_space_from_miller_indices
+        ).parameters.values()
+    )
+    names = [param.name for param in params]
+    assert names[:6] == [
+        "positions",
+        "charges",
+        "cell",
+        "miller_indices",
+        "alpha",
+        "batch_idx",
+    ]
+    assert names[6:10] == [
+        "max_atoms_per_system",
+        "compute_forces",
+        "compute_charge_gradients",
+        "compute_virial",
+    ]
+    assert "hybrid_forces" not in names
+    energy_reduction = params[names.index("energy_reduction")]
+    assert energy_reduction.kind is inspect.Parameter.KEYWORD_ONLY
+    assert energy_reduction.default == "atom"
+
+
 @pytest.mark.parametrize(
     "name",
     [

--- a/test/interactions/electrostatics/bindings/torch/test_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_ewald.py
@@ -50,11 +50,14 @@ from nvalchemiops.torch.interactions.electrostatics import (
 from nvalchemiops.torch.interactions.electrostatics.ewald import (
     ewald_real_space,
     ewald_reciprocal_space,
+    ewald_reciprocal_space_from_miller_indices,
     ewald_summation,
 )
 from nvalchemiops.torch.interactions.electrostatics.k_vectors import (
     _generate_miller_indices,
+    generate_ewald_miller_indices,
     generate_k_vectors_ewald_summation,
+    k_vectors_from_miller_indices,
 )
 from nvalchemiops.torch.neighbors import batch_cell_list, cell_list
 
@@ -5990,6 +5993,87 @@ class TestEwaldReciprocalSpaceVirial:
         )
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_retained_miller_indices_match_strain_fd_and_direct_virial(self, device):
+        """Caller-retained topology preserves the issue-136 strain derivative."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell, alpha = self._triclinic_system(device)
+        miller_indices = generate_ewald_miller_indices(cell, 4.0, (4, 4, 4))
+
+        def energy_fn(pos, q, c):
+            return ewald_reciprocal_space_from_miller_indices(
+                pos, q, c, miller_indices, alpha
+            )
+
+        fd_virial = fd_strain_virial(
+            energy_fn,
+            positions,
+            charges,
+            cell,
+            eps=1e-6,
+        )
+        autograd_virial = autograd_strain_virial(energy_fn, positions, charges, cell)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            _, direct_virial = ewald_reciprocal_space_from_miller_indices(
+                positions,
+                charges,
+                cell,
+                miller_indices,
+                alpha,
+                compute_virial=True,
+            )
+
+        torch.testing.assert_close(autograd_virial, fd_virial, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(
+            autograd_virial,
+            direct_virial,
+            rtol=1e-5,
+            atol=1e-6,
+        )
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_retained_miller_component_forwards_direct_outputs(self, device):
+        """The retained-index component preserves output order and warnings."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell, alpha = self._triclinic_system(device)
+        miller_indices = generate_ewald_miller_indices(cell, 4.0, (4, 4, 4))
+        k_vectors = k_vectors_from_miller_indices(cell, miller_indices)
+
+        with pytest.warns(DeprecationWarning):
+            retained = ewald_reciprocal_space_from_miller_indices(
+                positions,
+                charges,
+                cell,
+                miller_indices,
+                alpha,
+                compute_forces=True,
+                compute_charge_gradients=True,
+                compute_virial=True,
+                energy_reduction="system",
+            )
+        with pytest.warns(DeprecationWarning):
+            direct = ewald_reciprocal_space(
+                positions,
+                charges,
+                cell,
+                k_vectors,
+                alpha,
+                compute_forces=True,
+                compute_charge_gradients=True,
+                compute_virial=True,
+                energy_reduction="system",
+            )
+
+        assert len(retained) == 4
+        assert retained[0].shape == (1,)
+        for retained_value, direct_value in zip(retained, direct, strict=True):
+            torch.testing.assert_close(retained_value, direct_value)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_fixed_k_strain_autograd_matches_fixed_k_fd(self, device):
         """Fixed Cartesian reciprocal vectors retain fixed-k cell derivatives."""
         if device == "cuda" and not torch.cuda.is_available():
@@ -8399,6 +8483,190 @@ class TestEwaldMillerBounds:
         )
 
         torch.testing.assert_close(explicit, generated, rtol=1e-12, atol=1e-12)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_summation_retained_indices_match_generated_path(self, device):
+        """Full Ewald materializes caller-retained topology from the live cell."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell = _contract_dipole(device)
+        pbc = torch.tensor([[True, True, True]], device=device)
+        nl, nptr, ns = cell_list(
+            positions,
+            5.0,
+            cell,
+            pbc,
+            return_neighbor_list=True,
+        )
+        bounds = (4, 4, 4)
+        miller_indices = generate_ewald_miller_indices(cell, 2.0, bounds)
+
+        generated = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=None,
+            k_cutoff=2.0,
+            miller_bounds=bounds,
+            neighbor_list=nl,
+            neighbor_ptr=nptr,
+            neighbor_shifts=ns,
+        )
+        retained = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=None,
+            miller_indices=miller_indices,
+            neighbor_list=nl,
+            neighbor_ptr=nptr,
+            neighbor_shifts=ns,
+        )
+
+        torch.testing.assert_close(retained, generated, rtol=1e-12, atol=1e-12)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_summation_rejects_conflicting_topology_sources(self, device):
+        """Indices conflict, while legacy explicit vectors still override bounds."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell = _contract_dipole(device)
+        indices = generate_ewald_miller_indices(cell, 2.0, (4, 4, 4))
+        k_vectors = generate_k_vectors_ewald_summation(cell, 2.0, (4, 4, 4))
+        pbc = torch.tensor([[True, True, True]], device=device)
+        nl, nptr, ns = cell_list(
+            positions,
+            5.0,
+            cell,
+            pbc,
+            return_neighbor_list=True,
+        )
+
+        with pytest.raises(ValueError, match="miller_indices"):
+            ewald_summation(
+                positions,
+                charges,
+                cell,
+                alpha=0.3,
+                miller_indices=indices,
+                k_cutoff=2.0,
+            )
+        with pytest.raises(ValueError, match="k_vectors"):
+            ewald_summation(
+                positions,
+                charges,
+                cell,
+                alpha=0.3,
+                k_vectors=k_vectors,
+                miller_indices=indices,
+            )
+
+        explicit = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_vectors=k_vectors,
+            neighbor_list=nl,
+            neighbor_ptr=nptr,
+            neighbor_shifts=ns,
+        )
+        legacy_with_bounds = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            k_vectors=k_vectors,
+            miller_bounds=(1, 1, 1),
+            neighbor_list=nl,
+            neighbor_ptr=nptr,
+            neighbor_shifts=ns,
+        )
+        torch.testing.assert_close(legacy_with_bounds, explicit, rtol=0.0, atol=0.0)
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_summation_retained_indices_strain_gradient_matches_virial(self, device):
+        """Full Ewald retained topology preserves the live-cell virial route."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell = _contract_dipole(device)
+        pbc = torch.tensor([[True, True, True]], device=device)
+        nl, nptr, ns = cell_list(
+            positions,
+            5.0,
+            cell,
+            pbc,
+            return_neighbor_list=True,
+        )
+        alpha = torch.tensor([0.3], dtype=torch.float64, device=device)
+        miller_indices = generate_ewald_miller_indices(cell, 2.0, (4, 4, 4))
+
+        def energy_fn(pos, q, lattice):
+            return ewald_summation(
+                pos,
+                q,
+                lattice,
+                alpha=alpha,
+                miller_indices=miller_indices,
+                neighbor_list=nl,
+                neighbor_ptr=nptr,
+                neighbor_shifts=ns,
+            )
+
+        fd_virial = fd_strain_virial(energy_fn, positions, charges, cell, eps=1e-6)
+        autograd_virial = autograd_strain_virial(energy_fn, positions, charges, cell)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            _, direct_virial = ewald_summation(
+                positions,
+                charges,
+                cell,
+                alpha=alpha,
+                miller_indices=miller_indices,
+                neighbor_list=nl,
+                neighbor_ptr=nptr,
+                neighbor_shifts=ns,
+                compute_virial=True,
+            )
+
+        torch.testing.assert_close(autograd_virial, fd_virial, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(
+            autograd_virial,
+            direct_virial,
+            rtol=1e-5,
+            atol=1e-6,
+        )
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_summation_accepts_empty_miller_topology(self, device):
+        """Full Ewald accepts empty retained reciprocal topology."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        device = torch.device(device)
+        positions, charges, cell = _contract_dipole(device)
+        pbc = torch.tensor([[True, True, True]], device=device)
+        nl, nptr, ns = cell_list(
+            positions,
+            5.0,
+            cell,
+            pbc,
+            return_neighbor_list=True,
+        )
+        empty = torch.empty((0, 3), dtype=torch.int64, device=device)
+        energy = ewald_summation(
+            positions,
+            charges,
+            cell,
+            alpha=0.3,
+            miller_indices=empty,
+            neighbor_list=nl,
+            neighbor_ptr=nptr,
+            neighbor_shifts=ns,
+        )
+        assert torch.isfinite(energy).all()
 
 
 class TestEwaldPerSystemUniformCotangentFastPath:

--- a/test/interactions/electrostatics/bindings/torch/test_gradient_contract.py
+++ b/test/interactions/electrostatics/bindings/torch/test_gradient_contract.py
@@ -24,7 +24,9 @@ import torch
 from nvalchemiops.torch.interactions.electrostatics import (
     ewald_real_space,
     ewald_reciprocal_space,
+    ewald_reciprocal_space_from_miller_indices,
     ewald_summation,
+    generate_ewald_miller_indices,
     generate_k_vectors_ewald_summation,
     generate_k_vectors_pme,
     particle_mesh_ewald,
@@ -185,6 +187,40 @@ def test_compiled_ewald_first_order_gradients_match_eager() -> None:
     eager_loss = reciprocal_loss_fn(*eager_inputs)
     eager_grads = torch.autograd.grad(eager_loss, eager_inputs)
     compiled_loss = torch.compile(reciprocal_loss_fn)(*compiled_inputs)
+    compiled_grads = torch.autograd.grad(compiled_loss, compiled_inputs)
+    torch.testing.assert_close(compiled_loss, eager_loss)
+    for compiled_grad, eager_grad in zip(compiled_grads, eager_grads, strict=True):
+        torch.testing.assert_close(compiled_grad, eager_grad, rtol=5e-7, atol=5e-8)
+
+    miller_indices = generate_ewald_miller_indices(
+        cell,
+        k_cutoff=5.0,
+        miller_bounds=(5, 5, 5),
+    )
+
+    def retained_reciprocal_loss_fn(
+        pos: torch.Tensor,
+        q: torch.Tensor,
+        lattice: torch.Tensor,
+    ) -> torch.Tensor:
+        return ewald_reciprocal_space_from_miller_indices(
+            pos,
+            q,
+            lattice,
+            miller_indices,
+            alpha,
+        ).sum()
+
+    retained_reciprocal_loss_fn(positions, charges, cell).detach()
+    eager_inputs = (
+        positions.detach().requires_grad_(True),
+        charges.detach().requires_grad_(True),
+        cell.detach().requires_grad_(True),
+    )
+    compiled_inputs = tuple(t.detach().requires_grad_(True) for t in eager_inputs)
+    eager_loss = retained_reciprocal_loss_fn(*eager_inputs)
+    eager_grads = torch.autograd.grad(eager_loss, eager_inputs)
+    compiled_loss = torch.compile(retained_reciprocal_loss_fn)(*compiled_inputs)
     compiled_grads = torch.autograd.grad(compiled_loss, compiled_inputs)
     torch.testing.assert_close(compiled_loss, eager_loss)
     for compiled_grad, eager_grad in zip(compiled_grads, eager_grads, strict=True):

--- a/test/interactions/electrostatics/bindings/torch/test_kvectors.py
+++ b/test/interactions/electrostatics/bindings/torch/test_kvectors.py
@@ -30,8 +30,10 @@ import torch
 
 from nvalchemiops.torch.interactions.electrostatics.k_vectors import (
     _generate_miller_indices,
+    generate_ewald_miller_indices,
     generate_k_vectors_ewald_summation,
     generate_k_vectors_pme,
+    k_vectors_from_miller_indices,
 )
 
 try:
@@ -62,6 +64,30 @@ def generate_kvectors_for_pme_reference(cell, mesh_dimensions):
     return kvectors
 
 
+def _legacy_ewald_k_vectors(cell, k_cutoff, miller_bounds=None):
+    """Reproduce the pre-refactor Ewald vector enumeration exactly."""
+    if cell.ndim == 2:
+        cell = cell.unsqueeze(0)
+    if miller_bounds is None:
+        max_h, max_k, max_l = 2 * _generate_miller_indices(cell, k_cutoff) + 1
+    else:
+        max_h, max_k, max_l = (2 * bound + 1 for bound in miller_bounds)
+
+    h_range = torch.fft.fftfreq(max_h, device=cell.device, dtype=cell.dtype) * max_h
+    k_range = torch.fft.fftfreq(max_k, device=cell.device, dtype=cell.dtype) * max_k
+    l_range = torch.fft.fftfreq(max_l, device=cell.device, dtype=cell.dtype) * max_l
+    h_grid, k_grid, l_grid = torch.meshgrid(h_range, k_range, l_range, indexing="ij")
+    miller_indices = torch.stack(
+        [h_grid.flatten(), k_grid.flatten(), l_grid.flatten()], dim=1
+    )
+    h, k, m = miller_indices.unbind(dim=1)
+    halfspace = (h > 0) | ((h == 0) & (k > 0)) | ((h == 0) & (k == 0) & (m > 0))
+    reciprocal_cell = 2.0 * torch.pi * torch.linalg.inv_ex(cell.transpose(1, 2))[0]
+    return (
+        miller_indices[halfspace].to(reciprocal_cell.dtype) @ reciprocal_cell
+    ).squeeze(0)
+
+
 ###########################################################################################
 ########################### Ewald K-Vector Tests ##########################################
 ###########################################################################################
@@ -84,6 +110,108 @@ class TestKVectorsEwald:
         assert k_vectors.ndim == 2
         assert k_vectors.shape[1] == 3
         assert k_vectors.shape[0] > 0
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    @pytest.mark.parametrize(
+        ("dtype", "batch_size", "miller_bounds"),
+        [
+            (torch.float32, 0, None),
+            (torch.float64, 1, (2, 3, 4)),
+            (torch.float64, 2, None),
+        ],
+    )
+    def test_miller_topology_preserves_legacy_vectors(
+        self, device, dtype, batch_size, miller_bounds
+    ):
+        """Refactoring preserves historical values, order, and squeeze behavior."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        cell = torch.tensor(
+            [[6.0, 0.0, 0.0], [0.5, 7.0, 0.0], [0.2, 0.1, 8.0]],
+            dtype=dtype,
+            device=device,
+        )
+        if batch_size:
+            cell = cell.expand(batch_size, -1, -1).clone()
+            cell[1:] *= 1.1
+        k_cutoff = 2.0
+        indices = generate_ewald_miller_indices(cell, k_cutoff, miller_bounds)
+
+        actual = k_vectors_from_miller_indices(cell, indices)
+        expected = _legacy_ewald_k_vectors(cell, k_cutoff, miller_bounds)
+        public = generate_k_vectors_ewald_summation(cell, k_cutoff, miller_bounds)
+
+        assert indices.dtype == torch.int64
+        # Torch's float32 fftfreq grid can contain sub-ULP non-integer values;
+        # retained integer topology intentionally removes those artifacts.
+        torch.testing.assert_close(actual, expected, rtol=5e-7, atol=5e-7)
+        assert torch.equal(public, expected)
+        h, k, m = indices.unbind(dim=1)
+        assert torch.all(
+            (h > 0) | ((h == 0) & (k > 0)) | ((h == 0) & (k == 0) & (m > 0))
+        )
+        assert torch.unique(indices, dim=0).shape[0] == indices.shape[0]
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_miller_topology_rounds_fft_grid_before_integer_conversion(self, device):
+        """Integer topology does not truncate sub-ULP FFT-grid representation errors."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        dtype = torch.float32
+        bound = 20
+        cell = torch.eye(3, dtype=dtype, device=device)
+        indices = generate_ewald_miller_indices(cell, 1.0, (bound, 0, 0))
+        expected = torch.stack(
+            [
+                torch.arange(1, bound + 1, dtype=torch.int64, device=device),
+                torch.zeros(bound, dtype=torch.int64, device=device),
+                torch.zeros(bound, dtype=torch.int64, device=device),
+            ],
+            dim=1,
+        )
+
+        assert torch.equal(indices, expected)
+        assert torch.all(indices.any(dim=1))
+        assert torch.unique(indices, dim=0).shape[0] == indices.shape[0]
+
+    @pytest.mark.parametrize("device", ["cuda", "cpu"])
+    def test_miller_topology_empty_and_batched_materialization(self, device):
+        """Empty topology and shared batched topology retain public shapes."""
+        if device == "cuda" and not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        cell = torch.stack(
+            [
+                torch.eye(3, dtype=torch.float64, device=device) * side
+                for side in (8.0, 9.0)
+            ]
+        )
+        indices = generate_ewald_miller_indices(cell, 1.0, (0, 0, 0))
+        assert indices.shape == (0, 3)
+        assert k_vectors_from_miller_indices(cell, indices).shape == (2, 0, 3)
+
+    @pytest.mark.parametrize(
+        "bad_indices",
+        [
+            torch.zeros((3,), dtype=torch.int64),
+            torch.zeros((2, 2), dtype=torch.int64),
+            torch.zeros((2, 3), dtype=torch.float64),
+        ],
+    )
+    def test_miller_materialization_rejects_invalid_structure(self, bad_indices):
+        """Materialization rejects unsupported index ranks, widths, and dtypes."""
+        cell = torch.eye(3, dtype=torch.float64)
+        with pytest.raises(ValueError, match="miller_indices"):
+            k_vectors_from_miller_indices(cell, bad_indices)
+
+    @pytest.mark.cuda
+    def test_miller_materialization_rejects_device_mismatch(self):
+        """Torch rejects retained topology on a different device than the cell."""
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        cell = torch.eye(3, dtype=torch.float64, device="cpu")
+        indices = torch.zeros((0, 3), dtype=torch.int64, device="cuda")
+        with pytest.raises(ValueError, match="same device"):
+            k_vectors_from_miller_indices(cell, indices)
 
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_output_shape_batch(self, device):


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

Retain Ewald Miller topology separately from Cartesian reciprocal vectors, so changing-cell calls materialize vectors from the current cell. Fix JAX reciprocal-component autodiff to preserve the tangent carried by graph-derived `k_vectors`.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #147.

## Changes Made

- Add caller-retained Miller-index generators, live-cell materializers, and retained-index reciprocal components for Torch and JAX.
- Extend full Ewald with `miller_indices=` while preserving explicit-vector metadata behavior.
- Correct JAX reciprocal-component derivatives for graph-derived vectors and document fixed-vector semantics.
- Cover public topology, derivative, batch/JIT, direct-output, and compatibility behavior.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
