### PR TITLE
fix(jax): support warp-lang>=1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Changed
+
+- Raised the minimum supported Warp version to 1.15 and migrated JAX bindings
+  from Warp's removed experimental JAX module to its public JAX API, restoring
+  compatibility with `warp>=1.15`.
+- Warp initialization now retains warning-level diagnostics instead of
+  suppressing all Warp log output.
+
 ## 0.4.1 - 2026-08-03
 
 ### Added

--- a/docs/modules/jax/electrostatics.rst
+++ b/docs/modules/jax/electrostatics.rst
@@ -37,6 +37,12 @@ explicitly unsupported until a native transposable PME cell-HVP path is
 implemented and tested.
 Point-charge Ewald/PME inputs support ``float32`` and ``float64``. Keep all
 floating inputs and precomputed metadata in a call on a consistent dtype.
+Import :mod:`nvalchemiops.jax.interactions.electrostatics` before creating JAX
+arrays intended to be ``float64`` or compiling JAX functions that operate on
+``float64`` arrays. On import, the module sets JAX 64-bit support process-wide,
+including when it was previously disabled. This cannot restore precision in
+arrays already created as ``float32`` or update functions that JAX has already
+compiled. ``float32`` calculations remain supported.
 
 .. autofunction:: ewald_summation
 .. autofunction:: particle_mesh_ewald

--- a/docs/userguide/about/install.md
+++ b/docs/userguide/about/install.md
@@ -199,11 +199,11 @@ wheels can be obtained from the [Warp GitHub Releases](https://github.com/NVIDIA
 page. Copy the URL of the appropriate `+cu13` wheel for your platform and pass it to
 `pip install`. Select the wheel matching your architecture:
 
-- **x86**: `manylinux_2_34_x86_64` variant
+- **x86**: `manylinux_2_28_x86_64` variant
 - **Arm** (e.g. DGX Spark): `manylinux_2_34_aarch64` variant
 
 ```bash
-$ uv pip install https://github.com/NVIDIA/warp/releases/download/v1.12.1/warp_lang-1.12.1+cu13-py3-none-manylinux_2_34_aarch64.whl
+$ uv pip install https://github.com/NVIDIA/warp/releases/download/v1.17.0/warp_lang-1.17.0+cu13-py3-none-manylinux_2_34_aarch64.whl
 ```
 
 ```{tip}
@@ -249,8 +249,8 @@ $ uv pip install 'jax[cuda13]'
 
 ```bash
 $ uv venv --seed --python 3.12
-$ WARP_CU13_WHEEL="https://github.com/NVIDIA/warp/releases/download/v1.12.1/\
-warp_lang-1.12.1+cu13-py3-none-manylinux_2_34_x86_64.whl"
+$ WARP_CU13_WHEEL="https://github.com/NVIDIA/warp/releases/download/v1.17.0/\
+warp_lang-1.17.0+cu13-py3-none-manylinux_2_28_x86_64.whl"
 $ uv pip install nvalchemi-toolkit-ops \
     "$WARP_CU13_WHEEL" \
     torch==2.11.0 \
@@ -263,8 +263,8 @@ $ uv pip install nvalchemi-toolkit-ops \
 
 ```bash
 $ uv venv --seed --python 3.12
-$ WARP_CU13_WHEEL="https://github.com/NVIDIA/warp/releases/download/v1.12.1/\
-warp_lang-1.12.1+cu13-py3-none-manylinux_2_34_aarch64.whl"
+$ WARP_CU13_WHEEL="https://github.com/NVIDIA/warp/releases/download/v1.17.0/\
+warp_lang-1.17.0+cu13-py3-none-manylinux_2_34_aarch64.whl"
 $ uv pip install nvalchemi-toolkit-ops \
     "$WARP_CU13_WHEEL" \
     torch==2.11.0 \
@@ -285,8 +285,8 @@ $ uv pip install nvalchemi-toolkit-ops \
 $ git clone git@github.com:NVIDIA/nvalchemi-toolkit-ops.git
 $ cd nvalchemi-toolkit-ops
 $ uv sync --group dev
-$ WARP_CU13_WHEEL="https://github.com/NVIDIA/warp/releases/download/v1.12.1/\
-warp_lang-1.12.1+cu13-py3-none-manylinux_2_34_x86_64.whl"
+$ WARP_CU13_WHEEL="https://github.com/NVIDIA/warp/releases/download/v1.17.0/\
+warp_lang-1.17.0+cu13-py3-none-manylinux_2_28_x86_64.whl"
 $ uv pip install \
     "$WARP_CU13_WHEEL" \
     torch==2.11.0 \
@@ -302,8 +302,8 @@ $ uv pip install \
 $ git clone git@github.com:NVIDIA/nvalchemi-toolkit-ops.git
 $ cd nvalchemi-toolkit-ops
 $ uv sync --group dev
-$ WARP_CU13_WHEEL="https://github.com/NVIDIA/warp/releases/download/v1.12.1/\
-warp_lang-1.12.1+cu13-py3-none-manylinux_2_34_aarch64.whl"
+$ WARP_CU13_WHEEL="https://github.com/NVIDIA/warp/releases/download/v1.17.0/\
+warp_lang-1.17.0+cu13-py3-none-manylinux_2_34_aarch64.whl"
 $ uv pip install \
     "$WARP_CU13_WHEEL" \
     torch==2.11.0 \

--- a/docs/userguide/components/electrostatics.md
+++ b/docs/userguide/components/electrostatics.md
@@ -80,6 +80,17 @@ in a consistent dtype within each call. The examples use `float64` because
 reciprocal-space electrostatics and gradient checks are accuracy sensitive;
 `float32` is supported when throughput is the priority.
 
+```{important}
+Import `nvalchemiops.jax.interactions.electrostatics` before creating JAX
+arrays intended to be `float64` or compiling JAX functions that operate on
+`float64` arrays.
+
+On import, the module sets JAX 64-bit support process-wide, including when it
+was previously disabled. This cannot restore precision in arrays already
+created as `float32` or update functions that JAX has already compiled.
+`float32` calculations remain supported.
+```
+
 ## Quick Start
 
 :::::::{tab-set}

--- a/nvalchemiops/__init__.py
+++ b/nvalchemiops/__init__.py
@@ -17,7 +17,7 @@ __version__ = "0.4.1"
 
 import warp as wp
 
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 try:
     wp.init()
 except RuntimeError as e:

--- a/nvalchemiops/jax/interactions/dispersion/_dftd3.py
+++ b/nvalchemiops/jax/interactions/dispersion/_dftd3.py
@@ -65,7 +65,7 @@ from dataclasses import dataclass
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import jax_kernel
+from warp import jax_kernel
 
 from nvalchemiops.interactions.dispersion._dftd3 import (
     _cn_forces_contrib_kernel_matrix_overload as wp_cn_forces_contrib_nm,
@@ -104,7 +104,7 @@ from nvalchemiops.interactions.dispersion._dftd3 import (
     _direct_forces_and_dE_dCN_kernel_virial_overload as wp_direct_forces_kernel_nl_virial,
 )
 
-# block_dim is hardcoded to 256 in warp.jax_experimental.ffi, so block_stride
+# block_dim is hardcoded to 256 in Warp's JAX FFI, so block_stride
 # and the second launch_dims component must both be 256.
 JAX_DFTD3_BLOCK_DIM = 256
 

--- a/nvalchemiops/jax/interactions/electrostatics/__init__.py
+++ b/nvalchemiops/jax/interactions/electrostatics/__init__.py
@@ -13,22 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: E402
+
 """JAX bindings for electrostatics interactions."""
 
 from __future__ import annotations
 
 import inspect
 import warnings
-from warnings import warn
 
 import jax
 
-if not getattr(jax.config, "jax_enable_x64", False):
-    warn(
-        "Electrostatics kernels rely on FP64, and `jax_enable_x64` is set to False."
-        " `nvalchemiops` will set this value to True by default."
-    )
-    jax.config.update("jax_enable_x64", True)
+jax.config.update("jax_enable_x64", True)
 
 from nvalchemiops.jax.interactions.electrostatics.coulomb import (
     coulomb_energy,

--- a/nvalchemiops/jax/interactions/electrostatics/_lazy_jax_kernels.py
+++ b/nvalchemiops/jax/interactions/electrostatics/_lazy_jax_kernels.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import jax_kernel
+from warp import jax_kernel
 
 __all__: list[str] = []
 
@@ -85,7 +85,7 @@ def _make_jax_kernels(
     -------
     _LazyJaxKernels
         Subscript with ``jnp.float32`` / ``jnp.float64`` to obtain a
-        :func:`warp.jax_experimental.jax_kernel` instance. The wrapper
+        :func:`warp.jax_kernel` instance. The wrapper
         for each dtype is built lazily on first access.
     """
     return _LazyJaxKernels(wp_overload_dict, num_outputs, in_out_argnames)
@@ -143,6 +143,6 @@ def _make_jax_kernel_factory(
     -------
     _LazyJaxKernelFactory
         Subscript with ``jnp.float32`` / ``jnp.float64`` to obtain a lazy
-        :func:`warp.jax_experimental.jax_kernel` wrapper.
+        :func:`warp.jax_kernel` wrapper.
     """
     return _LazyJaxKernelFactory(wp_kernel_factory, num_outputs, in_out_argnames)

--- a/nvalchemiops/jax/interactions/electrostatics/coulomb.py
+++ b/nvalchemiops/jax/interactions/electrostatics/coulomb.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
-from warp.jax_experimental import jax_kernel
+from warp import jax_kernel
 
 from nvalchemiops.interactions.electrostatics.coulomb import (
     _batch_coulomb_energy_forces_kernel,

--- a/nvalchemiops/jax/interactions/electrostatics/ewald.py
+++ b/nvalchemiops/jax/interactions/electrostatics/ewald.py
@@ -37,7 +37,7 @@ import jax.numpy as jnp
 import warp as wp
 from jax.interpreters import ad as jax_ad
 from jax.scipy.special import erfc
-from warp.jax_experimental import GraphMode, jax_callable
+from warp import JaxCallableGraphMode, jax_callable
 
 from nvalchemiops.interactions.electrostatics._factory_common import _DerivState
 from nvalchemiops.interactions.electrostatics.ewald_kernels import (
@@ -348,7 +348,7 @@ _JAX_EWALD_RECIP_FILL_TILED = {
             "real_structure_factors",
             "imag_structure_factors",
         ],
-        graph_mode=GraphMode.NONE,
+        graph_mode=JaxCallableGraphMode.NONE,
     ),
     jnp.dtype(jnp.float64): jax_callable(
         _ewald_recip_fill_tiled_f64,
@@ -360,7 +360,7 @@ _JAX_EWALD_RECIP_FILL_TILED = {
             "real_structure_factors",
             "imag_structure_factors",
         ],
-        graph_mode=GraphMode.NONE,
+        graph_mode=JaxCallableGraphMode.NONE,
     ),
 }
 
@@ -376,7 +376,7 @@ _JAX_BATCH_EWALD_RECIP_FILL_TILED = {
             "real_structure_factors",
             "imag_structure_factors",
         ],
-        graph_mode=GraphMode.NONE,
+        graph_mode=JaxCallableGraphMode.NONE,
     ),
     jnp.dtype(jnp.float64): jax_callable(
         _batch_ewald_recip_fill_tiled_f64,
@@ -388,7 +388,7 @@ _JAX_BATCH_EWALD_RECIP_FILL_TILED = {
             "real_structure_factors",
             "imag_structure_factors",
         ],
-        graph_mode=GraphMode.NONE,
+        graph_mode=JaxCallableGraphMode.NONE,
     ),
 }
 

--- a/nvalchemiops/jax/interactions/electrostatics/pme.py
+++ b/nvalchemiops/jax/interactions/electrostatics/pme.py
@@ -49,7 +49,7 @@ import jax
 import jax.numpy as jnp
 import warp as wp
 from jax.interpreters import ad as jax_ad
-from warp.jax_experimental import GraphMode, jax_callable
+from warp import JaxCallableGraphMode, jax_callable
 
 from nvalchemiops.interactions.electrostatics.pme_factory import get_pme_kernel
 from nvalchemiops.interactions.electrostatics.pme_kernels import (
@@ -259,7 +259,7 @@ def _make_jax_pme_virial_bg_fused(wp_dtype):
         _fn,
         num_outputs=2,
         in_out_argnames=["total_charges"],
-        graph_mode=GraphMode.JAX,
+        graph_mode=JaxCallableGraphMode.JAX,
     )
 
 

--- a/nvalchemiops/jax/neighbors/_dispatch.py
+++ b/nvalchemiops/jax/neighbors/_dispatch.py
@@ -24,7 +24,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import warp as wp
-from warp.jax_experimental import jax_kernel
+from warp import jax_kernel
 
 from nvalchemiops.neighbors.base_dispatch import (
     _FLAG_NAMES,

--- a/nvalchemiops/jax/neighbors/_registration.py
+++ b/nvalchemiops/jax/neighbors/_registration.py
@@ -24,7 +24,7 @@ from typing import Any, Literal
 
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import GraphMode, jax_callable, jax_kernel
+from warp import JaxCallableGraphMode, jax_callable, jax_kernel
 
 from nvalchemiops.jax.neighbors._cluster_tile_preload import (
     _preload_cluster_tile_build_kernel,
@@ -105,7 +105,7 @@ def _register_jax_callable(
     callable_obj: Callable[..., Any],
     outputs: _Outputs,
     *,
-    graph_mode: GraphMode,
+    graph_mode: JaxCallableGraphMode,
 ) -> Any:
     """Register a Warp callable using a shared output tuple.
 
@@ -115,7 +115,7 @@ def _register_jax_callable(
         Warp callable to expose to JAX.
     outputs : tuple[str, ...]
         Ordered names of the callable's in-place output arguments.
-    graph_mode : GraphMode
+    graph_mode : JaxCallableGraphMode
         Execution mode used by Warp graph capture.
 
     Returns
@@ -275,7 +275,7 @@ def _cluster_tile_build_registration(
     registered = _register_jax_callable(
         callback,
         _cluster_tile_build_outputs(batched=batched, selective=selective),
-        graph_mode=GraphMode.WARP,
+        graph_mode=JaxCallableGraphMode.WARP,
     )
     return _GraphRegistration(
         callable=registered,
@@ -324,7 +324,7 @@ def _cluster_tile_matrix_registration(
             geometry=geometry,
             pair_fn=pair_fn,
         ),
-        graph_mode=GraphMode.WARP,
+        graph_mode=JaxCallableGraphMode.WARP,
     )
     preload = functools.partial(
         _preload_cluster_tile_query_kernel,
@@ -369,7 +369,7 @@ def _cluster_tile_coo_registration(
     registered = _register_jax_callable(
         callback,
         _cluster_tile_coo_outputs(coo_segmented=coo_segmented),
-        graph_mode=GraphMode.WARP,
+        graph_mode=JaxCallableGraphMode.WARP,
     )
     preload = functools.partial(
         _preload_cluster_tile_coo_kernel,

--- a/nvalchemiops/jax/neighbors/batch_cell_list.py
+++ b/nvalchemiops/jax/neighbors/batch_cell_list.py
@@ -23,7 +23,7 @@ from typing import Literal
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import GraphMode, jax_callable
+from warp import JaxCallableGraphMode, jax_callable
 
 from nvalchemiops.jax.neighbors._autograd import (
     _build_index_residuals,
@@ -258,14 +258,14 @@ def _construct_batch_cells_per_dimension(
 
 
 # ==============================================================================
-# Batched pair-centric query wrappers (GraphMode.NONE jax_callable)
+# Batched pair-centric query wrappers (JaxCallableGraphMode.NONE jax_callable)
 # ==============================================================================
 #
 # The batched pair-centric launcher
 # (:func:`batch_query_cell_list_pair_centric_sorted`) is CUDA-only and sizes its
 # launch grid from host-computed scalars (``total_cells``, ``n_outer``,
 # ``R_max``).  Those cannot be CUDA-graph-replayed across a changed radius, so we
-# wrap it with ``graph_mode=GraphMode.NONE`` (launch each call, no capture).  The
+# wrap it with ``graph_mode=JaxCallableGraphMode.NONE`` (launch each call, no capture).  The
 # launcher itself runs the gather into ``sorted_positions`` /
 # ``sorted_atom_periodic_shifts`` and the ``cell_to_system`` map fill before the
 # main pair-centric kernel, so this wrapper just forwards the donated scratch +
@@ -330,7 +330,7 @@ def _run_batch_query_cell_list_pair_centric(
     """
     num_neighbors.zero_()
 
-    # Graph-capture contract: this body runs under ``GraphMode.NONE`` (no CUDA
+    # Graph-capture contract: this body runs under ``JaxCallableGraphMode.NONE`` (no CUDA
     # graph capture), so ``str(positions.device)`` is read each call.  The
     # ``total_cells`` / ``n_outer`` / ``R_max`` scalars are baked at launch-build
     # time from the host-read radius in ``batch_query_cell_list``.
@@ -483,26 +483,26 @@ _BATCH_PAIR_CENTRIC_INOUT = [
     "neighbor_matrix_shifts",
     "num_neighbors",
 ]
-# GraphMode.NONE: the launch dim is baked from the host-read sizing scalars, so
+# JaxCallableGraphMode.NONE: the launch dim is baked from the host-read sizing scalars, so
 # CUDA-graph replay across a changed radius is unsafe.
 _jax_batch_query_cell_list_pair_centric_f32 = jax_callable(
     _batch_query_cell_list_pair_centric_f32,
     num_outputs=len(_BATCH_PAIR_CENTRIC_INOUT),
     in_out_argnames=_BATCH_PAIR_CENTRIC_INOUT,
-    graph_mode=GraphMode.NONE,
+    graph_mode=JaxCallableGraphMode.NONE,
 )
 _jax_batch_query_cell_list_pair_centric_f64 = jax_callable(
     _batch_query_cell_list_pair_centric_f64,
     num_outputs=len(_BATCH_PAIR_CENTRIC_INOUT),
     in_out_argnames=_BATCH_PAIR_CENTRIC_INOUT,
-    graph_mode=GraphMode.NONE,
+    graph_mode=JaxCallableGraphMode.NONE,
 )
 
 # --- Batched pair-centric PAIR-OUTPUT callables -----------------------------
 # Same launch mechanism as the matrix callables above, with per-pair geometry
 # (and optionally ``pair_fn`` energies / forces) written by the same kernel.
 # The sizing scalars (``total_cells`` / ``n_outer`` / ``R_max``) are host-read
-# statics, so ``GraphMode.NONE`` (eager-on-cutoff, like every pair-output path).
+# statics, so ``JaxCallableGraphMode.NONE`` (eager-on-cutoff, like every pair-output path).
 _BATCH_PAIR_CENTRIC_GEOM_INOUT = _BATCH_PAIR_CENTRIC_INOUT + [
     "neighbor_vectors",
     "neighbor_distances",
@@ -631,13 +631,13 @@ _jax_batch_query_cell_list_pair_centric_geom_f32 = jax_callable(
     _batch_query_cell_list_pair_centric_geom_f32,
     num_outputs=len(_BATCH_PAIR_CENTRIC_GEOM_INOUT),
     in_out_argnames=_BATCH_PAIR_CENTRIC_GEOM_INOUT,
-    graph_mode=GraphMode.NONE,
+    graph_mode=JaxCallableGraphMode.NONE,
 )
 _jax_batch_query_cell_list_pair_centric_geom_f64 = jax_callable(
     _batch_query_cell_list_pair_centric_geom_f64,
     num_outputs=len(_BATCH_PAIR_CENTRIC_GEOM_INOUT),
     in_out_argnames=_BATCH_PAIR_CENTRIC_GEOM_INOUT,
-    graph_mode=GraphMode.NONE,
+    graph_mode=JaxCallableGraphMode.NONE,
 )
 
 
@@ -647,7 +647,7 @@ def _get_jax_batch_cell_list_pair_centric_pair_fn_callable(pair_fn, wp_dtype):
     ``pair_fn`` (mirrors the single-system
     ``_get_jax_cell_list_pair_centric_pair_fn_callable``).  Two literal-typed
     callbacks keep the Warp annotations resolvable; cached by
-    ``(pair_fn identity, wp_dtype)``.  ``GraphMode.NONE`` + host-read static
+    ``(pair_fn identity, wp_dtype)``.  ``JaxCallableGraphMode.NONE`` + host-read static
     sizing scalars.
     """
     if wp_dtype == wp.float64:
@@ -784,7 +784,7 @@ def _get_jax_batch_cell_list_pair_centric_pair_fn_callable(pair_fn, wp_dtype):
         _callback,
         num_outputs=len(_BATCH_PAIR_CENTRIC_PAIR_FN_INOUT),
         in_out_argnames=_BATCH_PAIR_CENTRIC_PAIR_FN_INOUT,
-        graph_mode=GraphMode.NONE,
+        graph_mode=JaxCallableGraphMode.NONE,
     )
 
 
@@ -1241,7 +1241,7 @@ def batch_query_cell_list(
         raises a clear error under ``jax.jit`` with a traced radius.  ``"auto"``
         falls back to ``"atom_centric"`` when pair-centric launch sizing is
         traced.  It is full-fill only (``half_fill=True`` + explicit
-        ``pair_centric`` raises) and is registered with ``GraphMode.NONE``.
+        ``pair_centric`` raises) and is registered with ``JaxCallableGraphMode.NONE``.
     atom_centric_path : {"auto", "direct", "sorted"}, default "auto"
         Accepted for signature parity with the Torch binding.  JAX registers
         only the *sorted* atom-centric query kernel, so this option never

--- a/nvalchemiops/jax/neighbors/batch_naive.py
+++ b/nvalchemiops/jax/neighbors/batch_naive.py
@@ -22,7 +22,7 @@ import functools
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import GraphMode, jax_callable, jax_kernel
+from warp import JaxCallableGraphMode, jax_callable, jax_kernel
 
 from nvalchemiops.jax.neighbors._autograd import (
     _build_index_residuals,
@@ -353,9 +353,9 @@ _BATCH_NAIVE_TILE_SPECS = {
 def _register_batch_naive_tile_callables() -> dict[
     tuple[bool, bool, jnp.dtype], object
 ]:
-    """Register GraphMode.NONE tile callables for the batched naive eager path.
+    """Register JaxCallableGraphMode.NONE tile callables for the batched naive eager path.
 
-    ``GraphMode.NONE`` (not WARP): the tile bodies assume the caller has
+    ``JaxCallableGraphMode.NONE`` (not WARP): the tile bodies assume the caller has
     already pre-filled the output buffers, which the eager
     ``batch_naive_neighbor_list`` path does before dispatch.
     """
@@ -366,7 +366,7 @@ def _register_batch_naive_tile_callables() -> dict[
                 spec[dtype],
                 num_outputs=spec["num_outputs"],
                 in_out_argnames=spec["in_out_argnames"],
-                graph_mode=GraphMode.NONE,
+                graph_mode=JaxCallableGraphMode.NONE,
             )
     return registered
 

--- a/nvalchemiops/jax/neighbors/batch_naive_dual_cutoff.py
+++ b/nvalchemiops/jax/neighbors/batch_naive_dual_cutoff.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import jax_kernel
+from warp import jax_kernel
 
 from nvalchemiops.jax.neighbors._registration import _lazy_naive_kernel
 from nvalchemiops.jax.neighbors.neighbor_utils import (

--- a/nvalchemiops/jax/neighbors/cell_list.py
+++ b/nvalchemiops/jax/neighbors/cell_list.py
@@ -23,7 +23,7 @@ from typing import Literal
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import GraphMode, jax_callable
+from warp import JaxCallableGraphMode, jax_callable
 
 from nvalchemiops.jax.neighbors._autograd import (
     _build_index_residuals,
@@ -1081,7 +1081,7 @@ _jax_graph_build_cell_list_f32 = jax_callable(
         "cell_atom_start_indices",
         "cell_atom_list",
     ],
-    graph_mode=GraphMode.WARP,
+    graph_mode=JaxCallableGraphMode.WARP,
 )
 _jax_graph_build_cell_list_f64 = jax_callable(
     _graph_build_cell_list_f64,
@@ -1094,7 +1094,7 @@ _jax_graph_build_cell_list_f64 = jax_callable(
         "cell_atom_start_indices",
         "cell_atom_list",
     ],
-    graph_mode=GraphMode.WARP,
+    graph_mode=JaxCallableGraphMode.WARP,
 )
 _GRAPH_QUERY_INOUT = [
     "sorted_positions",
@@ -1107,61 +1107,61 @@ _jax_graph_query_cell_list_f32 = jax_callable(
     _graph_query_cell_list_f32,
     num_outputs=len(_GRAPH_QUERY_INOUT),
     in_out_argnames=_GRAPH_QUERY_INOUT,
-    graph_mode=GraphMode.WARP,
+    graph_mode=JaxCallableGraphMode.WARP,
 )
 _jax_graph_query_cell_list_f64 = jax_callable(
     _graph_query_cell_list_f64,
     num_outputs=len(_GRAPH_QUERY_INOUT),
     in_out_argnames=_GRAPH_QUERY_INOUT,
-    graph_mode=GraphMode.WARP,
+    graph_mode=JaxCallableGraphMode.WARP,
 )
 _jax_graph_query_cell_list_selective_f32 = jax_callable(
     _graph_query_cell_list_selective_f32,
     num_outputs=len(_GRAPH_QUERY_INOUT),
     in_out_argnames=_GRAPH_QUERY_INOUT,
-    graph_mode=GraphMode.WARP,
+    graph_mode=JaxCallableGraphMode.WARP,
 )
 _jax_graph_query_cell_list_selective_f64 = jax_callable(
     _graph_query_cell_list_selective_f64,
     num_outputs=len(_GRAPH_QUERY_INOUT),
     in_out_argnames=_GRAPH_QUERY_INOUT,
-    graph_mode=GraphMode.WARP,
+    graph_mode=JaxCallableGraphMode.WARP,
 )
 # Pair-centric query callables.  The launch dim is baked from the static
 # ``n_outer`` scalar (host-read from ``neighbor_search_radius``), so CUDA-graph
 # replay across a changed radius would be unsafe -> register with
-# ``GraphMode.NONE`` (launch each call, no capture/replay).  These are the only
+# ``JaxCallableGraphMode.NONE`` (launch each call, no capture/replay).  These are the only
 # ``jax_callable`` instances on the non-graph path; they still participate in
-# JAX tracing and in/out buffer aliasing like the ``GraphMode.WARP`` callables.
+# JAX tracing and in/out buffer aliasing like the ``JaxCallableGraphMode.WARP`` callables.
 _jax_query_cell_list_pair_centric_f32 = jax_callable(
     _graph_query_cell_list_pair_centric_f32,
     num_outputs=len(_GRAPH_QUERY_INOUT),
     in_out_argnames=_GRAPH_QUERY_INOUT,
-    graph_mode=GraphMode.NONE,
+    graph_mode=JaxCallableGraphMode.NONE,
 )
 _jax_query_cell_list_pair_centric_f64 = jax_callable(
     _graph_query_cell_list_pair_centric_f64,
     num_outputs=len(_GRAPH_QUERY_INOUT),
     in_out_argnames=_GRAPH_QUERY_INOUT,
-    graph_mode=GraphMode.NONE,
+    graph_mode=JaxCallableGraphMode.NONE,
 )
 _jax_query_cell_list_pair_centric_selective_f32 = jax_callable(
     _graph_query_cell_list_pair_centric_selective_f32,
     num_outputs=len(_GRAPH_QUERY_INOUT),
     in_out_argnames=_GRAPH_QUERY_INOUT,
-    graph_mode=GraphMode.NONE,
+    graph_mode=JaxCallableGraphMode.NONE,
 )
 _jax_query_cell_list_pair_centric_selective_f64 = jax_callable(
     _graph_query_cell_list_pair_centric_selective_f64,
     num_outputs=len(_GRAPH_QUERY_INOUT),
     in_out_argnames=_GRAPH_QUERY_INOUT,
-    graph_mode=GraphMode.NONE,
+    graph_mode=JaxCallableGraphMode.NONE,
 )
 # --- Pair-centric PAIR-OUTPUT callables -------------------------------------
 # Pair-centric analogue of the matrix callables above, with per-pair geometry
 # (and optionally ``pair_fn`` energies / forces) written by the same kernel.
 # ``n_outer`` is a host-read static scalar (last positional arg); the launcher
-# gathers internally, so there is no separate gather kernel.  ``GraphMode.NONE``
+# gathers internally, so there is no separate gather kernel.  ``JaxCallableGraphMode.NONE``
 # (eager-on-cutoff, like every pair-output path).  ``selective=True`` + an
 # always-true ``rebuild_flags`` mirrors the atom-centric pair-output path.
 _GRAPH_QUERY_PAIR_INOUT = [
@@ -1285,13 +1285,13 @@ _jax_query_cell_list_pair_centric_geom_f32 = jax_callable(
     _graph_query_cell_list_pair_centric_geom_f32,
     num_outputs=len(_GRAPH_QUERY_PAIR_INOUT),
     in_out_argnames=_GRAPH_QUERY_PAIR_INOUT,
-    graph_mode=GraphMode.NONE,
+    graph_mode=JaxCallableGraphMode.NONE,
 )
 _jax_query_cell_list_pair_centric_geom_f64 = jax_callable(
     _graph_query_cell_list_pair_centric_geom_f64,
     num_outputs=len(_GRAPH_QUERY_PAIR_INOUT),
     in_out_argnames=_GRAPH_QUERY_PAIR_INOUT,
-    graph_mode=GraphMode.NONE,
+    graph_mode=JaxCallableGraphMode.NONE,
 )
 
 _GRAPH_QUERY_PAIR_FN_INOUT = _GRAPH_QUERY_PAIR_INOUT + [
@@ -1309,7 +1309,7 @@ def _get_jax_cell_list_pair_centric_pair_fn_callable(pair_fn, wp_dtype):
     the JAX trace boundary as data, so the callback closes over it and adds the
     ``pair_params`` input + ``pair_energies`` / ``pair_forces`` outputs.  Two
     literal-typed callbacks (f32 / f64) keep the Warp annotations resolvable;
-    cached by ``(pair_fn identity, wp_dtype)``.  ``GraphMode.NONE`` + host-read
+    cached by ``(pair_fn identity, wp_dtype)``.  ``JaxCallableGraphMode.NONE`` + host-read
     static ``n_outer``, like the geometry pair-centric callables.
     """
     if wp_dtype == wp.float64:
@@ -1438,7 +1438,7 @@ def _get_jax_cell_list_pair_centric_pair_fn_callable(pair_fn, wp_dtype):
         _callback,
         num_outputs=len(_GRAPH_QUERY_PAIR_FN_INOUT),
         in_out_argnames=_GRAPH_QUERY_PAIR_FN_INOUT,
-        graph_mode=GraphMode.NONE,
+        graph_mode=JaxCallableGraphMode.NONE,
     )
 
 
@@ -1459,13 +1459,13 @@ _jax_graph_cell_list_f32 = jax_callable(
     _graph_cell_list_f32,
     num_outputs=len(_GRAPH_CELL_LIST_INOUT),
     in_out_argnames=_GRAPH_CELL_LIST_INOUT,
-    graph_mode=GraphMode.WARP,
+    graph_mode=JaxCallableGraphMode.WARP,
 )
 _jax_graph_cell_list_f64 = jax_callable(
     _graph_cell_list_f64,
     num_outputs=len(_GRAPH_CELL_LIST_INOUT),
     in_out_argnames=_GRAPH_CELL_LIST_INOUT,
-    graph_mode=GraphMode.WARP,
+    graph_mode=JaxCallableGraphMode.WARP,
 )
 
 

--- a/nvalchemiops/jax/neighbors/cluster_tile.py
+++ b/nvalchemiops/jax/neighbors/cluster_tile.py
@@ -261,7 +261,7 @@ def _compute_morton_codes(
 
 
 # =============================================================================
-# jax_callable wrappers (Warp launchers behind GraphMode.WARP callbacks)
+# jax_callable wrappers (Warp launchers behind JaxCallableGraphMode.WARP callbacks)
 # =============================================================================
 def _build_cluster_tile_list_callback(
     sorted_pos_x: wp.array(dtype=wp.float32),

--- a/nvalchemiops/jax/neighbors/naive.py
+++ b/nvalchemiops/jax/neighbors/naive.py
@@ -23,7 +23,7 @@ from typing import Literal
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import GraphMode, jax_callable, jax_kernel
+from warp import JaxCallableGraphMode, jax_callable, jax_kernel
 
 from nvalchemiops.jax.neighbors._autograd import (
     _build_index_residuals,
@@ -79,7 +79,7 @@ _DTYPE_TO_NAIVE_KERNELS = (wp.float32, wp.float64)
 )
 
 # Direct jax_kernel registrations are constructed lazily.  The retained
-# build_naive_kernel_tables tables below remain for GraphMode.WARP callbacks.
+# build_naive_kernel_tables tables below remain for JaxCallableGraphMode.WARP callbacks.
 
 
 _DIRECT_NAIVE_KERNELS = {
@@ -894,7 +894,7 @@ _GRAPH_NAIVE_DTYPE_TO_WARP_CALLABLES = {
 def _register_graph_naive_callables() -> dict[
     tuple[bool, bool, bool, jnp.dtype], object
 ]:
-    """Register GraphMode.WARP callables for all naive graph-mode paths."""
+    """Register JaxCallableGraphMode.WARP callables for all naive graph-mode paths."""
     registered: dict[tuple[bool, bool, bool, jnp.dtype], object] = {}
 
     for key, spec in _GRAPH_NAIVE_DTYPE_TO_WARP_CALLABLES.items():
@@ -910,7 +910,7 @@ def _register_graph_naive_callables() -> dict[
                 spec[dtype],
                 num_outputs=spec["num_outputs"],
                 in_out_argnames=spec["in_out_argnames"],
-                graph_mode=GraphMode.WARP,
+                graph_mode=JaxCallableGraphMode.WARP,
             )
             for wrap_positions in wrap_positions_values:
                 registered[(has_pbc, wrap_positions, selective, dtype)] = callable_obj
@@ -1146,9 +1146,9 @@ _GRAPH_NAIVE_TILE_SPECS = {
 def _register_graph_naive_tile_callables() -> dict[
     tuple[bool, bool, jnp.dtype], object
 ]:
-    """Register GraphMode.NONE tile callables for the naive eager path.
+    """Register JaxCallableGraphMode.NONE tile callables for the naive eager path.
 
-    ``GraphMode.NONE`` (not WARP): the tile bodies assume the caller has
+    ``JaxCallableGraphMode.NONE`` (not WARP): the tile bodies assume the caller has
     already pre-filled the output buffers, which only the eager
     (``graph_mode="none"``) path of ``naive_neighbor_list`` does.
     """
@@ -1159,7 +1159,7 @@ def _register_graph_naive_tile_callables() -> dict[
                 spec[dtype],
                 num_outputs=spec["num_outputs"],
                 in_out_argnames=spec["in_out_argnames"],
-                graph_mode=GraphMode.NONE,
+                graph_mode=JaxCallableGraphMode.NONE,
             )
     return registered
 
@@ -1599,7 +1599,7 @@ def naive_neighbor_list(
     graph_mode : {"none", "warp"}, default="none"
         Execution mode for the underlying Warp launches. ``"none"``
         preserves the existing per-kernel ``jax_kernel`` dispatch path.
-        ``"warp"`` uses fused ``jax_callable(..., graph_mode=GraphMode.WARP)``
+        ``"warp"`` uses fused ``jax_callable(..., graph_mode=JaxCallableGraphMode.WARP)``
         callbacks and is intended for ``jax.jit`` call sites that donate
         reusable output buffers.
 
@@ -1720,8 +1720,8 @@ def naive_neighbor_list(
     For lower host-side launch overhead on supported GPUs, setting
     ``XLA_FLAGS=--xla_gpu_enable_command_buffer=CUSTOM_CALL`` before
     importing JAX can improve the steady-state ``graph_mode="none"`` and
-    ``graph_mode="warp"`` paths. Advanced users can bound Warp's graph
-    cache via ``warp.jax_experimental.set_jax_callable_default_graph_cache_max(...)``.
+    ``graph_mode="warp"`` paths. Advanced users can bound each callable's graph
+    cache with the ``graph_cache_max`` argument to ``warp.jax_callable(...)``.
 
     For ``graph_mode="warp"`` to actually replay (rather than re-capture
     every call), every in/out buffer pointer the fused callable sees must

--- a/nvalchemiops/jax/neighbors/naive_dual_cutoff.py
+++ b/nvalchemiops/jax/neighbors/naive_dual_cutoff.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import jax_kernel
+from warp import jax_kernel
 
 from nvalchemiops.jax.neighbors._registration import _lazy_naive_kernel
 from nvalchemiops.jax.neighbors.neighbor_utils import (

--- a/nvalchemiops/jax/neighbors/neighbor_utils.py
+++ b/nvalchemiops/jax/neighbors/neighbor_utils.py
@@ -25,7 +25,7 @@ from typing import Literal
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import jax_kernel
+from warp import jax_kernel
 
 from nvalchemiops.neighbors.neighbor_utils import (
     NeighborOverflowError,

--- a/nvalchemiops/jax/neighbors/rebuild_detection.py
+++ b/nvalchemiops/jax/neighbors/rebuild_detection.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import jax_kernel
+from warp import jax_kernel
 
 from nvalchemiops.neighbors.rebuild import (
     get_cell_list_rebuild_kernel,

--- a/nvalchemiops/jax/segment_ops.py
+++ b/nvalchemiops/jax/segment_ops.py
@@ -20,7 +20,7 @@ registered with ``jax.custom_vjp`` and its backward is itself wrapped in a
 ``jax.custom_vjp`` so the second-order adjoint can be triggered by
 ``jax.grad(jax.grad(...))`` or ``jax.jacfwd(jax.jacrev(...))``.
 
-Kernel orchestration uses :func:`warp.jax_experimental.jax_callable`, which
+Kernel orchestration uses :func:`warp.jax_callable`, which
 runs the existing ``_launch_*`` Python wrappers directly on the JAX device
 arrays — no host roundtrip.
 
@@ -34,8 +34,8 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import GraphMode
-from warp.jax_experimental import jax_callable as _raw_jax_callable
+from warp import JaxCallableGraphMode
+from warp import jax_callable as _raw_jax_callable
 
 from nvalchemiops.segment_ops import (
     segment_div as _wp_segment_div,
@@ -73,15 +73,15 @@ from nvalchemiops.segment_ops_backward import (
 
 
 def jax_callable(*args, **kwargs):
-    """Wrap warp.jax_experimental.jax_callable with ``GraphMode.WARP``.
+    """Wrap warp.jax_callable with ``JaxCallableGraphMode.WARP``.
 
-    The default ``GraphMode.JAX`` fails when the orchestrator issues more than
+    The default ``JaxCallableGraphMode.JAX`` fails when the orchestrator issues more than
     one Warp kernel launch (e.g. mean, rms_norm forward, dot/matvec double-
     backward), because JAX can't embed multi-command FFI calls as subgraphs
-    in nested ``jax.jit`` + ``jax.grad`` contexts.  ``GraphMode.WARP`` lets
+    in nested ``jax.jit`` + ``jax.grad`` contexts.  ``JaxCallableGraphMode.WARP`` lets
     Warp own the capture and presents the call as opaque to JAX.
     """
-    kwargs.setdefault("graph_mode", GraphMode.WARP)
+    kwargs.setdefault("graph_mode", JaxCallableGraphMode.WARP)
     return _raw_jax_callable(*args, **kwargs)
 
 

--- a/nvalchemiops/jax/spline.py
+++ b/nvalchemiops/jax/spline.py
@@ -79,7 +79,7 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import warp as wp
-from warp.jax_experimental import jax_kernel
+from warp import jax_kernel
 
 from nvalchemiops.math.spline import (
     _PER_ORDER_BATCH_GATHER_WITH_FORCE_KERNELS,

--- a/nvalchemiops/math/spline.py
+++ b/nvalchemiops/math/spline.py
@@ -69,7 +69,7 @@ import warp as wp
 # Disable warp's automatic adjoint (backward) codegen for every kernel in
 # this module. All callers route through hand-written backward chains:
 # torch via register_warp_op_chain + register_autograd, JAX via
-# warp.jax_experimental.jax_kernel(..., enable_backward=False).
+# warp.jax_kernel(..., enable_backward=False).
 wp.set_module_options({"enable_backward": False})
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 requires-python = ">=3.11,<3.15"
 license = "Apache-2.0"
 dependencies = [
-    "warp-lang >= 1.13.0",
+    "warp-lang >= 1.15.0",
     "numpy",
 ]
 keywords = [

--- a/test/interactions/electrostatics/bindings/jax/test_public_api.py
+++ b/test/interactions/electrostatics/bindings/jax/test_public_api.py
@@ -16,12 +16,40 @@
 """Public API tests for JAX electrostatics exports."""
 
 import inspect
+import os
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 from typing import Literal, get_type_hints
 
 import pytest
 
 import nvalchemiops.jax.interactions.electrostatics as electrostatics
+
+
+def test_import_enables_jax_x64_when_initially_disabled() -> None:
+    """Importing electrostatics enables x64 before its kernels are registered."""
+    script = textwrap.dedent(
+        """
+        import jax
+
+        assert not jax.config.jax_enable_x64
+        import nvalchemiops.jax.interactions.electrostatics  # noqa: F401
+
+        assert jax.config.jax_enable_x64
+        """
+    )
+    environment = os.environ | {"JAX_ENABLE_X64": "False"}
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[5],
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_pme_metadata_preserves_legacy_positional_flag_order() -> None:

--- a/test/neighbors/bindings/jax/test_registration.py
+++ b/test/neighbors/bindings/jax/test_registration.py
@@ -23,7 +23,7 @@ import importlib
 import jax.numpy as jnp
 import pytest
 import warp as wp
-from warp.jax_experimental import GraphMode
+from warp import JaxCallableGraphMode
 
 from nvalchemiops.jax.neighbors import _cluster_tile_preload, _registration
 
@@ -109,7 +109,7 @@ class TestRegistrationHelpers:
         result = _registration._register_jax_callable(
             "warp-callable",
             outputs,
-            graph_mode=GraphMode.NONE,
+            graph_mode=JaxCallableGraphMode.NONE,
         )
 
         assert result == "registered-callable"
@@ -119,7 +119,7 @@ class TestRegistrationHelpers:
                 {
                     "num_outputs": 2,
                     "in_out_argnames": ["sorted_positions", "neighbor_matrix"],
-                    "graph_mode": GraphMode.NONE,
+                    "graph_mode": JaxCallableGraphMode.NONE,
                 },
             )
         ]
@@ -1149,7 +1149,7 @@ class TestGraphRegistrationFactories:
                     "tile_col_group",
                     "tile_system",
                 ),
-                GraphMode.WARP,
+                JaxCallableGraphMode.WARP,
             )
         ]
 
@@ -1197,7 +1197,7 @@ class TestGraphRegistrationFactories:
                 "num_neighbors2",
                 "neighbor_matrix_shifts2",
             ),
-            GraphMode.WARP,
+            JaxCallableGraphMode.WARP,
         )
         assert calls[1] == (
             "pair-callback",
@@ -1210,7 +1210,7 @@ class TestGraphRegistrationFactories:
                 "pair_energies",
                 "pair_forces",
             ),
-            GraphMode.WARP,
+            JaxCallableGraphMode.WARP,
         )
 
     def test_coo_registration_uses_exact_abi_and_warp_graph_mode(
@@ -1249,12 +1249,12 @@ class TestGraphRegistrationFactories:
         assert calls[0] == (
             "compact-callback",
             ("pair_counter", "coo_list", "coo_shifts"),
-            GraphMode.WARP,
+            JaxCallableGraphMode.WARP,
         )
         assert calls[1] == (
             "segmented-callback",
             ("pair_counter", "pair_counts", "coo_list", "coo_shifts"),
-            GraphMode.WARP,
+            JaxCallableGraphMode.WARP,
         )
 
     def test_preload_closures_forward_exact_matrix_options(self, monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1725,7 +1725,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'torch'", specifier = ">=2.8.0", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "nvalchemi-toolkit-ops", extra = "torch" } },
     { name = "torch", marker = "extra == 'torch-cu12'", specifier = ">=2.8.0", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "nvalchemi-toolkit-ops", extra = "torch-cu12" } },
     { name = "torch", marker = "extra == 'torch-cu13'", specifier = ">=2.8.0", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "nvalchemi-toolkit-ops", extra = "torch-cu13" } },
-    { name = "warp-lang", specifier = ">=1.13.0" },
+    { name = "warp-lang", specifier = ">=1.15.0" },
 ]
 provides-extras = ["jax", "jax-cu12", "jax-cu13", "torch", "torch-cu12", "torch-cu13"]
 
@@ -3574,16 +3574,16 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.13.0"
+version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/be/b79000cb5b551803416bc10c4fa43a37d31b48062683662a6c134d7452bc/warp_lang-1.13.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4375f572301991fe0fbf0af29fc84d76cd27d531432d6df8452b25088c21ea5a", size = 24584304, upload-time = "2026-05-04T04:30:03.621Z" },
-    { url = "https://files.pythonhosted.org/packages/58/8e/b42f0ddeaca25251e5bbf7db6a89351a0722432ce075ebcdece9118e955a/warp_lang-1.13.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ac2479c70ad410d58deb088c2a64168792be588efc1bec22dc51f92238e8c8c3", size = 138337580, upload-time = "2026-05-04T04:30:36.286Z" },
-    { url = "https://files.pythonhosted.org/packages/53/19/87b3a3a1a5e07ad34a3886ec38e96b6865359fd17a2511e78e5430c6bace/warp_lang-1.13.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:476b54f0dcf6767f23305a328660a9a74d01e371b6b7c3d77e03e18b4a1bb1a5", size = 139812627, upload-time = "2026-05-04T04:31:03.731Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/79/e4117177b88df67d7967c993a2234a3888d0e388076652e1f2a50551f95a/warp_lang-1.13.0-py3-none-win_amd64.whl", hash = "sha256:47975ea07252d45a4d09d2d1a6cffc55002fa7fbde771c8dceb1baf4b32d4fb8", size = 121601324, upload-time = "2026-05-04T04:31:37.814Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b0/9b1de407fa10b380f5ca4ed1c3e5b129be55ea26a927c7a49e45cdde14b0/warp_lang-1.17.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f2fec43afb81caa2190c0b7fa3aaf4d869f3599839f0c40b9ead84331f91e993", size = 27544218, upload-time = "2026-08-31T05:52:29.177Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/a1/e11aa6898e8bbb6910e89fe31a3338fb2566f038912010875c072e6dafd1/warp_lang-1.17.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:47cd93636828dd16e55eeb4e77a0e3547b5fb0f383000a3d228629df68f28fd8", size = 164347636, upload-time = "2026-08-31T05:53:14.441Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4f/a17b1f0ebfeabe37326f01afb6109961f20a0165c1258242f46d10a554f5/warp_lang-1.17.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:5051271048da956a8b94e2db9771ce60ce9591a3ac5bb49037f3d6812d1eea00", size = 172665443, upload-time = "2026-08-31T05:53:52.47Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/7a/36306a503085cbfc79c35a28e441c59dd1d8070d2dd65152345ebf2dfec2/warp_lang-1.17.0-py3-none-win_amd64.whl", hash = "sha256:ca35c82242a7553046f09023bbe56750b5c3d9af72625bd1a905a56d3189771d", size = 151236515, upload-time = "2026-08-31T05:54:27.944Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

Update JAX bindings and package configuration for compatibility with warp-lang>=1.15.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- Raise the minimum Warp requirement to 1.15 and update the lockfile to Warp 1.17.
- Migrate JAX bindings to Warp's public JAX APIs and retain warning-level Warp diagnostics.
- Configure JAX x64 before loading electrostatics exports, add import regression coverage, and update CUDA 13 installation guidance.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [ ] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of the code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
