### PR TITLE
Ewald fp32 nostore sf

### DIFF
--- a/docs/userguide/about/performance.md
+++ b/docs/userguide/about/performance.md
@@ -214,10 +214,12 @@ through as `rebuild_flags` instead to keep the decision on device under
 ```{note}
 As with neighbour lists, the API reference for the entry point lists what can be
 supplied: {func}`~nvalchemiops.torch.interactions.electrostatics.ewald_summation` and
-{func}`~nvalchemiops.torch.interactions.electrostatics.particle_mesh_ewald`. The real/reciprocal halves are separately
+{func}`~nvalchemiops.torch.interactions.electrostatics.particle_mesh_ewald`. The
+real/reciprocal halves are separately
 callable as {func}`~nvalchemiops.torch.interactions.electrostatics.ewald_real_space`,
 {func}`~nvalchemiops.torch.interactions.electrostatics.ewald_reciprocal_space` and
-{func}`~nvalchemiops.torch.interactions.electrostatics.pme_reciprocal_space`, which is what to profile against when
+{func}`~nvalchemiops.torch.interactions.electrostatics.pme_reciprocal_space`, which
+is what to profile against when
 attributing cost.
 ```
 
@@ -241,13 +243,16 @@ mesh = estimate_pme_mesh_dimensions(cell, params.alpha, accuracy=accuracy)
 ```
 
 Under NPT, refresh these on cell updates rather than per force evaluation.
-{func}`~nvalchemiops.torch.interactions.electrostatics.estimate_pme_parameters` returns alpha and the mesh together as a
-{class}`~nvalchemiops.torch.interactions.electrostatics.PMEParameters`; {func}`~nvalchemiops.torch.interactions.electrostatics.estimate_ewald_parameters` returns
+{func}`~nvalchemiops.torch.interactions.electrostatics.estimate_pme_parameters`
+returns alpha and the mesh together as a
+{class}`~nvalchemiops.torch.interactions.electrostatics.PMEParameters`;
+{func}`~nvalchemiops.torch.interactions.electrostatics.estimate_ewald_parameters`
+returns
 an {class}`~nvalchemiops.torch.interactions.electrostatics.EwaldParameters`.
 
 PME additionally precomputes B-spline moduli via
-{func}`~nvalchemiops.torch.interactions.electrostatics.compute_bspline_moduli_1d`, which depend only on the mesh and
-spline order.
+{func}`~nvalchemiops.torch.interactions.electrostatics.compute_bspline_moduli_1d`,
+which depend only on the mesh and spline order.
 
 Both methods consume a neighbour list for real space, so the neighbour-list
 section applies to that list as well. Pass the matrix and shifts you already
@@ -292,8 +297,10 @@ Reference tables are element-specific and independent of geometry. Build
 `D3Parameters` once and move it to the device at setup:
 
 ```{note}
-{func}`~nvalchemiops.torch.interactions.dispersion.dftd3` lists every optional buffer and table it accepts;
-{class}`~nvalchemiops.torch.interactions.dispersion.D3Parameters` documents the reference tables and their shapes.
+{func}`~nvalchemiops.torch.interactions.dispersion.dftd3` lists every
+optional buffer and table it accepts;
+{class}`~nvalchemiops.torch.interactions.dispersion.D3Parameters` documents
+the reference tables and their shapes.
 ```
 
 ```python
@@ -315,7 +322,8 @@ Set `compute_virial` only when the virial is needed.
 
 ### Sizing
 
-{func}`~nvalchemiops.torch.interactions.dispersion.dftd3` takes no cutoff argument: the cutoff is whatever the supplied
+{func}`~nvalchemiops.torch.interactions.dispersion.dftd3` takes no cutoff
+ argument: the cutoff is whatever the supplied
 neighbour list was built with.
 
 D3 cutoffs are typically several times larger than an electrostatics real-space
@@ -400,7 +408,7 @@ where a heuristic is wrong for a given workload.
 | `NVALCHEMIOPS_EWALD_RECIP_TILED` | Force the Ewald reciprocal fill to use (`1`) or avoid (`0`) a tiled launch. |
 | `NVALCHEMIOPS_EWALD_RECIP_MIN_ATOMS` | Atom-count threshold for automatic tiled fill selection. |
 | `NVALCHEMIOPS_EWALD_RECIP_TILE_DIM` | Block width for tiled reciprocal kernels. |
-| `NVALCHEMIOPS_EWALD_RECIP_FP32_SF` | Enable the float32 no-store reciprocal path (float32 CUDA inputs only). Changes float32 results at the ~1e-07 level. |
+| `NVALCHEMIOPS_ELECTROSTATICS_FP32` | Evaluate monopole electrostatics in float32 where the inputs are float32: the per-pair real-space cores and the no-store reciprocal path. Real space is shared by Ewald and PME, so both are affected. Changes float32 results at the ~1e-07 level. |
 | `NVALCHEMIOPS_DYNAMICS_TILE_DIM` | Block width for tiled dynamics kernels. |
 | `ALCH_EWALD_BATCH_BLOCK_SIZE` | Block size for batched Ewald kernels. |
 

--- a/docs/userguide/about/performance.md
+++ b/docs/userguide/about/performance.md
@@ -1,0 +1,417 @@
+(performance)=
+
+# Performance Guide
+
+Optimal settings depend on GPU, system size, cutoff, density and dtype. Measure
+on your own configuration.
+
+## Cost model
+
+At small and medium sizes, per-call cost is usually dominated by host/device
+synchronisation and allocation rather than kernel time.
+
+Synchronisation comes from shapes or control flow that depend on device data.
+Each component exposes arguments that let you supply the value instead, and
+these matter more than preallocating output buffers:
+
+| Argument omitted | Consequence |
+| --- | --- |
+| `batch_ptr` (given only `batch_idx`) | segment pointers derived via `torch.bincount`; output length depends on data |
+| `num_systems` (DFT-D3) | inferred from `cell` or `batch_idx` |
+| `method` (neighbour lists) | strategy selected per call on the host |
+| `max_neighbors`, `max_total_cells` | sizing helpers run per call and read device values |
+| rebuild decision read as a Python `bool` | forces a sync per step |
+
+Allocation cost comes from output and scratch buffers created per call. Every
+entry point accepts them.
+
+### Verifying
+
+`torch._dynamo.explain` reports graph breaks without changing execution. Each
+entry carries the reason and the user frame that caused it:
+
+```python
+import torch._dynamo
+
+report = torch._dynamo.explain(step_fn)(*args)
+print(report.graph_break_count)
+for b in report.break_reasons:
+    print(b.reason.splitlines()[0], "|", b.user_stack[-1])
+```
+
+A break on `Tensor.item()`, `torch.bincount` or similar points at a shape or
+control-flow decision still being made from device data.
+
+`TORCH_LOGS=graph_breaks` gives the same information from an ordinary run,
+which is useful when the call is buried in a larger model:
+
+```bash
+TORCH_LOGS=graph_breaks python train.py
+```
+
+`fullgraph=True` also surfaces breaks, by raising on the first one. That is a
+behaviour change rather than a diagnostic, so prefer it as an assertion in
+tests over a debugging tool.
+
+Allocation is separate from tracing; check allocator deltas across steps:
+
+```python
+step_fn(); torch.cuda.synchronize()
+before = torch.cuda.memory_allocated()
+for _ in range(10):
+    step_fn()
+torch.cuda.synchronize()
+print(torch.cuda.memory_allocated() - before)   # expect ~0
+```
+
+## Neighbour lists
+
+Strategies differ in scaling. Some are quadratic in atom count with low fixed
+overhead; others build a spatial data structure with fixed setup cost that
+amortises as the system grows. The crossover moves with GPU, cutoff and
+density.
+
+### Selecting a strategy
+
+```python
+from nvalchemiops.torch.neighbors import suggest_neighbor_list_method
+
+method = suggest_neighbor_list_method(...)   # setup only
+```
+
+{func}`~nvalchemiops.torch.neighbors.suggest_neighbor_list_method` inspects the
+problem on the host. Call it once at setup and pass the result as `method=`;
+calling it per step, or inside `torch.compile`, reintroduces a sync.
+
+{func}`~nvalchemiops.torch.neighbors.estimate_neighbor_list_costs` returns the
+full ranked list with costs if you want to see the runner-up.
+
+### Example: Preallocating a cell list
+
+```{note}
+Each strategy takes a different set of buffers. To know what to allocate, refer
+to the API reference for the entry point you are using --- every argument typed
+`torch.Tensor | None` can be preallocated and passed in, with its shape and
+dtype given there:
+{func}`~nvalchemiops.torch.neighbors.cell_list`,
+{func}`~nvalchemiops.torch.neighbors.naive_neighbor_list`,
+{func}`~nvalchemiops.torch.neighbors.cluster_tile_neighbor_list`,
+{func}`~nvalchemiops.torch.neighbors.batch_cell_list`,
+{func}`~nvalchemiops.torch.neighbors.batch_naive_neighbor_list`,
+{func}`~nvalchemiops.torch.neighbors.batch_cluster_tile_neighbor_list`.
+```
+
+`cell_list` accepts every buffer it would otherwise allocate. Sizing needs two
+host-side helpers:
+{func}`~nvalchemiops.torch.neighbors.estimate_cell_list_sizes` for the grid and
+{func}`~nvalchemiops.neighbors.neighbor_utils.estimate_max_neighbors` for the
+matrix width;
+{func}`~nvalchemiops.torch.neighbors.neighbor_utils.allocate_cell_list` returns
+the build-side tensors as a group.
+
+```python
+import torch
+from nvalchemiops.torch.neighbors import cell_list, estimate_cell_list_sizes
+from nvalchemiops.torch.neighbors.cell_list import allocate_query_sort_scratch
+from nvalchemiops.torch.neighbors.neighbor_utils import (
+    allocate_cell_list, estimate_max_neighbors,
+)
+
+# --- setup ---
+max_total_cells, search_radius = estimate_cell_list_sizes(cell, pbc, cutoff)
+max_neighbors = estimate_max_neighbors(cutoff, atomic_density=density)
+
+# build-side state: grid dimensions, per-atom cell assignment, cell contents
+(cells_per_dimension, neighbor_search_radius, atom_periodic_shifts,
+ atom_to_cell_mapping, atoms_per_cell_count, cell_atom_start_indices,
+ cell_atom_list) = allocate_cell_list(
+    n_atoms, max_total_cells, search_radius, device
+)
+
+# query outputs
+neighbor_matrix = torch.empty((n_atoms, max_neighbors), dtype=torch.int32,
+                              device=device)
+neighbor_matrix_shifts = torch.empty((n_atoms, max_neighbors, 3),
+                                     dtype=torch.int8, device=device)
+num_neighbors = torch.empty(n_atoms, dtype=torch.int32, device=device)
+
+# sort scratch: needed by the sorted atom-centric and pair-centric paths,
+# unused by direct atom-centric
+sorted_positions, sorted_shifts = allocate_query_sort_scratch(
+    n_atoms, dtype=positions.dtype, device=device
+)
+
+# --- per step ---
+cell_list(
+    positions, cutoff, cell, pbc,
+    max_neighbors=max_neighbors,
+    neighbor_matrix=neighbor_matrix,
+    neighbor_matrix_shifts=neighbor_matrix_shifts,
+    num_neighbors=num_neighbors,
+    cells_per_dimension=cells_per_dimension,
+    neighbor_search_radius=neighbor_search_radius,
+    atom_periodic_shifts=atom_periodic_shifts,
+    atom_to_cell_mapping=atom_to_cell_mapping,
+    atoms_per_cell_count=atoms_per_cell_count,
+    cell_atom_start_indices=cell_atom_start_indices,
+    cell_atom_list=cell_atom_list,
+    sorted_positions=sorted_positions,
+    sorted_shifts=sorted_shifts,
+    strategy="pair_centric",
+)
+```
+
+Notes:
+
+- `max_total_cells` is capped by `max_nbins` (default 524288). When the natural
+  `(box / cutoff)³` grid exceeds the cap, cells per dimension are halved until
+  it fits, which raises atoms-per-cell and increases inner-loop work
+  quadratically. Check the returned value against `(box / cutoff)³` for large
+  boxes.
+- `strategy` selects `"pair_centric"` or `"atom_centric"`; `atom_centric_path`
+  selects `"direct"` or `"sorted"` within the latter. `"auto"` decides on the
+  host.
+- Omit `sorted_positions` / `sorted_shifts` for direct atom-centric; they are
+  not read.
+- {func}`~nvalchemiops.torch.neighbors.cell_list.build_cell_list` and
+  {func}`~nvalchemiops.torch.neighbors.cell_list.query_cell_list` are separable
+  if you rebuild the grid less often than you query it.
+
+Batched systems use {func}`~nvalchemiops.torch.neighbors.batch_cell_list` with
+`estimate_batch_cell_list_sizes`, and additionally take `batch_idx` and
+`batch_ptr`.
+
+### Measuring the crossover
+
+1. Preallocate each strategy's buffers.
+2. Time each with warmup, taking medians.
+3. Rotate positions between iterations; some implementations cache on input
+   identity.
+4. Pin the winner with `method=`.
+
+Time build-included and build-amortised separately. With a Verlet skin the
+amortised figure reflects steady-state MD; the included figure gives rebuild
+cost.
+
+For many small systems, measure the batched path at constant total atom count
+while varying the split.
+
+### Rebuild detection
+
+`nvalchemiops.torch.neighbors.rebuild_detection` provides
+`neighbor_list_needs_rebuild` and `cell_list_needs_rebuild` (plus `batch_`
+variants), which test displacement against a skin on device rather than
+rebuilding every step.
+
+The result is a device tensor. Reading it to a Python bool syncs; pass it
+through as `rebuild_flags` instead to keep the decision on device under
+`torch.compile` or CUDA graphs.
+
+## Ewald and PME
+
+### Preallocation
+
+```{note}
+As with neighbour lists, the API reference for the entry point lists what can be
+supplied: {func}`~nvalchemiops.torch.interactions.electrostatics.ewald_summation` and
+{func}`~nvalchemiops.torch.interactions.electrostatics.particle_mesh_ewald`. The real/reciprocal halves are separately
+callable as {func}`~nvalchemiops.torch.interactions.electrostatics.ewald_real_space`,
+{func}`~nvalchemiops.torch.interactions.electrostatics.ewald_reciprocal_space` and
+{func}`~nvalchemiops.torch.interactions.electrostatics.pme_reciprocal_space`, which is what to profile against when
+attributing cost.
+```
+
+`alpha`, the k-vector set and the PME mesh depend on cell and accuracy, not
+positions. Recomputing them per step re-runs host-side estimation
+({func}`~nvalchemiops.torch.interactions.electrostatics.estimate_ewald_parameters`,
+{func}`~nvalchemiops.torch.interactions.electrostatics.estimate_pme_mesh_dimensions`,
+{func}`~nvalchemiops.torch.interactions.electrostatics.generate_k_vectors_ewald_summation`):
+
+```python
+from nvalchemiops.torch.interactions.electrostatics import (
+    estimate_ewald_parameters, estimate_pme_mesh_dimensions,
+    generate_k_vectors_ewald_summation,
+)
+
+params = estimate_ewald_parameters(positions, cell, accuracy=accuracy)
+k_vectors = generate_k_vectors_ewald_summation(
+    cell, params.reciprocal_space_cutoff
+)
+mesh = estimate_pme_mesh_dimensions(cell, params.alpha, accuracy=accuracy)
+```
+
+Under NPT, refresh these on cell updates rather than per force evaluation.
+{func}`~nvalchemiops.torch.interactions.electrostatics.estimate_pme_parameters` returns alpha and the mesh together as a
+{class}`~nvalchemiops.torch.interactions.electrostatics.PMEParameters`; {func}`~nvalchemiops.torch.interactions.electrostatics.estimate_ewald_parameters` returns
+an {class}`~nvalchemiops.torch.interactions.electrostatics.EwaldParameters`.
+
+PME additionally precomputes B-spline moduli via
+{func}`~nvalchemiops.torch.interactions.electrostatics.compute_bspline_moduli_1d`, which depend only on the mesh and
+spline order.
+
+Both methods consume a neighbour list for real space, so the neighbour-list
+section applies to that list as well. Pass the matrix and shifts you already
+built rather than letting the entry point construct one.
+
+For batched systems pass `batch_ptr` alongside `batch_idx`, and
+`max_atoms_per_system` where the entry point accepts it.
+
+### Work split
+
+`alpha` sets the balance between real and reciprocal space. Larger `alpha`
+narrows real space and widens reciprocal space.
+
+Scaling:
+
+| Component | Scales with |
+| --- | --- |
+| Real space | pair count: cutoff³ × density |
+| Ewald reciprocal | atom count × k-vector count; k-vector count grows with cell volume |
+| PME reciprocal | FFT mesh, largely independent of atom count |
+
+Profile the two halves separately before tuning. The dominant half determines
+whether to change `alpha`, the cutoff, or the method.
+
+When comparing Ewald against PME, hold the real-space cutoff and accuracy
+fixed. Both pin `alpha` and therefore the work split.
+
+### Precision
+
+Reciprocal-space sums cancel heavily across atoms, so reductions benefit from
+float64 even where per-element arithmetic does not. Some kernels use float32
+per-element with float64 reductions.
+
+Validate any float32 path against a float64 reference on your own system, and
+check forces as well as energies.
+
+## DFT-D3
+
+### Preallocation
+
+Reference tables are element-specific and independent of geometry. Build
+`D3Parameters` once and move it to the device at setup:
+
+```{note}
+{func}`~nvalchemiops.torch.interactions.dispersion.dftd3` lists every optional buffer and table it accepts;
+{class}`~nvalchemiops.torch.interactions.dispersion.D3Parameters` documents the reference tables and their shapes.
+```
+
+```python
+from nvalchemiops.torch.interactions.dispersion import dftd3, D3Parameters
+
+d3_params = D3Parameters(...).to(device)      # setup
+```
+
+Per call, supply:
+
+- `d3_params`, rather than letting the tables be rebuilt or re-transferred.
+- `neighbor_matrix` and `neighbor_matrix_shifts` (or the COO form with
+  `neighbor_list`, `neighbor_ptr`, `unit_shifts`) from a list you already built.
+- `num_systems` for batched calls. Omitting it infers the count from `cell` or
+  `batch_idx`, which synchronises.
+- `device`, if you want to skip inference from the positions tensor.
+
+Set `compute_virial` only when the virial is needed.
+
+### Sizing
+
+{func}`~nvalchemiops.torch.interactions.dispersion.dftd3` takes no cutoff argument: the cutoff is whatever the supplied
+neighbour list was built with.
+
+D3 cutoffs are typically several times larger than an electrostatics real-space
+cutoff. Neighbour count per atom scales with the cube of the cutoff, so the
+neighbour matrix dominates memory here and `max_neighbors` must be sized
+against the D3 cutoff rather than reused from an electrostatics list.
+
+## JAX
+
+The preceding guidance is written against the Torch API. The tuning targets are
+the same -- avoid per-call allocation, hoist host-side sizing, pin the strategy
+-- but the mechanisms differ.
+
+Not benchmarked; the following follows from the API surface.
+
+### What carries over
+
+`nvalchemiops.jax.neighbors` mirrors the Torch surface:
+`suggest_neighbor_list_method`, `estimate_neighbor_list_costs`,
+`estimate_cell_list_sizes`, `estimate_max_neighbors`, `allocate_cell_list`,
+`build_cell_list` / `query_cell_list`, and the `rebuild_detection` helpers.
+Strategy selection and sizing are host-side in both backends, so both belong in
+setup.
+
+### Differences
+
+**Shapes are static.** JAX traces on shape, so `max_neighbors` and
+`max_total_cells` are effectively compile-time constants. Changing either
+retraces. Pick values that cover the whole run rather than the current
+configuration, and avoid recomputing them from device data inside a jitted
+function.
+
+**Buffers are donated, not mutated.** Torch preallocation works by writing into
+tensors you own. JAX is functional: pass the same buffers in and use
+`jax.jit(..., donate_argnums=...)` so XLA reuses the storage rather than
+allocating new outputs each call.
+
+**`graph_mode="warp"`.** `cell_list` takes a `graph_mode` argument absent from
+the Torch signature. `"warp"` targets jitted call sites that donate and reuse
+the cell-list caches and output buffers, fusing build and query. Combined with
+an explicit `max_total_cells` it requires an explicit `neighbor_search_radius`,
+since the fused path cannot inspect the constructed grid between the two
+stages.
+
+**`max_total_cells` is an argument.** The Torch entry point derives it
+internally from `estimate_cell_list_sizes`; the JAX one accepts it directly and
+estimates only when it is `None`. Passing it explicitly keeps the estimate out
+of the traced region.
+
+**Rebuild flags.** The same device-tensor rule applies, and matters more:
+reading a rebuild decision to a Python bool forces a host sync and breaks the
+trace. Keep it on device.
+
+### Measuring
+
+Time after the first call. The first invocation of a jitted function includes
+tracing and XLA compilation, which will otherwise dominate. `block_until_ready()`
+is the synchronisation point.
+
+```python
+fn = jax.jit(step_fn, donate_argnums=(...,))
+fn(*args)[0].block_until_ready()          # warm up: trace + compile
+
+times = []
+for _ in range(n):
+    t0 = time.perf_counter()
+    out = fn(*args)
+    jax.block_until_ready(out)
+    times.append(time.perf_counter() - t0)
+```
+
+Watch for retracing during a sweep: a changed `max_neighbors` or atom count
+recompiles, and that cost can land inside a timed region.
+
+## Environment overrides
+
+Defaults are chosen to be reasonable; these exist for measurement and for cases
+where a heuristic is wrong for a given workload.
+
+| Variable | Effect |
+| --- | --- |
+| `NVALCHEMIOPS_EWALD_RECIP_TILED` | Force the Ewald reciprocal fill to use (`1`) or avoid (`0`) a tiled launch. |
+| `NVALCHEMIOPS_EWALD_RECIP_MIN_ATOMS` | Atom-count threshold for automatic tiled fill selection. |
+| `NVALCHEMIOPS_EWALD_RECIP_TILE_DIM` | Block width for tiled reciprocal kernels. |
+| `NVALCHEMIOPS_EWALD_RECIP_FP32_SF` | Enable the float32 no-store reciprocal path (float32 CUDA inputs only). Changes float32 results at the ~1e-07 level. |
+| `NVALCHEMIOPS_DYNAMICS_TILE_DIM` | Block width for tiled dynamics kernels. |
+| `ALCH_EWALD_BATCH_BLOCK_SIZE` | Block size for batched Ewald kernels. |
+
+## Benchmarking
+
+- Warm up before timing; first-call cost includes kernel compilation.
+- Take medians, not means.
+- Synchronise around the timed region.
+- Vary inputs between iterations.
+- Record peak memory alongside time.
+- Benchmark energy and forces if production uses forces; backward cost is not
+  proportional to forward cost.
+- Measure `torch.compile` per component. It helps some paths and hurts others,
+  particularly where a hand-written analytic backward is re-derived.

--- a/docs/userguide/index.md
+++ b/docs/userguide/index.md
@@ -134,6 +134,7 @@ See the [PyTorch API Reference](../modules/torch/neighbors.rst) and
 - [Install](about/install)
 - [Introduction](about/intro)
 - [Conventions](about/conventions)
+- [Performance Guide](about/performance)
 
 ## Core Components
 
@@ -153,6 +154,7 @@ See the [PyTorch API Reference](../modules/torch/neighbors.rst) and
 about/install
 about/intro
 about/conventions
+about/performance
 about/migration
 about/faq
 

--- a/nvalchemiops/interactions/electrostatics/_factory_common.py
+++ b/nvalchemiops/interactions/electrostatics/_factory_common.py
@@ -42,6 +42,7 @@ orchestration stays outside, on Torch autograd.
 
 import enum
 import math
+import os
 from collections.abc import Iterable, Mapping, Sequence
 from functools import lru_cache
 from typing import Any, Literal, NamedTuple
@@ -124,6 +125,30 @@ _DISTANCE_EPSILON = 1e-8
 # Reciprocal-space ``k_sq`` guard: k-points with ``|k|^2`` below this (the k=0 term)
 # are skipped in the recip / PME convolve kernels.
 _K_SQUARED_EPSILON = 1e-10
+
+
+def _use_fp32_electrostatics() -> bool:
+    """Return whether float32 electrostatics kernels may compute in float32.
+
+    Reads ``NVALCHEMIOPS_ELECTROSTATICS_FP32``; unset or empty means off, as
+    does any of ``0``/``false``/``off``. Governs both halves of the monopole
+    split: the real-space per-pair cores below and the reciprocal structure
+    factors in ``ewald_kernels``. Real space is shared by Ewald and PME, so
+    this affects both.
+
+    Off by default because it changes float32 results at the ~1e-07 level,
+    which is a semantic change for existing callers rather than a pure
+    optimisation.
+
+    Returns
+    -------
+    bool
+        ``True`` if float32 evaluation is requested, ``False`` otherwise.
+    """
+    value = os.environ.get("NVALCHEMIOPS_ELECTROSTATICS_FP32")
+    if value is None or value == "":
+        return False
+    return value not in {"0", "false", "False", "off", "OFF"}
 
 
 # === Shared per-pair scalar cores (input precision) ===

--- a/nvalchemiops/interactions/electrostatics/_factory_common.py
+++ b/nvalchemiops/interactions/electrostatics/_factory_common.py
@@ -126,7 +126,14 @@ _DISTANCE_EPSILON = 1e-8
 _K_SQUARED_EPSILON = 1e-10
 
 
-# === Shared per-pair scalar cores (float64) ===
+# === Shared per-pair scalar cores (input precision) ===
+#
+# These evaluate in whatever precision the caller passes. They used to be
+# hard-typed float64, which cost the float32 kernels a float64 erfc, exp and
+# several divides on every pair while buying nothing: wp_erfc is an
+# Abramowitz-Stegun polynomial whose own error is ~1.5e-7, so float64 evaluation
+# cannot make it more accurate than float32 evaluation. Accumulators in the
+# calling kernels stay float64 -- that is where the cancellation lives.
 #
 # Component-agnostic erfc calculus shared by the ewald_real forward / backward /
 # double-backward kernels. Charge-unbundled factors (no division by a charge, so
@@ -139,21 +146,19 @@ _K_SQUARED_EPSILON = 1e-10
 
 
 @wp.func
-def _ewald_half_force_scale(distance: wp.float64, alpha: wp.float64) -> wp.float64:
+def _ewald_half_force_scale(distance: Any, alpha: Any) -> Any:
     """``(1/2) S(r)`` -- charge-unbundled force-magnitude scale."""
-    two_over_sqrt_pi = wp.float64(_TWO_OVER_SQRT_PI)
+    two_over_sqrt_pi = type(distance)(_TWO_OVER_SQRT_PI)
     alpha_r = alpha * distance
     erfc_alpha_r = wp_erfc(alpha_r)
     exp_term = wp.exp(-alpha_r * alpha_r)
     r2 = distance * distance
     s = erfc_alpha_r / (r2 * distance) + two_over_sqrt_pi * alpha * exp_term / r2
-    return wp.float64(0.5) * s
+    return type(distance)(0.5) * s
 
 
 @wp.func
-def _ewald_half_force_scale_deriv(
-    distance: wp.float64, alpha: wp.float64
-) -> wp.float64:
+def _ewald_half_force_scale_deriv(distance: Any, alpha: Any) -> Any:
     """``(1/2) S'(r)`` -- radial derivative of the force-magnitude scale.
 
     .. math::
@@ -161,17 +166,18 @@ def _ewald_half_force_scale_deriv(
         S'(r) = -3\\,\\mathrm{erfc}(a r)/r^4
                 - (2a/\\sqrt{\\pi}) e^{-a^2 r^2} (3/r^3 + 2 a^2 / r).
     """
-    two_over_sqrt_pi = wp.float64(_TWO_OVER_SQRT_PI)
+    two_over_sqrt_pi = type(distance)(_TWO_OVER_SQRT_PI)
     alpha_r = alpha * distance
     erfc_alpha_r = wp_erfc(alpha_r)
     exp_term = wp.exp(-alpha_r * alpha_r)
     r2 = distance * distance
     r3 = r2 * distance
     r4 = r3 * distance
-    s_prime = -wp.float64(3.0) * erfc_alpha_r / r4 - two_over_sqrt_pi * alpha * (
-        exp_term * (wp.float64(3.0) / r3 + wp.float64(2.0) * alpha * alpha / distance)
+    three = type(distance)(3.0)
+    s_prime = -three * erfc_alpha_r / r4 - two_over_sqrt_pi * alpha * (
+        exp_term * (three / r3 + type(distance)(2.0) * alpha * alpha / distance)
     )
-    return wp.float64(0.5) * s_prime
+    return type(distance)(0.5) * s_prime
 
 
 @wp.func
@@ -192,9 +198,7 @@ def _pair_virial_outer(sep: Any, force: Any) -> wp.mat33d:
 
 
 @wp.func
-def _ewald_charge_potential_deriv(
-    distance: wp.float64, alpha: wp.float64
-) -> wp.float64:
+def _ewald_charge_potential_deriv(distance: Any, alpha: Any) -> Any:
     """``g'(r) = (1/2) d/dr[erfc(a r)/r]``.
 
     .. math::
@@ -202,12 +206,12 @@ def _ewald_charge_potential_deriv(
         g'(r) = -\\tfrac{1}{2}\\left[(2a/\\sqrt{\\pi}) e^{-a^2 r^2}/r
                 + \\mathrm{erfc}(a r)/r^2\\right].
     """
-    two_over_sqrt_pi = wp.float64(_TWO_OVER_SQRT_PI)
+    two_over_sqrt_pi = type(distance)(_TWO_OVER_SQRT_PI)
     alpha_r = alpha * distance
     erfc_alpha_r = wp_erfc(alpha_r)
     exp_term = wp.exp(-alpha_r * alpha_r)
     r2 = distance * distance
-    return -wp.float64(0.5) * (
+    return -type(distance)(0.5) * (
         two_over_sqrt_pi * alpha * exp_term / distance + erfc_alpha_r / r2
     )
 

--- a/nvalchemiops/interactions/electrostatics/ewald_kernels.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_kernels.py
@@ -1036,8 +1036,16 @@ def _recip_atom_accumulate_fp32(
     real_structure_factors: wp.array(dtype=wp.float64),
     imag_structure_factors: wp.array(dtype=wp.float64),
     num_k: int,
+    k_start: int,
+    k_stride: int,
 ):
     """Per-atom reciprocal sums, recomputing phases rather than reading them.
+
+    ``k_start`` / ``k_stride`` select this thread's slice of the k range:
+    ``(0, 1)`` walks all of it, which is what the atom-major kernel wants, while
+    the tiled kernel passes ``(lane, block_dim)`` so a block's lanes split the
+    range and combine afterwards with ``wp.tile_reduce``. Keeping it a parameter
+    is what lets both kernels share this loop instead of duplicating it.
 
     Returns ``(potential, Fx, Fy, Fz, potential_uncharged)`` where
 
@@ -1056,7 +1064,7 @@ def _recip_atom_accumulate_fp32(
     fy = wp.float64(0.0)
     fz = wp.float64(0.0)
 
-    for k_idx in range(num_k):
+    for k_idx in range(k_start, num_k, k_stride):
         kvec = k_vectors[k_idx]
         phase = _recip_phase_fp32(px, py, pz, kvec)
         cos_kr = wp.float64(phase[0])
@@ -1106,6 +1114,8 @@ def _ewald_recip_compute_fp32_recompute(
         real_structure_factors,
         imag_structure_factors,
         num_k,
+        0,
+        1,
     )
     reciprocal_energies[atom_idx] = wp.float64(0.5) * acc[0]
     atomic_forces[atom_idx] = type(atomic_forces[atom_idx])(
@@ -1146,6 +1156,8 @@ def _batch_ewald_recip_compute_fp32_recompute(
         real_structure_factors[system_id],
         imag_structure_factors[system_id],
         num_k,
+        0,
+        1,
     )
     reciprocal_energies[atom_idx] = wp.float64(0.5) * acc[0]
     atomic_forces[atom_idx] = type(atomic_forces[atom_idx])(
@@ -1154,6 +1166,104 @@ def _batch_ewald_recip_compute_fp32_recompute(
         type(atomic_forces[atom_idx][0])(acc[3]),
     )
     charge_gradients[atom_idx] = acc[4]
+
+
+@wp.kernel
+def _ewald_recip_compute_fp32_recompute_tiled(
+    positions: wp.array(dtype=Any),
+    charges: wp.array(dtype=Any),
+    k_vectors: wp.array(dtype=Any),
+    real_structure_factors: wp.array(dtype=wp.float64),
+    imag_structure_factors: wp.array(dtype=wp.float64),
+    reciprocal_energies: wp.array(dtype=wp.float64),
+    atomic_forces: wp.array(dtype=Any),
+    charge_gradients: wp.array(dtype=wp.float64),
+):
+    """Cooperative counterpart of :func:`_ewald_recip_compute_fp32_recompute`.
+
+    The atom-major kernel gives each thread the whole k range, which at
+    K ~ 6e4 is a very long serial loop and leaves the machine idle whenever
+    there are fewer atoms than it can occupy. Here one block owns one atom and
+    its lanes split the k range, mirroring how the fill kernel splits atoms
+    across lanes for a fixed k.
+
+    Thread launch
+    -------------
+    ``wp.launch_tiled(dim=N, block_dim=RECIP_TILED_BLOCK_DIM)``.
+    """
+    atom_idx, lane = wp.tid()
+    num_k = real_structure_factors.shape[0]
+    position = positions[atom_idx]
+    acc = _recip_atom_accumulate_fp32(
+        wp.float32(position[0]),
+        wp.float32(position[1]),
+        wp.float32(position[2]),
+        wp.float64(charges[atom_idx]),
+        k_vectors,
+        real_structure_factors,
+        imag_structure_factors,
+        num_k,
+        lane,
+        wp.static(RECIP_TILED_BLOCK_DIM),
+    )
+    pot = wp.tile_reduce(wp.add, wp.tile(acc[0]))
+    fx = wp.tile_reduce(wp.add, wp.tile(acc[1]))
+    fy = wp.tile_reduce(wp.add, wp.tile(acc[2]))
+    fz = wp.tile_reduce(wp.add, wp.tile(acc[3]))
+    unq = wp.tile_reduce(wp.add, wp.tile(acc[4]))
+    if lane == 0:
+        reciprocal_energies[atom_idx] = wp.float64(0.5) * wp.tile_extract(pot, 0)
+        atomic_forces[atom_idx] = type(atomic_forces[atom_idx])(
+            type(atomic_forces[atom_idx][0])(wp.tile_extract(fx, 0)),
+            type(atomic_forces[atom_idx][0])(wp.tile_extract(fy, 0)),
+            type(atomic_forces[atom_idx][0])(wp.tile_extract(fz, 0)),
+        )
+        charge_gradients[atom_idx] = wp.tile_extract(unq, 0)
+
+
+@wp.kernel
+def _batch_ewald_recip_compute_fp32_recompute_tiled(
+    positions: wp.array(dtype=Any),
+    charges: wp.array(dtype=Any),
+    batch_idx: wp.array(dtype=wp.int32),
+    k_vectors: wp.array2d(dtype=Any),
+    real_structure_factors: wp.array2d(dtype=wp.float64),
+    imag_structure_factors: wp.array2d(dtype=wp.float64),
+    reciprocal_energies: wp.array(dtype=wp.float64),
+    atomic_forces: wp.array(dtype=Any),
+    charge_gradients: wp.array(dtype=wp.float64),
+):
+    """Batched counterpart of
+    :func:`_ewald_recip_compute_fp32_recompute_tiled`."""
+    atom_idx, lane = wp.tid()
+    system_id = batch_idx[atom_idx]
+    num_k = real_structure_factors.shape[1]
+    position = positions[atom_idx]
+    acc = _recip_atom_accumulate_fp32(
+        wp.float32(position[0]),
+        wp.float32(position[1]),
+        wp.float32(position[2]),
+        wp.float64(charges[atom_idx]),
+        k_vectors[system_id],
+        real_structure_factors[system_id],
+        imag_structure_factors[system_id],
+        num_k,
+        lane,
+        wp.static(RECIP_TILED_BLOCK_DIM),
+    )
+    pot = wp.tile_reduce(wp.add, wp.tile(acc[0]))
+    fx = wp.tile_reduce(wp.add, wp.tile(acc[1]))
+    fy = wp.tile_reduce(wp.add, wp.tile(acc[2]))
+    fz = wp.tile_reduce(wp.add, wp.tile(acc[3]))
+    unq = wp.tile_reduce(wp.add, wp.tile(acc[4]))
+    if lane == 0:
+        reciprocal_energies[atom_idx] = wp.float64(0.5) * wp.tile_extract(pot, 0)
+        atomic_forces[atom_idx] = type(atomic_forces[atom_idx])(
+            type(atomic_forces[atom_idx][0])(wp.tile_extract(fx, 0)),
+            type(atomic_forces[atom_idx][0])(wp.tile_extract(fy, 0)),
+            type(atomic_forces[atom_idx][0])(wp.tile_extract(fz, 0)),
+        )
+        charge_gradients[atom_idx] = wp.tile_extract(unq, 0)
 
 
 @wp.kernel

--- a/nvalchemiops/interactions/electrostatics/ewald_kernels.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_kernels.py
@@ -257,11 +257,11 @@ def can_tile_ewald_recip_on_device(device: object) -> bool:
 
 @wp.func
 def _ewald_real_space_energy_kernel_compute_energy(
-    qi: wp.float64,
-    qj: wp.float64,
-    distance: wp.float64,
-    alpha: wp.float64,
-) -> wp.float64:
+    qi: Any,
+    qj: Any,
+    distance: Any,
+    alpha: Any,
+) -> Any:
     """Compute damped Coulomb energy for a single pair.
 
     Formula:
@@ -275,11 +275,11 @@ def _ewald_real_space_energy_kernel_compute_energy(
 
     Parameters
     ----------
-    qi, qj : wp.float64
-        Charges of atoms i and j.
-    distance : wp.float64
-        Distance |r_j - r_i|.
-    alpha : wp.float64
+    qi, qj : Any
+        Charges of atoms i and j, in the caller's precision.
+    distance : Any
+        Distance |r_j - r_i|, in the caller's precision.
+    alpha : Any
         Ewald splitting parameter.
 
     Returns
@@ -287,16 +287,16 @@ def _ewald_real_space_energy_kernel_compute_energy(
     wp.float64
         Damped Coulomb energy contribution.
     """
-    return wp.float64(0.5) * qi * qj * wp_erfc(alpha * distance) / distance
+    return type(distance)(0.5) * qi * qj * wp_erfc(alpha * distance) / distance
 
 
 @wp.func
 def _ewald_real_space_force_magnitude(
-    qi: wp.float64,
-    qj: wp.float64,
-    distance: wp.float64,
-    alpha: wp.float64,
-) -> wp.float64:
+    qi: Any,
+    qj: Any,
+    distance: Any,
+    alpha: Any,
+) -> Any:
     """Compute damped Coulomb force magnitude factor for a single pair.
 
     Returns the scalar part of the force:
@@ -309,11 +309,11 @@ def _ewald_real_space_force_magnitude(
 
     Parameters
     ----------
-    qi, qj : wp.float64
-        Charges of atoms i and j.
-    distance : wp.float64
-        Distance |r_j - r_i|.
-    alpha : wp.float64
+    qi, qj : Any
+        Charges of atoms i and j, in the caller's precision.
+    distance : Any
+        Distance |r_j - r_i|, in the caller's precision.
+    alpha : Any
         Ewald splitting parameter.
 
     Returns
@@ -321,9 +321,9 @@ def _ewald_real_space_force_magnitude(
     wp.float64
         Force magnitude factor.
     """
-    two_over_sqrt_pi = wp.float64(TWO_OVER_SQRT_PI)
+    two_over_sqrt_pi = type(distance)(TWO_OVER_SQRT_PI)
 
-    prefactor = wp.float64(0.5) * qi * qj
+    prefactor = type(distance)(0.5) * qi * qj
     alpha_r = alpha * distance
     alpha_r_squared = alpha_r * alpha_r
 
@@ -339,9 +339,9 @@ def _ewald_real_space_force_magnitude(
 
 @wp.func
 def _ewald_real_space_charge_grad_potential(
-    distance: wp.float64,
-    alpha: wp.float64,
-) -> wp.float64:
+    distance: Any,
+    alpha: Any,
+) -> Any:
     r"""Compute the damped Coulomb potential for charge gradient.
 
     Returns :math:`\frac{1}{2} \frac{\text{erfc}(\alpha r)}{r}`, which when multiplied by q_j gives
@@ -357,9 +357,9 @@ def _ewald_real_space_charge_grad_potential(
 
     Parameters
     ----------
-    distance : wp.float64
-        Distance |r_j - r_i|.
-    alpha : wp.float64
+    distance : Any
+        Distance |r_j - r_i|, in the caller's precision.
+    alpha : Any
         Ewald splitting parameter.
 
     Returns
@@ -367,7 +367,7 @@ def _ewald_real_space_charge_grad_potential(
     wp.float64
         Potential factor for charge gradient computation.
     """
-    return wp.float64(0.5) * wp_erfc(alpha * distance) / distance
+    return type(distance)(0.5) * wp_erfc(alpha * distance) / distance
 
 
 ###########################################################################################

--- a/nvalchemiops/interactions/electrostatics/ewald_kernels.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_kernels.py
@@ -814,6 +814,348 @@ def _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled(
         cellgrad_cache[k_idx, 7] = wp.tile_extract(rb_z_tile, 0)
 
 
+# ---------------------------------------------------------------------------
+# fp32, no-store reciprocal structure factors
+# ---------------------------------------------------------------------------
+#
+# The default fill kernels compute k.r, cos/sin and the accumulators in float64
+# and write the unweighted phases to two float64 (K, N) arrays. Both are costly:
+#
+#   * float64 is 785x slower than float32 for matmul and 24x for transcendentals
+#     on B300 (measured); ~22x / ~4.8x on a workstation Blackwell part.
+#   * the (K, N) phases are 3.6 GiB of traffic per call at N=8192, K=29659.
+#
+# These kernels do the phase arithmetic in float32 and never materialise
+# (K, N); the per-k reduction is still promoted to float64, which is where the
+# cross-atom cancellation that motivates float64 actually bites. Measured
+# against the shipped tiled kernel on B300: 24-34x faster, max relative error
+# ~1e-07 on the structure factors.
+#
+# Because the phases are not stored, the energy kernel below recomputes them.
+# In float32 that recompute is far cheaper than the round-trip it replaces:
+# at N=8192 on B300 it is ~0.7 ms of cos/sin against 7.2 GiB of traffic.
+#
+# Opt in with NVALCHEMIOPS_EWALD_RECIP_FP32_SF=1. Off by default: it changes
+# float32 results at the ~1e-07 level, which is a semantic change for existing
+# callers rather than a pure optimisation.
+
+
+def use_fp32_structure_factors() -> bool:
+    """Return whether the float32 no-store reciprocal path is enabled.
+
+    Controlled by ``NVALCHEMIOPS_EWALD_RECIP_FP32_SF``. Defaults to off.
+    """
+    value = os.environ.get("NVALCHEMIOPS_EWALD_RECIP_FP32_SF")
+    if value is None or value == "":
+        return False
+    return value not in {"0", "false", "False", "off", "OFF"}
+
+
+@wp.kernel
+def _ewald_recip_fill_sf_fp32_nostore(
+    positions: wp.array(dtype=Any),
+    charges: wp.array(dtype=Any),
+    k_vectors: wp.array(dtype=Any),
+    cell: wp.array(dtype=Any),
+    alpha: wp.array(dtype=Any),
+    total_charge: wp.array(dtype=wp.float64),
+    real_structure_factors: wp.array(dtype=wp.float64),
+    imag_structure_factors: wp.array(dtype=wp.float64),
+):
+    """Single-system weighted structure factors, float32 phases, no (K, N) store.
+
+    Thread launch
+    -------------
+    ``wp.launch_tiled(dim=K, block_dim=RECIP_TILED_BLOCK_DIM)``. One block owns
+    one k-vector; its lanes cooperate over all atoms.
+
+    Modifies
+    --------
+    ``total_charge``, ``real_structure_factors``, ``imag_structure_factors``.
+    The unweighted phases are deliberately not written -- see the module note.
+    """
+    k_idx, lane = wp.tid()
+    num_atoms = positions.shape[0]
+    block = wp.static(RECIP_TILED_BLOCK_DIM)
+
+    alpha_ = wp.float32(alpha[0])
+    exp_factor = wp.float32(0.25) / (alpha_ * alpha_)
+    volume = wp.float32(wp.abs(wp.determinant(cell[0])))
+    inv_volume = wp.float32(1.0) / volume
+
+    k_vector = k_vectors[k_idx]
+    kx = wp.float32(k_vector[0])
+    ky = wp.float32(k_vector[1])
+    kz = wp.float32(k_vector[2])
+    k_squared = kx * kx + ky * ky + kz * kz
+
+    green_function = wp.float32(0.0)
+    if k_squared >= wp.float32(1e-10):
+        green_function = (
+            wp.exp(-exp_factor * k_squared)
+            / k_squared
+            * wp.float32(EIGHTPI)
+            * inv_volume
+        )
+
+    real_sum = wp.float32(0.0)
+    imag_sum = wp.float32(0.0)
+    charge_sum = wp.float64(0.0)
+
+    for atom_start in range(0, num_atoms, block):
+        atom_idx = atom_start + lane
+        if atom_idx < num_atoms:
+            charge = wp.float32(charges[atom_idx])
+            if k_idx == 0:
+                charge_sum += wp.float64(charge) * wp.float64(inv_volume)
+            if k_squared >= wp.float32(1e-10):
+                position = positions[atom_idx]
+                phase = _recip_phase_fp32(
+                    wp.float32(position[0]),
+                    wp.float32(position[1]),
+                    wp.float32(position[2]),
+                    k_vector,
+                )
+                real_sum += charge * phase[0]
+                imag_sum += charge * phase[1]
+
+    # Promote before the cross-lane reduction: the per-atom terms are O(q) but
+    # the sum over atoms cancels heavily, which is the part that needs float64.
+    real_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(real_sum * green_function)))
+    imag_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(imag_sum * green_function)))
+    charge_tile = wp.tile_reduce(wp.add, wp.tile(charge_sum))
+
+    wp.tile_store(real_structure_factors, real_tile, k_idx)
+    wp.tile_store(imag_structure_factors, imag_tile, k_idx)
+    if k_idx == 0:
+        wp.tile_store(total_charge, charge_tile, 0)
+
+
+@wp.kernel
+def _batch_ewald_recip_fill_sf_fp32_nostore(
+    positions: wp.array(dtype=Any),
+    charges: wp.array(dtype=Any),
+    k_vectors: wp.array2d(dtype=Any),
+    cell: wp.array(dtype=Any),
+    alpha: wp.array(dtype=Any),
+    atom_start: wp.array(dtype=wp.int32),
+    atom_end: wp.array(dtype=wp.int32),
+    total_charge: wp.array(dtype=wp.float64),
+    real_structure_factors: wp.array2d(dtype=wp.float64),
+    imag_structure_factors: wp.array2d(dtype=wp.float64),
+):
+    """Batched counterpart of :func:`_ewald_recip_fill_sf_fp32_nostore`.
+
+    Thread launch
+    -------------
+    ``wp.launch_tiled(dim=(K, S), block_dim=RECIP_TILED_BLOCK_DIM)``.
+    """
+    k_idx, system_id, lane = wp.tid()
+    block = wp.static(RECIP_TILED_BLOCK_DIM)
+    start = atom_start[system_id]
+    end = atom_end[system_id]
+
+    alpha_ = wp.float32(alpha[system_id])
+    exp_factor = wp.float32(0.25) / (alpha_ * alpha_)
+    inv_volume = wp.float32(1.0) / wp.float32(wp.abs(wp.determinant(cell[system_id])))
+
+    k_vector = k_vectors[system_id, k_idx]
+    kx = wp.float32(k_vector[0])
+    ky = wp.float32(k_vector[1])
+    kz = wp.float32(k_vector[2])
+    k_squared = kx * kx + ky * ky + kz * kz
+
+    green_function = wp.float32(0.0)
+    if k_squared >= wp.float32(1e-10):
+        green_function = (
+            wp.exp(-exp_factor * k_squared)
+            / k_squared
+            * wp.float32(EIGHTPI)
+            * inv_volume
+        )
+
+    real_sum = wp.float32(0.0)
+    imag_sum = wp.float32(0.0)
+    charge_sum = wp.float64(0.0)
+
+    for offset in range(start, end, block):
+        atom_idx = offset + lane
+        if atom_idx < end:
+            charge = wp.float32(charges[atom_idx])
+            if k_idx == 0:
+                charge_sum += wp.float64(charge) * wp.float64(inv_volume)
+            if k_squared >= wp.float32(1e-10):
+                position = positions[atom_idx]
+                phase = _recip_phase_fp32(
+                    wp.float32(position[0]),
+                    wp.float32(position[1]),
+                    wp.float32(position[2]),
+                    k_vector,
+                )
+                real_sum += charge * phase[0]
+                imag_sum += charge * phase[1]
+
+    real_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(real_sum * green_function)))
+    imag_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(imag_sum * green_function)))
+    charge_tile = wp.tile_reduce(wp.add, wp.tile(charge_sum))
+
+    if lane == 0:
+        real_structure_factors[system_id, k_idx] = wp.tile_extract(real_tile, 0)
+        imag_structure_factors[system_id, k_idx] = wp.tile_extract(imag_tile, 0)
+        if k_idx == 0:
+            total_charge[system_id] = wp.tile_extract(charge_tile, 0)
+
+
+# Five float64 accumulators per atom: (charged potential, Fx, Fy, Fz,
+# uncharged potential). Returned as one value so the k-loop below can be shared
+# by every consumer instead of being copy-pasted per derivative state.
+_recip_vec5d = wp.types.vector(length=5, dtype=wp.float64)
+
+
+@wp.func
+def _recip_phase_fp32(px: wp.float32, py: wp.float32, pz: wp.float32, kvec: Any):
+    """cos(k.r) and sin(k.r) evaluated in float32, returned as a vec2f.
+
+    The single place phases are computed for the float32 reciprocal path, used
+    by both the structure-factor fill and the per-atom compute so the two can
+    never drift apart.
+    """
+    k_dot_r = (
+        wp.float32(kvec[0]) * px + wp.float32(kvec[1]) * py + wp.float32(kvec[2]) * pz
+    )
+    return wp.vec2f(wp.cos(k_dot_r), wp.sin(k_dot_r))
+
+
+@wp.func
+def _recip_atom_accumulate_fp32(
+    px: wp.float32,
+    py: wp.float32,
+    pz: wp.float32,
+    charge: wp.float64,
+    k_vectors: wp.array(dtype=Any),
+    real_structure_factors: wp.array(dtype=wp.float64),
+    imag_structure_factors: wp.array(dtype=wp.float64),
+    num_k: int,
+):
+    """Per-atom reciprocal sums, recomputing phases rather than reading them.
+
+    Returns ``(potential, Fx, Fy, Fz, potential_uncharged)`` where
+
+    .. math::
+        E_i = \\tfrac{1}{2} \\sum_k [S_{re} q_i \\cos + S_{im} q_i \\sin], \\quad
+        F_i = \\sum_k k [S_{re} q_i \\sin - S_{im} q_i \\cos], \\quad
+        \\frac{\\partial E}{\\partial q_i} = \\sum_k [S_{re}\\cos + S_{im}\\sin]
+
+    Forces and the charge gradient cost three FMAs per k on top of the energy;
+    the loop is dominated by the transcendentals, so they are always computed
+    and the caller writes only what it needs.
+    """
+    potential = wp.float64(0.0)
+    potential_uncharged = wp.float64(0.0)
+    fx = wp.float64(0.0)
+    fy = wp.float64(0.0)
+    fz = wp.float64(0.0)
+
+    for k_idx in range(num_k):
+        kvec = k_vectors[k_idx]
+        phase = _recip_phase_fp32(px, py, pz, kvec)
+        cos_kr = wp.float64(phase[0])
+        sin_kr = wp.float64(phase[1])
+
+        s_real = real_structure_factors[k_idx]
+        s_imag = imag_structure_factors[k_idx]
+
+        phase_sum = s_real * cos_kr + s_imag * sin_kr
+        potential += charge * phase_sum
+        potential_uncharged += phase_sum
+
+        force_scalar = charge * (s_real * sin_kr - s_imag * cos_kr)
+        fx += force_scalar * wp.float64(kvec[0])
+        fy += force_scalar * wp.float64(kvec[1])
+        fz += force_scalar * wp.float64(kvec[2])
+
+    return _recip_vec5d(potential, fx, fy, fz, potential_uncharged)
+
+
+@wp.kernel
+def _ewald_recip_compute_fp32_recompute(
+    positions: wp.array(dtype=Any),
+    charges: wp.array(dtype=Any),
+    k_vectors: wp.array(dtype=Any),
+    real_structure_factors: wp.array(dtype=wp.float64),
+    imag_structure_factors: wp.array(dtype=wp.float64),
+    reciprocal_energies: wp.array(dtype=wp.float64),
+    atomic_forces: wp.array(dtype=Any),
+    charge_gradients: wp.array(dtype=wp.float64),
+):
+    """Single-system per-atom energies, forces and dE/dq, phases recomputed.
+
+    Atom-major, so each thread owns its outputs and no atomics are needed. The
+    counterpart to :func:`_ewald_recip_fill_sf_fp32_nostore`, which leaves the
+    ``(K, N)`` phases unwritten.
+    """
+    atom_idx = wp.tid()
+    num_k = real_structure_factors.shape[0]
+    position = positions[atom_idx]
+    acc = _recip_atom_accumulate_fp32(
+        wp.float32(position[0]),
+        wp.float32(position[1]),
+        wp.float32(position[2]),
+        wp.float64(charges[atom_idx]),
+        k_vectors,
+        real_structure_factors,
+        imag_structure_factors,
+        num_k,
+    )
+    reciprocal_energies[atom_idx] = wp.float64(0.5) * acc[0]
+    atomic_forces[atom_idx] = type(atomic_forces[atom_idx])(
+        type(atomic_forces[atom_idx][0])(acc[1]),
+        type(atomic_forces[atom_idx][0])(acc[2]),
+        type(atomic_forces[atom_idx][0])(acc[3]),
+    )
+    charge_gradients[atom_idx] = acc[4]
+
+
+@wp.kernel
+def _batch_ewald_recip_compute_fp32_recompute(
+    positions: wp.array(dtype=Any),
+    charges: wp.array(dtype=Any),
+    batch_idx: wp.array(dtype=wp.int32),
+    k_vectors: wp.array2d(dtype=Any),
+    real_structure_factors: wp.array2d(dtype=wp.float64),
+    imag_structure_factors: wp.array2d(dtype=wp.float64),
+    reciprocal_energies: wp.array(dtype=wp.float64),
+    atomic_forces: wp.array(dtype=Any),
+    charge_gradients: wp.array(dtype=wp.float64),
+):
+    """Batched counterpart of :func:`_ewald_recip_compute_fp32_recompute`.
+
+    Each system's row is sliced out of the 2D inputs and handed to the same
+    accumulation function the single-system kernel uses.
+    """
+    atom_idx = wp.tid()
+    system_id = batch_idx[atom_idx]
+    num_k = real_structure_factors.shape[1]
+    position = positions[atom_idx]
+    acc = _recip_atom_accumulate_fp32(
+        wp.float32(position[0]),
+        wp.float32(position[1]),
+        wp.float32(position[2]),
+        wp.float64(charges[atom_idx]),
+        k_vectors[system_id],
+        real_structure_factors[system_id],
+        imag_structure_factors[system_id],
+        num_k,
+    )
+    reciprocal_energies[atom_idx] = wp.float64(0.5) * acc[0]
+    atomic_forces[atom_idx] = type(atomic_forces[atom_idx])(
+        type(atomic_forces[atom_idx][0])(acc[1]),
+        type(atomic_forces[atom_idx][0])(acc[2]),
+        type(atomic_forces[atom_idx][0])(acc[3]),
+    )
+    charge_gradients[atom_idx] = acc[4]
+
+
 @wp.kernel
 def _ewald_reciprocal_space_energy_kernel_compute_energy(
     charges: wp.array(dtype=Any),

--- a/nvalchemiops/interactions/electrostatics/ewald_kernels.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_kernels.py
@@ -208,6 +208,25 @@ def _recip_tiling_override() -> bool | None:
     return value not in {"0", "false", "False", "off", "OFF"}
 
 
+def _use_fp32_structure_factors() -> bool:
+    """Return whether the float32 no-store reciprocal path is enabled.
+
+    Reads ``NVALCHEMIOPS_EWALD_RECIP_FP32_SF``; unset or empty means off, as
+    does any of ``0``/``false``/``off``. The path computes structure-factor
+    phases in float32 and recomputes them per atom instead of materializing the
+    ``(K, N)`` phase arrays.
+
+    Returns
+    -------
+    bool
+        ``True`` if the float32 no-store path is requested, ``False`` otherwise.
+    """
+    value = os.environ.get("NVALCHEMIOPS_EWALD_RECIP_FP32_SF")
+    if value is None or value == "":
+        return False
+    return value not in {"0", "false", "False", "off", "OFF"}
+
+
 def should_tile_ewald_recip_fill(num_atoms: int) -> bool:
     """Return whether reciprocal fill should use a tiled launch.
 
@@ -821,34 +840,24 @@ def _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled(
 # The default fill kernels compute k.r, cos/sin and the accumulators in float64
 # and write the unweighted phases to two float64 (K, N) arrays. Both are costly:
 #
-#   * float64 is 785x slower than float32 for matmul and 24x for transcendentals
-#     on B300 (measured); ~22x / ~4.8x on a workstation Blackwell part.
-#   * the (K, N) phases are 3.6 GiB of traffic per call at N=8192, K=29659.
+#   * float64 transcendental throughput is a fraction of float32 on every part
+#     this runs on, and the ratio varies widely between them.
+#   * the (K, N) phases scale as the product of the k-vector and atom counts,
+#     so the traffic grows faster than either alone.
 #
 # These kernels do the phase arithmetic in float32 and never materialise
 # (K, N); the per-k reduction is still promoted to float64, which is where the
-# cross-atom cancellation that motivates float64 actually bites. Measured
-# against the shipped tiled kernel on B300: 24-34x faster, max relative error
-# ~1e-07 on the structure factors.
+# cross-atom cancellation that motivates float64 actually bites. Maximum
+# relative error on the structure factors is ~1e-07.
 #
 # Because the phases are not stored, the energy kernel below recomputes them.
-# In float32 that recompute is far cheaper than the round-trip it replaces:
-# at N=8192 on B300 it is ~0.7 ms of cos/sin against 7.2 GiB of traffic.
+# Recomputing float32 cos/sin is cheaper than the float64 round-trip it
+# replaces; the crossover depends on the part's transcendental throughput
+# against its memory bandwidth, so measure rather than assume.
 #
 # Opt in with NVALCHEMIOPS_EWALD_RECIP_FP32_SF=1. Off by default: it changes
 # float32 results at the ~1e-07 level, which is a semantic change for existing
 # callers rather than a pure optimisation.
-
-
-def use_fp32_structure_factors() -> bool:
-    """Return whether the float32 no-store reciprocal path is enabled.
-
-    Controlled by ``NVALCHEMIOPS_EWALD_RECIP_FP32_SF``. Defaults to off.
-    """
-    value = os.environ.get("NVALCHEMIOPS_EWALD_RECIP_FP32_SF")
-    if value is None or value == "":
-        return False
-    return value not in {"0", "false", "False", "off", "OFF"}
 
 
 @wp.kernel
@@ -862,7 +871,31 @@ def _ewald_recip_fill_sf_fp32_nostore(
     real_structure_factors: wp.array(dtype=wp.float32),
     imag_structure_factors: wp.array(dtype=wp.float32),
 ):
-    """Single-system weighted structure factors, float32 phases, no (K, N) store.
+    r"""Single-system weighted structure factors, float32 phases, no (K, N) store.
+
+    Phases are formed in float32 and accumulated in float32 per lane; the
+    cross-lane reduction widens to float64, so the stored values are as accurate
+    as a float64 array would hold them.
+
+    Parameters
+    ----------
+    positions : wp.array, shape (N,), dtype=wp.vec3f
+        Atomic coordinates.
+    charges : wp.array, shape (N,), dtype=wp.float32
+        Atomic charges.
+    k_vectors : wp.array, shape (K,), dtype=wp.vec3f
+        Half-space reciprocal lattice vectors (excludes -k for each k).
+    cell : wp.array, shape (1, 3, 3), dtype=wp.mat33f
+        Unit cell matrix, used for the volume.
+    alpha : wp.array, shape (1,), dtype=wp.float32
+        Ewald splitting parameter.
+    total_charge : wp.array, shape (1,), dtype=wp.float64
+        OUTPUT: Q/V for the background correction. Only the k_idx == 0 block
+        accumulates it.
+    real_structure_factors : wp.array, shape (K,), dtype=wp.float32
+        OUTPUT: :math:`(G(k)/V) \sum_i q_i \cos(k \cdot r_i)`.
+    imag_structure_factors : wp.array, shape (K,), dtype=wp.float32
+        OUTPUT: :math:`(G(k)/V) \sum_i q_i \sin(k \cdot r_i)`.
 
     Thread launch
     -------------
@@ -936,6 +969,160 @@ def _ewald_recip_fill_sf_fp32_nostore(
 
 
 @wp.kernel
+def _ewald_recip_fill_sf_fp32_nostore_cellgrad(
+    positions: wp.array(dtype=Any),
+    charges: wp.array(dtype=Any),
+    k_vectors: wp.array(dtype=Any),
+    cell: wp.array(dtype=Any),
+    alpha: wp.array(dtype=Any),
+    total_charge: wp.array(dtype=wp.float64),
+    real_structure_factors: wp.array(dtype=wp.float32),
+    imag_structure_factors: wp.array(dtype=wp.float32),
+    cellgrad_cache: wp.array2d(dtype=wp.float64),
+):
+    r"""Single-system float32 no-store fill, plus the cell-gradient cache.
+
+    Phases are formed in float32 and accumulated in float32 per lane; the
+    cross-lane reduction widens to float64, so the stored values are as accurate
+    as a float64 array would hold them.
+
+    Parameters
+    ----------
+    positions : wp.array, shape (N,), dtype=wp.vec3f
+        Atomic coordinates.
+    charges : wp.array, shape (N,), dtype=wp.float32
+        Atomic charges.
+    k_vectors : wp.array, shape (K,), dtype=wp.vec3f
+        Half-space reciprocal lattice vectors (excludes -k for each k).
+    cell : wp.array, shape (1, 3, 3), dtype=wp.mat33f
+        Unit cell matrix, used for the volume.
+    alpha : wp.array, shape (1,), dtype=wp.float32
+        Ewald splitting parameter.
+    total_charge : wp.array, shape (1,), dtype=wp.float64
+        OUTPUT: Q/V for the background correction. Only the k_idx == 0 block
+        accumulates it.
+    real_structure_factors : wp.array, shape (K,), dtype=wp.float32
+        OUTPUT: :math:`(G(k)/V) \sum_i q_i \cos(k \cdot r_i)`.
+    imag_structure_factors : wp.array, shape (K,), dtype=wp.float32
+        OUTPUT: :math:`(G(k)/V) \sum_i q_i \sin(k \cdot r_i)`.
+    cellgrad_cache : wp.array2d, shape (K, 8), dtype=wp.float64
+        OUTPUT: per-k unweighted reductions consumed by the cell-gradient
+        backward -- ``[Sre, Sim, (Sre*r)_xyz, (Sim*r)_xyz]``. Unweighted means
+        before the Green's function, which the backward applies itself.
+
+    Thread launch
+    -------------
+    ``wp.launch_tiled(dim=K, block_dim=RECIP_TILED_BLOCK_DIM)``. One block owns
+    one k-vector; its lanes cooperate over all atoms.
+
+    Modifies
+    --------
+    ``total_charge``, ``real_structure_factors``, ``imag_structure_factors``,
+    ``cellgrad_cache``.
+    The unweighted phases are deliberately not written -- see the module note.
+    """
+    k_idx, lane = wp.tid()
+    num_atoms = positions.shape[0]
+    block = wp.static(RECIP_TILED_BLOCK_DIM)
+
+    alpha_ = wp.float32(alpha[0])
+    exp_factor = wp.float32(0.25) / (alpha_ * alpha_)
+    volume = wp.float32(wp.abs(wp.determinant(cell[0])))
+    inv_volume = wp.float32(1.0) / volume
+
+    k_vector = k_vectors[k_idx]
+    kx = wp.float32(k_vector[0])
+    ky = wp.float32(k_vector[1])
+    kz = wp.float32(k_vector[2])
+    k_squared = kx * kx + ky * ky + kz * kz
+
+    green_function = wp.float32(0.0)
+    if k_squared >= wp.float32(1e-10):
+        green_function = (
+            wp.exp(-exp_factor * k_squared)
+            / k_squared
+            * wp.float32(EIGHTPI)
+            * inv_volume
+        )
+
+    real_sum = wp.float32(0.0)
+    imag_sum = wp.float32(0.0)
+    # r-weighted phase sums for dE/dcell. Same reduction shape as the
+    # structure factors, so they ride along in the same pass.
+    ra_x = wp.float32(0.0)
+    ra_y = wp.float32(0.0)
+    ra_z = wp.float32(0.0)
+    rb_x = wp.float32(0.0)
+    rb_y = wp.float32(0.0)
+    rb_z = wp.float32(0.0)
+    charge_sum = wp.float64(0.0)
+
+    for atom_start in range(0, num_atoms, block):
+        atom_idx = atom_start + lane
+        if atom_idx < num_atoms:
+            charge = wp.float32(charges[atom_idx])
+            if k_idx == 0:
+                charge_sum += wp.float64(charge) * wp.float64(inv_volume)
+            if k_squared >= wp.float32(1e-10):
+                position = positions[atom_idx]
+                phase = _recip_phase_fp32(
+                    wp.float32(position[0]),
+                    wp.float32(position[1]),
+                    wp.float32(position[2]),
+                    k_vector,
+                )
+                qc = charge * phase[0]
+                qs = charge * phase[1]
+                real_sum += qc
+                imag_sum += qs
+                px = wp.float32(position[0])
+                py = wp.float32(position[1])
+                pz = wp.float32(position[2])
+                ra_x += qc * px
+                ra_y += qc * py
+                ra_z += qc * pz
+                rb_x += qs * px
+                rb_y += qs * py
+                rb_z += qs * pz
+
+    # Promote before the cross-lane reduction: the per-atom terms are O(q) but
+    # the sum over atoms cancels heavily, which is the part that needs float64.
+    real_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(real_sum * green_function)))
+    imag_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(imag_sum * green_function)))
+    charge_tile = wp.tile_reduce(wp.add, wp.tile(charge_sum))
+
+    # tile_store cannot narrow float64 -> float32, so extract and write the
+    # single reduced value from lane 0. total_charge stays a collective store:
+    # it is guarded by k_idx, which is block-uniform, unlike lane.
+    if lane == 0:
+        real_structure_factors[k_idx] = wp.float32(wp.tile_extract(real_tile, 0))
+        imag_structure_factors[k_idx] = wp.float32(wp.tile_extract(imag_tile, 0))
+    if k_idx == 0:
+        wp.tile_store(total_charge, charge_tile, 0)
+
+    # Cell-gradient cache: unweighted (pre-Green's-function) reductions.
+    # Reduced in float64 like the structure factors, so the cache is as
+    # accurate as the float64 fill's despite float32 accumulation per lane.
+    a_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(real_sum)))
+    b_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(imag_sum)))
+    rax_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(ra_x)))
+    ray_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(ra_y)))
+    raz_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(ra_z)))
+    rbx_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(rb_x)))
+    rby_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(rb_y)))
+    rbz_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(rb_z)))
+    if lane == 0:
+        cellgrad_cache[k_idx, 0] = wp.tile_extract(a_tile, 0)
+        cellgrad_cache[k_idx, 1] = wp.tile_extract(b_tile, 0)
+        cellgrad_cache[k_idx, 2] = wp.tile_extract(rax_tile, 0)
+        cellgrad_cache[k_idx, 3] = wp.tile_extract(ray_tile, 0)
+        cellgrad_cache[k_idx, 4] = wp.tile_extract(raz_tile, 0)
+        cellgrad_cache[k_idx, 5] = wp.tile_extract(rbx_tile, 0)
+        cellgrad_cache[k_idx, 6] = wp.tile_extract(rby_tile, 0)
+        cellgrad_cache[k_idx, 7] = wp.tile_extract(rbz_tile, 0)
+
+
+@wp.kernel
 def _batch_ewald_recip_fill_sf_fp32_nostore(
     positions: wp.array(dtype=Any),
     charges: wp.array(dtype=Any),
@@ -948,11 +1135,38 @@ def _batch_ewald_recip_fill_sf_fp32_nostore(
     real_structure_factors: wp.array2d(dtype=wp.float32),
     imag_structure_factors: wp.array2d(dtype=wp.float32),
 ):
-    """Batched counterpart of :func:`_ewald_recip_fill_sf_fp32_nostore`.
+    r"""Batched counterpart of :func:`_ewald_recip_fill_sf_fp32_nostore`.
+
+    Parameters
+    ----------
+    positions : wp.array, shape (N_total,), dtype=wp.vec3f
+        Concatenated atomic coordinates for all systems.
+    charges : wp.array, shape (N_total,), dtype=wp.float32
+        Concatenated atomic charges.
+    k_vectors : wp.array2d, shape (S, K), dtype=wp.vec3f
+        Per-system half-space reciprocal lattice vectors.
+    cell : wp.array, shape (S, 3, 3), dtype=wp.mat33f
+        Per-system unit cell matrices.
+    alpha : wp.array, shape (S,), dtype=wp.float32
+        Per-system Ewald splitting parameters.
+    atom_start, atom_end : wp.array, shape (S,), dtype=wp.int32
+        Half-open atom range owned by each system.
+    total_charge : wp.array, shape (S,), dtype=wp.float64
+        OUTPUT: per-system Q/V for the background correction.
+    real_structure_factors : wp.array2d, shape (S, K), dtype=wp.float32
+        OUTPUT: per-system weighted real structure factors.
+    imag_structure_factors : wp.array2d, shape (S, K), dtype=wp.float32
+        OUTPUT: per-system weighted imaginary structure factors.
 
     Thread launch
     -------------
-    ``wp.launch_tiled(dim=(K, S), block_dim=RECIP_TILED_BLOCK_DIM)``.
+    ``wp.launch_tiled(dim=(K, S), block_dim=RECIP_TILED_BLOCK_DIM)``. One block
+    owns one (k-vector, system) pair; its lanes cooperate over that system's
+    atoms.
+
+    Modifies
+    --------
+    ``total_charge``, ``real_structure_factors``, ``imag_structure_factors``.
     """
     k_idx, system_id, lane = wp.tid()
     block = wp.static(RECIP_TILED_BLOCK_DIM)
@@ -1010,6 +1224,159 @@ def _batch_ewald_recip_fill_sf_fp32_nostore(
             total_charge[system_id] = wp.tile_extract(charge_tile, 0)
 
 
+@wp.kernel
+def _batch_ewald_recip_fill_sf_fp32_nostore_cellgrad(
+    positions: wp.array(dtype=Any),
+    charges: wp.array(dtype=Any),
+    k_vectors: wp.array2d(dtype=Any),
+    cell: wp.array(dtype=Any),
+    alpha: wp.array(dtype=Any),
+    atom_start: wp.array(dtype=wp.int32),
+    atom_end: wp.array(dtype=wp.int32),
+    total_charge: wp.array(dtype=wp.float64),
+    real_structure_factors: wp.array2d(dtype=wp.float32),
+    imag_structure_factors: wp.array2d(dtype=wp.float32),
+    cellgrad_cache: wp.array2d(dtype=wp.float64),
+):
+    r"""Batched counterpart of :func:`_ewald_recip_fill_sf_fp32_nostore_cellgrad`.
+
+    Parameters
+    ----------
+    positions : wp.array, shape (N_total,), dtype=wp.vec3f
+        Concatenated atomic coordinates for all systems.
+    charges : wp.array, shape (N_total,), dtype=wp.float32
+        Concatenated atomic charges.
+    k_vectors : wp.array2d, shape (S, K), dtype=wp.vec3f
+        Per-system half-space reciprocal lattice vectors.
+    cell : wp.array, shape (S, 3, 3), dtype=wp.mat33f
+        Per-system unit cell matrices.
+    alpha : wp.array, shape (S,), dtype=wp.float32
+        Per-system Ewald splitting parameters.
+    atom_start, atom_end : wp.array, shape (S,), dtype=wp.int32
+        Half-open atom range owned by each system.
+    total_charge : wp.array, shape (S,), dtype=wp.float64
+        OUTPUT: per-system Q/V for the background correction.
+    real_structure_factors : wp.array2d, shape (S, K), dtype=wp.float32
+        OUTPUT: per-system weighted real structure factors.
+    imag_structure_factors : wp.array2d, shape (S, K), dtype=wp.float32
+        OUTPUT: per-system weighted imaginary structure factors.
+    cellgrad_cache : wp.array2d, shape (S*K, 8), dtype=wp.float64
+        OUTPUT: per-k unweighted reductions consumed by the cell-gradient
+        backward -- ``[Sre, Sim, (Sre*r)_xyz, (Sim*r)_xyz]``. Unweighted means
+        before the Green's function, which the backward applies itself.
+
+    Thread launch
+    -------------
+    ``wp.launch_tiled(dim=(K, S), block_dim=RECIP_TILED_BLOCK_DIM)``. One block
+    owns one (k-vector, system) pair; its lanes cooperate over that system's
+    atoms.
+
+    Modifies
+    --------
+    ``total_charge``, ``real_structure_factors``, ``imag_structure_factors``,
+    ``cellgrad_cache``.
+    """
+    k_idx, system_id, lane = wp.tid()
+    num_k = real_structure_factors.shape[1]
+    block = wp.static(RECIP_TILED_BLOCK_DIM)
+    start = atom_start[system_id]
+    end = atom_end[system_id]
+
+    alpha_ = wp.float32(alpha[system_id])
+    exp_factor = wp.float32(0.25) / (alpha_ * alpha_)
+    inv_volume = wp.float32(1.0) / wp.float32(wp.abs(wp.determinant(cell[system_id])))
+
+    k_vector = k_vectors[system_id, k_idx]
+    kx = wp.float32(k_vector[0])
+    ky = wp.float32(k_vector[1])
+    kz = wp.float32(k_vector[2])
+    k_squared = kx * kx + ky * ky + kz * kz
+
+    green_function = wp.float32(0.0)
+    if k_squared >= wp.float32(1e-10):
+        green_function = (
+            wp.exp(-exp_factor * k_squared)
+            / k_squared
+            * wp.float32(EIGHTPI)
+            * inv_volume
+        )
+
+    real_sum = wp.float32(0.0)
+    imag_sum = wp.float32(0.0)
+    # r-weighted phase sums for dE/dcell. Same reduction shape as the
+    # structure factors, so they ride along in the same pass.
+    ra_x = wp.float32(0.0)
+    ra_y = wp.float32(0.0)
+    ra_z = wp.float32(0.0)
+    rb_x = wp.float32(0.0)
+    rb_y = wp.float32(0.0)
+    rb_z = wp.float32(0.0)
+    charge_sum = wp.float64(0.0)
+
+    for offset in range(start, end, block):
+        atom_idx = offset + lane
+        if atom_idx < end:
+            charge = wp.float32(charges[atom_idx])
+            if k_idx == 0:
+                charge_sum += wp.float64(charge) * wp.float64(inv_volume)
+            if k_squared >= wp.float32(1e-10):
+                position = positions[atom_idx]
+                phase = _recip_phase_fp32(
+                    wp.float32(position[0]),
+                    wp.float32(position[1]),
+                    wp.float32(position[2]),
+                    k_vector,
+                )
+                qc = charge * phase[0]
+                qs = charge * phase[1]
+                real_sum += qc
+                imag_sum += qs
+                px = wp.float32(position[0])
+                py = wp.float32(position[1])
+                pz = wp.float32(position[2])
+                ra_x += qc * px
+                ra_y += qc * py
+                ra_z += qc * pz
+                rb_x += qs * px
+                rb_y += qs * py
+                rb_z += qs * pz
+
+    real_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(real_sum * green_function)))
+    imag_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(imag_sum * green_function)))
+    charge_tile = wp.tile_reduce(wp.add, wp.tile(charge_sum))
+
+    # Cell-gradient cache: unweighted (pre-Green's-function) reductions, in the
+    # flattened (S*K, 8) layout the backward expects. Reduced in float64 like the
+    # structure factors, so the cache is as accurate as the float64 fill's.
+    a_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(real_sum)))
+    b_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(imag_sum)))
+    rax_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(ra_x)))
+    ray_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(ra_y)))
+    raz_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(ra_z)))
+    rbx_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(rb_x)))
+    rby_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(rb_y)))
+    rbz_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(rb_z)))
+
+    if lane == 0:
+        real_structure_factors[system_id, k_idx] = wp.float32(
+            wp.tile_extract(real_tile, 0)
+        )
+        imag_structure_factors[system_id, k_idx] = wp.float32(
+            wp.tile_extract(imag_tile, 0)
+        )
+        if k_idx == 0:
+            total_charge[system_id] = wp.tile_extract(charge_tile, 0)
+        row = system_id * num_k + k_idx
+        cellgrad_cache[row, 0] = wp.tile_extract(a_tile, 0)
+        cellgrad_cache[row, 1] = wp.tile_extract(b_tile, 0)
+        cellgrad_cache[row, 2] = wp.tile_extract(rax_tile, 0)
+        cellgrad_cache[row, 3] = wp.tile_extract(ray_tile, 0)
+        cellgrad_cache[row, 4] = wp.tile_extract(raz_tile, 0)
+        cellgrad_cache[row, 5] = wp.tile_extract(rbx_tile, 0)
+        cellgrad_cache[row, 6] = wp.tile_extract(rby_tile, 0)
+        cellgrad_cache[row, 7] = wp.tile_extract(rbz_tile, 0)
+
+
 # Five float64 accumulators per atom: (charged potential, Fx, Fy, Fz,
 # uncharged potential). Returned as one value so the k-loop below can be shared
 # by every consumer instead of being copy-pasted per derivative state.
@@ -1043,24 +1410,45 @@ def _recip_atom_accumulate_fp32(
     k_start: int,
     k_stride: int,
 ):
-    """Per-atom reciprocal sums, recomputing phases rather than reading them.
+    r"""Per-atom reciprocal sums, recomputing phases rather than reading them.
 
-    ``k_start`` / ``k_stride`` select this thread's slice of the k range:
-    ``(0, 1)`` walks all of it, which is what the atom-major kernel wants, while
-    the tiled kernel passes ``(lane, block_dim)`` so a block's lanes split the
-    range and combine afterwards with ``wp.tile_reduce``. Keeping it a parameter
-    is what lets both kernels share this loop instead of duplicating it.
-
-    Returns ``(potential, Fx, Fy, Fz, potential_uncharged)`` where
+    The counterpart to :func:`_ewald_recip_fill_sf_fp32_nostore`: the fill
+    leaves the ``(K, N)`` phases unwritten, so this recomputes them. Forces and
+    the charge gradient cost three FMAs per k on top of the energy, against a
+    transcendental pair, so all five quantities are always computed and the
+    caller writes only what it needs.
 
     .. math::
-        E_i = \\tfrac{1}{2} \\sum_k [S_{re} q_i \\cos + S_{im} q_i \\sin], \\quad
-        F_i = \\sum_k k [S_{re} q_i \\sin - S_{im} q_i \\cos], \\quad
-        \\frac{\\partial E}{\\partial q_i} = \\sum_k [S_{re}\\cos + S_{im}\\sin]
 
-    Forces and the charge gradient cost three FMAs per k on top of the energy;
-    the loop is dominated by the transcendentals, so they are always computed
-    and the caller writes only what it needs.
+        E_i = \tfrac{1}{2} \sum_k [S_{re} q_i \cos + S_{im} q_i \sin], \quad
+        F_i = \sum_k k [S_{re} q_i \sin - S_{im} q_i \cos], \quad
+        \frac{\partial E}{\partial q_i} = \sum_k [S_{re}\cos + S_{im}\sin]
+
+    Parameters
+    ----------
+    px, py, pz : wp.float32
+        Coordinates of the atom this call owns.
+    charge : wp.float32
+        Charge of that atom.
+    k_vectors : wp.array, shape (K,), dtype=wp.vec3f or wp.vec3d
+        Half-space reciprocal lattice vectors.
+    real_structure_factors : wp.array, shape (K,), dtype=wp.float32
+        Green's-function-weighted :math:`\sum_j q_j \cos(k \cdot r_j)`.
+    imag_structure_factors : wp.array, shape (K,), dtype=wp.float32
+        Green's-function-weighted :math:`\sum_j q_j \sin(k \cdot r_j)`.
+    num_k : int
+        Number of k-vectors.
+    k_start, k_stride : int
+        This thread's slice of the k range. The atom-major kernels pass
+        ``(0, 1)`` to walk all of it; the tiled kernels pass
+        ``(lane, block_dim)`` so a block's lanes split the range and combine
+        afterwards with ``wp.tile_reduce``. Keeping these as parameters is what
+        lets both kernel families share this loop instead of duplicating it.
+
+    Returns
+    -------
+    _recip_vec5d
+        ``(potential, Fx, Fy, Fz, potential_uncharged)``, widened to float64.
     """
     potential = wp.float32(0.0)
     potential_uncharged = wp.float32(0.0)
@@ -1089,7 +1477,6 @@ def _recip_atom_accumulate_fp32(
     return _recip_vec5d(wp.float64(potential), wp.float64(fx), wp.float64(fy),
                         wp.float64(fz), wp.float64(potential_uncharged))
 
-
 @wp.kernel
 def _ewald_recip_compute_fp32_recompute(
     positions: wp.array(dtype=Any),
@@ -1101,11 +1488,40 @@ def _ewald_recip_compute_fp32_recompute(
     atomic_forces: wp.array(dtype=Any),
     charge_gradients: wp.array(dtype=wp.float64),
 ):
-    """Single-system per-atom energies, forces and dE/dq, phases recomputed.
+    r"""Single-system per-atom energies, forces and dE/dq, phases recomputed.
 
     Atom-major, so each thread owns its outputs and no atomics are needed. The
     counterpart to :func:`_ewald_recip_fill_sf_fp32_nostore`, which leaves the
-    ``(K, N)`` phases unwritten.
+    ``(K, N)`` phases unwritten. Prefer
+    :func:`_ewald_recip_compute_fp32_recompute_tiled` -- one thread walking all
+    of K is a long serial loop and underfills the device when N is small.
+
+    Parameters
+    ----------
+    positions : wp.array, shape (N,), dtype=wp.vec3f
+        Atomic coordinates.
+    charges : wp.array, shape (N,), dtype=wp.float32
+        Atomic charges.
+    k_vectors : wp.array, shape (K,), dtype=wp.vec3f
+        Half-space reciprocal lattice vectors.
+    real_structure_factors : wp.array, shape (K,), dtype=wp.float32
+        Weighted real structure factors from the fill kernel.
+    imag_structure_factors : wp.array, shape (K,), dtype=wp.float32
+        Weighted imaginary structure factors from the fill kernel.
+    reciprocal_energies : wp.array, shape (N,), dtype=wp.float64
+        OUTPUT: per-atom reciprocal-space energy.
+    atomic_forces : wp.array, shape (N,), dtype=wp.vec3f
+        OUTPUT: per-atom reciprocal-space force.
+    charge_gradients : wp.array, shape (N,), dtype=wp.float64
+        OUTPUT: per-atom :math:`\partial E / \partial q_i`.
+
+    Modifies
+    --------
+    ``reciprocal_energies``, ``atomic_forces``, ``charge_gradients``.
+
+    Thread launch
+    -------------
+    ``wp.launch(dim=N)``. One thread per atom.
     """
     atom_idx = wp.tid()
     num_k = real_structure_factors.shape[0]
@@ -1143,10 +1559,39 @@ def _batch_ewald_recip_compute_fp32_recompute(
     atomic_forces: wp.array(dtype=Any),
     charge_gradients: wp.array(dtype=wp.float64),
 ):
-    """Batched counterpart of :func:`_ewald_recip_compute_fp32_recompute`.
+    r"""Batched counterpart of :func:`_ewald_recip_compute_fp32_recompute`.
 
     Each system's row is sliced out of the 2D inputs and handed to the same
     accumulation function the single-system kernel uses.
+
+    Parameters
+    ----------
+    positions : wp.array, shape (N_total,), dtype=wp.vec3f
+        Atomic coordinates.
+    charges : wp.array, shape (N_total,), dtype=wp.float32
+        Atomic charges.
+    batch_idx : wp.array, shape (N_total,), dtype=wp.int32
+        System index for each atom.
+    k_vectors : wp.array2d, shape (S, K), dtype=wp.vec3f
+        Half-space reciprocal lattice vectors.
+    real_structure_factors : wp.array, shape (S, K), dtype=wp.float32
+        Per-system weighted real structure factors from the fill kernel.
+    imag_structure_factors : wp.array, shape (S, K), dtype=wp.float32
+        Per-system weighted imaginary structure factors from the fill kernel.
+    reciprocal_energies : wp.array, shape (N_total,), dtype=wp.float64
+        OUTPUT: per-atom reciprocal-space energy.
+    atomic_forces : wp.array, shape (N_total,), dtype=wp.vec3f
+        OUTPUT: per-atom reciprocal-space force.
+    charge_gradients : wp.array, shape (N_total,), dtype=wp.float64
+        OUTPUT: per-atom :math:`\partial E / \partial q_i`.
+
+    Modifies
+    --------
+    ``reciprocal_energies``, ``atomic_forces``, ``charge_gradients``.
+
+    Thread launch
+    -------------
+    ``wp.launch(dim=N_total)``. One thread per atom.
     """
     atom_idx = wp.tid()
     system_id = batch_idx[atom_idx]
@@ -1184,7 +1629,7 @@ def _ewald_recip_compute_fp32_recompute_tiled(
     atomic_forces: wp.array(dtype=Any),
     charge_gradients: wp.array(dtype=wp.float64),
 ):
-    """Cooperative counterpart of :func:`_ewald_recip_compute_fp32_recompute`.
+    r"""Cooperative counterpart of :func:`_ewald_recip_compute_fp32_recompute`.
 
     The atom-major kernel gives each thread the whole k range, which at
     K ~ 6e4 is a very long serial loop and leaves the machine idle whenever
@@ -1192,9 +1637,33 @@ def _ewald_recip_compute_fp32_recompute_tiled(
     its lanes split the k range, mirroring how the fill kernel splits atoms
     across lanes for a fixed k.
 
+    Parameters
+    ----------
+    positions : wp.array, shape (N,), dtype=wp.vec3f
+        Atomic coordinates.
+    charges : wp.array, shape (N,), dtype=wp.float32
+        Atomic charges.
+    k_vectors : wp.array, shape (K,), dtype=wp.vec3f
+        Half-space reciprocal lattice vectors.
+    real_structure_factors : wp.array, shape (K,), dtype=wp.float32
+        Weighted real structure factors from the fill kernel.
+    imag_structure_factors : wp.array, shape (K,), dtype=wp.float32
+        Weighted imaginary structure factors from the fill kernel.
+    reciprocal_energies : wp.array, shape (N,), dtype=wp.float64
+        OUTPUT: per-atom reciprocal-space energy.
+    atomic_forces : wp.array, shape (N,), dtype=wp.vec3f
+        OUTPUT: per-atom reciprocal-space force.
+    charge_gradients : wp.array, shape (N,), dtype=wp.float64
+        OUTPUT: per-atom :math:`\partial E / \partial q_i`.
+
+    Modifies
+    --------
+    ``reciprocal_energies``, ``atomic_forces``, ``charge_gradients``.
+
     Thread launch
     -------------
-    ``wp.launch_tiled(dim=N, block_dim=RECIP_TILED_BLOCK_DIM)``.
+    ``wp.launch_tiled(dim=N, block_dim=RECIP_TILED_BLOCK_DIM)``. One block owns
+    one atom; its lanes split the k range and combine with ``wp.tile_reduce``.
     """
     atom_idx, lane = wp.tid()
     num_k = real_structure_factors.shape[0]
@@ -1238,8 +1707,38 @@ def _batch_ewald_recip_compute_fp32_recompute_tiled(
     atomic_forces: wp.array(dtype=Any),
     charge_gradients: wp.array(dtype=wp.float64),
 ):
-    """Batched counterpart of
-    :func:`_ewald_recip_compute_fp32_recompute_tiled`."""
+    r"""Batched counterpart of :func:`_ewald_recip_compute_fp32_recompute_tiled`.
+
+    Parameters
+    ----------
+    positions : wp.array, shape (N_total,), dtype=wp.vec3f
+        Atomic coordinates.
+    charges : wp.array, shape (N_total,), dtype=wp.float32
+        Atomic charges.
+    batch_idx : wp.array, shape (N_total,), dtype=wp.int32
+        System index for each atom.
+    k_vectors : wp.array2d, shape (S, K), dtype=wp.vec3f
+        Half-space reciprocal lattice vectors.
+    real_structure_factors : wp.array, shape (S, K), dtype=wp.float32
+        Per-system weighted real structure factors from the fill kernel.
+    imag_structure_factors : wp.array, shape (S, K), dtype=wp.float32
+        Per-system weighted imaginary structure factors from the fill kernel.
+    reciprocal_energies : wp.array, shape (N_total,), dtype=wp.float64
+        OUTPUT: per-atom reciprocal-space energy.
+    atomic_forces : wp.array, shape (N_total,), dtype=wp.vec3f
+        OUTPUT: per-atom reciprocal-space force.
+    charge_gradients : wp.array, shape (N_total,), dtype=wp.float64
+        OUTPUT: per-atom :math:`\partial E / \partial q_i`.
+
+    Modifies
+    --------
+    ``reciprocal_energies``, ``atomic_forces``, ``charge_gradients``.
+
+    Thread launch
+    -------------
+    ``wp.launch_tiled(dim=N_total, block_dim=RECIP_TILED_BLOCK_DIM)``. One block
+    owns one atom; its lanes split that system's k range.
+    """
     atom_idx, lane = wp.tid()
     system_id = batch_idx[atom_idx]
     num_k = real_structure_factors.shape[1]

--- a/nvalchemiops/interactions/electrostatics/ewald_kernels.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_kernels.py
@@ -208,25 +208,6 @@ def _recip_tiling_override() -> bool | None:
     return value not in {"0", "false", "False", "off", "OFF"}
 
 
-def _use_fp32_structure_factors() -> bool:
-    """Return whether the float32 no-store reciprocal path is enabled.
-
-    Reads ``NVALCHEMIOPS_EWALD_RECIP_FP32_SF``; unset or empty means off, as
-    does any of ``0``/``false``/``off``. The path computes structure-factor
-    phases in float32 and recomputes them per atom instead of materializing the
-    ``(K, N)`` phase arrays.
-
-    Returns
-    -------
-    bool
-        ``True`` if the float32 no-store path is requested, ``False`` otherwise.
-    """
-    value = os.environ.get("NVALCHEMIOPS_EWALD_RECIP_FP32_SF")
-    if value is None or value == "":
-        return False
-    return value not in {"0", "false", "False", "off", "OFF"}
-
-
 def should_tile_ewald_recip_fill(num_atoms: int) -> bool:
     """Return whether reciprocal fill should use a tiled launch.
 
@@ -855,7 +836,7 @@ def _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled(
 # replaces; the crossover depends on the part's transcendental throughput
 # against its memory bandwidth, so measure rather than assume.
 #
-# Opt in with NVALCHEMIOPS_EWALD_RECIP_FP32_SF=1. Off by default: it changes
+# Opt in with NVALCHEMIOPS_ELECTROSTATICS_FP32=1. Off by default: it changes
 # float32 results at the ~1e-07 level, which is a semantic change for existing
 # callers rather than a pure optimisation.
 

--- a/nvalchemiops/interactions/electrostatics/ewald_kernels.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_kernels.py
@@ -1058,31 +1058,33 @@ def _recip_atom_accumulate_fp32(
     the loop is dominated by the transcendentals, so they are always computed
     and the caller writes only what it needs.
     """
-    potential = wp.float64(0.0)
-    potential_uncharged = wp.float64(0.0)
-    fx = wp.float64(0.0)
-    fy = wp.float64(0.0)
-    fz = wp.float64(0.0)
+    q32 = wp.float32(charge)
+    potential = wp.float32(0.0)
+    potential_uncharged = wp.float32(0.0)
+    fx = wp.float32(0.0)
+    fy = wp.float32(0.0)
+    fz = wp.float32(0.0)
 
     for k_idx in range(k_start, num_k, k_stride):
         kvec = k_vectors[k_idx]
         phase = _recip_phase_fp32(px, py, pz, kvec)
-        cos_kr = wp.float64(phase[0])
-        sin_kr = wp.float64(phase[1])
+        cos_kr = phase[0]
+        sin_kr = phase[1]
 
-        s_real = real_structure_factors[k_idx]
-        s_imag = imag_structure_factors[k_idx]
+        s_real = wp.float32(real_structure_factors[k_idx])
+        s_imag = wp.float32(imag_structure_factors[k_idx])
 
         phase_sum = s_real * cos_kr + s_imag * sin_kr
-        potential += charge * phase_sum
+        potential += q32 * phase_sum
         potential_uncharged += phase_sum
 
-        force_scalar = charge * (s_real * sin_kr - s_imag * cos_kr)
-        fx += force_scalar * wp.float64(kvec[0])
-        fy += force_scalar * wp.float64(kvec[1])
-        fz += force_scalar * wp.float64(kvec[2])
+        force_scalar = q32 * (s_real * sin_kr - s_imag * cos_kr)
+        fx += force_scalar * wp.float32(kvec[0])
+        fy += force_scalar * wp.float32(kvec[1])
+        fz += force_scalar * wp.float32(kvec[2])
 
-    return _recip_vec5d(potential, fx, fy, fz, potential_uncharged)
+    return _recip_vec5d(wp.float64(potential), wp.float64(fx), wp.float64(fy),
+                        wp.float64(fz), wp.float64(potential_uncharged))
 
 
 @wp.kernel

--- a/nvalchemiops/interactions/electrostatics/ewald_kernels.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_kernels.py
@@ -859,8 +859,8 @@ def _ewald_recip_fill_sf_fp32_nostore(
     cell: wp.array(dtype=Any),
     alpha: wp.array(dtype=Any),
     total_charge: wp.array(dtype=wp.float64),
-    real_structure_factors: wp.array(dtype=wp.float64),
-    imag_structure_factors: wp.array(dtype=wp.float64),
+    real_structure_factors: wp.array(dtype=wp.float32),
+    imag_structure_factors: wp.array(dtype=wp.float32),
 ):
     """Single-system weighted structure factors, float32 phases, no (K, N) store.
 
@@ -925,8 +925,12 @@ def _ewald_recip_fill_sf_fp32_nostore(
     imag_tile = wp.tile_reduce(wp.add, wp.tile(wp.float64(imag_sum * green_function)))
     charge_tile = wp.tile_reduce(wp.add, wp.tile(charge_sum))
 
-    wp.tile_store(real_structure_factors, real_tile, k_idx)
-    wp.tile_store(imag_structure_factors, imag_tile, k_idx)
+    # tile_store cannot narrow float64 -> float32, so extract and write the
+    # single reduced value from lane 0. total_charge stays a collective store:
+    # it is guarded by k_idx, which is block-uniform, unlike lane.
+    if lane == 0:
+        real_structure_factors[k_idx] = wp.float32(wp.tile_extract(real_tile, 0))
+        imag_structure_factors[k_idx] = wp.float32(wp.tile_extract(imag_tile, 0))
     if k_idx == 0:
         wp.tile_store(total_charge, charge_tile, 0)
 
@@ -941,8 +945,8 @@ def _batch_ewald_recip_fill_sf_fp32_nostore(
     atom_start: wp.array(dtype=wp.int32),
     atom_end: wp.array(dtype=wp.int32),
     total_charge: wp.array(dtype=wp.float64),
-    real_structure_factors: wp.array2d(dtype=wp.float64),
-    imag_structure_factors: wp.array2d(dtype=wp.float64),
+    real_structure_factors: wp.array2d(dtype=wp.float32),
+    imag_structure_factors: wp.array2d(dtype=wp.float32),
 ):
     """Batched counterpart of :func:`_ewald_recip_fill_sf_fp32_nostore`.
 
@@ -1000,8 +1004,8 @@ def _batch_ewald_recip_fill_sf_fp32_nostore(
     charge_tile = wp.tile_reduce(wp.add, wp.tile(charge_sum))
 
     if lane == 0:
-        real_structure_factors[system_id, k_idx] = wp.tile_extract(real_tile, 0)
-        imag_structure_factors[system_id, k_idx] = wp.tile_extract(imag_tile, 0)
+        real_structure_factors[system_id, k_idx] = wp.float32(wp.tile_extract(real_tile, 0))
+        imag_structure_factors[system_id, k_idx] = wp.float32(wp.tile_extract(imag_tile, 0))
         if k_idx == 0:
             total_charge[system_id] = wp.tile_extract(charge_tile, 0)
 
@@ -1031,10 +1035,10 @@ def _recip_atom_accumulate_fp32(
     px: wp.float32,
     py: wp.float32,
     pz: wp.float32,
-    charge: wp.float64,
+    charge: wp.float32,
     k_vectors: wp.array(dtype=Any),
-    real_structure_factors: wp.array(dtype=wp.float64),
-    imag_structure_factors: wp.array(dtype=wp.float64),
+    real_structure_factors: wp.array(dtype=wp.float32),
+    imag_structure_factors: wp.array(dtype=wp.float32),
     num_k: int,
     k_start: int,
     k_stride: int,
@@ -1058,7 +1062,6 @@ def _recip_atom_accumulate_fp32(
     the loop is dominated by the transcendentals, so they are always computed
     and the caller writes only what it needs.
     """
-    q32 = wp.float32(charge)
     potential = wp.float32(0.0)
     potential_uncharged = wp.float32(0.0)
     fx = wp.float32(0.0)
@@ -1071,14 +1074,14 @@ def _recip_atom_accumulate_fp32(
         cos_kr = phase[0]
         sin_kr = phase[1]
 
-        s_real = wp.float32(real_structure_factors[k_idx])
-        s_imag = wp.float32(imag_structure_factors[k_idx])
+        s_real = real_structure_factors[k_idx]
+        s_imag = imag_structure_factors[k_idx]
 
         phase_sum = s_real * cos_kr + s_imag * sin_kr
-        potential += q32 * phase_sum
+        potential += charge * phase_sum
         potential_uncharged += phase_sum
 
-        force_scalar = q32 * (s_real * sin_kr - s_imag * cos_kr)
+        force_scalar = charge * (s_real * sin_kr - s_imag * cos_kr)
         fx += force_scalar * wp.float32(kvec[0])
         fy += force_scalar * wp.float32(kvec[1])
         fz += force_scalar * wp.float32(kvec[2])
@@ -1092,8 +1095,8 @@ def _ewald_recip_compute_fp32_recompute(
     positions: wp.array(dtype=Any),
     charges: wp.array(dtype=Any),
     k_vectors: wp.array(dtype=Any),
-    real_structure_factors: wp.array(dtype=wp.float64),
-    imag_structure_factors: wp.array(dtype=wp.float64),
+    real_structure_factors: wp.array(dtype=wp.float32),
+    imag_structure_factors: wp.array(dtype=wp.float32),
     reciprocal_energies: wp.array(dtype=wp.float64),
     atomic_forces: wp.array(dtype=Any),
     charge_gradients: wp.array(dtype=wp.float64),
@@ -1111,7 +1114,7 @@ def _ewald_recip_compute_fp32_recompute(
         wp.float32(position[0]),
         wp.float32(position[1]),
         wp.float32(position[2]),
-        wp.float64(charges[atom_idx]),
+        wp.float32(charges[atom_idx]),
         k_vectors,
         real_structure_factors,
         imag_structure_factors,
@@ -1134,8 +1137,8 @@ def _batch_ewald_recip_compute_fp32_recompute(
     charges: wp.array(dtype=Any),
     batch_idx: wp.array(dtype=wp.int32),
     k_vectors: wp.array2d(dtype=Any),
-    real_structure_factors: wp.array2d(dtype=wp.float64),
-    imag_structure_factors: wp.array2d(dtype=wp.float64),
+    real_structure_factors: wp.array2d(dtype=wp.float32),
+    imag_structure_factors: wp.array2d(dtype=wp.float32),
     reciprocal_energies: wp.array(dtype=wp.float64),
     atomic_forces: wp.array(dtype=Any),
     charge_gradients: wp.array(dtype=wp.float64),
@@ -1153,7 +1156,7 @@ def _batch_ewald_recip_compute_fp32_recompute(
         wp.float32(position[0]),
         wp.float32(position[1]),
         wp.float32(position[2]),
-        wp.float64(charges[atom_idx]),
+        wp.float32(charges[atom_idx]),
         k_vectors[system_id],
         real_structure_factors[system_id],
         imag_structure_factors[system_id],
@@ -1175,8 +1178,8 @@ def _ewald_recip_compute_fp32_recompute_tiled(
     positions: wp.array(dtype=Any),
     charges: wp.array(dtype=Any),
     k_vectors: wp.array(dtype=Any),
-    real_structure_factors: wp.array(dtype=wp.float64),
-    imag_structure_factors: wp.array(dtype=wp.float64),
+    real_structure_factors: wp.array(dtype=wp.float32),
+    imag_structure_factors: wp.array(dtype=wp.float32),
     reciprocal_energies: wp.array(dtype=wp.float64),
     atomic_forces: wp.array(dtype=Any),
     charge_gradients: wp.array(dtype=wp.float64),
@@ -1200,7 +1203,7 @@ def _ewald_recip_compute_fp32_recompute_tiled(
         wp.float32(position[0]),
         wp.float32(position[1]),
         wp.float32(position[2]),
-        wp.float64(charges[atom_idx]),
+        wp.float32(charges[atom_idx]),
         k_vectors,
         real_structure_factors,
         imag_structure_factors,
@@ -1229,8 +1232,8 @@ def _batch_ewald_recip_compute_fp32_recompute_tiled(
     charges: wp.array(dtype=Any),
     batch_idx: wp.array(dtype=wp.int32),
     k_vectors: wp.array2d(dtype=Any),
-    real_structure_factors: wp.array2d(dtype=wp.float64),
-    imag_structure_factors: wp.array2d(dtype=wp.float64),
+    real_structure_factors: wp.array2d(dtype=wp.float32),
+    imag_structure_factors: wp.array2d(dtype=wp.float32),
     reciprocal_energies: wp.array(dtype=wp.float64),
     atomic_forces: wp.array(dtype=Any),
     charge_gradients: wp.array(dtype=wp.float64),
@@ -1245,7 +1248,7 @@ def _batch_ewald_recip_compute_fp32_recompute_tiled(
         wp.float32(position[0]),
         wp.float32(position[1]),
         wp.float32(position[2]),
-        wp.float64(charges[atom_idx]),
+        wp.float32(charges[atom_idx]),
         k_vectors[system_id],
         real_structure_factors[system_id],
         imag_structure_factors[system_id],

--- a/nvalchemiops/interactions/electrostatics/ewald_kernels.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_kernels.py
@@ -1218,8 +1218,12 @@ def _batch_ewald_recip_fill_sf_fp32_nostore(
     charge_tile = wp.tile_reduce(wp.add, wp.tile(charge_sum))
 
     if lane == 0:
-        real_structure_factors[system_id, k_idx] = wp.float32(wp.tile_extract(real_tile, 0))
-        imag_structure_factors[system_id, k_idx] = wp.float32(wp.tile_extract(imag_tile, 0))
+        real_structure_factors[system_id, k_idx] = wp.float32(
+            wp.tile_extract(real_tile, 0)
+        )
+        imag_structure_factors[system_id, k_idx] = wp.float32(
+            wp.tile_extract(imag_tile, 0)
+        )
         if k_idx == 0:
             total_charge[system_id] = wp.tile_extract(charge_tile, 0)
 
@@ -1474,8 +1478,14 @@ def _recip_atom_accumulate_fp32(
         fy += force_scalar * wp.float32(kvec[1])
         fz += force_scalar * wp.float32(kvec[2])
 
-    return _recip_vec5d(wp.float64(potential), wp.float64(fx), wp.float64(fy),
-                        wp.float64(fz), wp.float64(potential_uncharged))
+    return _recip_vec5d(
+        wp.float64(potential),
+        wp.float64(fx),
+        wp.float64(fy),
+        wp.float64(fz),
+        wp.float64(potential_uncharged),
+    )
+
 
 @wp.kernel
 def _ewald_recip_compute_fp32_recompute(

--- a/nvalchemiops/interactions/electrostatics/ewald_real_factory.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_real_factory.py
@@ -344,9 +344,7 @@ def _make_forward_pair_fn(
                             distance, alpha_s
                         )
                         cg_i_acc += wp.float64(qj_s * potential)
-                        wp.atomic_add(
-                            charge_gradients, j, wp.float64(qi_s * potential)
-                        )
+                        wp.atomic_add(charge_gradients, j, wp.float64(qi_s * potential))
                     if CELL_GRAD:
                         virial_acc += _pair_virial_outer(separation_vector, force)
                     # Literal dE/dcell block for atom i: n (x) dE/dsep, dE/dsep = -force.
@@ -483,9 +481,7 @@ def _make_backward_pair_fn(
             ge_fm = wp.float64(0.0)
             if HAS_FORCE or CELL_GRAD:
                 force_mag = wp.float64(
-                    _ewald_real_space_force_magnitude(
-                        qi_s, qj_s, distance, alpha_s
-                    )
+                    _ewald_real_space_force_magnitude(qi_s, qj_s, distance, alpha_s)
                 )
                 ge_fm = ge * force_mag
                 if HAS_FORCE:

--- a/nvalchemiops/interactions/electrostatics/ewald_real_factory.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_real_factory.py
@@ -311,31 +311,42 @@ def _make_forward_pair_fn(
             ``dE/dsep``; ``n`` == integer shift). The block is f64 (``wp.mat33d``)
             regardless of ``wp_dtype`` to match the f64 cache the chain allocates.
             """
-            qj = wp.float64(charges[j])
+            # Pair math runs in input precision; only the accumulators stay
+            # float64. wp_erfc is an Abramowitz-Stegun polynomial with ~1.5e-7
+            # error, so evaluating it in float64 cannot beat evaluating it in
+            # float32 -- it just costs a float64 erfc, exp and several divides
+            # on every pair.
+            qj_s = charges[j]
             separation_vector = _periodic_separation(pos_i, pos_j, cell_t, shift_vec)
-            distance = wp.float64(wp.length(separation_vector))
+            distance = wp.length(separation_vector)
+            qi_s = type(distance)(qi)
+            alpha_s = type(distance)(alpha_)
 
-            if distance > wp.float64(_DISTANCE_EPSILON):
-                energy_acc += _ewald_real_space_energy_kernel_compute_energy(
-                    qi, qj, distance, alpha_
+            if distance > type(distance)(_DISTANCE_EPSILON):
+                energy_acc += wp.float64(
+                    _ewald_real_space_energy_kernel_compute_energy(
+                        qi_s, qj_s, distance, alpha_s
+                    )
                 )
                 if HAS_FORCE:
                     force_mag = _ewald_real_space_force_magnitude(
-                        qi, qj, distance, alpha_
+                        qi_s, qj_s, distance, alpha_s
                     )
                     force = type(pos_i)(
-                        type(pos_i[0])(force_mag) * separation_vector[0],
-                        type(pos_i[0])(force_mag) * separation_vector[1],
-                        type(pos_i[0])(force_mag) * separation_vector[2],
+                        force_mag * separation_vector[0],
+                        force_mag * separation_vector[1],
+                        force_mag * separation_vector[2],
                     )
                     force_i_acc -= force
                     wp.atomic_add(atomic_forces, j, force)
                     if HAS_CHARGE:
                         potential = _ewald_real_space_charge_grad_potential(
-                            distance, alpha_
+                            distance, alpha_s
                         )
-                        cg_i_acc += qj * potential
-                        wp.atomic_add(charge_gradients, j, qi * potential)
+                        cg_i_acc += wp.float64(qj_s * potential)
+                        wp.atomic_add(
+                            charge_gradients, j, wp.float64(qi_s * potential)
+                        )
                     if CELL_GRAD:
                         virial_acc += _pair_virial_outer(separation_vector, force)
                     # Literal dE/dcell block for atom i: n (x) dE/dsep, dE/dsep = -force.
@@ -380,29 +391,39 @@ def _make_forward_pair_fn(
         ``i``. ``HAS_FORCE``, ``HAS_CHARGE`` and ``CELL_GRAD`` are static
         specializations, so inactive sentinel buffers are not read.
         """
-        qj = wp.float64(charges[j])
+        # Pair math runs in input precision; only the accumulators stay float64.
+        # wp_erfc is an Abramowitz-Stegun polynomial with ~1.5e-7 error, so
+        # evaluating it in float64 cannot beat evaluating it in float32 -- it just
+        # costs a float64 erfc, exp and several divides on every pair.
+        qj_s = charges[j]
         separation_vector = _periodic_separation(pos_i, pos_j, cell_t, shift_vec)
-        distance = wp.float64(wp.length(separation_vector))
+        distance = wp.length(separation_vector)
+        qi_s = type(distance)(qi)
+        alpha_s = type(distance)(alpha_)
 
-        if distance > wp.float64(_DISTANCE_EPSILON):
-            energy_acc += _ewald_real_space_energy_kernel_compute_energy(
-                qi, qj, distance, alpha_
+        if distance > type(distance)(_DISTANCE_EPSILON):
+            energy_acc += wp.float64(
+                _ewald_real_space_energy_kernel_compute_energy(
+                    qi_s, qj_s, distance, alpha_s
+                )
             )
             if HAS_FORCE:
-                force_mag = _ewald_real_space_force_magnitude(qi, qj, distance, alpha_)
+                force_mag = _ewald_real_space_force_magnitude(
+                    qi_s, qj_s, distance, alpha_s
+                )
                 force = type(pos_i)(
-                    type(pos_i[0])(force_mag) * separation_vector[0],
-                    type(pos_i[0])(force_mag) * separation_vector[1],
-                    type(pos_i[0])(force_mag) * separation_vector[2],
+                    force_mag * separation_vector[0],
+                    force_mag * separation_vector[1],
+                    force_mag * separation_vector[2],
                 )
                 force_i_acc -= force
                 wp.atomic_add(atomic_forces, j, force)
                 if CELL_GRAD:
                     virial_acc += _pair_virial_outer(separation_vector, force)
             if HAS_CHARGE:
-                potential = _ewald_real_space_charge_grad_potential(distance, alpha_)
-                cg_i_acc += qj * potential
-                wp.atomic_add(charge_gradients, j, qi * potential)
+                potential = _ewald_real_space_charge_grad_potential(distance, alpha_s)
+                cg_i_acc += wp.float64(qj_s * potential)
+                wp.atomic_add(charge_gradients, j, wp.float64(qi_s * potential))
 
         return energy_acc, force_i_acc, cg_i_acc, virial_acc
 
@@ -449,13 +470,23 @@ def _make_backward_pair_fn(
         thread-local atom-``i`` accumulators. ``HAS_CHARGE`` and ``CELL_GRAD`` are
         static specializations, so inactive sentinel buffers are not read.
         """
-        qj = wp.float64(charges[j])
+        # Pair math runs in input precision; only the accumulators stay float64.
+        # wp_erfc is an Abramowitz-Stegun polynomial with ~1.5e-7 error, so
+        # evaluating it in float64 cannot beat evaluating it in float32 -- it just
+        # costs a float64 erfc, exp and several divides on every pair.
+        qj_s = charges[j]
         separation_vector = _periodic_separation(pos_i, pos_j, cell_t, shift_vec)
-        distance = wp.float64(wp.length(separation_vector))
-        if distance > wp.float64(_DISTANCE_EPSILON):
+        distance = wp.length(separation_vector)
+        qi_s = type(distance)(qi)
+        alpha_s = type(distance)(alpha_)
+        if distance > type(distance)(_DISTANCE_EPSILON):
             ge_fm = wp.float64(0.0)
             if HAS_FORCE or CELL_GRAD:
-                force_mag = _ewald_real_space_force_magnitude(qi, qj, distance, alpha_)
+                force_mag = wp.float64(
+                    _ewald_real_space_force_magnitude(
+                        qi_s, qj_s, distance, alpha_s
+                    )
+                )
                 ge_fm = ge * force_mag
                 if HAS_FORCE:
                     # dL/dR_i += ge*(+F); dL/dR_j += ge*(-F).
@@ -474,7 +505,10 @@ def _make_backward_pair_fn(
                         ),
                     )
             if HAS_CHARGE:
-                potential = _ewald_real_space_charge_grad_potential(distance, alpha_)
+                potential = wp.float64(
+                    _ewald_real_space_charge_grad_potential(distance, alpha_s)
+                )
+                qj = wp.float64(qj_s)
                 cg_i_acc += ge * qj * potential
                 wp.atomic_add(charge_gradients, j, ge * qi * potential)
             if CELL_GRAD:

--- a/nvalchemiops/interactions/electrostatics/ewald_real_factory.py
+++ b/nvalchemiops/interactions/electrostatics/ewald_real_factory.py
@@ -88,6 +88,7 @@ from nvalchemiops.interactions.electrostatics._factory_common import (
     _pair_virial_outer,
     _require_component,
     _require_supported_dtype,
+    _use_fp32_electrostatics,
     _validate_common_axes,
 )
 from nvalchemiops.interactions.electrostatics.ewald_kernels import (
@@ -256,6 +257,21 @@ def _name_and_document(
 # === Per-pair helper factories ===
 
 
+def _core_scalar(wp_dtype: type) -> type:
+    """Precision for the per-pair scalar cores.
+
+    float64 callers always evaluate in float64. float32 callers do so as well
+    unless ``NVALCHEMIOPS_ELECTROSTATICS_FP32`` is set, which keeps default
+    results bit-identical while making the faster path available.
+
+    Read at kernel-specialisation time, not per call: the value is part of the
+    ``lru_cache`` key on the ``_make_*_pair_fn`` builders.
+    """
+    if wp_dtype is wp.float64:
+        return wp.float64
+    return wp_dtype if _use_fp32_electrostatics() else wp.float64
+
+
 @lru_cache(maxsize=None)
 def _make_forward_pair_fn(
     wp_dtype: type,
@@ -263,6 +279,7 @@ def _make_forward_pair_fn(
     deriv_state: _DerivState,
     cell_grad: bool,
     cell_literal: bool = False,
+    core_scalar: type = wp.float64,
 ) -> wp.Function:
     """Build the specialized forward per-pair accumulator.
 
@@ -316,13 +333,13 @@ def _make_forward_pair_fn(
             # error, so evaluating it in float64 cannot beat evaluating it in
             # float32 -- it just costs a float64 erfc, exp and several divides
             # on every pair.
-            qj_s = charges[j]
+            qj_s = core_scalar(charges[j])
             separation_vector = _periodic_separation(pos_i, pos_j, cell_t, shift_vec)
-            distance = wp.length(separation_vector)
-            qi_s = type(distance)(qi)
-            alpha_s = type(distance)(alpha_)
+            distance = core_scalar(wp.length(separation_vector))
+            qi_s = core_scalar(qi)
+            alpha_s = core_scalar(alpha_)
 
-            if distance > type(distance)(_DISTANCE_EPSILON):
+            if distance > core_scalar(_DISTANCE_EPSILON):
                 energy_acc += wp.float64(
                     _ewald_real_space_energy_kernel_compute_energy(
                         qi_s, qj_s, distance, alpha_s
@@ -332,10 +349,11 @@ def _make_forward_pair_fn(
                     force_mag = _ewald_real_space_force_magnitude(
                         qi_s, qj_s, distance, alpha_s
                     )
+                    fm = type(pos_i[0])(force_mag)
                     force = type(pos_i)(
-                        force_mag * separation_vector[0],
-                        force_mag * separation_vector[1],
-                        force_mag * separation_vector[2],
+                        fm * separation_vector[0],
+                        fm * separation_vector[1],
+                        fm * separation_vector[2],
                     )
                     force_i_acc -= force
                     wp.atomic_add(atomic_forces, j, force)
@@ -393,13 +411,13 @@ def _make_forward_pair_fn(
         # wp_erfc is an Abramowitz-Stegun polynomial with ~1.5e-7 error, so
         # evaluating it in float64 cannot beat evaluating it in float32 -- it just
         # costs a float64 erfc, exp and several divides on every pair.
-        qj_s = charges[j]
+        qj_s = core_scalar(charges[j])
         separation_vector = _periodic_separation(pos_i, pos_j, cell_t, shift_vec)
-        distance = wp.length(separation_vector)
-        qi_s = type(distance)(qi)
-        alpha_s = type(distance)(alpha_)
+        distance = core_scalar(wp.length(separation_vector))
+        qi_s = core_scalar(qi)
+        alpha_s = core_scalar(alpha_)
 
-        if distance > type(distance)(_DISTANCE_EPSILON):
+        if distance > core_scalar(_DISTANCE_EPSILON):
             energy_acc += wp.float64(
                 _ewald_real_space_energy_kernel_compute_energy(
                     qi_s, qj_s, distance, alpha_s
@@ -409,10 +427,11 @@ def _make_forward_pair_fn(
                 force_mag = _ewald_real_space_force_magnitude(
                     qi_s, qj_s, distance, alpha_s
                 )
+                fm = type(pos_i[0])(force_mag)
                 force = type(pos_i)(
-                    force_mag * separation_vector[0],
-                    force_mag * separation_vector[1],
-                    force_mag * separation_vector[2],
+                    fm * separation_vector[0],
+                    fm * separation_vector[1],
+                    fm * separation_vector[2],
                 )
                 force_i_acc -= force
                 wp.atomic_add(atomic_forces, j, force)
@@ -434,6 +453,7 @@ def _make_backward_pair_fn(
     *,
     deriv_state: _DerivState,
     cell_grad: bool,
+    core_scalar: type = wp.float64,
 ) -> wp.Function:
     """Build the specialized backward per-pair accumulator."""
     info = _DTYPE_INFO[wp_dtype]
@@ -472,12 +492,12 @@ def _make_backward_pair_fn(
         # wp_erfc is an Abramowitz-Stegun polynomial with ~1.5e-7 error, so
         # evaluating it in float64 cannot beat evaluating it in float32 -- it just
         # costs a float64 erfc, exp and several divides on every pair.
-        qj_s = charges[j]
+        qj_s = core_scalar(charges[j])
         separation_vector = _periodic_separation(pos_i, pos_j, cell_t, shift_vec)
-        distance = wp.length(separation_vector)
-        qi_s = type(distance)(qi)
-        alpha_s = type(distance)(alpha_)
-        if distance > type(distance)(_DISTANCE_EPSILON):
+        distance = core_scalar(wp.length(separation_vector))
+        qi_s = core_scalar(qi)
+        alpha_s = core_scalar(alpha_)
+        if distance > core_scalar(_DISTANCE_EPSILON):
             ge_fm = wp.float64(0.0)
             if HAS_FORCE or CELL_GRAD:
                 force_mag = wp.float64(
@@ -531,6 +551,7 @@ def _make_double_backward_pair_fn(
     *,
     deriv_state: _DerivState,
     cell_grad: bool,
+    core_scalar: type = wp.float64,
 ) -> wp.Function:
     """Build the specialized double-backward per-pair accumulator."""
     info = _DTYPE_INFO[wp_dtype]
@@ -964,7 +985,10 @@ def _make_forward_kernel(
         wp_dtype, BATCHED, neighbor_input, "forward", energy_layout=energy_layout
     )
     accumulate_pair = _make_forward_pair_fn(
-        wp_dtype, deriv_state=deriv_state, cell_grad=cell_grad
+        wp_dtype,
+        core_scalar=_core_scalar(wp_dtype),
+        deriv_state=deriv_state,
+        cell_grad=cell_grad,
     )
 
     @wp.kernel(module=module_name)
@@ -1122,7 +1146,11 @@ def _make_forward_kernel_cell_literal(
         energy_layout=energy_layout,
     )
     accumulate_pair = _make_forward_pair_fn(
-        wp_dtype, deriv_state=deriv_state, cell_grad=cell_grad, cell_literal=True
+        wp_dtype,
+        core_scalar=_core_scalar(wp_dtype),
+        deriv_state=deriv_state,
+        cell_grad=cell_grad,
+        cell_literal=True,
     )
 
     @wp.kernel(module=module_name)
@@ -1268,7 +1296,10 @@ def _make_forward_kernel_tiled(
         energy_layout=energy_layout,
     )
     accumulate_pair = _make_forward_pair_fn(
-        wp_dtype, deriv_state=deriv_state, cell_grad=cell_grad
+        wp_dtype,
+        core_scalar=_core_scalar(wp_dtype),
+        deriv_state=deriv_state,
+        cell_grad=cell_grad,
     )
 
     @wp.kernel(module=module_name)
@@ -1417,7 +1448,11 @@ def _make_forward_kernel_tiled_cell_literal(
         energy_layout=energy_layout,
     )
     accumulate_pair = _make_forward_pair_fn(
-        wp_dtype, deriv_state=deriv_state, cell_grad=cell_grad, cell_literal=True
+        wp_dtype,
+        core_scalar=_core_scalar(wp_dtype),
+        deriv_state=deriv_state,
+        cell_grad=cell_grad,
+        cell_literal=True,
     )
 
     @wp.kernel(module=module_name)
@@ -1576,7 +1611,10 @@ def _make_backward_kernel(
 
     module_name = _ewald_real_module_name(wp_dtype, BATCHED, neighbor_input, "backward")
     accumulate_pair = _make_backward_pair_fn(
-        wp_dtype, deriv_state=deriv_state, cell_grad=cell_grad
+        wp_dtype,
+        core_scalar=_core_scalar(wp_dtype),
+        deriv_state=deriv_state,
+        cell_grad=cell_grad,
     )
 
     @wp.kernel(module=module_name)
@@ -1754,7 +1792,10 @@ def _make_double_backward_kernel(
         wp_dtype, BATCHED, neighbor_input, "double_backward"
     )
     accumulate_pair = _make_double_backward_pair_fn(
-        wp_dtype, deriv_state=deriv_state, cell_grad=cell_grad
+        wp_dtype,
+        core_scalar=_core_scalar(wp_dtype),
+        deriv_state=deriv_state,
+        cell_grad=cell_grad,
     )
 
     @wp.kernel(module=module_name)
@@ -1945,7 +1986,10 @@ def _make_double_backward_kernel_tiled(
         wp_dtype, BATCHED, neighbor_input, "double_backward", tiled=True
     )
     accumulate_pair = _make_double_backward_pair_fn(
-        wp_dtype, deriv_state=deriv_state, cell_grad=cell_grad
+        wp_dtype,
+        core_scalar=_core_scalar(wp_dtype),
+        deriv_state=deriv_state,
+        cell_grad=cell_grad,
     )
 
     @wp.kernel(module=module_name)

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
@@ -65,12 +65,17 @@ from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     BATCH_BLOCK_SIZE,
     EIGHTPI,
     RECIP_TILED_BLOCK_DIM,
+    _batch_ewald_recip_compute_fp32_recompute,
+    _batch_ewald_recip_fill_sf_fp32_nostore,
     _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
     _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled,
+    _ewald_recip_compute_fp32_recompute,
+    _ewald_recip_fill_sf_fp32_nostore,
     _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
     _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled,
     can_tile_ewald_recip_on_device,
     should_tile_ewald_recip_fill,
+    use_fp32_structure_factors,
 )
 from nvalchemiops.interactions.electrostatics.ewald_recip_factory import (
     _make_backward_kspace_from_cache_kernel,
@@ -453,6 +458,159 @@ def _atom_cotangent(grad_energy_atom, batch_idx, num_systems, num_atoms):
     )
 
 
+def _can_use_fp32_nostore(need_cell, input_dtype, torch_device) -> bool:
+    """Whether the float32 no-store reciprocal path may serve this call.
+
+    Covers energies, forces and dE/dq: the compute kernel recomputes the phases
+    in float32 rather than reading the ``(K, N)`` arrays this path never writes,
+    which is cheaper than the round-trip it replaces.
+
+    Cell gradients are excluded. The cellgrad fill accumulates extra per-k
+    quantities into a separate cache consumed by the O(S*K) kspace backward, and
+    that path has no recompute counterpart here.
+
+    float32 input is required: dropping the phase arithmetic to float32 is only
+    defensible when the caller already chose float32 positions.
+
+    Requires ``NVALCHEMIOPS_EWALD_RECIP_FP32_SF``; off by default because it
+    changes float32 results at the ~1e-07 level.
+    """
+    return (
+        use_fp32_structure_factors()
+        and not need_cell
+        and input_dtype == torch.float32
+        and torch_device.type == "cuda"
+    )
+
+
+def _run_fp32_nostore(
+    positions,
+    charges,
+    cell,
+    k_vectors_2d,
+    alpha,
+    batch_idx,
+    atom_start,
+    atom_end,
+    num_k,
+    num_systems,
+    num_atoms,
+    energies,
+    forces,
+    charge_grads,
+    wp_vec,
+    wp_scalar,
+    device,
+    batched,
+):
+    """Energy-only reciprocal space with float32 phases and no ``(K, N)`` store.
+
+    Two launches: a tiled fill reducing to the ``(K,)`` weighted structure
+    factors, then an atom-major pass that *recomputes* the phases rather than
+    reading them back. In float32 the recompute is far cheaper than the
+    round-trip it replaces, and peak memory becomes independent of ``K``.
+
+    Energies, forces and dE/dq are all produced: they share the k-loop, and the
+    extra work over energy alone is three FMAs per k against a transcendental
+    pair, so it is not worth branching on the derivative state here.
+
+    ``total_charge`` is written into a scratch buffer: the background correction
+    is applied by the caller from ``volume`` and the charges, so this path only
+    owes it the per-atom reciprocal quantities.
+    """
+    dev_t = positions.device
+    real_sf = torch.zeros(
+        (num_systems, num_k) if batched else (num_k,),
+        dtype=torch.float64,
+        device=dev_t,
+    )
+    imag_sf = torch.zeros_like(real_sf)
+    total_charge = torch.zeros(
+        num_systems if batched else 1, dtype=torch.float64, device=dev_t
+    )
+    wp_pos = _wp(positions, wp_vec)
+    wp_chg = _wp(charges, wp_scalar)
+    # k_vectors_2d is (S, K) of vec3 even for a single system; the single
+    # kernel takes a flat (K,) array, so hand it row 0.
+    wp_kv = _wp(k_vectors_2d, wp_vec)
+    wp_kv_single = _wp(k_vectors_2d[0].contiguous(), wp_vec)
+    wp_cell = _wp(cell, get_wp_mat_dtype(cell.dtype))
+    wp_alpha = _wp(alpha, wp_scalar)
+    wp_re, wp_im = _wp(real_sf, wp.float64), _wp(imag_sf, wp.float64)
+    wp_en = _wp(energies, wp.float64)
+    wp_f = _wp(forces, wp_vec)
+    wp_cg = _wp(charge_grads, wp.float64)
+
+    with _scoped_stream(dev_t):
+        if batched:
+            wp.launch_tiled(
+                _batch_ewald_recip_fill_sf_fp32_nostore,
+                dim=(num_k, num_systems),
+                inputs=[
+                    wp_pos,
+                    wp_chg,
+                    wp_kv,
+                    wp_cell,
+                    wp_alpha,
+                    _wp(atom_start, wp.int32),
+                    _wp(atom_end, wp.int32),
+                    _wp(total_charge, wp.float64),
+                    wp_re,
+                    wp_im,
+                ],
+                device=device,
+                block_dim=RECIP_TILED_BLOCK_DIM,
+            )
+            wp.launch(
+                _batch_ewald_recip_compute_fp32_recompute,
+                dim=num_atoms,
+                inputs=[
+                    wp_pos,
+                    wp_chg,
+                    _wp(batch_idx, wp.int32),
+                    wp_kv,
+                    wp_re,
+                    wp_im,
+                    wp_en,
+                    wp_f,
+                    wp_cg,
+                ],
+                device=device,
+            )
+        else:
+            wp.launch_tiled(
+                _ewald_recip_fill_sf_fp32_nostore,
+                dim=num_k,
+                inputs=[
+                    wp_pos,
+                    wp_chg,
+                    wp_kv_single,
+                    wp_cell,
+                    wp_alpha,
+                    _wp(total_charge, wp.float64),
+                    wp_re,
+                    wp_im,
+                ],
+                device=device,
+                block_dim=RECIP_TILED_BLOCK_DIM,
+            )
+            wp.launch(
+                _ewald_recip_compute_fp32_recompute,
+                dim=num_atoms,
+                inputs=[
+                    wp_pos,
+                    wp_chg,
+                    wp_kv_single,
+                    wp_re,
+                    wp_im,
+                    wp_en,
+                    wp_f,
+                    wp_cg,
+                ],
+                device=device,
+            )
+
+
 def _forward_impl(
     positions,
     charges,
@@ -506,6 +664,35 @@ def _forward_impl(
         deriv_state = _DerivState.E_F
     else:
         deriv_state = _DerivState.E
+    if _can_use_fp32_nostore(need_cell, input_dtype, positions.device):
+        forces_f = torch.zeros(num_atoms, 3, device=positions.device, dtype=input_dtype)
+        dEdq_f = torch.zeros(num_atoms, device=positions.device, dtype=torch.float64)
+        _run_fp32_nostore(
+            positions,
+            charges,
+            cell,
+            k_vectors_2d,
+            alpha,
+            batch_idx,
+            atom_start,
+            atom_end,
+            num_k,
+            num_systems,
+            num_atoms,
+            energies,
+            forces_f,
+            dEdq_f,
+            wp_vec,
+            wp_scalar,
+            device,
+            batched,
+        )
+        if need_pos:
+            dEdR = (-forces_f).detach()
+        if need_charge:
+            dEdq = dEdq_f.detach()
+        return energies, dEdR, dEdq, cellgrad_cache
+
     bundle = get_ewald_recip_kernel(
         wp_scalar, batched=batched, deriv_state=deriv_state, order="forward"
     )

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
@@ -59,6 +59,7 @@ import warp as wp
 
 from nvalchemiops.interactions.electrostatics._factory_common import (
     _DerivState,
+    _use_fp32_electrostatics,
     get_backward_scale_kernel,
 )
 from nvalchemiops.interactions.electrostatics.ewald_kernels import (
@@ -75,7 +76,6 @@ from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     _ewald_recip_fill_sf_fp32_nostore_cellgrad,
     _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
     _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled,
-    _use_fp32_structure_factors,
     can_tile_ewald_recip_on_device,
     should_tile_ewald_recip_fill,
 )
@@ -476,11 +476,12 @@ def _can_use_fp32_nostore(input_dtype, torch_device) -> bool:
     float32 input is required: dropping the phase arithmetic to float32 is only
     defensible when the caller already chose float32 positions.
 
-    Requires ``NVALCHEMIOPS_EWALD_RECIP_FP32_SF``; off by default because it
-    changes float32 results at the ~1e-07 level.
+    Requires ``NVALCHEMIOPS_ELECTROSTATICS_FP32``; off by default because it
+    changes float32 results at the ~1e-07 level. The same flag governs the
+    real-space per-pair cores, so both halves of the split move together.
     """
     return (
-        _use_fp32_structure_factors()
+        _use_fp32_electrostatics()
         and input_dtype == torch.float32
         and torch_device.type == "cuda"
     )

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
@@ -67,15 +67,17 @@ from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     RECIP_TILED_BLOCK_DIM,
     _batch_ewald_recip_compute_fp32_recompute_tiled,
     _batch_ewald_recip_fill_sf_fp32_nostore,
+    _batch_ewald_recip_fill_sf_fp32_nostore_cellgrad,
     _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
     _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled,
     _ewald_recip_compute_fp32_recompute_tiled,
     _ewald_recip_fill_sf_fp32_nostore,
+    _ewald_recip_fill_sf_fp32_nostore_cellgrad,
     _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
     _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled,
     can_tile_ewald_recip_on_device,
     should_tile_ewald_recip_fill,
-    use_fp32_structure_factors,
+    _use_fp32_structure_factors,
 )
 from nvalchemiops.interactions.electrostatics.ewald_recip_factory import (
     _make_backward_kspace_from_cache_kernel,
@@ -458,16 +460,18 @@ def _atom_cotangent(grad_energy_atom, batch_idx, num_systems, num_atoms):
     )
 
 
-def _can_use_fp32_nostore(need_cell, input_dtype, torch_device) -> bool:
+def _can_use_fp32_nostore(input_dtype, torch_device) -> bool:
     """Whether the float32 no-store reciprocal path may serve this call.
 
     Covers energies, forces and dE/dq: the compute kernel recomputes the phases
     in float32 rather than reading the ``(K, N)`` arrays this path never writes,
     which is cheaper than the round-trip it replaces.
 
-    Cell gradients are excluded. The cellgrad fill accumulates extra per-k
-    quantities into a separate cache consumed by the O(S*K) kspace backward, and
-    that path has no recompute counterpart here.
+    Cell gradients are served by the ``_cellgrad`` fill variants, which ride the
+    same reduction and additionally emit the unweighted per-k cache the O(S*K)
+    kspace backward consumes. Second-order (double-backward) cell gradients are
+    not affected: that path builds its own float64 ``(S, K)`` accumulators and
+    never reads these.
 
     float32 input is required: dropping the phase arithmetic to float32 is only
     defensible when the caller already chose float32 positions.
@@ -476,8 +480,7 @@ def _can_use_fp32_nostore(need_cell, input_dtype, torch_device) -> bool:
     changes float32 results at the ~1e-07 level.
     """
     return (
-        use_fp32_structure_factors()
-        and not need_cell
+        _use_fp32_structure_factors()
         and input_dtype == torch.float32
         and torch_device.type == "cuda"
     )
@@ -502,6 +505,7 @@ def _run_fp32_nostore(
     wp_scalar,
     device,
     batched,
+    cellgrad_cache=None,
 ):
     """Energy-only reciprocal space with float32 phases and no ``(K, N)`` store.
 
@@ -517,6 +521,10 @@ def _run_fp32_nostore(
     ``total_charge`` is written into a scratch buffer: the background correction
     is applied by the caller from ``volume`` and the charges, so this path only
     owes it the per-atom reciprocal quantities.
+
+    When ``cellgrad_cache`` is supplied the ``_cellgrad`` fill variants run
+    instead; they emit the same unweighted per-k reductions the float64 fill
+    does, so the kspace cell-gradient backward is unchanged.
     """
     dev_t = positions.device
     # float32: the fill reduces across lanes in float64 and narrows only on the
@@ -545,11 +553,14 @@ def _run_fp32_nostore(
     wp_en = _wp(energies, wp.float64)
     wp_f = _wp(forces, wp_vec)
     wp_cg = _wp(charge_grads, wp.float64)
+    # Distinct name: `wp_cg` above is the charge-gradient output array.
+    want_cellgrad = cellgrad_cache is not None
+    wp_cgcache = _wp(cellgrad_cache, wp.float64) if want_cellgrad else None
 
     with _scoped_stream(dev_t):
         if batched:
             wp.launch_tiled(
-                _batch_ewald_recip_fill_sf_fp32_nostore,
+                _batch_ewald_recip_fill_sf_fp32_nostore_cellgrad if want_cellgrad else _batch_ewald_recip_fill_sf_fp32_nostore,
                 dim=(num_k, num_systems),
                 inputs=[
                     wp_pos,
@@ -562,7 +573,8 @@ def _run_fp32_nostore(
                     _wp(total_charge, wp.float64),
                     wp_re,
                     wp_im,
-                ],
+                ]
+                + ([wp_cgcache] if want_cellgrad else []),
                 device=device,
                 block_dim=RECIP_TILED_BLOCK_DIM,
             )
@@ -585,7 +597,7 @@ def _run_fp32_nostore(
             )
         else:
             wp.launch_tiled(
-                _ewald_recip_fill_sf_fp32_nostore,
+                _ewald_recip_fill_sf_fp32_nostore_cellgrad if want_cellgrad else _ewald_recip_fill_sf_fp32_nostore,
                 dim=num_k,
                 inputs=[
                     wp_pos,
@@ -596,7 +608,8 @@ def _run_fp32_nostore(
                     _wp(total_charge, wp.float64),
                     wp_re,
                     wp_im,
-                ],
+                ]
+                + ([wp_cgcache] if want_cellgrad else []),
                 device=device,
                 block_dim=RECIP_TILED_BLOCK_DIM,
             )
@@ -671,9 +684,15 @@ def _forward_impl(
         deriv_state = _DerivState.E_F
     else:
         deriv_state = _DerivState.E
-    if _can_use_fp32_nostore(need_cell, input_dtype, positions.device):
+    if _can_use_fp32_nostore(input_dtype, positions.device):
         forces_f = torch.zeros(num_atoms, 3, device=positions.device, dtype=input_dtype)
         dEdq_f = torch.zeros(num_atoms, device=positions.device, dtype=torch.float64)
+        if need_cell:
+            # Same (S*K, 8) layout the float64 cellgrad fill produces, so the
+            # kspace backward consumes it without knowing which fill ran.
+            cellgrad_cache = torch.zeros(
+                num_systems * num_k, 8, device=positions.device, dtype=torch.float64
+            )
         _run_fp32_nostore(
             positions,
             charges,
@@ -693,6 +712,7 @@ def _forward_impl(
             wp_scalar,
             device,
             batched,
+            cellgrad_cache if need_cell else None,
         )
         if need_pos:
             dEdR = (-forces_f).detach()

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
@@ -65,11 +65,11 @@ from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     BATCH_BLOCK_SIZE,
     EIGHTPI,
     RECIP_TILED_BLOCK_DIM,
-    _batch_ewald_recip_compute_fp32_recompute,
+    _batch_ewald_recip_compute_fp32_recompute_tiled,
     _batch_ewald_recip_fill_sf_fp32_nostore,
     _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
     _batch_ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled,
-    _ewald_recip_compute_fp32_recompute,
+    _ewald_recip_compute_fp32_recompute_tiled,
     _ewald_recip_fill_sf_fp32_nostore,
     _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
     _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled,
@@ -561,8 +561,8 @@ def _run_fp32_nostore(
                 device=device,
                 block_dim=RECIP_TILED_BLOCK_DIM,
             )
-            wp.launch(
-                _batch_ewald_recip_compute_fp32_recompute,
+            wp.launch_tiled(
+                _batch_ewald_recip_compute_fp32_recompute_tiled,
                 dim=num_atoms,
                 inputs=[
                     wp_pos,
@@ -576,6 +576,7 @@ def _run_fp32_nostore(
                     wp_cg,
                 ],
                 device=device,
+                block_dim=RECIP_TILED_BLOCK_DIM,
             )
         else:
             wp.launch_tiled(
@@ -594,8 +595,8 @@ def _run_fp32_nostore(
                 device=device,
                 block_dim=RECIP_TILED_BLOCK_DIM,
             )
-            wp.launch(
-                _ewald_recip_compute_fp32_recompute,
+            wp.launch_tiled(
+                _ewald_recip_compute_fp32_recompute_tiled,
                 dim=num_atoms,
                 inputs=[
                     wp_pos,
@@ -608,6 +609,7 @@ def _run_fp32_nostore(
                     wp_cg,
                 ],
                 device=device,
+                block_dim=RECIP_TILED_BLOCK_DIM,
             )
 
 

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
@@ -519,9 +519,14 @@ def _run_fp32_nostore(
     owes it the per-atom reciprocal quantities.
     """
     dev_t = positions.device
+    # float32: the fill reduces across lanes in float64 and narrows only on the
+    # final store, so the values are as accurate as a float64 array would hold
+    # them -- but the recompute pass reads these K entries once per atom, so the
+    # width is on the hot path and float64 would cost a narrowing conversion per
+    # element as well as twice the traffic.
     real_sf = torch.zeros(
         (num_systems, num_k) if batched else (num_k,),
-        dtype=torch.float64,
+        dtype=torch.float32,
         device=dev_t,
     )
     imag_sf = torch.zeros_like(real_sf)
@@ -536,7 +541,7 @@ def _run_fp32_nostore(
     wp_kv_single = _wp(k_vectors_2d[0].contiguous(), wp_vec)
     wp_cell = _wp(cell, get_wp_mat_dtype(cell.dtype))
     wp_alpha = _wp(alpha, wp_scalar)
-    wp_re, wp_im = _wp(real_sf, wp.float64), _wp(imag_sf, wp.float64)
+    wp_re, wp_im = _wp(real_sf, wp.float32), _wp(imag_sf, wp.float32)
     wp_en = _wp(energies, wp.float64)
     wp_f = _wp(forces, wp_vec)
     wp_cg = _wp(charge_grads, wp.float64)

--- a/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
+++ b/nvalchemiops/torch/interactions/electrostatics/_ewald_recip_chain.py
@@ -75,9 +75,9 @@ from nvalchemiops.interactions.electrostatics.ewald_kernels import (
     _ewald_recip_fill_sf_fp32_nostore_cellgrad,
     _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad,
     _ewald_reciprocal_space_energy_kernel_fill_structure_factors_cellgrad_tiled,
+    _use_fp32_structure_factors,
     can_tile_ewald_recip_on_device,
     should_tile_ewald_recip_fill,
-    _use_fp32_structure_factors,
 )
 from nvalchemiops.interactions.electrostatics.ewald_recip_factory import (
     _make_backward_kspace_from_cache_kernel,
@@ -560,7 +560,9 @@ def _run_fp32_nostore(
     with _scoped_stream(dev_t):
         if batched:
             wp.launch_tiled(
-                _batch_ewald_recip_fill_sf_fp32_nostore_cellgrad if want_cellgrad else _batch_ewald_recip_fill_sf_fp32_nostore,
+                _batch_ewald_recip_fill_sf_fp32_nostore_cellgrad
+                if want_cellgrad
+                else _batch_ewald_recip_fill_sf_fp32_nostore,
                 dim=(num_k, num_systems),
                 inputs=[
                     wp_pos,
@@ -597,7 +599,9 @@ def _run_fp32_nostore(
             )
         else:
             wp.launch_tiled(
-                _ewald_recip_fill_sf_fp32_nostore_cellgrad if want_cellgrad else _ewald_recip_fill_sf_fp32_nostore,
+                _ewald_recip_fill_sf_fp32_nostore_cellgrad
+                if want_cellgrad
+                else _ewald_recip_fill_sf_fp32_nostore,
                 dim=num_k,
                 inputs=[
                     wp_pos,

--- a/test/interactions/electrostatics/test_ewald_recip_fp32_nostore.py
+++ b/test/interactions/electrostatics/test_ewald_recip_fp32_nostore.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the float32, no-store reciprocal structure-factor path.
+
+Enabled by ``NVALCHEMIOPS_EWALD_RECIP_FP32_SF``. It computes the phases in
+float32 and never materialises the ``(K, N)`` ``cos_k_dot_r`` / ``sin_k_dot_r``
+arrays, recomputing them in the per-atom pass instead. That trades a float64
+round-trip for float32 transcendentals, which is strongly favourable on parts
+with weak float64 throughput.
+
+These tests go through ``ewald_summation`` rather than the kernels directly:
+the gate lives in ``_ewald_recip_chain._forward_impl``, so kernel-level tests
+would bypass it entirely. Each test asserts the fast path was actually taken,
+because a silently-disabled gate would otherwise make every comparison pass
+trivially.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from nvalchemiops.torch.interactions.electrostatics import (
+    ewald_summation,
+    generate_k_vectors_ewald_summation,
+)
+from nvalchemiops.torch.neighbors import neighbor_list
+from nvalchemiops.torch.neighbors.neighbor_utils import estimate_max_neighbors
+
+pytestmark = pytest.mark.gpu
+
+DENSITY = 0.15
+CUTOFF = 9.0
+ALPHA = 0.4130
+K_CUTOFF = 2.6
+
+
+def _make_system(n_atoms, n_systems=1, dtype=torch.float32, device="cuda:0", seed=0):
+    """A jittered-lattice periodic system, sized so minimum image holds."""
+    gen = torch.Generator().manual_seed(seed)
+    box = float((n_atoms / DENSITY) ** (1.0 / 3.0))
+    n_side = int(round(n_atoms ** (1.0 / 3.0) + 0.5))
+    grid = torch.arange(n_side, dtype=torch.float64)
+    coords = torch.stack(
+        torch.meshgrid(grid, grid, grid, indexing="ij"), dim=-1
+    ).reshape(-1, 3)[:n_atoms] * (box / n_side)
+    jitter = torch.rand(coords.shape, generator=gen, dtype=torch.float64) * 2 - 1
+    positions = torch.cat(
+        [((coords + 0.2 * (box / n_side) * jitter) % box) for _ in range(n_systems)]
+    )
+    total = n_atoms * n_systems
+    charges = torch.empty(total, dtype=torch.float64)
+    for s in range(n_systems):
+        q = torch.randn(n_atoms, generator=gen, dtype=torch.float64)
+        charges[s * n_atoms : (s + 1) * n_atoms] = q - q.mean()
+    cell = torch.eye(3, dtype=torch.float64).expand(n_systems, 3, 3) * box
+    batch_idx = (
+        torch.arange(n_systems, dtype=torch.int32).repeat_interleave(n_atoms)
+        if n_systems > 1
+        else None
+    )
+    return dict(
+        positions=positions.to(device=device, dtype=dtype).contiguous(),
+        charges=charges.to(device=device, dtype=dtype).contiguous(),
+        cell=cell.to(device=device, dtype=dtype).contiguous(),
+        pbc=torch.ones((n_systems, 3), dtype=torch.bool, device=device),
+        batch_idx=None if batch_idx is None else batch_idx.to(device),
+        atoms_per_system=n_atoms,
+    )
+
+
+def _energy_and_forces(sysd, want_forces=True):
+    """Run ``ewald_summation``, returning (energy, forces or None)."""
+    positions = sysd["positions"]
+    max_nb = estimate_max_neighbors(CUTOFF, atomic_density=2.0 * DENSITY)
+    nbmat, _, shifts = neighbor_list(
+        positions,
+        CUTOFF,
+        cell=sysd["cell"],
+        pbc=sysd["pbc"],
+        batch_idx=sysd["batch_idx"],
+        return_neighbor_list=False,
+        half_fill=False,
+        max_neighbors=max_nb,
+    )
+    k_vectors = generate_k_vectors_ewald_summation(sysd["cell"], K_CUTOFF)
+    pos = positions.detach().clone().requires_grad_(want_forces)
+    energy = ewald_summation(
+        pos,
+        sysd["charges"],
+        sysd["cell"],
+        alpha=ALPHA,
+        k_vectors=k_vectors,
+        neighbor_matrix=nbmat,
+        neighbor_matrix_shifts=shifts,
+        batch_idx=sysd["batch_idx"],
+        max_atoms_per_system=sysd["atoms_per_system"],
+    ).sum()
+    if not want_forces:
+        return float(energy.detach()), None
+    forces = -torch.autograd.grad(energy, pos)[0]
+    return float(energy.detach()), forces
+
+
+@pytest.fixture
+def gate_counter(monkeypatch):
+    """Enable the fast path and count how often the gate admits a call.
+
+    Without this the tests could pass with the path silently never taken.
+    """
+    import nvalchemiops.torch.interactions.electrostatics._ewald_recip_chain as chain
+
+    monkeypatch.setenv("NVALCHEMIOPS_EWALD_RECIP_FP32_SF", "1")
+    counts = {"fast": 0, "slow": 0}
+    original = chain._can_use_fp32_nostore
+
+    def counting(*args, **kwargs):
+        taken = original(*args, **kwargs)
+        counts["fast" if taken else "slow"] += 1
+        return taken
+
+    monkeypatch.setattr(chain, "_can_use_fp32_nostore", counting)
+    return counts
+
+
+@pytest.mark.parametrize("n_systems", [1, 4], ids=["single", "batched"])
+def test_energy_matches_default_path(cuda_available, gate_counter, n_systems):
+    """float32 no-store energy agrees with the float64 stored-phase path."""
+    if not cuda_available:
+        pytest.skip("No GPU")
+    sysd = _make_system(1024, n_systems=n_systems)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.delenv("NVALCHEMIOPS_EWALD_RECIP_FP32_SF", raising=False)
+        reference, _ = _energy_and_forces(sysd, want_forces=False)
+
+    fast, _ = _energy_and_forces(sysd, want_forces=False)
+
+    assert gate_counter["fast"] > 0, "fast path was never taken"
+    assert abs(fast - reference) / abs(reference) < 1e-5
+
+
+@pytest.mark.parametrize("n_systems", [1, 4], ids=["single", "batched"])
+def test_forces_match_default_path(cuda_available, gate_counter, n_systems):
+    """Forces agree too -- the recompute path must serve derivatives, not just E."""
+    if not cuda_available:
+        pytest.skip("No GPU")
+    sysd = _make_system(1024, n_systems=n_systems)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.delenv("NVALCHEMIOPS_EWALD_RECIP_FP32_SF", raising=False)
+        _, reference = _energy_and_forces(sysd)
+
+    _, fast = _energy_and_forces(sysd)
+
+    assert gate_counter["fast"] > 0, "fast path was never taken"
+    scale = reference.abs().max().clamp_min(1e-30)
+    assert float((fast - reference).abs().max() / scale) < 1e-5
+
+
+def test_peak_memory_is_independent_of_k(cuda_available, gate_counter):
+    """The point of the path: footprint must stop scaling with K.
+
+    The stored-phase path allocates two float64 ``(K, N)`` arrays, so its peak
+    grows with the k-vector count; this path allocates neither.
+    """
+    if not cuda_available:
+        pytest.skip("No GPU")
+    sysd = _make_system(2048)
+
+    def peak():
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        _energy_and_forces(sysd, want_forces=False)
+        torch.cuda.synchronize()
+        return torch.cuda.max_memory_allocated()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.delenv("NVALCHEMIOPS_EWALD_RECIP_FP32_SF", raising=False)
+        stored = peak()
+    nostore = peak()
+
+    assert gate_counter["fast"] > 0, "fast path was never taken"
+    assert nostore < stored / 2
+
+
+def test_gate_refuses_float64(cuda_available, gate_counter):
+    """float64 callers keep the float64 phases: the gate must not downgrade them."""
+    if not cuda_available:
+        pytest.skip("No GPU")
+    sysd = _make_system(512, dtype=torch.float64)
+    _energy_and_forces(sysd, want_forces=False)
+    assert gate_counter["fast"] == 0
+    assert gate_counter["slow"] > 0
+
+
+def test_gate_disabled_by_default(cuda_available, monkeypatch):
+    """Absent the environment variable the path must stay off."""
+    if not cuda_available:
+        pytest.skip("No GPU")
+    import nvalchemiops.torch.interactions.electrostatics._ewald_recip_chain as chain
+
+    monkeypatch.delenv("NVALCHEMIOPS_EWALD_RECIP_FP32_SF", raising=False)
+    counts = {"fast": 0}
+    original = chain._can_use_fp32_nostore
+
+    def counting(*args, **kwargs):
+        taken = original(*args, **kwargs)
+        counts["fast"] += int(taken)
+        return taken
+
+    monkeypatch.setattr(chain, "_can_use_fp32_nostore", counting)
+    _energy_and_forces(_make_system(512), want_forces=False)
+    assert counts["fast"] == 0

--- a/test/interactions/electrostatics/test_ewald_recip_fp32_nostore.py
+++ b/test/interactions/electrostatics/test_ewald_recip_fp32_nostore.py
@@ -87,15 +87,25 @@ def _cell_gradient(sysd):
     positions = sysd["positions"]
     max_nb = estimate_max_neighbors(CUTOFF, atomic_density=2.0 * DENSITY)
     nbmat, _, shifts = neighbor_list(
-        positions, CUTOFF, cell=sysd["cell"], pbc=sysd["pbc"],
-        batch_idx=sysd["batch_idx"], return_neighbor_list=False,
-        half_fill=False, max_neighbors=max_nb,
+        positions,
+        CUTOFF,
+        cell=sysd["cell"],
+        pbc=sysd["pbc"],
+        batch_idx=sysd["batch_idx"],
+        return_neighbor_list=False,
+        half_fill=False,
+        max_neighbors=max_nb,
     )
     k_vectors = generate_k_vectors_ewald_summation(sysd["cell"], K_CUTOFF)
     cell = sysd["cell"].detach().clone().requires_grad_(True)
     energy = ewald_summation(
-        positions, sysd["charges"], cell, alpha=ALPHA, k_vectors=k_vectors,
-        neighbor_matrix=nbmat, neighbor_matrix_shifts=shifts,
+        positions,
+        sysd["charges"],
+        cell,
+        alpha=ALPHA,
+        k_vectors=k_vectors,
+        neighbor_matrix=nbmat,
+        neighbor_matrix_shifts=shifts,
         batch_idx=sysd["batch_idx"],
         max_atoms_per_system=sysd["atoms_per_system"],
     ).sum()

--- a/test/interactions/electrostatics/test_ewald_recip_fp32_nostore.py
+++ b/test/interactions/electrostatics/test_ewald_recip_fp32_nostore.py
@@ -82,6 +82,26 @@ def _make_system(n_atoms, n_systems=1, dtype=torch.float32, device="cuda:0", see
     )
 
 
+def _cell_gradient(sysd):
+    """dE/dcell through the same entry point, which selects the cellgrad fill."""
+    positions = sysd["positions"]
+    max_nb = estimate_max_neighbors(CUTOFF, atomic_density=2.0 * DENSITY)
+    nbmat, _, shifts = neighbor_list(
+        positions, CUTOFF, cell=sysd["cell"], pbc=sysd["pbc"],
+        batch_idx=sysd["batch_idx"], return_neighbor_list=False,
+        half_fill=False, max_neighbors=max_nb,
+    )
+    k_vectors = generate_k_vectors_ewald_summation(sysd["cell"], K_CUTOFF)
+    cell = sysd["cell"].detach().clone().requires_grad_(True)
+    energy = ewald_summation(
+        positions, sysd["charges"], cell, alpha=ALPHA, k_vectors=k_vectors,
+        neighbor_matrix=nbmat, neighbor_matrix_shifts=shifts,
+        batch_idx=sysd["batch_idx"],
+        max_atoms_per_system=sysd["atoms_per_system"],
+    ).sum()
+    return torch.autograd.grad(energy, cell)[0]
+
+
 def _energy_and_forces(sysd, want_forces=True):
     """Run ``ewald_summation``, returning (energy, forces or None)."""
     positions = sysd["positions"]
@@ -225,3 +245,27 @@ def test_gate_disabled_by_default(cuda_available, monkeypatch):
     monkeypatch.setattr(chain, "_can_use_fp32_nostore", counting)
     _energy_and_forces(_make_system(512), want_forces=False)
     assert counts["fast"] == 0
+
+
+@pytest.mark.parametrize("n_systems", [1, 4], ids=["single", "batched"])
+def test_cell_gradient_matches_default_path(cuda_available, gate_counter, n_systems):
+    """dE/dcell agrees: the fill variant emits the same unweighted per-k cache.
+
+    The cache is reduced in float64 even though the phases are float32, so most
+    entries round identically to the float64 fill's; this asserts agreement
+    rather than bitwise equality because the phase difference does surface at
+    some sizes.
+    """
+    if not cuda_available:
+        pytest.skip("No GPU")
+    sysd = _make_system(4096, n_systems=n_systems)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.delenv("NVALCHEMIOPS_EWALD_RECIP_FP32_SF", raising=False)
+        reference = _cell_gradient(sysd)
+
+    fast = _cell_gradient(sysd)
+
+    assert gate_counter["fast"] > 0, "fast path was never taken"
+    scale = reference.abs().max().clamp_min(1e-30)
+    assert float((fast - reference).abs().max() / scale) < 1e-5

--- a/test/interactions/electrostatics/test_ewald_recip_fp32_nostore.py
+++ b/test/interactions/electrostatics/test_ewald_recip_fp32_nostore.py
@@ -15,7 +15,7 @@
 
 """Tests for the float32, no-store reciprocal structure-factor path.
 
-Enabled by ``NVALCHEMIOPS_EWALD_RECIP_FP32_SF``. It computes the phases in
+Enabled by ``NVALCHEMIOPS_ELECTROSTATICS_FP32``. It computes the phases in
 float32 and never materialises the ``(K, N)`` ``cos_k_dot_r`` / ``sin_k_dot_r``
 arrays, recomputing them in the per-atom pass instead. That trades a float64
 round-trip for float32 transcendentals, which is strongly favourable on parts
@@ -153,7 +153,7 @@ def gate_counter(monkeypatch):
     """
     import nvalchemiops.torch.interactions.electrostatics._ewald_recip_chain as chain
 
-    monkeypatch.setenv("NVALCHEMIOPS_EWALD_RECIP_FP32_SF", "1")
+    monkeypatch.setenv("NVALCHEMIOPS_ELECTROSTATICS_FP32", "1")
     counts = {"fast": 0, "slow": 0}
     original = chain._can_use_fp32_nostore
 
@@ -174,7 +174,7 @@ def test_energy_matches_default_path(cuda_available, gate_counter, n_systems):
     sysd = _make_system(1024, n_systems=n_systems)
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.delenv("NVALCHEMIOPS_EWALD_RECIP_FP32_SF", raising=False)
+        mp.delenv("NVALCHEMIOPS_ELECTROSTATICS_FP32", raising=False)
         reference, _ = _energy_and_forces(sysd, want_forces=False)
 
     fast, _ = _energy_and_forces(sysd, want_forces=False)
@@ -191,7 +191,7 @@ def test_forces_match_default_path(cuda_available, gate_counter, n_systems):
     sysd = _make_system(1024, n_systems=n_systems)
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.delenv("NVALCHEMIOPS_EWALD_RECIP_FP32_SF", raising=False)
+        mp.delenv("NVALCHEMIOPS_ELECTROSTATICS_FP32", raising=False)
         _, reference = _energy_and_forces(sysd)
 
     _, fast = _energy_and_forces(sysd)
@@ -219,7 +219,7 @@ def test_peak_memory_is_independent_of_k(cuda_available, gate_counter):
         return torch.cuda.max_memory_allocated()
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.delenv("NVALCHEMIOPS_EWALD_RECIP_FP32_SF", raising=False)
+        mp.delenv("NVALCHEMIOPS_ELECTROSTATICS_FP32", raising=False)
         stored = peak()
     nostore = peak()
 
@@ -243,7 +243,7 @@ def test_gate_disabled_by_default(cuda_available, monkeypatch):
         pytest.skip("No GPU")
     import nvalchemiops.torch.interactions.electrostatics._ewald_recip_chain as chain
 
-    monkeypatch.delenv("NVALCHEMIOPS_EWALD_RECIP_FP32_SF", raising=False)
+    monkeypatch.delenv("NVALCHEMIOPS_ELECTROSTATICS_FP32", raising=False)
     counts = {"fast": 0}
     original = chain._can_use_fp32_nostore
 
@@ -271,7 +271,7 @@ def test_cell_gradient_matches_default_path(cuda_available, gate_counter, n_syst
     sysd = _make_system(4096, n_systems=n_systems)
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.delenv("NVALCHEMIOPS_EWALD_RECIP_FP32_SF", raising=False)
+        mp.delenv("NVALCHEMIOPS_ELECTROSTATICS_FP32", raising=False)
         reference = _cell_gradient(sysd)
 
     fast = _cell_gradient(sysd)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

Two independent float64->float32 changes in the monopole electrostatics path,
both motivated by profiling and benchmarking work.

1. **A new float32 no-store Ewald reciprocal path**, off by default behind
   `NVALCHEMIOPS_EWALD_RECIP_FP32_SF`. It computes structure-factor phases in
   float32 and never materialises the `(K, N)` `cos_k_dot_r`/`sin_k_dot_r`
   arrays, recomputing them in the per-atom pass instead.
2. **The shared per-pair real-space cores now evaluate in the caller's
   precision** instead of being hard-typed float64. This one is unconditional
   and affects both Ewald and PME.

The justification is that `wp_erfc` is an Abramowitz-Stegun polynomial whose own 
maximum error is ~1.5e-7 so evaluating it in float64 cannot make it more accurate --
it only makes it slower. 

The float64 path is unchanged by construction: generic cores instantiated at
float64 are the previous code.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change


## Changes Made

**Ewald reciprocal, float32 no-store path (opt-in)**

- `ewald_kernels.py`: `use_fp32_structure_factors()` reads the environment gate;
  `_recip_phase_fp32` and `_recip_atom_accumulate_fp32` are the shared `@wp.func`
  bodies. The accumulate takes `k_start`/`k_stride` so the atom-major kernels
  pass `(0, 1)` and the tiled ones pass `(lane, block_dim)` -- one loop body
  serves both rather than being duplicated.
- Fill kernels `_ewald_recip_fill_sf_fp32_nostore` / `_batch_...`: one block per
  k-vector, lanes over atoms, float32 accumulation widened only for the final
  cross-lane reduction.
- Compute kernels `_ewald_recip_compute_fp32_recompute{,_tiled}` / `_batch_...`:
  one block per atom, lanes over the k range, combined with `wp.tile_reduce`.
- `_ewald_recip_chain.py`: `_can_use_fp32_nostore()` gates on the environment
  variable AND float32 input AND CUDA AND no cell gradient; `_run_fp32_nostore()`
  launches the two kernels. One branch added to `_forward_impl` ahead of the
  existing path; nothing else in the chain changes.

**Per-pair real-space cores, input precision (always on)**

- `_factory_common.py`: `_ewald_half_force_scale`, `_ewald_half_force_scale_deriv`
  and `_ewald_charge_potential_deriv` go `wp.float64` -> `Any`, with constants
  built via `type(distance)(...)`.
- `ewald_kernels.py`: same for `_ewald_real_space_energy_kernel_compute_energy`,
  `_ewald_real_space_force_magnitude` and
  `_ewald_real_space_charge_grad_potential`.
- `ewald_real_factory.py`: the forward and backward pair loops stop widening
  `charges[j]` and `wp.length(sep)` to float64, call the cores at input
  precision, and widen only the scalar result before it reaches an accumulator.
  **Accumulators stay float64** -- that is where the cancellation lives, and it
  is not where the cost was.

## Testing

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

`test_ewald_recip_fp32_nostore.py` adds 7 tests covering energy and force
agreement (single and batched), the memory property, and gate behaviour. They
go through `ewald_summation` rather than calling kernels directly, because the
gate lives in `_forward_impl` and kernel-level tests would bypass it entirely.
A `gate_counter` fixture monkeypatches the gate and **every test asserts it was
actually taken** -- a silently-disabled path would otherwise make every
comparison pass trivially.

**Accuracy** (float32 vs a float64 reference, N=8192, K=29659):

| | before | after |
|---|---|---|
| ewald dE | 5.647e-07 | 5.650e-07 |
| ewald dF | 2.554e-06 | 2.626e-06 |
| pme dE | 1.890e-05 | 1.890e-05 |
| pme dF | 8.768e-05 | 8.767e-05 |

The float32 no-store path agrees with the default path to dE 4.5e-07 /
dF 3.6e-07 against a 1e-5 tolerance, verified on both B300 and RTX PRO 4500.

**Performance**, Ewald energy+forces vs the default path (B300):

| shape | speedup | peak memory |
|---|---|---|
| 1x2048 | 5.17x | |
| 1x8192 | 9.11x | |
| 1x16384 | **18.17x** | 15119 -> 473 MiB |
| 8x2048 | 5.30x | |

Real-space cores at N=8192, mesh 256^3, order 5, with forces:

| | before | after |
|---|---|---|
| `ewald_real_forward` (f32) | 1.694 ms | **0.364 ms** (4.65x) |
| PME total | 5.335 ms | **4.051 ms** (1.32x) |
| PME total (f64) | 17.601 ms | 17.035 ms (unchanged) |

On B300, PME gains 1.5-2.8x from the real-space change alone at 32k-131k atoms.

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
