### PR TITLE
fix(electrostatics): correct multipole background term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- Corrected the multipole Ewald/PME uniform-background coefficient for
+  non-neutral cells. Split Ewald, PME, and cached Ewald now use the same
+  zero-mode convention as the direct reciprocal calculation, including charge
+  and cell derivatives.
+
 ## 0.4.1 - 2026-08-03
 
 ### Added

--- a/docs/userguide/components/electrostatics.md
+++ b/docs/userguide/components/electrostatics.md
@@ -413,7 +413,7 @@ Removes the spurious self-interaction introduced by the Gaussian charge distribu
 **Background Correction** (for non-neutral systems):
 
 ```{math}
-E_{\text{background}} = \frac{\pi}{2\alpha^2 V} Q_{\text{total}}^2
+E_{\text{background}} = \frac{\mathrm{FIELD\_CONSTANT}}{8\alpha^2 V} Q_{\text{total}}^2
 ```
 
 ### Usage Examples
@@ -1673,14 +1673,26 @@ computes the full periodic multipole energy as a single composite call. It uses
 the GTO-Ewald split
 
 $$
-E = E_{\text{real}} + E_{\text{recip}} - E_{\text{self}},
+E = E_{\text{real}} + E_{\text{recip}} - E_{\text{self}} - E_{\text{background}},
 $$
 
 where the real-space term is a short-ranged pair sum over a neighbor list, the
 reciprocal term is a direct $k$-space sum, and the self term removes the
-spurious self-interaction of each smeared multipole. It supports $l_{\max}=0/1/2$
-energy, forces, stress, and force-loss ($\texttt{create\_graph=True}$) training,
-for both single systems and batches (via `batch_idx`).
+spurious self-interaction of each smeared multipole. For a non-neutral system,
+the positive correction subtracted from the split sum is
+
+$$
+E_{\text{background}} = \frac{\mathrm{FIELD\_CONSTANT}}{8\alpha^2 V} Q^2.
+$$
+
+This is the uniform-neutralizing-background convention. It makes the split
+Ewald and PME routes agree with `multipole_electrostatic_energy`, whose direct
+reciprocal sum omits the $k=0$ mode. The resulting charged-cell energy is a
+well-defined periodic reference, but its absolute value remains dependent on
+total charge, cell volume, and that convention; it is not a model of explicit
+counterions. It supports $l_{\max}=0/1/2$ energy, forces, stress, and force-loss
+($\texttt{create\_graph=True}$) training, for both single systems and batches
+(via `batch_idx`).
 
 The real-space term requires a CSR-style neighbor list: a flat `idx_j` (target
 atoms), a `neighbor_ptr` row pointer of shape $(N+1,)$, and per-pair PBC
@@ -2655,8 +2667,9 @@ higher-order support is limited to tested position and charge scalar losses.
 JAX PME stress/cell/strain, alpha, and precomputed-metadata higher-order
 derivatives are unsupported until implemented and tested, including high-level
 `particle_mesh_ewald(..., slab_correction=True)` calls. Energy-returning Ewald,
-PME, and slab paths support non-uniform per-atom losses such as `loss = (weights
-* energies).sum()` for positions, charges, and supported cell derivatives.
+PME, and slab paths support non-uniform per-atom losses such as
+`loss = (weights * energies).sum()` for positions, charges, and supported cell
+derivatives.
 Precomputed static caches still do not recover the derivative of how those
 caches were generated; omit the cache when that derivative is part of the
 intended loss.
@@ -3188,7 +3201,7 @@ For periodic systems, overall charge neutrality is required for the electrostati
 energy to be well-defined. Non-neutral systems include a background correction:
 
 ```{math}
-E_{\text{background}} = \frac{\pi}{2\alpha^2 V} Q_{\text{total}}^2
+E_{\text{background}} = \frac{\mathrm{FIELD\_CONSTANT}}{8\alpha^2 V} Q_{\text{total}}^2
 ```
 
 This term represents the interaction of the charged system with a uniform

--- a/nvalchemiops/torch/interactions/electrostatics/multipole_ewald.py
+++ b/nvalchemiops/torch/interactions/electrostatics/multipole_ewald.py
@@ -4897,6 +4897,32 @@ def _multipole_ewald_self_energy_per_atom(
     )
 
 
+def _multipole_ewald_background_energy_per_atom(
+    source_feats: torch.Tensor,
+    alpha: float,
+    volume: torch.Tensor,
+    *,
+    batch_idx: torch.Tensor | None = None,
+    n_systems: int | None = None,
+) -> torch.Tensor:
+    """Return the positive per-atom uniform-background correction.
+
+    This is subtracted from the split Ewald energy so it matches the direct-k
+    convention with the reciprocal zero mode removed.
+    """
+    from nvalchemiops.torch.interactions.electrostatics.pme_multipole import (
+        _multipole_background_energy_per_atom,
+    )
+
+    return _multipole_background_energy_per_atom(
+        source_feats[..., 0],
+        alpha,
+        volume,
+        batch_idx=batch_idx,
+        n_systems=n_systems,
+    )
+
+
 def multipole_ewald_summation(
     positions: torch.Tensor,
     multipole_moments: torch.Tensor,
@@ -4916,7 +4942,7 @@ def multipole_ewald_summation(
 ) -> torch.Tensor:
     r"""Full GTO-Ewald multipole electrostatic total energy.
 
-    Composes the three canonical Ewald pieces:
+    Composes the four canonical Ewald pieces:
 
     * **real-space**: GTO-Ewald-damped pair sum on a CSR neighbor list, via
       :func:`multipole_real_space_energy` or its batched analog, using
@@ -4930,6 +4956,9 @@ def multipole_ewald_summation(
     * **self-energy correction**: the analytical per-atom term from
       :func:`_multipole_ewald_self_energy_per_atom`, subtracted to remove the
       :math:`i=j`, :math:`n=0` image that the reciprocal sum includes.
+    * **background correction**: the positive per-atom uniform-background
+      magnitude :math:`F q_i Q/(8\alpha^2 V)`, subtracted for non-neutral
+      systems so the split sum matches the direct-k zero-mode convention.
 
     The total is mathematically identical to
     :func:`multipole_electrostatic_energy` (direct k-space) for any
@@ -5074,6 +5103,18 @@ def multipole_ewald_summation(
         if l_max >= 1
         else multipole_moments[:, :1].contiguous()
     )
+    volume = (
+        cache.volume
+        if cache is not None
+        else torch.abs(torch.det(cell.to(torch.float64)))
+    )
+    atom_background = _multipole_ewald_background_energy_per_atom(
+        source_feats,
+        alpha,
+        volume,
+        batch_idx=batch_idx,
+        n_systems=cell.shape[0] if is_batch else None,
+    )
 
     # l_max=2 path: full Ewald total = real-space + direct-k reciprocal − self.
     if l_max == 2:
@@ -5132,7 +5173,9 @@ def multipole_ewald_summation(
                 alpha,
                 quadrupoles=quadrupoles,
             )
-            return (e_real_atom + e_recip_atom - atom_self).to(torch.float64)
+            return (e_real_atom + e_recip_atom - atom_self - atom_background).to(
+                torch.float64
+            )
 
         if cell.ndim == 3:
             cell_l2 = cell
@@ -5169,7 +5212,7 @@ def multipole_ewald_summation(
             quadrupoles=quadrupoles,
         )
         # Per-atom (N,); caller owns the reduction.
-        return (e_real + e_recip - e_self).to(torch.float64)
+        return (e_real + e_recip - e_self - atom_background).to(torch.float64)
 
     # Delayed imports avoid a circular module graph.
     from nvalchemiops.torch.interactions.electrostatics.multipole_electrostatics import (
@@ -5219,7 +5262,7 @@ def multipole_ewald_summation(
             cache=cache,
         )
         atom_self = _multipole_ewald_self_energy_per_atom(source_feats, sigma, alpha)
-        return (e_real + e_recip - atom_self).to(torch.float64)
+        return (e_real + e_recip - atom_self - atom_background).to(torch.float64)
 
     sigma_t = torch.tensor([sigma], dtype=input_dtype, device=device)
     alpha_t = torch.tensor([alpha], dtype=input_dtype, device=device)
@@ -5245,4 +5288,4 @@ def multipole_ewald_summation(
         cache=cache,
     )
     e_self = _multipole_ewald_self_energy_per_atom(source_feats, sigma, alpha)
-    return (e_real + e_recip - e_self).to(torch.float64)
+    return (e_real + e_recip - e_self - atom_background).to(torch.float64)

--- a/nvalchemiops/torch/interactions/electrostatics/multipole_scf_step.py
+++ b/nvalchemiops/torch/interactions/electrostatics/multipole_scf_step.py
@@ -897,6 +897,7 @@ def multipole_ewald_scf_step_energy(
 
     # Delayed imports to avoid circular module graph.
     from nvalchemiops.torch.interactions.electrostatics.multipole_ewald import (
+        _multipole_ewald_background_energy_per_atom,
         _multipole_ewald_self_energy_per_atom,
         multipole_real_space_energy,
     )
@@ -962,5 +963,14 @@ def multipole_ewald_scf_step_energy(
     atom_self = _multipole_ewald_self_energy_per_atom(
         source_feats_l1, sigma, alpha, quadrupoles=quadrupoles
     )
+    atom_background = _multipole_ewald_background_energy_per_atom(
+        source_feats_l1,
+        alpha,
+        cache.volume,
+        batch_idx=batch_idx,
+        n_systems=cache.batch_size if is_batch else None,
+    )
     # Return per-atom (N,)/(N_total,) — caller owns the reduction.
-    return (e_real_per_atom + e_recip_per_atom - atom_self).to(torch.float64)
+    return (e_real_per_atom + e_recip_per_atom - atom_self - atom_background).to(
+        torch.float64
+    )

--- a/nvalchemiops/torch/interactions/electrostatics/pme_multipole.py
+++ b/nvalchemiops/torch/interactions/electrostatics/pme_multipole.py
@@ -4269,6 +4269,50 @@ register_warp_op_chain(
 )
 
 
+def _multipole_background_coefficient(alpha: float) -> float:
+    """Return the positive Ewald-background coefficient excluding volume."""
+    return FIELD_CONSTANT / (8.0 * alpha**2)
+
+
+def _multipole_background_energy_per_atom(
+    charges: torch.Tensor,
+    alpha: float,
+    volume: torch.Tensor,
+    *,
+    batch_idx: torch.Tensor | None = None,
+    n_systems: int | None = None,
+) -> torch.Tensor:
+    """Return the positive uniform-background correction per atom.
+
+    The caller subtracts this correction from a raw reciprocal-space energy.
+    """
+    charges_f64 = charges.to(torch.float64)
+    c_bg_no_v = _multipole_background_coefficient(alpha)
+    if batch_idx is None:
+        total_charge = charges_f64.sum()
+        return (
+            c_bg_no_v
+            * charges_f64
+            * total_charge
+            / volume.to(torch.float64).reshape(())
+        )
+
+    if n_systems is None:
+        n_systems = int(batch_idx.max().item()) + 1
+    total_charge = torch.zeros(
+        n_systems, dtype=torch.float64, device=charges.device
+    ).scatter_add(0, batch_idx, charges_f64)
+    vol_per_system = volume.to(torch.float64).reshape(-1)
+    if vol_per_system.numel() == 1 and n_systems > 1:
+        vol_per_system = vol_per_system.expand(n_systems)
+    return (
+        c_bg_no_v
+        * charges_f64
+        * total_charge.index_select(0, batch_idx)
+        / vol_per_system.index_select(0, batch_idx)
+    )
+
+
 def multipole_pme_energy_corrections(
     charges: torch.Tensor,
     dipoles: torch.Tensor | None,
@@ -4305,7 +4349,7 @@ def multipole_pme_energy_corrections(
 
     .. math::
 
-        E_\text{background} = \frac{F \pi}{2 \alpha^2 V}\, Q_\text{total}^2
+        E_\text{background} = \frac{F}{8 \alpha^2 V}\, Q_\text{total}^2
 
     For neutral systems (``Q_total = 0``) the background term vanishes;
     for non-neutral systems it is included via the standard
@@ -4350,9 +4394,9 @@ def multipole_pme_energy_corrections(
     Returns
     -------
     correction : torch.Tensor
-        ``E_self - E_background`` per system (or scalar). Caller
-        SUBTRACTS this from the raw reciprocal energy: ``E_recip_corr
-        = E_recip_raw - correction``.
+        ``E_self + E_background`` per system (or scalar), where
+        ``E_background`` is the positive magnitude. The caller subtracts this
+        from the raw reciprocal energy.
     """
     if dipoles is not None and dipoles.shape != (charges.shape[0], 3):
         raise ValueError(
@@ -4371,7 +4415,7 @@ def multipole_pme_energy_corrections(
     c_self_q = _corr_scalar_array(F / (8.0 * pi32 * sigma_c), device)
     c_self_mu = _corr_scalar_array(F / (48.0 * pi32 * sigma_c**3), device)
     c_self_q2 = _corr_scalar_array(F / (320.0 * pi32 * sigma_c**5), device)
-    c_bg_no_v = _corr_scalar_array(F * math.pi / (2.0 * alpha**2), device)
+    c_bg_no_v = _corr_scalar_array(_multipole_background_coefficient(alpha), device)
 
     charges_f64 = charges.to(torch.float64)
     # Optional moments → zeros (bit-for-bit equal to the explicit-zero call)
@@ -4463,11 +4507,11 @@ def multipole_pme_energy_corrections_per_atom(
         \text{self}_i &= \frac{F q_i^2}{8\pi^{3/2}\sigma_c}
           + \frac{F |\mu_i|^2}{48\pi^{3/2}\sigma_c^3}
           + \frac{F |Q_i|_F^2}{320\pi^{3/2}\sigma_c^5}, \\
-        \text{bg}_i &= \frac{F\pi}{2\alpha^2 V}\, q_i\, Q_\text{total}, \\
-        \text{correction}_i &= \text{self}_i - \text{bg}_i.
+        \text{bg}_i &= \frac{F}{8\alpha^2 V}\, q_i\, Q_\text{total}, \\
+        \text{correction}_i &= \text{self}_i + \text{bg}_i.
 
     The background is split per atom as :math:`q_i \cdot Q_\text{total}` so the per-atom sum
-    recovers the collective :math:`(F\pi / 2\alpha^2 V) Q_\text{total}^2`. Pure-torch
+    recovers the collective :math:`(F / 8\alpha^2 V) Q_\text{total}^2`. Pure-torch
     elementwise (twice-differentiable for free) — matches the
     ``multipole_pme_corrections`` Warp op's reduced value/grads to machine eps.
 
@@ -4486,7 +4530,6 @@ def multipole_pme_energy_corrections_per_atom(
     c_self_q = F / (8.0 * pi32 * sigma_c)
     c_self_mu = F / (48.0 * pi32 * sigma_c**3)
     c_self_q2 = F / (320.0 * pi32 * sigma_c**5)
-    c_bg_no_v = F * math.pi / (2.0 * alpha**2)
 
     charges_f64 = charges.to(torch.float64)
     self_e = c_self_q * charges_f64.square()
@@ -4497,24 +4540,13 @@ def multipole_pme_energy_corrections_per_atom(
             (-1, -2)
         )
 
-    # Background: per-atom share q_i · Q_total / V so Σ_i = Q_total² / V (× c_bg).
-    if batch_idx is None:
-        total_charge = charges_f64.sum()
-        inv_v = (c_bg_no_v / volume.to(torch.float64).reshape(())).reshape(())
-        bg = inv_v * charges_f64 * total_charge
-    else:
-        if n_systems is None:
-            n_systems = int(batch_idx.max().item()) + 1
-        total_charge = torch.zeros(
-            n_systems, dtype=torch.float64, device=charges.device
-        )
-        total_charge = total_charge.scatter_add(0, batch_idx, charges_f64)
-        vol_ps = volume.to(torch.float64).reshape(-1)
-        if vol_ps.numel() == 1 and n_systems > 1:
-            vol_ps = vol_ps.expand(n_systems)
-        per_atom_v = vol_ps.index_select(0, batch_idx)
-        per_atom_qtot = total_charge.index_select(0, batch_idx)
-        bg = c_bg_no_v * charges_f64 * per_atom_qtot / per_atom_v
+    bg = _multipole_background_energy_per_atom(
+        charges_f64,
+        alpha,
+        volume,
+        batch_idx=batch_idx,
+        n_systems=n_systems,
+    )
 
     return self_e + bg
 

--- a/test/interactions/electrostatics/bindings/torch/test_multipole_api.py
+++ b/test/interactions/electrostatics/bindings/torch/test_multipole_api.py
@@ -781,6 +781,9 @@ class TestCapabilityMatrix:
         """Value-loss training: ∂value/∂multipole_moments vs central FD."""
         td = _torch_device(device)
         sys = _build_system(mode, l_max, td, seed=3)
+        if entry in ("ewald", "pme"):
+            sys["mm"] = sys["mm"].clone()
+            sys["mm"][:, 0] += 0.2
         value = _make_value_fn(entry, mode, l_max, sys)
         pos, cell = sys["pos"], sys["cell"]
         m = sys["mm"].clone().requires_grad_(True)
@@ -809,6 +812,9 @@ class TestCapabilityMatrix:
         """Stress / virial: d value/d cell vs central FD (fixed topological nlist)."""
         td = _torch_device(device)
         sys = _build_system(mode, l_max, td, seed=5)
+        if entry in ("ewald", "pme"):
+            sys["mm"] = sys["mm"].clone()
+            sys["mm"][:, 0] += 0.2
         value = _make_value_fn(entry, mode, l_max, sys)
         pos, mm = sys["pos"], sys["mm"]
         c = sys["cell"].clone().requires_grad_(True)
@@ -835,6 +841,7 @@ class TestCrossMethodPhysics:
         pos = torch.tensor(pos_np, device=td)
         cell = torch.tensor(np.eye(3) * _BOX, device=td)
         mm = _rand_moments(n, l_max, rng, td)
+        mm[:, 0] += 0.125
         totals = []
         for alpha in (0.4, 0.6, 0.9):
             sc = math.sqrt(_SIGMA**2 + 1.0 / (4.0 * alpha**2))
@@ -867,6 +874,7 @@ class TestCrossMethodPhysics:
         pos = torch.tensor(pos_np, device=td)
         cell = torch.tensor(np.eye(3) * _BOX, device=td)
         mm = _rand_moments(n, l_max, rng, td)
+        mm[:, 0] += 0.125
         idx, cnt, sh = _neigh(pos_np, _BOX, _RCUT)
         ptr = [0] + list(np.cumsum(cnt))
         ij = torch.tensor(idx, dtype=torch.int32, device=td)

--- a/test/interactions/electrostatics/bindings/torch/test_multipole_ewald.py
+++ b/test/interactions/electrostatics/bindings/torch/test_multipole_ewald.py
@@ -2117,14 +2117,15 @@ def _neigh(positions: np.ndarray, L: float, cutoff: float):
     )
 
 
-def _build(n: int, device: str, seed: int, l_max: int):
-    """BCC system with alternating charges (and optional random dipoles)."""
+def _build(n: int, device: str, seed: int, l_max: int, total_charge: float = 0.0):
+    """BCC system with the requested total charge and optional multipoles."""
     rng = np.random.default_rng(seed)
     pos_np, cell_np = _bcc(n)
     N = pos_np.shape[0]
     chg_np = np.array([1.0 if i % 2 == 0 else -1.0 for i in range(N)])
     if abs(chg_np.sum()) > 1e-12:
         chg_np[-1] -= chg_np.sum()
+    chg_np += total_charge / N
     dip_np = 0.3 * rng.standard_normal((N, 3)) if l_max >= 1 else None
     quad_np = None
     if l_max >= 2:
@@ -2145,9 +2146,17 @@ def _build(n: int, device: str, seed: int, l_max: int):
 
 
 def _path_a_vs_b(
-    device: str, n: int, sigma: float, alpha: float, l_max: int, seed: int
+    device: str,
+    n: int,
+    sigma: float,
+    alpha: float,
+    l_max: int,
+    seed: int,
+    total_charge: float = 0.0,
 ) -> float:
-    pos, source_feats, cell, cell_np, pos_np = _build(n, device, seed, l_max)
+    pos, source_feats, cell, cell_np, pos_np = _build(
+        n, device, seed, l_max, total_charge
+    )
     L = cell_np[0, 0]
     td = _torch_device(device)
 
@@ -2184,30 +2193,34 @@ def _path_a_vs_b(
 
 
 class TestPathAEquivPathB:
-    """Path A (real + reciprocal − self) must equal Path B (direct k-space)."""
+    """Split Ewald (including background) must equal direct k-space."""
 
     @pytest.mark.parametrize("alpha", [0.3, 0.4, 0.6, 0.9])
     @pytest.mark.parametrize("sigma", [0.8, 1.0, 1.2])
     def test_monopole_bcc(self, device, sigma: float, alpha: float):
         """l_max=0 BCC supercell: |Δ| bounded by accumulated wp_erfc error."""
-        delta = _path_a_vs_b(device, n=2, sigma=sigma, alpha=alpha, l_max=0, seed=41)
+        delta = _path_a_vs_b(
+            device, n=2, sigma=sigma, alpha=alpha, l_max=0, seed=41, total_charge=1.0
+        )
         assert abs(delta) < 5e-4, f"σ={sigma}  α={alpha}  Δ={delta:.3e}"
 
     @pytest.mark.parametrize("alpha", [0.3, 0.4, 0.6, 0.9])
     @pytest.mark.parametrize("sigma", [0.8, 1.0, 1.2])
     def test_dipole_bcc(self, device, sigma: float, alpha: float):
         """l_max=1 BCC supercell: dipole + charge cross terms."""
-        delta = _path_a_vs_b(device, n=2, sigma=sigma, alpha=alpha, l_max=1, seed=47)
+        delta = _path_a_vs_b(
+            device, n=2, sigma=sigma, alpha=alpha, l_max=1, seed=47, total_charge=-1.0
+        )
         assert abs(delta) < 5e-4, f"σ={sigma}  α={alpha}  Δ={delta:.3e}"
 
     @pytest.mark.parametrize("alpha", [0.5, 1.0])
     def test_two_atom_sigma1(self, device, alpha: float):
-        """2-atom (+1, −1) at separation 3 in large box — tighter tolerance."""
+        """Charged two-atom system at separation 3 in a large box."""
         td = _torch_device(device)
         L = 30.0
         pos_np = np.array([[0.0, 0.0, 0.0], [3.0, 0.0, 0.0]])
         cell_np = np.eye(3) * L
-        chg = torch.tensor([1.0, -1.0], dtype=torch.float64, device=td)
+        chg = torch.tensor([1.25, -0.75], dtype=torch.float64, device=td)
         sf = pack_charges_dipoles(chg, None)
         pos = torch.from_numpy(pos_np).to(td, torch.float64)
         cell = torch.from_numpy(cell_np).to(td, torch.float64)
@@ -2243,7 +2256,9 @@ class TestPathAEquivPathB:
 
     def test_alpha_limit_recovers_pathb(self, device):
         """Large α: all energy in real-space, should still match Path B."""
-        delta = _path_a_vs_b(device, n=2, sigma=1.0, alpha=2.0, l_max=1, seed=53)
+        delta = _path_a_vs_b(
+            device, n=2, sigma=1.0, alpha=2.0, l_max=1, seed=53, total_charge=0.75
+        )
         assert abs(delta) < 1e-4, f"α=2.0 Δ={delta:.3e}"
 
 
@@ -2254,7 +2269,7 @@ class TestBatchedEwaldSummation:
     still owns a unique ``atom_i`` in the batched kernels.
     """
 
-    @pytest.mark.parametrize("l_max", [0, 1])
+    @pytest.mark.parametrize("l_max", [0, 1, 2])
     def test_batch_matches_per_system_loop(self, device, l_max: int):
         """Stack B identical systems and verify E_A_batch[b] ≈ E_A_single per b."""
         td = _torch_device(device)
@@ -2267,7 +2282,7 @@ class TestBatchedEwaldSummation:
         systems = []
         for seed in (41, 47, 53):
             pos, sf, cell, cell_np, pos_np = _build(
-                n=2, device=device, seed=seed, l_max=l_max
+                n=2, device=device, seed=seed, l_max=l_max, total_charge=0.5
             )
             L = cell_np[0, 0]
             idx_j_np, nptr_np, sh_np = _neigh(pos_np, L, cutoff)
@@ -2363,7 +2378,7 @@ class TestBatchedEwaldSummation:
                 f"single={e_ref:.6e}"
             )
 
-    @pytest.mark.parametrize("l_max", [0, 1])
+    @pytest.mark.parametrize("l_max", [0, 1, 2])
     def test_batch_matches_path_b(self, device, l_max: int):
         """Batched Path A ≡ Path B (direct k-space, per-system loop)."""
         td = _torch_device(device)
@@ -2377,7 +2392,7 @@ class TestBatchedEwaldSummation:
         per_b = []
         for seed in (71, 73):
             pos, sf, cell, cell_np, pos_np = _build(
-                n=2, device=device, seed=seed, l_max=l_max
+                n=2, device=device, seed=seed, l_max=l_max, total_charge=-0.5
             )
             per_b.append(
                 float(
@@ -2457,7 +2472,7 @@ class TestEwaldSCFStepEnergy:
         kcut = 6.0 / sigma_c
 
         pos, sf, cell, cell_np, pos_np = _build(
-            n=2, device=device, seed=11, l_max=l_max
+            n=2, device=device, seed=11, l_max=l_max, total_charge=0.5
         )
         L = cell_np[0, 0]
         idx_j_np, nptr_np, sh_np = _neigh(pos_np, L, cutoff)
@@ -2507,7 +2522,7 @@ class TestEwaldSCFStepEnergy:
         systems = []
         for seed in (31, 37, 41):
             pos, sf, cell, cell_np, pos_np = _build(
-                n=2, device=device, seed=seed, l_max=l_max
+                n=2, device=device, seed=seed, l_max=l_max, total_charge=0.5
             )
             L = cell_np[0, 0]
             idx_j_np, nptr_np, sh_np = _neigh(pos_np, L, cutoff)
@@ -2800,6 +2815,7 @@ def test_quadrupole_total_is_alpha_independent():
     pos_np = rng.uniform(0.0, L, size=(n, 3))
     q = rng.normal(size=(n,))
     q -= q.mean()
+    q += 0.25 / n
     mu = rng.normal(size=(n, 3))
     Qr = rng.normal(size=(n, 3, 3))
     Q = 0.5 * (Qr + Qr.transpose(0, 2, 1))

--- a/test/interactions/electrostatics/bindings/torch/test_multipole_pme.py
+++ b/test/interactions/electrostatics/bindings/torch/test_multipole_pme.py
@@ -821,26 +821,32 @@ class TestEnergyCorrections:
         torch.testing.assert_close(ours, path_a, rtol=1e-15, atol=1e-15)
 
     def test_background_for_non_neutral(self):
-        """Background term ``F π Q² / (2 α² V)`` for non-neutral systems."""
+        """Background term ``F Q² / (8 α² V)`` and its derivatives."""
         td = (
             torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
         )
         N = 4
         L = 8.0
         # All-positive charges → Q_total = N · q.
-        charges = torch.full((N,), 1.0, dtype=torch.float64, device=td)
+        charges = torch.full(
+            (N,), 1.0, dtype=torch.float64, device=td, requires_grad=True
+        )
         dipoles = torch.zeros((N, 3), dtype=torch.float64, device=td)
-        volume = torch.tensor(L**3, device=td, dtype=torch.float64)
+        volume = torch.tensor(L**3, device=td, dtype=torch.float64, requires_grad=True)
         sigma = 1.0
         alpha = 0.5
 
         sigma_c = math.sqrt(sigma**2 + 1.0 / (4.0 * alpha**2))
         pi32 = math.pi**1.5
 
-        # Expected: E_self + E_bg.
+        # Expected correction: E_self + positive E_bg. The reciprocal
+        # composite subtracts this complete correction.
         F = 1.0 / 5.526349406e-3  # FIELD_CONSTANT.
-        e_self_expected = (F / (8.0 * pi32 * sigma_c)) * sum(c**2 for c in [1.0] * N)
-        e_bg_expected = (F * math.pi / (2.0 * alpha**2 * L**3)) * (N * 1.0) ** 2
+        c_self = F / (8.0 * pi32 * sigma_c)
+        c_bg = F / (8.0 * alpha**2)
+        total_charge = N * 1.0
+        e_self_expected = c_self * total_charge
+        e_bg_expected = c_bg * total_charge**2 / L**3
         expected = e_self_expected + e_bg_expected
 
         got = multipole_pme_energy_corrections(
@@ -852,6 +858,34 @@ class TestEnergyCorrections:
             rtol=1e-12,
             atol=1e-10,
         )
+
+        grad_q, grad_v = torch.autograd.grad(got, (charges, volume), create_graph=True)
+        expected_grad_q = torch.full_like(
+            charges, 2.0 * c_self + 2.0 * c_bg * total_charge / L**3
+        )
+        expected_grad_v = torch.tensor(
+            -c_bg * total_charge**2 / L**6, dtype=torch.float64, device=td
+        )
+        torch.testing.assert_close(grad_q, expected_grad_q, rtol=1e-12, atol=1e-10)
+        torch.testing.assert_close(grad_v, expected_grad_v, rtol=1e-12, atol=1e-10)
+
+        direction_q = torch.linspace(0.1, 0.4, N, dtype=torch.float64, device=td)
+        direction_v = torch.tensor(0.25, dtype=torch.float64, device=td)
+        hvp_q, hvp_v = torch.autograd.grad(
+            (grad_q * direction_q).sum() + grad_v * direction_v,
+            (charges, volume),
+        )
+        expected_hvp_q = (
+            2.0 * c_self * direction_q
+            + 2.0 * c_bg * direction_q.sum() / L**3
+            - 2.0 * c_bg * total_charge * direction_v / L**6
+        )
+        expected_hvp_v = (
+            -2.0 * c_bg * total_charge * direction_q.sum() / L**6
+            + 2.0 * c_bg * total_charge**2 * direction_v / L**9
+        )
+        torch.testing.assert_close(hvp_q, expected_hvp_q, rtol=1e-12, atol=1e-10)
+        torch.testing.assert_close(hvp_v, expected_hvp_v, rtol=1e-12, atol=1e-10)
 
     def test_batched_per_system_corrections(self):
         """Batched call returns per-system corrections of shape ``(B,)``."""
@@ -867,9 +901,10 @@ class TestEnergyCorrections:
 
         charges_list = []
         dipoles_list = []
-        for _ in range(B):
+        for system_idx in range(B):
             q = rng.uniform(-1.0, 1.0, N_per)
             q = q - q.mean()
+            q += 0.25 * (system_idx + 1) / N_per
             charges_list.append(q)
             dipoles_list.append(rng.standard_normal((N_per, 3)) * 0.4)
         charges = torch.from_numpy(np.concatenate(charges_list)).to(td, torch.float64)
@@ -891,11 +926,17 @@ class TestEnergyCorrections:
         )
         assert per_sys.shape == (B,)
 
-        # Each system independently: per-system Path A oracle.
+        # Each system independently: self plus the positive background
+        # magnitude that the composite subtracts.
+        c_bg = (1.0 / 5.526349406e-3) / (8.0 * alpha**2)
         for b in range(B):
             mask = batch_idx == b
             sf_b = _path_a_pack_source_feats(charges[mask], dipoles[mask])
-            expected_b = _multipole_ewald_self_energy_per_atom(sf_b, sigma, alpha).sum()
+            q_b = charges[mask].sum()
+            expected_b = (
+                _multipole_ewald_self_energy_per_atom(sf_b, sigma, alpha).sum()
+                + c_bg * q_b.square() / volume[b]
+            )
             torch.testing.assert_close(per_sys[b], expected_b, rtol=1e-15, atol=1e-15)
 
 
@@ -966,36 +1007,55 @@ class TestEnergyCorrectionsPerAtom:
         )
         torch.testing.assert_close(_reduce(per_atom), reduced, rtol=1e-13, atol=1e-13)
 
-        # Gradient: grad(Σ per-atom, charges) == grad(reduced, charges).
+        # Gradient and charge-volume HVP: the pure-Torch per-atom path must
+        # match the reduced Warp correction op.
         q1 = charges.clone().requires_grad_(True)
-        g_pa = torch.autograd.grad(
+        v1 = volume.clone().requires_grad_(True)
+        g_pa, gv_pa = torch.autograd.grad(
             _reduce(
                 multipole_pme_energy_corrections_per_atom(
                     q1,
                     dipoles,
                     sigma,
                     alpha,
-                    volume,
+                    v1,
                     batch_idx=batch_idx,
                     quadrupoles=quadrupoles,
                 )
             ).sum(),
-            q1,
-        )[0]
+            (q1, v1),
+            create_graph=True,
+        )
         q2 = charges.clone().requires_grad_(True)
-        g_red = torch.autograd.grad(
+        v2 = volume.clone().requires_grad_(True)
+        g_red, gv_red = torch.autograd.grad(
             multipole_pme_energy_corrections(
                 q2,
                 dipoles,
                 sigma=sigma,
                 alpha=alpha,
-                volume=volume,
+                volume=v2,
                 batch_idx=batch_idx,
                 quadrupoles=quadrupoles,
             ).sum(),
-            q2,
-        )[0]
+            (q2, v2),
+            create_graph=True,
+        )
         torch.testing.assert_close(g_pa, g_red, rtol=1e-12, atol=1e-12)
+        torch.testing.assert_close(gv_pa, gv_red, rtol=1e-12, atol=1e-12)
+
+        direction_q = torch.linspace(0.1, 0.8, N, dtype=torch.float64, device=td)
+        direction_v = torch.ones_like(v1) * 0.2
+        h_pa = torch.autograd.grad(
+            (g_pa * direction_q).sum() + (gv_pa * direction_v).sum(),
+            (q1, v1),
+        )
+        h_red = torch.autograd.grad(
+            (g_red * direction_q).sum() + (gv_red * direction_v).sum(),
+            (q2, v2),
+        )
+        torch.testing.assert_close(h_pa[0], h_red[0], rtol=1e-12, atol=1e-12)
+        torch.testing.assert_close(h_pa[1], h_red[1], rtol=1e-12, atol=1e-12)
 
 
 class TestReciprocalSpace:
@@ -1228,14 +1288,21 @@ def _o_n2_csr_neighbors(
 class TestParticleMeshEwald:
     """Top-level composite parity vs ``multipole_ewald_summation``.
 
-    The composite returns ``E_real + E_recip - E_self - E_bg``; Path A
-    omits the background (its reciprocal sum zeroes ``k=0``). For neutral
-    systems the background vanishes and the two agree to the
-    spline-truncation floor.
+    Both routes return ``E_real + E_recip - E_self - E_bg`` and use the
+    zero-mode/direct-space convention. They agree to the spline-truncation
+    floor, including for non-neutral systems.
     """
 
-    def _setup(self, N: int, L: float, seed: int, sigma: float, alpha: float):
-        """Build a neutral random system + matching CSR neighbor list."""
+    def _setup(
+        self,
+        N: int,
+        L: float,
+        seed: int,
+        sigma: float,
+        alpha: float,
+        total_charge: float = 0.0,
+    ):
+        """Build a random system with the requested total charge and CSR list."""
         td = (
             torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
         )
@@ -1243,6 +1310,7 @@ class TestParticleMeshEwald:
         positions_np = rng.uniform(0.5, L - 0.5, size=(N, 3))
         charges_np = rng.uniform(-1.0, 1.0, N)
         charges_np -= charges_np.mean()
+        charges_np += total_charge / N
         dipoles_np = rng.standard_normal((N, 3)) * 0.4
         cell_np = np.eye(3) * L
 
@@ -1275,13 +1343,13 @@ class TestParticleMeshEwald:
     @pytest.mark.parametrize("sigma", [0.8, 1.0, 1.2])
     @pytest.mark.parametrize("spline_order", [4, 5, 6])
     def test_charges_only_matches_path_a(self, sigma, alpha, spline_order):
-        """l_max=0 parity: Path A vs PME on a neutral random system."""
+        """l_max=0 parity: Ewald vs PME on a charged random system."""
         if not torch.cuda.is_available():
             pytest.skip("Path A reference uses Warp launchers (GPU-only)")
         N = 8
         L = 10.0
         _, positions, charges, _, cell, idx_j, nptr, sh, kcut = self._setup(
-            N=N, L=L, seed=0xABCD, sigma=sigma, alpha=alpha
+            N=N, L=L, seed=0xABCD, sigma=sigma, alpha=alpha, total_charge=1.5
         )
         sf = pack_charges_dipoles(charges, None)
 
@@ -1320,7 +1388,7 @@ class TestParticleMeshEwald:
         N = 8
         L = 10.0
         _, positions, charges, dipoles, cell, idx_j, nptr, sh, kcut = self._setup(
-            N=N, L=L, seed=0xBEEF, sigma=sigma, alpha=alpha
+            N=N, L=L, seed=0xBEEF, sigma=sigma, alpha=alpha, total_charge=-1.5
         )
         sf = pack_charges_dipoles(charges, dipoles)
 
@@ -1877,6 +1945,7 @@ class TestBatchedParticleMeshEwald:
             p = rng.uniform(0.5, L - 0.5, (size, 3))
             q = rng.uniform(-1, 1, size)
             q -= q.mean()
+            q += 0.25 / size
             d = rng.standard_normal((size, 3)) * 0.4
             systems.append((p, q, d))
 
@@ -2645,7 +2714,7 @@ def _small_quadrupole_fixture(device: str = "cuda:0"):
         dtype=dtype,
         device=device,
     )
-    charges = torch.tensor([1.0, -1.0, 0.5, -0.5], dtype=dtype, device=device)
+    charges = torch.tensor([1.0, -1.0, 0.5, -0.3], dtype=dtype, device=device)
     dipoles = torch.tensor(
         [[0.1, 0.2, 0.3], [-0.2, 0.1, -0.1], [0.05, 0.05, 0.05], [0.3, -0.2, 0.1]],
         dtype=dtype,


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

Fix the multipole uniform-background correction for non-neutral periodic systems. Use the standard `FIELD_CONSTANT / (8 alpha^2 V)` coefficient and subtract the correction consistently in direct-sum Ewald, PME, and cached Ewald calculations while retaining the direct reciprocal zero-mode convention.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

Fixes #156

## Changes Made

<!-- List the key changes made in this PR -->

- Correct the multipole PME background coefficient and centralize its per-atom, single-system, and batched evaluation.
- Apply the same correction to direct-sum and cached Ewald energies for monopoles, dipoles, and quadrupoles.
- Extend existing charged-system coverage for cross-method agreement, alpha invariance, batching, charge and volume derivatives, and update the documented convention.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
