### PR TITLE
fix(neighbors): detect cluster-tile buffer overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Added
+
+- `TileBufferOverflow` reports how many cluster-tile pairs were required, how
+  many the buffer could hold, and which system overflowed a segmented batch.
+  Torch `cluster_tile_neighbor_list` and JAX `build_cluster_tile_list`,
+  `batch_build_cluster_tile_list`, `cluster_tile_neighbor_list`, and
+  `batch_cluster_tile_neighbor_list` now accept `max_tiles_per_group`.
+
+### Changed
+
+- Eager Torch and JAX cluster-tile neighbor-list calls now raise
+  `TileBufferOverflow` when tile-pair construction exceeds the allocated
+  capacity. For cluster-tile calls, `NeighborOverflowError` identifies an
+  undersized final matrix or COO buffer.
+- Compiled JAX cluster-tile calls now require `max_tiles_per_group` to be a
+  positive static Python integer. Compiled calls do not raise
+  `TileBufferOverflow`.
+
 ## 0.4.1 - 2026-08-03
 
 ### Added

--- a/docs/modules/jax/neighbors.rst
+++ b/docs/modules/jax/neighbors.rst
@@ -102,6 +102,10 @@ Exceptions
    :no-index:
    :show-inheritance:
 
+.. autoexception:: nvalchemiops.jax.neighbors.TileBufferOverflow
+   :no-index:
+   :show-inheritance:
+
 Utility Functions
 -----------------
 

--- a/docs/modules/torch/neighbors.rst
+++ b/docs/modules/torch/neighbors.rst
@@ -27,6 +27,17 @@ High-Level Interface
 
 .. autofunction:: nvalchemiops.torch.neighbors.neighbor_list
 
+Exceptions
+----------
+
+.. autoexception:: nvalchemiops.torch.neighbors.NeighborOverflowError
+   :no-index:
+   :show-inheritance:
+
+.. autoexception:: nvalchemiops.torch.neighbors.TileBufferOverflow
+   :no-index:
+   :show-inheritance:
+
 Method Selection
 ^^^^^^^^^^^^^^^^
 

--- a/docs/modules/warp/neighbors.rst
+++ b/docs/modules/warp/neighbors.rst
@@ -170,6 +170,9 @@ Exceptions
 .. autoexception:: nvalchemiops.neighbors.NeighborOverflowError
    :show-inheritance:
 
+.. autoexception:: nvalchemiops.neighbors.TileBufferOverflow
+   :show-inheritance:
+
 Utility Functions
 ^^^^^^^^^^^^^^^^^
 

--- a/docs/userguide/about/migration.md
+++ b/docs/userguide/about/migration.md
@@ -8,6 +8,31 @@ This guide lists user-visible migrations by release.
 
 ## Unreleased
 
+### Cluster-Tile Buffer Capacity
+
+Cluster-tile construction writes candidate tile pairs to a fixed-size
+intermediate buffer before producing a neighbor matrix or COO list. Previously,
+some eager return paths did not check whether construction filled that buffer,
+while existing guards reported the condition as `NeighborOverflowError`. All
+eager Torch and JAX cluster-tile paths now raise `TileBufferOverflow` when the
+required tile-pair count exceeds the allocated capacity. The exception provides
+the required count as `num_tiles`, the capacity as `max_tiles`, and the affected
+`system_index` for a segmented batch.
+
+The convenience functions continue to estimate the buffer size when
+`max_tiles_per_group` is `None`. An explicit value that is too small now raises
+instead of returning incomplete neighbor output. The
+{ref}`cluster-tile-buffer-capacity` section explains how the parameter changes
+the allocation and how to calculate a retry value from the exception.
+
+JAX transformations require `max_tiles_per_group` to be a positive static
+Python integer because it determines output shapes. Compiled output shapes
+remain fixed, and a compiled function cannot turn a data-dependent tile count
+into a Python exception. To detect an undersized bound, a compiled workflow can
+use the lower-level build and query functions to return the tile counts, then
+compare those counts with the buffer capacities after leaving the compiled
+region.
+
 ## v0.4.1: Energy Output Layout
 
 ### Energy Output Layout (`energy_reduction`)

--- a/docs/userguide/components/neighborlist.md
+++ b/docs/userguide/components/neighborlist.md
@@ -539,6 +539,93 @@ steps; batched workflows accept `rebuild_flags` to re-enumerate only systems who
 atoms moved beyond the skin distance. Dual cutoff is supported in matrix format but
 cannot be combined with pair-potential outputs.
 
+(cluster-tile-buffer-capacity)=
+
+### Tile-buffer capacity
+
+Cluster-tile construction divides each system into groups of at most 32 atoms.
+A system with $N$ atoms has $\lceil N/32\rceil$ groups. Groups do not
+cross system boundaries, so a compact batch containing systems of sizes $N_i$
+has $g=\sum_i\lceil N_i/32\rceil$ groups in total.
+
+The build stores discovered tile pairs in one buffer shared by all row groups.
+If `max_tiles_per_group` is $m$, a compact build with $g$ groups reserves
+$C=g\,\min(g,m)$ records. Increasing $m$ by one adds $g$ records until $m$
+reaches $g$; larger values do not increase the allocation. Each record contains
+two `int32` group indices, so the tile-index arrays use $8C$ bytes for one
+system. A compact batch also records the system index and uses $12C$ bytes.
+Other scratch buffers and the neighbor output do not depend on $m$.
+
+#### Choosing a capacity
+
+`cluster_tile_neighbor_list` and `batch_cluster_tile_neighbor_list` construct
+the tile list and query the neighbor output in the same call. During eager
+execution, they call
+{func}`~nvalchemiops.neighbors.cluster_tile.estimate_max_tiles_per_group` when
+`max_tiles_per_group` is `None`. The estimator uses each system's atom count,
+cell volume, and cutoff; its `safety` parameter adds headroom for uneven density
+or changing geometries.
+
+There are three ways to choose a capacity:
+
+- Before execution, use the estimator for a heuristic based on the current
+  geometry.
+- After an eager overflow, use the reported tile count to calculate the exact
+  requirement for that geometry.
+- For a geometry-independent single-system bound, use the upper-triangular
+  maximum of $g(g+1)/2$ tile pairs. This requires
+  `max_tiles_per_group=ceil((g + 1) / 2)`.
+
+Dual-cutoff sizing uses `max(cutoff, cutoff2)`. By convention, `cutoff2` is the
+outer cutoff and is at least `cutoff`, but the cluster-tile convenience
+functions accept either order. Use the same larger cutoff when calling the
+estimator directly.
+
+#### Recovering from eager overflow
+
+`TileBufferOverflow` reports the required tile-pair count as
+`error.num_tiles` and the allocated capacity as `error.max_tiles`. For a compact
+single-system or batch build, the exact retry value for that geometry is
+
+$$
+m_{\mathrm{retry}} = \left\lceil\frac{\mathtt{error.num\_tiles}}{g}\right\rceil,
+$$
+
+where $g$ is the total group count for the compact build.
+
+A segmented batch gives each system its own interval in the tile buffer. System
+$i$ has capacity `tile_offsets[i + 1] - tile_offsets[i]` and reports its required
+count in `tile_counts[i]`. The exact shared retry value for the current batch is
+
+$$
+m_{\mathrm{retry}} =
+\max_{i:\,g_i>0}\left\lceil\frac{\mathtt{tile\_counts}[i]}{g_i}\right\rceil.
+$$
+
+For a trajectory, retain the largest observed requirement and add headroom for
+later geometries. `TileBufferOverflow` reports exhaustion of the intermediate
+tile-pair buffer. `NeighborOverflowError` reports that the final matrix or COO
+neighbor output is too small.
+
+#### Compiled JAX
+
+JAX fixes array shapes while tracing a transformed or compiled function, and
+`max_tiles_per_group` determines the tile-buffer shape. The value must therefore
+be a positive static Python integer. Close over it or mark the argument static
+with `static_argnames`.
+
+The runtime tile count cannot be converted to a Python value inside the compiled
+region, so an undersized bound does not raise `TileBufferOverflow` there. A
+compiled workflow can use the lower-level build and query functions and return
+the tile counters alongside the neighbor output. After the compiled call:
+
+- For a compact buffer, require
+  `int(num_tiles[0]) <= tile_row_group.shape[0]`.
+- For segmented buffers, require
+  `tile_counts <= tile_offsets[1:] - tile_offsets[:-1]` element by element.
+
+The neighbor output is incomplete when either check fails.
+
 (nl_performance)=
 
 ## Performance Tuning
@@ -552,6 +639,14 @@ cannot be combined with pair-potential outputs.
   as improve kernel performance. The `estimate_max_neighbors()` method will
   otherwise provide a **very** conservative estimate based on atomic
   density.
+
+`max_tiles_per_group`
+: Sets the capacity of the tile-pair buffer shared by all row groups. For $g$
+  32-atom groups, a value $m$ reserves $g\,\min(g,m)$ records. The tile-index
+  arrays use 8 bytes per record for one system and 12 bytes per record for a
+  compact batch. The combined build/query functions estimate the value during
+  eager execution when it is `None`. A transformed or compiled JAX call
+  requires a positive static Python integer.
 
 `atomic_density`
 : Atomic density in atoms per unit volume, used by `estimate_max_neighbors()`.

--- a/nvalchemiops/jax/neighbors/__init__.py
+++ b/nvalchemiops/jax/neighbors/__init__.py
@@ -92,6 +92,7 @@ from nvalchemiops.jax.neighbors.naive_dual_cutoff import (
 # Utility functions
 from nvalchemiops.jax.neighbors.neighbor_utils import (
     NeighborOverflowError,
+    TileBufferOverflow,
     allocate_cell_list,
     compute_naive_num_shifts,
     estimate_max_neighbors,
@@ -203,6 +204,14 @@ def neighbor_list(
         max_neighbors2 : int, optional
             Maximum number of neighbors per atom within cutoff2.
             Can be provided to aid in allocation for naive dual cutoff method.
+        max_tiles_per_group : int, optional
+            Capacity factor for the intermediate tile-pair buffer used by
+            cluster-tile methods. For ``g`` row groups, the buffer holds
+            ``g * min(g, max_tiles_per_group)`` tile pairs. Increasing the value
+            up to ``g`` uses more memory and accommodates more candidate tile
+            pairs. Eager calls estimate the value when it is ``None``.
+            Transformed or compiled calls require a positive static Python
+            integer. See :ref:`cluster-tile-buffer-capacity` for sizing details.
         neighbor_matrix : jax.Array, optional
             Pre-shaped array of shape (num_rows, max_neighbors) for neighbor indices,
             where ``num_rows`` is ``total_atoms`` normally and
@@ -649,4 +658,5 @@ __all__ = [
     "allocate_cell_list",
     "estimate_max_neighbors",
     "NeighborOverflowError",
+    "TileBufferOverflow",
 ]

--- a/nvalchemiops/jax/neighbors/batch_cluster_tile.py
+++ b/nvalchemiops/jax/neighbors/batch_cluster_tile.py
@@ -57,7 +57,7 @@ from nvalchemiops.neighbors.cluster_tile import (
     estimate_batch_max_tiles_per_group as _estimate_batch_max_tiles_per_group,
 )
 from nvalchemiops.neighbors.neighbor_utils import (
-    NeighborOverflowError,
+    TileBufferOverflow,
     estimate_max_neighbors,
 )
 
@@ -80,20 +80,20 @@ __all__ = [
 def _batch_tile_buffer_max_tiles_per_group(
     positions, batch_ptr, cutoff, cell_batch
 ) -> int:
-    """``max_tiles_per_group`` for the batched compact tile buffer.
+    """Choose ``max_tiles_per_group`` for a compact batched tile buffer.
 
-    The compact buffer is ``ngroup_total * min(ngroup_total, mtpg)``.
-    ``batch_ptr`` is structural (always concrete), so per-system ``ngroup`` is
-    available.  When ``positions`` and ``cell_batch`` are concrete we
-    density-size from each system's geometry and take the max.  When traced
-    (e.g. ``grad`` w.r.t. cell, or ``jit``) we fall back to ``max_i ngroup_i``:
-    the compact capacity ``ngroup_total * max_i ngroup_i >= sum_i ngroup_i**2``
-    then bounds the upper-triangular maximum, so it can never overflow.
+    Concrete eager inputs use the geometry estimator and take the largest
+    per-system result. When an input is traced, runtime geometry is unavailable
+    and the caller must provide ``max_tiles_per_group`` explicitly.
     """
-    counts = np.asarray(batch_ptr).reshape(-1)
+    try:
+        counts = np.asarray(batch_ptr).reshape(-1)
+    except Exception as exc:
+        raise ValueError(
+            "max_tiles_per_group must be provided as a positive static Python "
+            "integer when a cluster-tile call is transformed or compiled by JAX"
+        ) from exc
     per_sys = (counts[1:] - counts[:-1]).astype(np.int64)
-    ngroups = [(int(n) + TILE_GROUP_SIZE - 1) // TILE_GROUP_SIZE for n in per_sys]
-    max_ng = max(ngroups) if ngroups else 1
     cutoff_concrete = not isinstance(cutoff, jax.core.Tracer)
     vols = _concrete_cell_batch_volumes(cell_batch)
     empty_batch = len(per_sys) == 0 and vols == []
@@ -103,8 +103,42 @@ def _batch_tile_buffer_max_tiles_per_group(
         or empty_batch
         or not cutoff_concrete
     ):
-        return max(max_ng, 1)
+        raise ValueError(
+            "max_tiles_per_group must be provided as a positive static Python "
+            "integer when a cluster-tile call is transformed or compiled by JAX"
+        )
     return estimate_batch_max_tiles_per_group(batch_ptr, cutoff, cell_batch)
+
+
+def _check_eager_tile_buffer_capacity(
+    num_tiles: jax.Array,
+    tile_row_group: jax.Array,
+    *,
+    tile_offsets: jax.Array | None = None,
+    tile_counts: jax.Array | None = None,
+) -> None:
+    """Raise if a concrete compact or segmented tile build overflowed."""
+    if isinstance(num_tiles, jax.core.Tracer):
+        return
+    if tile_offsets is None:
+        discovered = int(num_tiles[0])
+        capacity = int(tile_row_group.shape[0])
+        if discovered > capacity:
+            raise TileBufferOverflow(capacity, discovered)
+        return
+    if tile_counts is None or isinstance(tile_counts, jax.core.Tracer):
+        return
+    counts = np.asarray(tile_counts).reshape(-1)
+    offsets = np.asarray(tile_offsets).reshape(-1)
+    capacities = offsets[1:] - offsets[:-1]
+    overflowing = np.nonzero(counts > capacities)[0]
+    if overflowing.size:
+        system_index = int(overflowing[0])
+        raise TileBufferOverflow(
+            int(capacities[system_index]),
+            int(counts[system_index]),
+            system_index=system_index,
+        )
 
 
 def _concrete_cell_batch_volumes(cell_batch) -> list[float] | None:
@@ -161,8 +195,8 @@ def estimate_batch_max_tiles_per_group(
     Raises
     ------
     ValueError
-        If ``batch_ptr`` or ``cell_batch`` is traced / not host-concrete, or if
-        ``cell_batch`` does not have shape ``(num_systems, 3, 3)``.
+        If ``batch_ptr`` or ``cell_batch`` is traced or unavailable to Python,
+        or if ``cell_batch`` does not have shape ``(num_systems, 3, 3)``.
     """
     ptr_values = _concrete_batch_ptr_values(batch_ptr)
     if ptr_values is None:
@@ -208,7 +242,9 @@ def estimate_batch_cluster_tile_list_sizes(
     batch_ptr : jax.Array, shape (num_systems + 1,), dtype=int32
         Cumulative atom counts across systems.
     max_tiles_per_group : int, default 256
-        Per-group tile capacity used to size the compact tile buffer.
+        Sets the capacity of the tile-pair buffer shared by all row groups. If
+        the batch has ``ngroup`` groups in total, its compact capacity is
+        ``ngroup * min(ngroup, max_tiles_per_group)`` entries.
 
     Returns
     -------
@@ -260,7 +296,9 @@ def estimate_batch_cluster_tile_segments(
     max_neighbors : int
         Per-atom neighbor capacity used to size the per-system COO segments.
     max_tiles_per_group : int, default 256
-        Per-group tile capacity used by the segment estimator.
+        Sets each system's tile-pair segment capacity. A system with ``g_i``
+        groups receives ``g_i * min(g_i, max_tiles_per_group)`` entries. Its
+        group count is ``ceil(num_atoms_i / 32)``.
 
     Returns
     -------
@@ -323,9 +361,11 @@ def allocate_batch_cluster_tile_list(
     batch_ptr : jax.Array, shape (S + 1,), dtype=int32
         Cumulative atom counts.
     max_neighbors : int
-        Per-atom neighbor capacity; sizes the per-system tile segments.
+        Per-atom neighbor capacity used to size the per-system COO segments.
     max_tiles_per_group : int, default 256
-        Per-group tile cap used by the segment estimator.
+        Sets each system's tile-pair segment capacity. A system with ``g_i``
+        groups receives ``g_i * min(g_i, max_tiles_per_group)`` tile-pair
+        entries. Its group count is ``ceil(num_atoms_i / 32)``.
 
     Returns
     -------
@@ -1032,6 +1072,7 @@ def batch_build_cluster_tile_list(
     cell_batch: jax.Array,
     batch_ptr: jax.Array,
     *,
+    max_tiles_per_group: int | None = None,
     rebuild_flags: jax.Array | None = None,
     tile_offsets: jax.Array | None = None,
     tile_counts: jax.Array | None = None,
@@ -1055,6 +1096,15 @@ def batch_build_cluster_tile_list(
         Per-system unit cell matrices.
     batch_ptr : jax.Array, shape (S + 1,), dtype=int32
         Cumulative atom counts.
+    max_tiles_per_group : int, optional
+        Capacity factor for an internally allocated intermediate tile-pair
+        buffer. For ``g`` row groups, the buffer holds
+        ``g * min(g, max_tiles_per_group)`` tile pairs. Increasing the value up
+        to ``g`` uses more memory and accommodates more candidate tile pairs.
+        Eager calls estimate the value when it is ``None``. Transformed or
+        compiled calls require a positive static Python integer. Caller-owned
+        tile arrays determine the actual capacity. See
+        :ref:`cluster-tile-buffer-capacity` for sizing details.
     rebuild_flags : jax.Array, shape (S,), dtype=bool, optional
         Per-system rebuild flags. When provided, only systems with a True
         flag have their tiles rebuilt. Requires ``tile_offsets`` and
@@ -1110,12 +1160,21 @@ def batch_build_cluster_tile_list(
         batch_ptr = batch_ptr.astype(jnp.int32)
     if int(batch_ptr.shape[0]) < 2:
         raise ValueError("batch_ptr must have length at least 2")
+    if max_tiles_per_group is not None and (
+        not isinstance(max_tiles_per_group, int)
+        or isinstance(max_tiles_per_group, bool)
+        or max_tiles_per_group <= 0
+    ):
+        raise ValueError("max_tiles_per_group must be a positive integer")
 
-    # Geometry-size the compact tile buffer so dense/high-cutoff systems don't
-    # silently overflow; trace-safe ``max_i ngroup_i`` fallback when traced.
-    max_tiles_per_group = _batch_tile_buffer_max_tiles_per_group(
-        positions, batch_ptr, cutoff, cell_batch
-    )
+    # Concrete eager calls use the geometry estimator. A transformed call must
+    # supply max_tiles_per_group because it determines an array shape.
+    if max_tiles_per_group is None:
+        max_tiles_per_group = _batch_tile_buffer_max_tiles_per_group(
+            positions, batch_ptr, cutoff, cell_batch
+        )
+    else:
+        max_tiles_per_group = int(max_tiles_per_group)
     n_padded, ngroup, ngroup_padded, max_tiles, _num_systems = (
         estimate_batch_cluster_tile_list_sizes(
             batch_ptr, max_tiles_per_group=max_tiles_per_group
@@ -1904,8 +1963,9 @@ def batch_cluster_tile_neighbor_list(
     neighbor_distances: jax.Array | None = None,
     pair_energies: jax.Array | None = None,
     pair_forces: jax.Array | None = None,
+    max_tiles_per_group: int | None = None,
 ) -> tuple[jax.Array, ...]:
-    """Build a batched cluster-pair tile neighbor list (one-shot convenience).
+    """Build and query a batched cluster-pair tile neighbor list in one call.
 
     Batched JAX binding for the cluster-pair tile algorithm.  Per-system
     Morton sort and padded SoA gather happen in JAX; bbox reduction,
@@ -1920,8 +1980,10 @@ def batch_cluster_tile_neighbor_list(
     cutoff : float
         Cutoff distance in Cartesian units. Must be positive.
     cutoff2 : float, optional
-        Matrix-format second cutoff. Cannot be combined with pair outputs
-        or COO/tile formats.
+        Cutoff for the second matrix. It is normally the outer cutoff and may
+        equal ``cutoff``. Either order is accepted because the tile buffer is
+        sized for the larger value. Cannot be combined with pair outputs or
+        COO/tile formats.
     rebuild_flags : jax.Array, shape (num_systems,), dtype=bool, optional
         Selective rebuild flags for matrix or segmented COO output. Requires
         fixed tile segments and previous output buffers.
@@ -1942,6 +2004,15 @@ def batch_cluster_tile_neighbor_list(
     max_pairs : int, optional
         Upper bound for compact COO output; defaults to
         ``total_atoms * max_neighbors``.
+    max_tiles_per_group : int, optional
+        Capacity factor for an internally allocated intermediate tile-pair
+        buffer. For ``g`` row groups, the buffer holds
+        ``g * min(g, max_tiles_per_group)`` tile pairs. Increasing the value up
+        to ``g`` uses more memory and accommodates more candidate tile pairs.
+        Eager calls estimate the value when it is ``None``. Transformed or
+        compiled calls require a positive static Python integer. Caller-owned
+        tile arrays determine the actual capacity. See
+        :ref:`cluster-tile-buffer-capacity` for sizing details.
     tile_offsets, previous_tile_counts, pair_offsets, previous_pair_counts : jax.Array, optional
         Fixed per-system segmented tile/COO buffers used with
         ``rebuild_flags``. Size them with
@@ -2016,6 +2087,10 @@ def batch_cluster_tile_neighbor_list(
     - Cluster-tile is CUDA float32 only.
     - Cluster-tile does not support partial neighbor lists (no
       ``target_indices`` kwarg).
+    - A transformed or compiled call cannot raise :class:`TileBufferOverflow`
+      from its runtime tile counts. To detect an undersized explicit bound, use
+      the lower-level build and query functions and check the returned compact
+      or per-system counts after leaving the transformed region.
     - The unified :func:`nvalchemiops.jax.neighbors.neighbor_list` entry
       point may select this binding automatically when the selector guards
       and cost model prefer it; pass ``method="batch_cluster_tile"`` to
@@ -2045,6 +2120,12 @@ def batch_cluster_tile_neighbor_list(
         raise ValueError(
             f"format must be 'matrix' | 'coo' | 'tile'; got {format!r}",
         )
+    if max_tiles_per_group is not None and (
+        not isinstance(max_tiles_per_group, int)
+        or isinstance(max_tiles_per_group, bool)
+        or max_tiles_per_group <= 0
+    ):
+        raise ValueError("max_tiles_per_group must be a positive integer")
     if pair_fn is not None and pair_params is None:
         raise ValueError(
             "pair_fn requires pair_params (a per-atom (n_atoms, K) parameter array).",
@@ -2262,7 +2343,14 @@ def batch_cluster_tile_neighbor_list(
                 trg,
                 tcg,
                 ts,
-            ) = batch_build_cluster_tile_list(p_det, cutoff, c_det, batch_ptr)
+            ) = batch_build_cluster_tile_list(
+                p_det,
+                cutoff,
+                c_det,
+                batch_ptr,
+                max_tiles_per_group=max_tiles_per_group,
+            )
+            _check_eager_tile_buffer_capacity(nt, trg)
             out = batch_query_cluster_tile(
                 sai,
                 spx,
@@ -2355,15 +2443,15 @@ def batch_cluster_tile_neighbor_list(
     positions_topology = jax.lax.stop_gradient(positions)
     cell_batch_topology = jax.lax.stop_gradient(cell_batch)
 
-    # Tile candidates must cover the larger radius so the cutoff2 matrix cannot
-    # miss pairs in the (cutoff, cutoff2] shell; the query filters each matrix
-    # by its own cutoff.
+    # Candidate tiles must cover both radii. The query filters each matrix with
+    # its own cutoff.
     build_cutoff = cutoff if cutoff2 is None else max(float(cutoff), float(cutoff2))
     build_out = batch_build_cluster_tile_list(
         positions_topology,
         build_cutoff,
         cell_batch_topology,
         batch_ptr,
+        max_tiles_per_group=max_tiles_per_group,
         rebuild_flags=rebuild_flags,
         tile_offsets=tile_offsets,
         tile_counts=previous_tile_counts,
@@ -2419,26 +2507,14 @@ def batch_cluster_tile_neighbor_list(
         ) = build_out
         tile_counts = None
 
-    # Eager guard: raise on tile-buffer overflow instead of silently dropping
-    # tiles.  Skipped under trace (the geometry fallback sizes the buffer so it
-    # can never overflow).  Compact path checks the global ``num_tiles``;
-    # segmented (selective) checks per-system ``tile_counts``.
-    if not isinstance(num_tiles, jax.core.Tracer):
-        tile_capacity = int(tile_row_group.shape[0])
-        if tile_offsets is None:
-            n_tiles_host = int(num_tiles[0])
-            if n_tiles_host > tile_capacity:
-                raise NeighborOverflowError(tile_capacity, n_tiles_host)
-        elif tile_counts is not None and not isinstance(tile_counts, jax.core.Tracer):
-            counts_host = np.asarray(tile_counts).reshape(-1)
-            offs = np.asarray(tile_offsets).reshape(-1)
-            seg_caps = offs[1:] - offs[:-1]
-            over = np.nonzero(counts_host > seg_caps)[0]
-            if over.size > 0:
-                isys = int(over[0])
-                raise NeighborOverflowError(
-                    int(seg_caps[isys]), int(counts_host[isys]), system_index=isys
-                )
+    # A traced/compiled callback cannot synchronize its data-dependent counts.
+    # Concrete eager calls fail before any query can consume truncated tiles.
+    _check_eager_tile_buffer_capacity(
+        num_tiles,
+        tile_row_group,
+        tile_offsets=tile_offsets,
+        tile_counts=tile_counts,
+    )
 
     if format == "tile":
         # 11-tuple matching the torch sibling at

--- a/nvalchemiops/jax/neighbors/cluster_tile.py
+++ b/nvalchemiops/jax/neighbors/cluster_tile.py
@@ -66,7 +66,7 @@ from nvalchemiops.neighbors.cluster_tile import (
     query_cluster_tile_coo as _warp_query_cluster_tile_coo,
 )
 from nvalchemiops.neighbors.neighbor_utils import (
-    NeighborOverflowError,
+    TileBufferOverflow,
     estimate_max_neighbors,
 )
 
@@ -88,7 +88,7 @@ def _concrete_cell_volume(cell) -> float | None:
     """Return ``abs(det(cell))`` if ``cell`` is concrete, else ``None``.
 
     Under ``jit``/``grad`` the cell may be a tracer; ``np.asarray`` raises and
-    we return ``None`` so the caller falls back to a trace-safe static size.
+    we return ``None`` so the caller can require an explicit static size.
     """
     try:
         arr = np.asarray(cell)
@@ -102,16 +102,12 @@ def _concrete_cell_volume(cell) -> float | None:
 
 
 def _tile_buffer_max_tiles_per_group(positions, total_atoms: int, cutoff, cell) -> int:
-    """``max_tiles_per_group`` for the JAX tile buffer.
+    """Choose ``max_tiles_per_group`` for a JAX compact tile buffer.
 
-    The tile-buffer size must be a *static* Python int (it's an array shape).
-    When ``positions`` and ``cell`` are concrete (eager, or ``grad`` w.r.t.
-    positions where the cell is a closure constant) we density-size from the
-    geometry so dense/high-cutoff systems don't silently overflow.  When either
-    is traced (e.g. ``grad`` w.r.t. cell, or ``jit`` of the whole call) the
-    volume is unavailable, so fall back to ``ngroup`` -> capacity ``ngroup**2``,
-    the upper-triangular maximum, which can *never* overflow (at the cost of
-    more memory for very large traced systems).
+    ``max_tiles_per_group`` determines an array shape and must therefore be a
+    static Python integer. Concrete eager inputs use the geometry estimator.
+    When an input is traced, runtime geometry is unavailable and the caller
+    must provide the value explicitly.
     """
     ngroup = (int(total_atoms) + TILE_GROUP_SIZE - 1) // TILE_GROUP_SIZE
     if ngroup <= 1:
@@ -119,8 +115,24 @@ def _tile_buffer_max_tiles_per_group(positions, total_atoms: int, cutoff, cell) 
     cutoff_concrete = not isinstance(cutoff, jax.core.Tracer)
     vol = _concrete_cell_volume(cell)
     if isinstance(positions, jax.core.Tracer) or vol is None or not cutoff_concrete:
-        return ngroup  # trace-safe upper-triangular cap (capacity ngroup**2)
+        raise ValueError(
+            "max_tiles_per_group must be provided as a positive static Python "
+            "integer when a cluster-tile call is transformed or compiled by JAX"
+        )
     return _estimate_max_tiles_per_group(int(total_atoms), float(cutoff), vol)
+
+
+def _check_eager_tile_buffer_capacity(
+    num_tiles: jax.Array,
+    tile_row_group: jax.Array,
+) -> None:
+    """Raise if a concrete cluster-tile build exceeded its output buffer."""
+    if isinstance(num_tiles, jax.core.Tracer):
+        return
+    discovered = int(num_tiles[0])
+    capacity = int(tile_row_group.shape[0])
+    if discovered > capacity:
+        raise TileBufferOverflow(capacity, discovered)
 
 
 def estimate_cluster_tile_list_sizes(
@@ -136,18 +148,21 @@ def estimate_cluster_tile_list_sizes(
     total_atoms : int
         Real atom count.  Any ``total_atoms >= 0`` is accepted.
     max_tiles_per_group : int, default 256
-        Upper bound on neighbor groups per row_group.
+        Sets the capacity of the tile-pair buffer shared by all row groups. The
+        allocated group count is ``ngroup = max(1, ceil(total_atoms / 32))``.
+        The capacity is ``ngroup * min(ngroup, max_tiles_per_group)`` entries.
 
     Returns
     -------
     n_padded : int
-        Padded atom count = ``ceil(total_atoms / TILE_GROUP_SIZE) * TILE_GROUP_SIZE``.
+        Padded atom count. This is at least ``TILE_GROUP_SIZE``; nonempty inputs
+        are rounded up to a multiple of ``TILE_GROUP_SIZE``.
     ngroup : int
         ``n_padded // TILE_GROUP_SIZE``.
     ngroup_padded : int
         Group-array pad length, multiple of TILE_GROUP_SIZE.
     max_tiles : int
-        Upper bound on the tile-pair list size.
+        Allocated tile-pair list capacity.
     """
     if total_atoms < 0:
         raise ValueError(f"total_atoms must be >= 0; got {total_atoms}")
@@ -181,9 +196,11 @@ def allocate_cluster_tile_list(
         Floating-point dtype for position and bounding-box arrays.
         Defaults to ``jnp.float32``.
     max_tiles_per_group : int, optional
-        Upper bound on neighbor groups per row_group; controls the
-        ``tile_row_group`` / ``tile_col_group`` buffer capacity.
-        Defaults to 256.
+        Capacity factor for the intermediate tile-pair buffer. For ``g`` row
+        groups, the buffer holds ``g * min(g, max_tiles_per_group)`` tile pairs.
+        Increasing the value up to ``g`` uses more memory and accommodates more
+        candidate tile pairs. Defaults to 256. See
+        :ref:`cluster-tile-buffer-capacity` for sizing details.
 
     Returns
     -------
@@ -826,6 +843,7 @@ def build_cluster_tile_list(
     cutoff: float,
     cell: jax.Array,
     *,
+    max_tiles_per_group: int | None = None,
     rebuild_flags: jax.Array | None = None,
     num_tiles: jax.Array | None = None,
     tile_row_group: jax.Array | None = None,
@@ -860,13 +878,22 @@ def build_cluster_tile_list(
         Cutoff distance for the bbox filter.
     cell : jax.Array, shape (3, 3) or (1, 3, 3), dtype=float32
         Unit cell matrix (orthorhombic or triclinic).
+    max_tiles_per_group : int, optional
+        Capacity factor for an internally allocated intermediate tile-pair
+        buffer. For ``g`` row groups, the buffer holds
+        ``g * min(g, max_tiles_per_group)`` tile pairs. Increasing the value up
+        to ``g`` uses more memory and accommodates more candidate tile pairs.
+        Eager calls estimate the value when it is ``None``. Transformed or
+        compiled calls require a positive static Python integer. Caller-owned
+        tile arrays determine the actual capacity. See
+        :ref:`cluster-tile-buffer-capacity` for sizing details.
     rebuild_flags : jax.Array, shape (1,), dtype=bool, optional
         Selective-rebuild flag. When set, only tiles for flagged systems/atoms
         are rebuilt via the selective Warp callback.  On the first call,
         ``num_tiles``, ``tile_row_group``, and ``tile_col_group`` may be
         omitted and are allocated as zeros; on subsequent selective calls
-        pass the tile state returned by the prior build or selective one-shot
-        wrapper.
+        pass the tile state returned by the prior build or combined build/query
+        call.
     num_tiles : jax.Array, shape (1,), dtype=int32, optional
         Previous global tile-count buffer reused across selective rebuilds.
         Allocated as zeros on the first selective call when omitted.
@@ -894,10 +921,21 @@ def build_cluster_tile_list(
         raise TypeError(
             "positions must be float32 (cluster_tile kernels are float32 only)"
         )
+    if max_tiles_per_group is not None and (
+        not isinstance(max_tiles_per_group, int)
+        or isinstance(max_tiles_per_group, bool)
+        or max_tiles_per_group <= 0
+    ):
+        raise ValueError("max_tiles_per_group must be a positive integer")
     N = positions.shape[0]
-    # Geometry-size the tile buffer so dense/high-cutoff systems don't silently
-    # overflow; trace-safe ``ngroup**2`` fallback when positions/cell are tracers.
-    max_tiles_per_group = _tile_buffer_max_tiles_per_group(positions, N, cutoff, cell)
+    # Concrete eager calls use the geometry estimator. A transformed call must
+    # supply max_tiles_per_group because it determines an array shape.
+    if max_tiles_per_group is None:
+        max_tiles_per_group = _tile_buffer_max_tiles_per_group(
+            positions, N, cutoff, cell
+        )
+    else:
+        max_tiles_per_group = int(max_tiles_per_group)
     n_padded, ngroup, ngroup_padded, max_tiles = estimate_cluster_tile_list_sizes(
         N, max_tiles_per_group=max_tiles_per_group
     )
@@ -1671,6 +1709,7 @@ def _cluster_tile_pair_outputs_forward(
     cutoff: float,
     max_neighbors: int,
     fill_value: int,
+    max_tiles_per_group: int | None,
     pair_fn=None,
     pair_params: jax.Array | None = None,
 ) -> _NeighborForwardOutput:
@@ -1701,7 +1740,13 @@ def _cluster_tile_pair_outputs_forward(
         num_tiles,
         tile_row_group,
         tile_col_group,
-    ) = build_cluster_tile_list(positions, cutoff, cell)
+    ) = build_cluster_tile_list(
+        positions,
+        cutoff,
+        cell,
+        max_tiles_per_group=max_tiles_per_group,
+    )
+    _check_eager_tile_buffer_capacity(num_tiles, tile_row_group)
 
     out = query_cluster_tile(
         sorted_atom_index,
@@ -1756,6 +1801,7 @@ def cluster_tile_neighbor_list(
     format: str = "matrix",
     max_pairs: int | None = None,
     *,
+    max_tiles_per_group: int | None = None,
     cutoff2: float | None = None,
     rebuild_flags: jax.Array | None = None,
     pair_offsets: jax.Array | None = None,
@@ -1780,7 +1826,7 @@ def cluster_tile_neighbor_list(
     pair_energies: jax.Array | None = None,
     pair_forces: jax.Array | None = None,
 ) -> tuple[jax.Array, ...]:
-    """Build a cluster-pair tile neighbor list (one-shot convenience).
+    """Build and query a cluster-pair tile neighbor list in one call.
 
     Single-system JAX binding for the cluster-pair tile algorithm.  Runs
     Morton sort, bounding-box reduction, and tile enumeration, then emits
@@ -1795,8 +1841,10 @@ def cluster_tile_neighbor_list(
     cutoff : float
         Cutoff distance in Cartesian units. Must be positive.
     cutoff2 : float, optional
-        Matrix-format second cutoff. Cannot be combined with pair outputs
-        or COO/tile formats.
+        Cutoff for the second matrix. It is normally the outer cutoff and may
+        equal ``cutoff``. Either order is accepted because the tile buffer is
+        sized for the larger value. Cannot be combined with pair outputs or
+        COO/tile formats.
     rebuild_flags : jax.Array, shape (1,), dtype=bool, optional
         Selective rebuild flag for matrix or segmented COO output. Requires
         previous tile state plus previous output buffers.
@@ -1811,6 +1859,14 @@ def cluster_tile_neighbor_list(
         Output representation. See Returns.
     max_pairs : int, optional
         Upper bound for compact COO output; defaults to ``N * max_neighbors``.
+    max_tiles_per_group : int, optional
+        Capacity factor for an internally allocated intermediate tile-pair
+        buffer. For ``g`` row groups, the buffer holds
+        ``g * min(g, max_tiles_per_group)`` tile pairs. Increasing the value up
+        to ``g`` uses more memory and accommodates more candidate tile pairs.
+        Eager calls estimate the value when it is ``None``. Transformed or
+        compiled calls require a positive static Python integer. See
+        :ref:`cluster-tile-buffer-capacity` for sizing details.
     pair_offsets, previous_pair_counts, previous_neighbor_list, previous_neighbor_list_shifts : jax.Array, optional
         Single fixed segmented-COO state used with ``rebuild_flags`` and
         ``format="coo"``. ``pair_offsets`` must be
@@ -1880,6 +1936,10 @@ def cluster_tile_neighbor_list(
     - Cluster-tile is CUDA float32 only.
     - Cluster-tile does not support partial neighbor lists; there is no
       ``target_indices`` kwarg.
+    - A transformed or compiled call cannot raise :class:`TileBufferOverflow`
+      from its runtime tile count. To detect an undersized explicit bound, use
+      the lower-level build and query functions and check the returned tile
+      count after leaving the transformed region.
     - The unified
       :func:`nvalchemiops.jax.neighbors.neighbor_list` entry point selects
       this binding automatically for fully-periodic float32 CUDA inputs
@@ -1902,6 +1962,12 @@ def cluster_tile_neighbor_list(
         raise ValueError(
             f"format must be 'matrix' | 'coo' | 'tile'; got {format!r}",
         )
+    if max_tiles_per_group is not None and (
+        not isinstance(max_tiles_per_group, int)
+        or isinstance(max_tiles_per_group, bool)
+        or max_tiles_per_group <= 0
+    ):
+        raise ValueError("max_tiles_per_group must be a positive integer")
     if pair_fn is not None and pair_params is None:
         raise ValueError(
             "pair_fn requires pair_params (a per-atom (n_atoms, K) parameter array).",
@@ -2095,6 +2161,7 @@ def cluster_tile_neighbor_list(
             "cutoff": float(cutoff),
             "max_neighbors": int(max_neighbors),
             "fill_value": int(fill_value),
+            "max_tiles_per_group": max_tiles_per_group,
             "pair_fn": pair_fn,
             "pair_params": pair_params,
         }
@@ -2151,9 +2218,8 @@ def cluster_tile_neighbor_list(
     positions_topology = jax.lax.stop_gradient(positions)
     cell_topology = jax.lax.stop_gradient(cell)
 
-    # Tile candidates must cover the larger radius so the cutoff2 matrix cannot
-    # miss pairs in the (cutoff, cutoff2] shell; the query filters each matrix
-    # by its own cutoff.
+    # Candidate tiles must cover both radii. The query filters each matrix with
+    # its own cutoff.
     build_cutoff = cutoff if cutoff2 is None else max(float(cutoff), float(cutoff2))
     (
         sorted_atom_index,
@@ -2174,20 +2240,16 @@ def cluster_tile_neighbor_list(
         positions_topology,
         build_cutoff,
         cell_topology,
+        max_tiles_per_group=max_tiles_per_group,
         rebuild_flags=rebuild_flags,
         num_tiles=previous_num_tiles,
         tile_row_group=previous_tile_row_group,
         tile_col_group=previous_tile_col_group,
     )
 
-    # Eager guard: raise on tile-buffer overflow instead of silently dropping
-    # tiles.  Skipped under trace (positions/num_tiles are tracers) -- there the
-    # ``ngroup**2`` geometry fallback guarantees the buffer never overflows.
-    if not isinstance(num_tiles, jax.core.Tracer):
-        n_tiles_host = int(num_tiles[0])
-        tile_capacity = int(tile_row_group.shape[0])
-        if n_tiles_host > tile_capacity:
-            raise NeighborOverflowError(tile_capacity, n_tiles_host)
+    # A traced/compiled callback cannot synchronize its data-dependent count.
+    # Concrete eager calls fail before any query can consume truncated tiles.
+    _check_eager_tile_buffer_capacity(num_tiles, tile_row_group)
 
     if format == "tile":
         return (

--- a/nvalchemiops/jax/neighbors/neighbor_utils.py
+++ b/nvalchemiops/jax/neighbors/neighbor_utils.py
@@ -29,6 +29,7 @@ from warp.jax_experimental import jax_kernel
 
 from nvalchemiops.neighbors.neighbor_utils import (
     NeighborOverflowError,
+    TileBufferOverflow,
     estimate_max_neighbors,
     get_compute_naive_num_shifts_kernel,
 )
@@ -43,6 +44,7 @@ __all__ = [
     "allocate_cell_list",
     "estimate_max_neighbors",
     "NeighborOverflowError",
+    "TileBufferOverflow",
 ]
 
 

--- a/nvalchemiops/neighborlist/__init__.py
+++ b/nvalchemiops/neighborlist/__init__.py
@@ -33,6 +33,7 @@ import warnings
 from nvalchemiops import neighbors as _neighbors
 from nvalchemiops.neighbors import (
     NeighborOverflowError,
+    TileBufferOverflow,
     estimate_max_neighbors,
 )
 from nvalchemiops.neighbors import (
@@ -161,6 +162,7 @@ def __getattr__(name: str):  # pragma: no cover
 
 __all__ = [
     "NeighborOverflowError",
+    "TileBufferOverflow",
     "wp_naive_neighbor_matrix",
     "wp_naive_neighbor_matrix_pbc",
     "wp_build_cell_list",

--- a/nvalchemiops/neighbors/__init__.py
+++ b/nvalchemiops/neighbors/__init__.py
@@ -55,6 +55,7 @@ from nvalchemiops.neighbors.naive import (
 )
 from nvalchemiops.neighbors.neighbor_utils import (
     NeighborOverflowError,
+    TileBufferOverflow,
     compute_naive_num_shifts,
     estimate_max_neighbors,
     zero_array,
@@ -123,6 +124,7 @@ def __getattr__(name: str):  # pragma: no cover
 # selectors live only at their canonical package paths.
 __all__ = [
     "NeighborOverflowError",
+    "TileBufferOverflow",
     "TILE_GROUP_SIZE",
     "batch_build_cell_list",
     "batch_build_cluster_tile_list",

--- a/nvalchemiops/neighbors/cluster_tile/launchers.py
+++ b/nvalchemiops/neighbors/cluster_tile/launchers.py
@@ -72,36 +72,32 @@ def estimate_max_tiles_per_group(
     safety: float = 2.0,
     floor: int = 256,
 ) -> int:
-    """Estimate neighbor cluster-groups per row group from density and cutoff.
+    """Estimate ``max_tiles_per_group`` for a compact cluster-tile buffer.
 
-    The tile-list capacity is ``ngroup * min(ngroup, max_tiles_per_group)``.
-    The fixed default (256) silently truncates dense / high-cutoff periodic
-    systems where many cluster bounding boxes fall within the cutoff, so
-    estimate it from the expected number of 32-atom clusters whose bounding box
-    can fall within ``cutoff`` of a row group.  ``min(ngroup, ...)`` in the
-    capacity formula
-    clamps the per-row count, so over-estimates cost nothing; the ``floor``
-    keeps parity with the old default for sparse / low-cutoff systems.
+    The estimate uses atom density and ``cutoff`` to approximate how many group
+    pairs pass the bounding-box filter; ``safety`` adds headroom. For ``g`` row
+    groups, the returned value ``m`` gives the buffer
+    ``g * min(g, m)`` tile-pair entries.
 
     Parameters
     ----------
     total_atoms : int
         Atom count for the system (single system, not batched total).
     cutoff : float
-        Cartesian cutoff (use ``max(cutoff, cutoff2)`` for dual-cutoff).
+        Cartesian cutoff. For dual cutoff, this is the larger of ``cutoff`` and
+        ``cutoff2``.
     cell_volume : float or None
         ``abs(det(cell))``.  ``None`` / non-positive falls back to ``floor``.
     safety : float, default 2.0
         Multiplier on the volumetric estimate.
     floor : int, default 256
-        Minimum returned value (the historical default).
+        Baseline for the estimate. The allocation formula still limits useful
+        values to ``ngroup``.
 
     Returns
     -------
     int
-        Estimated ``max_tiles_per_group`` for compact tile-list capacity
-        planning.  Clamped by ``min(ngroup, ...)`` in downstream capacity
-        formulas.
+        Estimated ``max_tiles_per_group`` value.
     """
     ngroup = (int(total_atoms) + TILE_GROUP_SIZE - 1) // TILE_GROUP_SIZE
     if ngroup <= 1:
@@ -131,30 +127,30 @@ def estimate_batch_max_tiles_per_group(
     safety: float = 2.0,
     floor: int = 256,
 ) -> int:
-    """Estimate batched ``max_tiles_per_group`` from per-system density.
+    """Estimate ``max_tiles_per_group`` for a compact batched tile buffer.
 
-    The compact batched tile buffer is ``ngroup_total * min(ngroup_total,
-    max_tiles_per_group)``, so the shared ``max_tiles_per_group`` must cover
-    the densest system.  Returns the maximum per-system estimate from
-    :func:`estimate_max_tiles_per_group`, floored at ``floor``.
+    The function estimates each system from its atom density and returns the
+    largest result. For ``g`` row groups in the batch, the returned value ``m``
+    gives the shared buffer ``g * min(g, m)`` tile-pair entries.
 
     Parameters
     ----------
     batch_ptr : sequence of int
         CSR atom pointer with length ``num_systems + 1``.
     cutoff : float
-        Cartesian cutoff (use ``max(cutoff, cutoff2)`` for dual-cutoff).
+        Cartesian cutoff. For dual cutoff, this is the larger of ``cutoff`` and
+        ``cutoff2``.
     cell_volumes : sequence of float
         Per-system ``abs(det(cell))`` with one entry per batch segment.
     safety : float, default 2.0
         Multiplier on the volumetric estimate passed to each system estimate.
     floor : int, default 256
-        Minimum returned value for batched compact buffers.
+        Baseline for the returned estimate.
 
     Returns
     -------
     int
-        Shared ``max_tiles_per_group`` for the batched compact tile buffer.
+        Estimated ``max_tiles_per_group`` value shared by the batch.
     """
     ptr_values = [int(v) for v in _host_int_float_list(batch_ptr)]
     volume_values = [float(v) for v in _host_int_float_list(cell_volumes)]
@@ -195,7 +191,9 @@ def estimate_batch_cluster_tile_segments(
     max_neighbors : int
         Per-atom COO capacity multiplier.
     max_tiles_per_group : int, default 256
-        Upper bound on neighbor groups per row group.
+        Sets each system's tile-pair segment capacity. A system with ``g_i``
+        groups receives ``g_i * min(g_i, max_tiles_per_group)`` entries. Each
+        system's group count is ``ceil(num_atoms_i / 32)``.
 
     Returns
     -------

--- a/nvalchemiops/neighbors/neighbor_utils.py
+++ b/nvalchemiops/neighbors/neighbor_utils.py
@@ -225,9 +225,50 @@ class NeighborOverflowError(Exception):
         self.system_index = system_index
 
 
+class TileBufferOverflow(Exception):
+    """Raised when an eager cluster-tile build exceeds its tile-pair buffer.
+
+    See :ref:`cluster-tile-buffer-capacity` for allocation and retry sizing.
+
+    Parameters
+    ----------
+    max_tiles : int
+        Number of tile-pair entries the compact buffer or overflowing system
+        segment can hold.
+    num_tiles : int
+        Number of tile-pair entries discovered by the compact build or
+        overflowing system.
+    system_index : int, optional
+        System index for a segmented batched tile buffer.
+    """
+
+    def __init__(self, max_tiles: int, num_tiles: int, system_index: int | None = None):
+        if system_index is None:
+            message = (
+                f"Cluster-tile construction required {num_tiles} tile-pair "
+                f"entries, but the buffer holds {max_tiles}. Allocate at least "
+                f"{num_tiles} entries before retrying. If you did not supply "
+                "the tile arrays, increase max_tiles_per_group."
+            )
+        else:
+            message = (
+                f"Cluster-tile construction for system {system_index} required "
+                f"{num_tiles} tile-pair entries, but its segment holds "
+                f"{max_tiles}. Reallocate the segmented tile state so that "
+                f"system has at least {num_tiles} entries before retrying. "
+                "When using estimate_batch_cluster_tile_segments, increase "
+                "max_tiles_per_group."
+            )
+        super().__init__(message)
+        self.max_tiles = max_tiles
+        self.num_tiles = num_tiles
+        self.system_index = system_index
+
+
 __all__ = [
     "DTYPE_INFO_ALL",
     "NeighborOverflowError",
+    "TileBufferOverflow",
     "dtype_info",
     "empty_sentinel",
     "compute_naive_num_shifts",

--- a/nvalchemiops/torch/neighbors/__init__.py
+++ b/nvalchemiops/torch/neighbors/__init__.py
@@ -83,6 +83,8 @@ from nvalchemiops.torch.neighbors.naive_dual_cutoff import (
 
 # Utility functions
 from nvalchemiops.torch.neighbors.neighbor_utils import (
+    NeighborOverflowError,
+    TileBufferOverflow,
     prepare_batch_idx_ptr,
     synthesize_cell_for_batch,
     synthesize_cell_for_ss,
@@ -180,6 +182,13 @@ def neighbor_list(
         max_neighbors2 : int, optional
             Maximum number of neighbors per atom within cutoff2.
             Can be provided to aid in allocation for naive dual cutoff method.
+        max_tiles_per_group : int, optional
+            Capacity factor for the intermediate tile-pair buffer used by
+            cluster-tile methods. For ``g`` row groups, the buffer holds
+            ``g * min(g, max_tiles_per_group)`` tile pairs. Increasing the value
+            up to ``g`` uses more memory and accommodates more candidate tile
+            pairs. Eager calls estimate the value when it is ``None``. See
+            :ref:`cluster-tile-buffer-capacity` for sizing details.
         neighbor_matrix : torch.Tensor, optional
             Pre-allocated tensor of shape (num_rows, max_neighbors) for neighbor indices,
             where ``num_rows`` is ``total_atoms`` normally and
@@ -604,6 +613,8 @@ __all__ = [
     "suggest_neighbor_list_method",
     "CompiledPairFn",
     "compile_pair_fn",
+    "NeighborOverflowError",
+    "TileBufferOverflow",
     # Unbatched algorithms
     "cell_list",
     "naive_neighbor_list",

--- a/nvalchemiops/torch/neighbors/batch_cluster_tile.py
+++ b/nvalchemiops/torch/neighbors/batch_cluster_tile.py
@@ -51,6 +51,7 @@ from nvalchemiops.neighbors.cluster_tile import (
 )
 from nvalchemiops.neighbors.neighbor_utils import (
     NeighborOverflowError,
+    TileBufferOverflow,
     estimate_max_neighbors,
 )
 from nvalchemiops.neighbors.neighbor_utils import (
@@ -171,7 +172,9 @@ def estimate_batch_cluster_tile_list_sizes(
     batch_ptr : torch.Tensor, shape (num_systems + 1,), dtype=int32
         Cumulative atom counts defining per-system ranges.
     max_tiles_per_group : int, default 256
-        Upper bound on neighbor groups per row_group (dense-cutoff cap).
+        Sets the capacity of the tile-pair buffer shared by all row groups. If
+        the batch has ``ngroup_total`` groups, its compact capacity is
+        ``ngroup_total * min(ngroup_total, max_tiles_per_group)`` entries.
 
     Returns
     -------
@@ -183,7 +186,7 @@ def estimate_batch_cluster_tile_list_sizes(
         Group-array pad length for in-bounds ``wp.tile_load`` at any
         TILE-aligned offset.
     max_tiles : int
-        Upper bound on the tile pair list size.
+        Allocated tile-pair list capacity.
     num_systems : int
     """
     if batch_ptr.shape[0] < 2:
@@ -222,7 +225,9 @@ def estimate_batch_cluster_tile_segments(
     max_neighbors : int
         Upper bound on neighbors per atom used to size per-system COO segments.
     max_tiles_per_group : int, default 256
-        Upper bound on neighbor groups per row_group (dense-cutoff cap).
+        Sets each system's tile-pair segment capacity. A system with ``g_i``
+        groups receives ``g_i * min(g_i, max_tiles_per_group)`` entries. Its
+        group count is ``ceil(num_atoms_i / 32)``.
 
     Returns
     -------
@@ -288,8 +293,11 @@ def allocate_batch_cluster_tile_list(
     dtype : torch.dtype, default torch.float32
         Floating-point dtype for position and group-centroid tensors.
     max_tiles_per_group : int, default 256
-        Upper bound on neighbor groups per row_group; controls the tile buffer
-        size via :func:`estimate_batch_cluster_tile_list_sizes`.
+        Capacity factor for the intermediate tile-pair buffer. For ``g`` row
+        groups, the buffer holds ``g * min(g, max_tiles_per_group)`` tile pairs.
+        Increasing the value up to ``g`` uses more memory and accommodates more
+        candidate tile pairs. See :ref:`cluster-tile-buffer-capacity` for
+        sizing details.
 
     Returns
     -------
@@ -1086,7 +1094,7 @@ def batch_query_cluster_tile(
         else:
             n_tiles = int(num_tiles.item())
             if n_tiles > tile_capacity:
-                raise NeighborOverflowError(tile_capacity, n_tiles)
+                raise TileBufferOverflow(tile_capacity, n_tiles)
     else:
         n_tiles = 0  # segmented: count is per-system; full-buffer launch
         if tile_counts is not None:
@@ -1094,7 +1102,7 @@ def batch_query_cluster_tile(
             overflow = tile_counts > seg_caps
             if bool(overflow.any().item()):
                 isys = int(torch.nonzero(overflow, as_tuple=False)[0, 0].item())
-                raise NeighborOverflowError(
+                raise TileBufferOverflow(
                     int(seg_caps[isys].item()),
                     int(tile_counts[isys].item()),
                     system_index=isys,
@@ -1658,7 +1666,7 @@ def batch_query_cluster_tile_coo(
         else:
             n_tiles = int(num_tiles.item())
             if n_tiles > tile_capacity:
-                raise NeighborOverflowError(tile_capacity, n_tiles)
+                raise TileBufferOverflow(tile_capacity, n_tiles)
     else:
         n_tiles = 0  # segmented: full-buffer launch
         if tile_counts is not None:
@@ -1666,7 +1674,7 @@ def batch_query_cluster_tile_coo(
             overflow = tile_counts > seg_caps
             if bool(overflow.any().item()):
                 isys = int(torch.nonzero(overflow, as_tuple=False)[0, 0].item())
-                raise NeighborOverflowError(
+                raise TileBufferOverflow(
                     int(seg_caps[isys].item()),
                     int(tile_counts[isys].item()),
                     system_index=isys,
@@ -1757,6 +1765,7 @@ def _batch_cluster_tile_pair_outputs_forward(
     max_neighbors: int,
     fill_value: int,
     batch_idx_atom: torch.Tensor,
+    max_tiles_per_group: int | None,
 ) -> "_NeighborForwardOutput":
     """Forward closure for the torch batch_cluster_tile autograd path."""
     from nvalchemiops.torch.neighbors._autograd import (
@@ -1792,6 +1801,11 @@ def _batch_cluster_tile_pair_outputs_forward(
         batch_ptr,
         device,
         dtype=positions_det.dtype,
+        max_tiles_per_group=(
+            int(max_tiles_per_group)
+            if max_tiles_per_group is not None
+            else estimate_batch_max_tiles_per_group(batch_ptr, cutoff, cell_det)
+        ),
     )
     batch_build_cluster_tile_list(
         positions_det,
@@ -1999,7 +2013,7 @@ def batch_cluster_tile_neighbor_list(
     pair_forces: torch.Tensor | None = None,
     max_tiles_per_group: int | None = None,
 ) -> tuple[torch.Tensor, ...]:
-    """Build a batched cluster-pair tile neighbor list (one-shot convenience).
+    """Build and query a batched cluster-pair tile neighbor list in one call.
 
     Batched PyTorch binding for the cluster-pair tile algorithm.  Supports
     triclinic ``cell_batch`` of shape ``(num_systems, 3, 3)`` and arbitrary
@@ -2034,8 +2048,10 @@ def batch_cluster_tile_neighbor_list(
         Upper bound for COO output; defaults to
         ``total_atoms * max_neighbors``.
     cutoff2 : float, optional
-        Secondary cutoff for matrix output. Dual cutoff is matrix-only and
-        cannot be combined with pair-output buffers.
+        Cutoff for the second matrix. It is normally the outer cutoff and may
+        equal ``cutoff``. Either order is accepted because the tile buffer is
+        sized for the larger value. Dual cutoff is matrix-only and cannot be
+        combined with pair-output buffers.
     rebuild_flags : torch.Tensor, shape (num_systems,), dtype=torch.bool, optional
         Per-system selective rebuild flags. Supported for matrix output and
         segmented COO output. Across selective calls, callers must retain and
@@ -2126,9 +2142,13 @@ def batch_cluster_tile_neighbor_list(
         OUTPUT buffers, written only when the corresponding enable flag
         / ``pair_fn`` is active.
     max_tiles_per_group : int, optional
-        Upper bound on neighbor groups per row group for scratch allocation.
-        Passing this skips the geometry-aware sizing preflight, which otherwise
-        synchronizes per-system counts and cell volumes to the host.
+        Capacity factor for an internally allocated intermediate tile-pair
+        buffer. For ``g`` row groups, the buffer holds
+        ``g * min(g, max_tiles_per_group)`` tile pairs. Increasing the value up
+        to ``g`` uses more memory and accommodates more candidate tile pairs.
+        Eager calls estimate the value when it is ``None``. Caller-owned tile
+        arrays determine the actual capacity. See
+        :ref:`cluster-tile-buffer-capacity` for sizing details.
 
     Returns
     -------
@@ -2187,6 +2207,12 @@ def batch_cluster_tile_neighbor_list(
         raise ValueError(
             f"format must be 'matrix' | 'coo' | 'tile'; got {format!r}",
         )
+    if max_tiles_per_group is not None and (
+        not isinstance(max_tiles_per_group, int)
+        or isinstance(max_tiles_per_group, bool)
+        or max_tiles_per_group <= 0
+    ):
+        raise ValueError("max_tiles_per_group must be a positive integer")
     has_pair_outputs = (
         bool(return_vectors)
         or bool(return_distances)
@@ -2331,6 +2357,8 @@ def batch_cluster_tile_neighbor_list(
         max_tiles_per_group = estimate_batch_max_tiles_per_group(
             batch_ptr, build_cutoff, cell_batch
         )
+    else:
+        max_tiles_per_group = int(max_tiles_per_group)
     if (
         rebuild_flags is not None
         and format == "matrix"
@@ -2411,6 +2439,7 @@ def batch_cluster_tile_neighbor_list(
             "max_neighbors": int(max_neighbors),
             "fill_value": int(fill_value),
             "batch_idx_atom": batch_idx_atom,
+            "max_tiles_per_group": max_tiles_per_group,
         }
         distances_out, vectors_out, nm_out, nn_out, shifts_out = _route_pair_outputs(
             positions,
@@ -2540,7 +2569,7 @@ def batch_cluster_tile_neighbor_list(
         n_tiles = int(num_tiles.item())
         tile_capacity = int(tile_row_group.shape[0])
         if n_tiles > tile_capacity:
-            raise NeighborOverflowError(tile_capacity, n_tiles)
+            raise TileBufferOverflow(tile_capacity, n_tiles)
         return (
             num_tiles,
             tile_row_group,

--- a/nvalchemiops/torch/neighbors/cluster_tile.py
+++ b/nvalchemiops/torch/neighbors/cluster_tile.py
@@ -47,6 +47,7 @@ from nvalchemiops.neighbors.cluster_tile import (
 )
 from nvalchemiops.neighbors.neighbor_utils import (
     NeighborOverflowError,
+    TileBufferOverflow,
     estimate_max_neighbors,
 )
 from nvalchemiops.neighbors.neighbor_utils import (
@@ -123,25 +124,27 @@ def estimate_cluster_tile_list_sizes(
 ) -> tuple[int, int, int, int]:
     """Estimate allocation sizes for the tile neighbor list state.
 
-    Any ``total_atoms >= 0`` is accepted; internally the state is sized
-    at ``n_padded = ceil(total_atoms / TILE_GROUP_SIZE) * TILE_GROUP_SIZE`` so
-    the kernels see a 32-aligned layout.  Padding slots receive a
-    sentinel max Morton code (see ``_compute_morton_kernel``) so they
-    sort to the end and are dropped by the convert/coo kernels'
-    ``i_sorted < natom`` filter.
+    Any ``total_atoms >= 0`` is accepted. Nonempty inputs use
+    ``n_padded = ceil(total_atoms / TILE_GROUP_SIZE) * TILE_GROUP_SIZE`` so the
+    kernels see a 32-aligned layout; empty input reserves one tile group.
+    Padding slots receive a sentinel maximum Morton code (see
+    ``_compute_morton_kernel``), sort to the end, and are dropped by the
+    convert/COO kernels' ``i_sorted < natom`` filter.
 
     Parameters
     ----------
     total_atoms : int
         Real atom count.
     max_tiles_per_group : int, default 256
-        Upper bound on neighbor groups per row_group (dense-cutoff cap).
+        Sets the capacity of the tile-pair buffer shared by all row groups. The
+        allocated group count is ``ngroup = max(1, ceil(total_atoms / 32))``.
+        The capacity is ``ngroup * min(ngroup, max_tiles_per_group)`` entries.
 
     Returns
     -------
     n_padded : int
-        Padded atom count = ``ceil(total_atoms / TILE_GROUP_SIZE) * TILE_GROUP_SIZE``.
-        Used to size positions / sorted SoA / sorted_atom_index scratch arrays.
+        Padded atom count. This is at least ``TILE_GROUP_SIZE``; nonempty inputs
+        are rounded up to a multiple of ``TILE_GROUP_SIZE``.
     ngroup : int
         Number of 32-atom groups: ``n_padded // TILE_GROUP_SIZE``.
     ngroup_padded : int
@@ -149,7 +152,7 @@ def estimate_cluster_tile_list_sizes(
         TILE-aligned offset.  Multiple of ``TILE_GROUP_SIZE``; at least one
         TILE slack over ``ngroup``.
     max_tiles : int
-        Upper bound on the tile-pair list size.
+        Allocated tile-pair list capacity.
     """
     if total_atoms < 0:
         raise ValueError(f"total_atoms must be >= 0; got {total_atoms}")
@@ -205,8 +208,11 @@ def allocate_cluster_tile_list(
         Floating-point dtype for position and bounding-box arrays.
         Default is ``torch.float32``.
     max_tiles_per_group : int, optional
-        Upper bound on neighbor groups per row_group used to size the tile
-        pair buffer. Default is 256.
+        Capacity factor for the intermediate tile-pair buffer. For ``g`` row
+        groups, the buffer holds ``g * min(g, max_tiles_per_group)`` tile pairs.
+        Increasing the value up to ``g`` uses more memory and accommodates more
+        candidate tile pairs. Defaults to 256. See
+        :ref:`cluster-tile-buffer-capacity` for sizing details.
 
     Returns
     -------
@@ -863,7 +869,7 @@ def query_cluster_tile(
     else:
         n_tiles = int(num_tiles.item())
         if n_tiles > tile_capacity:
-            raise NeighborOverflowError(tile_capacity, n_tiles)
+            raise TileBufferOverflow(tile_capacity, n_tiles)
 
     feature_path = (
         cutoff2 is not None
@@ -1705,7 +1711,7 @@ def query_cluster_tile_coo(
     else:
         n_tiles = int(num_tiles.item())
         if n_tiles > tile_capacity:
-            raise NeighborOverflowError(tile_capacity, n_tiles)
+            raise TileBufferOverflow(tile_capacity, n_tiles)
     pair_counter.zero_()
 
     if segmented:
@@ -1839,6 +1845,7 @@ def _cluster_tile_pair_outputs_forward(
     cutoff: float,
     max_neighbors: int,
     fill_value: int,
+    max_tiles_per_group: int | None,
 ) -> "_NeighborForwardOutput":
     """Forward closure for the torch cluster_tile autograd path."""
     from nvalchemiops.torch.neighbors._autograd import (
@@ -1865,7 +1872,16 @@ def _cluster_tile_pair_outputs_forward(
         num_tiles,
         tile_row_group,
         tile_col_group,
-    ) = allocate_cluster_tile_list(N, device, dtype=positions_det.dtype)
+    ) = allocate_cluster_tile_list(
+        N,
+        device,
+        dtype=positions_det.dtype,
+        max_tiles_per_group=(
+            int(max_tiles_per_group)
+            if max_tiles_per_group is not None
+            else estimate_max_tiles_per_group(N, cutoff, float(_cell_volume(cell_det)))
+        ),
+    )
     build_cluster_tile_list(
         positions_det,
         cutoff,
@@ -1984,8 +2000,10 @@ def cluster_tile_neighbor_list(
     neighbor_distances: torch.Tensor | None = None,
     pair_energies: torch.Tensor | None = None,
     pair_forces: torch.Tensor | None = None,
+    *,
+    max_tiles_per_group: int | None = None,
 ) -> tuple[torch.Tensor, ...]:
-    """Build a cluster-pair tile neighbor list (one-shot convenience).
+    """Build and query a cluster-pair tile neighbor list in one call.
 
     Single-system PyTorch binding for the cluster-pair tile algorithm.
     Runs Morton sort, Warp bounding-box reduction, and tile enumeration,
@@ -2004,10 +2022,10 @@ def cluster_tile_neighbor_list(
     cutoff : float
         Cutoff distance in Cartesian units. Must be positive.
     cutoff2 : float, optional
-        Matrix-format second cutoff. When provided, the function returns a
-        second ``(neighbor_matrix2, num_neighbors2, neighbor_matrix_shifts2)``
-        group for neighbors within ``cutoff2``. Cannot be combined with pair
-        outputs or COO/tile formats.
+        Cutoff for the second matrix. It is normally the outer cutoff and may
+        equal ``cutoff``. Either order is accepted because the tile buffer is
+        sized for the larger value. Cannot be combined with pair outputs or
+        COO/tile formats.
     cell : torch.Tensor, shape (1, 3, 3) or (3, 3), dtype=float32
         Any non-degenerate cell (orthorhombic or triclinic).
     max_neighbors : int, optional
@@ -2039,6 +2057,14 @@ def cluster_tile_neighbor_list(
           The consumer chooses atom-level fill.
     max_pairs : int, optional
         Upper bound for COO output; defaults to ``N * max_neighbors``.
+    max_tiles_per_group : int, optional
+        Capacity factor for an internally allocated intermediate tile-pair
+        buffer. For ``g`` row groups, the buffer holds
+        ``g * min(g, max_tiles_per_group)`` tile pairs. Increasing the value up
+        to ``g`` uses more memory and accommodates more candidate tile pairs.
+        Eager calls estimate the value when it is ``None``. Caller-owned tile
+        arrays determine the actual capacity. See
+        :ref:`cluster-tile-buffer-capacity` for sizing details.
     rebuild_flags : torch.Tensor, shape (1,), dtype=bool, optional
         Selective rebuild flag. An eager all-true call may bootstrap omitted
         state. When false, caller-owned fixed topology and tile state are
@@ -2137,6 +2163,12 @@ def cluster_tile_neighbor_list(
         raise ValueError(
             f"format must be 'matrix' | 'coo' | 'tile'; got {format!r}",
         )
+    if max_tiles_per_group is not None and (
+        not isinstance(max_tiles_per_group, int)
+        or isinstance(max_tiles_per_group, bool)
+        or max_tiles_per_group <= 0
+    ):
+        raise ValueError("max_tiles_per_group must be a positive integer")
     has_pair_outputs = (
         bool(return_vectors)
         or bool(return_distances)
@@ -2361,6 +2393,7 @@ def cluster_tile_neighbor_list(
             "cutoff": cutoff,
             "max_neighbors": int(max_neighbors),
             "fill_value": int(fill_value),
+            "max_tiles_per_group": max_tiles_per_group,
         }
         distances_out, vectors_out, nm_out, nn_out, shifts_out = _route_pair_outputs(
             positions,
@@ -2375,16 +2408,17 @@ def cluster_tile_neighbor_list(
             return (*base, distances_out)
         return (*base, vectors_out)
 
-    # Tile candidates must cover the *larger* radius so the cutoff2 matrix
-    # cannot miss pairs in the (cutoff, cutoff2] shell; the query then filters
-    # each matrix by its own cutoff.
+    # Candidate tiles must cover both radii. The query then filters each matrix
+    # with its own cutoff.
     build_cutoff = cutoff if cutoff2 is None else max(float(cutoff), float(cutoff2))
 
     # Allocate scratch if caller didn't supply.  ``sorted_atom_index`` is the
     # all-or-nothing sentinel.
     if sorted_atom_index is None:
         previous_tile_state = (num_tiles, tile_row_group, tile_col_group)
-        if selective and torch.compiler.is_compiling():
+        if max_tiles_per_group is not None:
+            max_tiles_per_group = int(max_tiles_per_group)
+        elif selective and torch.compiler.is_compiling():
             if tile_row_group is None:
                 raise ValueError("selective compiled COO requires tile_row_group")
             groups = max(1, (N + TILE_GROUP_SIZE - 1) // TILE_GROUP_SIZE)
@@ -2451,7 +2485,7 @@ def cluster_tile_neighbor_list(
         n_tiles = int(num_tiles.item())
         tile_capacity = int(tile_row_group.shape[0])
         if n_tiles > tile_capacity:
-            raise NeighborOverflowError(tile_capacity, n_tiles)
+            raise TileBufferOverflow(tile_capacity, n_tiles)
         return (
             num_tiles,
             tile_row_group,

--- a/nvalchemiops/torch/neighbors/neighbor_utils.py
+++ b/nvalchemiops/torch/neighbors/neighbor_utils.py
@@ -25,6 +25,7 @@ import warp as wp
 
 from nvalchemiops.neighbors.neighbor_utils import (
     NeighborOverflowError,
+    TileBufferOverflow,
     estimate_max_neighbors,
 )
 from nvalchemiops.neighbors.neighbor_utils import (
@@ -41,6 +42,7 @@ __all__ = [
     "synthesize_cell_for_batch",
     "synthesize_cell_for_ss",
     "NeighborOverflowError",
+    "TileBufferOverflow",
 ]
 
 

--- a/test/neighbors/bindings/jax/test_batch_cluster_tile.py
+++ b/test/neighbors/bindings/jax/test_batch_cluster_tile.py
@@ -37,6 +37,7 @@ from nvalchemiops.jax.neighbors.batch_cluster_tile import (
     estimate_batch_max_tiles_per_group,
 )
 from nvalchemiops.neighbors.cluster_tile import estimate_max_tiles_per_group
+from nvalchemiops.neighbors.neighbor_utils import TileBufferOverflow
 
 from .conftest import requires_gpu
 
@@ -153,6 +154,7 @@ class TestBatchTileNeighborListCorrectness:
                 cell_batch,
                 batch_ptr,
                 max_neighbors=32,
+                max_tiles_per_group=1,
             )
             return (
                 neighbor_matrix.astype(pos.dtype).sum()
@@ -280,6 +282,7 @@ class TestBatchClusterTileGraphPreload:
                 cell_batch,
                 batch_ptr,
                 max_neighbors=32,
+                max_tiles_per_group=1,
             )
 
         neighbor_matrix, num_neighbors, _shifts = query(positions)
@@ -474,6 +477,55 @@ class TestBatchTileNeighborListErrors:
         with pytest.raises(ValueError, match="cell_batch"):
             batch_cluster_tile_neighbor_list(positions, 1.0, cell_batch, batch_ptr)
 
+    def test_tile_buffer_overflow_raises(self):
+        """Compact and segmented eager paths report tile-buffer overflow."""
+        positions = jnp.zeros((128, 3), dtype=jnp.float32)
+        cell_batch = jnp.eye(3, dtype=jnp.float32)[None] * 12.0
+        batch_ptr = jnp.array([0, 128], dtype=jnp.int32)
+        for return_distances in (False, True):
+            with pytest.raises(TileBufferOverflow) as caught:
+                batch_cluster_tile_neighbor_list(
+                    positions,
+                    5.0,
+                    cell_batch,
+                    batch_ptr,
+                    max_neighbors=256,
+                    max_tiles_per_group=1,
+                    return_distances=return_distances,
+                )
+            assert caught.value.num_tiles > caught.value.max_tiles
+            assert caught.value.system_index is None
+
+        segmented_positions = jnp.zeros((160, 3), dtype=jnp.float32)
+        segmented_cells = jnp.tile(
+            jnp.eye(3, dtype=jnp.float32)[None] * 12.0, (2, 1, 1)
+        )
+        segmented_ptr = jnp.array([0, 32, 160], dtype=jnp.int32)
+        with pytest.raises(TileBufferOverflow) as segmented:
+            batch_cluster_tile_neighbor_list(
+                segmented_positions,
+                5.0,
+                segmented_cells,
+                segmented_ptr,
+                max_neighbors=256,
+                rebuild_flags=jnp.ones(2, dtype=jnp.bool_),
+                tile_offsets=jnp.array([0, 1, 2], dtype=jnp.int32),
+                previous_tile_counts=jnp.zeros(2, dtype=jnp.int32),
+                previous_num_tiles=jnp.zeros(1, dtype=jnp.int32),
+                previous_tile_row_group=jnp.zeros(2, dtype=jnp.int32),
+                previous_tile_col_group=jnp.zeros(2, dtype=jnp.int32),
+                previous_tile_system=jnp.zeros(2, dtype=jnp.int32),
+                previous_neighbor_matrix=jnp.empty((160, 256), dtype=jnp.int32),
+                previous_num_neighbors=jnp.zeros(160, dtype=jnp.int32),
+                previous_neighbor_matrix_shifts=jnp.empty(
+                    (160, 256, 3), dtype=jnp.int32
+                ),
+                max_tiles_per_group=1,
+            )
+        assert segmented.value.system_index == 1
+        assert segmented.value.max_tiles == 1
+        assert segmented.value.num_tiles > segmented.value.max_tiles
+
 
 class TestEstimateBatchSizes:
     """Pure-Python sizing helper tests."""
@@ -615,6 +667,7 @@ class TestJaxBatchClusterTileAutograd:
                 1.5,
                 cell_batch,
                 batch_ptr,
+                max_tiles_per_group=2,
                 return_distances=True,
                 return_vectors=True,
             )
@@ -633,6 +686,7 @@ class TestJaxBatchClusterTileAutograd:
                 1.5,
                 c,
                 batch_ptr,
+                max_tiles_per_group=2,
                 return_distances=True,
                 return_vectors=True,
             )
@@ -663,6 +717,7 @@ class TestJaxBatchClusterTileAutograd:
                 5.0,
                 cell_batch,
                 batch_ptr,
+                max_tiles_per_group=2,
                 return_distances=True,
                 return_vectors=True,
             )
@@ -706,6 +761,7 @@ class TestJaxBatchClusterTileAutograd:
                 1.5,
                 cell_batch,
                 batch_ptr,
+                max_tiles_per_group=2,
                 return_distances=True,
                 return_vectors=True,
             )

--- a/test/neighbors/bindings/jax/test_cluster_tile.py
+++ b/test/neighbors/bindings/jax/test_cluster_tile.py
@@ -33,6 +33,7 @@ from nvalchemiops.jax.neighbors.cluster_tile import (
     estimate_cluster_tile_list_sizes,
     query_cluster_tile_coo,
 )
+from nvalchemiops.neighbors.neighbor_utils import TileBufferOverflow
 
 from .conftest import requires_gpu
 
@@ -139,6 +140,7 @@ class TestTileNeighborListCorrectness:
                 2.0,
                 cell,
                 max_neighbors=32,
+                max_tiles_per_group=2,
             )
             return (
                 neighbor_matrix.astype(pos.dtype).sum()
@@ -223,6 +225,7 @@ class TestClusterTileGraphPreload:
                 1.0,
                 cell,
                 max_neighbors=32,
+                max_tiles_per_group=1,
             )
 
         neighbor_matrix, num_neighbors, _shifts = query(positions)
@@ -250,6 +253,7 @@ class TestClusterTileGraphPreload:
                 1.0,
                 cell,
                 max_neighbors=32,
+                max_tiles_per_group=1,
             )
 
         first = query(positions)
@@ -420,6 +424,24 @@ class TestTileNeighborListErrors:
         with pytest.raises(ValueError, match="format"):
             cluster_tile_neighbor_list(positions, 1.0, cell, format="bogus")
 
+    def test_tile_buffer_overflow_raises(self):
+        """Eager neighbor and pair-output paths report tile-buffer overflow."""
+        positions = jnp.zeros((128, 3), dtype=jnp.float32)
+        cell = _orthorhombic_cell(12.0)
+
+        for return_distances in (False, True):
+            with pytest.raises(TileBufferOverflow) as caught:
+                cluster_tile_neighbor_list(
+                    positions,
+                    5.0,
+                    cell,
+                    max_neighbors=256,
+                    max_tiles_per_group=1,
+                    return_distances=return_distances,
+                )
+            assert caught.value.num_tiles > caught.value.max_tiles
+            assert caught.value.system_index is None
+
 
 class TestEstimateSizes:
     """Pure-Python sizing helper tests."""
@@ -496,6 +518,7 @@ class TestJaxClusterTileAutograd:
                 p,
                 1.5,
                 cell,
+                max_tiles_per_group=2,
                 return_distances=True,
                 return_vectors=True,
             )
@@ -524,6 +547,7 @@ class TestJaxClusterTileAutograd:
                 p,
                 5.0,
                 cell,
+                max_tiles_per_group=1,
                 return_distances=True,
                 return_vectors=True,
             )
@@ -582,6 +606,7 @@ class TestJaxClusterTileAutograd:
                 p,
                 1.5,
                 cell,
+                max_tiles_per_group=2,
                 return_distances=True,
                 return_vectors=True,
             )
@@ -608,6 +633,7 @@ class TestJaxClusterTileAutograd:
                 cutoff,
                 cell,
                 max_neighbors=64,
+                max_tiles_per_group=2,
                 return_distances=True,
                 return_vectors=True,
             )
@@ -947,6 +973,7 @@ class TestJaxClusterTileCutoff2Selective:
                 2.0,
                 cell,
                 max_neighbors=64,
+                max_tiles_per_group=1,
                 format="coo",
                 rebuild_flags=jnp.array([False], dtype=jnp.bool_),
                 previous_num_tiles=num_tiles,
@@ -1323,12 +1350,7 @@ class TestJaxClusterTileNeighborListDispatcher:
 
 
 class TestJaxClusterTileTileSizing:
-    """The JAX tile buffer must geometry-size (concrete) / fall back (traced).
-
-    Guards the fix that stopped the JAX default/auto-select path from silently
-    undercounting dense high-cutoff systems where a fixed
-    ``max_tiles_per_group=256`` cannot cover all neighboring row groups.
-    """
+    """JAX estimates eager buffers and requires explicit bounds while tracing."""
 
     def test_geometry_sizing_scales_with_cutoff_when_concrete(self):
         from nvalchemiops.jax.neighbors.cluster_tile import (
@@ -1347,7 +1369,7 @@ class TestJaxClusterTileTileSizing:
         # 25 A on this cell needs ~ngroup neighbour groups per row (dense).
         assert high >= 1024
 
-    def test_traced_inputs_fall_back_to_ngroup(self):
+    def test_traced_inputs_require_explicit_bound(self):
         from nvalchemiops.jax.neighbors.cluster_tile import (
             _tile_buffer_max_tiles_per_group,
         )
@@ -1355,15 +1377,9 @@ class TestJaxClusterTileTileSizing:
         n = 2048  # ngroup = 64
         cell = _orthorhombic_cell(20.0)
 
-        # Tracing positions (e.g. grad/jit) -> trace-safe ngroup fallback.
+        # Geometry-dependent sizing cannot run while JAX is tracing the call.
         def f(p):
             return _tile_buffer_max_tiles_per_group(p, n, 5.0, cell)
 
-        captured = {}
-
-        def grab(p):
-            captured["mtpg"] = f(p)
-            return p.sum()
-
-        jax.grad(grab)(jnp.zeros((n, 3), dtype=jnp.float32))
-        assert captured["mtpg"] == 64  # ngroup, capacity ngroup**2 (no overflow)
+        with pytest.raises(ValueError, match="static Python integer"):
+            jax.make_jaxpr(f)(jnp.zeros((n, 3), dtype=jnp.float32))

--- a/test/neighbors/bindings/torch/test_batch_cluster_tile.py
+++ b/test/neighbors/bindings/torch/test_batch_cluster_tile.py
@@ -25,7 +25,9 @@ from nvalchemiops.neighbors.cluster_tile import (
 from nvalchemiops.neighbors.cluster_tile import (
     estimate_max_tiles_per_group,
 )
-from nvalchemiops.neighbors.neighbor_utils import NeighborOverflowError
+from nvalchemiops.neighbors.neighbor_utils import (
+    TileBufferOverflow,
+)
 from nvalchemiops.torch.neighbors.batch_cluster_tile import (
     TILE_GROUP_SIZE,
     allocate_batch_cluster_tile_list,
@@ -84,7 +86,7 @@ def _make_batch(
 def _scratch_kwargs(
     scratch: tuple[torch.Tensor, ...],
 ) -> dict[str, torch.Tensor]:
-    """Map allocator outputs to one-shot API keyword arguments."""
+    """Map allocator outputs to combined build/query keyword arguments."""
     names = (
         "sorted_atom_index",
         "sort_inv",
@@ -362,7 +364,7 @@ class TestBatchClusterTileValidation:
 
 
 def test_batch_cluster_tile_max_tiles_per_group_bypasses_sizing(monkeypatch):
-    """Explicit max_tiles_per_group skips geometry-aware sizing sync."""
+    """An explicit allocation factor avoids synchronizing geometry to the host."""
 
     def fail_sizing(*args, **kwargs):
         del args, kwargs
@@ -814,77 +816,53 @@ class TestBatchTileNeighborListCorrectness:
             [256, 256], [8.0, 8.0], device=device, dtype=dtype, seed=9
         )
         cutoff = 4.0
-        N = positions.shape[0]
-        scratch = allocate_batch_cluster_tile_list(
-            batch_ptr, torch.device(device), dtype=dtype, max_tiles_per_group=1
-        )
-        (
-            sorted_atom_index,
-            sort_inv,
-            sorted_pos_x,
-            sorted_pos_y,
-            sorted_pos_z,
-            batch_idx_sorted,
-            batch_ptr_padded,
-            group_system,
-            group_ptr,
-            group_ctr_x,
-            group_ctr_y,
-            group_ctr_z,
-            group_ext_x,
-            group_ext_y,
-            group_ext_z,
-            num_tiles,
-            tile_row_group,
-            tile_col_group,
-            tile_system,
-        ) = scratch
-        batch_build_cluster_tile_list(
-            positions,
-            cutoff,
-            cell_batch,
-            batch_ptr,
-            sorted_atom_index,
-            sort_inv,
-            sorted_pos_x,
-            sorted_pos_y,
-            sorted_pos_z,
-            batch_idx_sorted,
-            batch_ptr_padded,
-            group_system,
-            group_ptr,
-            group_ctr_x,
-            group_ctr_y,
-            group_ctr_z,
-            group_ext_x,
-            group_ext_y,
-            group_ext_z,
-            num_tiles,
-            tile_row_group,
-            tile_col_group,
-            tile_system,
-        )
-        assert int(num_tiles.item()) > int(tile_row_group.shape[0])
-        nm = torch.empty((N, 64), dtype=torch.int32, device=device)
-        nn = torch.zeros(N, dtype=torch.int32, device=device)
-        nms = torch.empty((N, 64, 3), dtype=torch.int32, device=device)
-        with pytest.raises(NeighborOverflowError):
-            batch_query_cluster_tile(
-                sorted_atom_index,
-                sorted_pos_x,
-                sorted_pos_y,
-                sorted_pos_z,
-                cell_batch,
-                num_tiles,
-                tile_row_group,
-                tile_col_group,
-                tile_system,
+        with pytest.raises(TileBufferOverflow) as caught:
+            batch_cluster_tile_neighbor_list(
+                positions,
                 cutoff,
-                N,
-                nm,
-                nn,
-                nms,
+                cell_batch,
+                batch_ptr,
+                max_neighbors=256,
+                max_tiles_per_group=1,
             )
+        assert caught.value.num_tiles > caught.value.max_tiles
+        assert caught.value.system_index is None
+
+        segmented_positions = torch.zeros((160, 3), dtype=dtype, device=device)
+        segmented_cells = torch.eye(3, dtype=dtype, device=device).repeat(2, 1, 1)
+        segmented_cells *= 12.0
+        segmented_ptr = torch.tensor([0, 32, 160], dtype=torch.int32, device=device)
+        scratch = _scratch_kwargs(
+            allocate_batch_cluster_tile_list(
+                segmented_ptr,
+                torch.device(device),
+                dtype=dtype,
+                max_tiles_per_group=1,
+            )
+        )
+        with pytest.raises(TileBufferOverflow) as segmented:
+            batch_cluster_tile_neighbor_list(
+                segmented_positions,
+                cutoff,
+                segmented_cells,
+                segmented_ptr,
+                max_neighbors=256,
+                rebuild_flags=torch.ones(2, dtype=torch.bool, device=device),
+                neighbor_matrix=torch.empty(
+                    (160, 256), dtype=torch.int32, device=device
+                ),
+                num_neighbors=torch.zeros(160, dtype=torch.int32, device=device),
+                neighbor_matrix_shifts=torch.empty(
+                    (160, 256, 3), dtype=torch.int32, device=device
+                ),
+                tile_offsets=torch.tensor([0, 1, 2], dtype=torch.int32, device=device),
+                tile_counts=torch.zeros(2, dtype=torch.int32, device=device),
+                max_tiles_per_group=1,
+                **scratch,
+            )
+        assert segmented.value.system_index == 1
+        assert segmented.value.max_tiles == 1
+        assert segmented.value.num_tiles > segmented.value.max_tiles
 
 
 # =============================================================================

--- a/test/neighbors/bindings/torch/test_cluster_tile.py
+++ b/test/neighbors/bindings/torch/test_cluster_tile.py
@@ -18,7 +18,10 @@
 import pytest
 import torch
 
-from nvalchemiops.neighbors.neighbor_utils import NeighborOverflowError
+from nvalchemiops.neighbors.neighbor_utils import (
+    NeighborOverflowError,
+    TileBufferOverflow,
+)
 from nvalchemiops.torch.neighbors.cell_list import cell_list
 from nvalchemiops.torch.neighbors.cluster_tile import (
     TILE_GROUP_SIZE,
@@ -1699,60 +1702,13 @@ class TestClusterTileCellListParity:
         n, box, cutoff = 128, 12.0, 5.0
         pos = torch.rand(n, 3, dtype=dtype, device=device) * box
         cell = _orthorhombic_cell(box, device, dtype)
-        (
-            sai,
-            mc,
-            spx,
-            spy,
-            spz,
-            gcx,
-            gcy,
-            gcz,
-            gex,
-            gey,
-            gez,
-            num_tiles,
-            trg,
-            tcg,
-        ) = allocate_cluster_tile_list(
-            n, torch.device(device), dtype=dtype, max_tiles_per_group=1
-        )
-        build_cluster_tile_list(
-            pos,
-            cutoff,
-            cell,
-            sai,
-            mc,
-            spx,
-            spy,
-            spz,
-            gcx,
-            gcy,
-            gcz,
-            gex,
-            gey,
-            gez,
-            num_tiles,
-            trg,
-            tcg,
-        )
-        assert int(num_tiles.item()) > int(trg.shape[0])  # overflow really occurred
-        nm = torch.empty((n, 256), dtype=torch.int32, device=device)
-        nn = torch.zeros(n, dtype=torch.int32, device=device)
-        nms = torch.empty((n, 256, 3), dtype=torch.int32, device=device)
-        with pytest.raises(NeighborOverflowError):
-            query_cluster_tile(
-                sai,
-                spx,
-                spy,
-                spz,
-                num_tiles,
-                trg,
-                tcg,
-                cell,
+        with pytest.raises(TileBufferOverflow) as caught:
+            cluster_tile_neighbor_list(
+                pos,
                 cutoff,
-                n,
-                nm,
-                nn,
-                nms,
+                cell,
+                max_neighbors=256,
+                max_tiles_per_group=1,
             )
+        assert caught.value.num_tiles > caught.value.max_tiles
+        assert caught.value.system_index is None


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# ALCHEMI Toolkit-Ops Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

Detect exhausted intermediate cluster-tile buffers in eager Torch and JAX neighbor-list paths, report the required capacity with a dedicated exception, and define explicit capacity requirements for transformed JAX calls. Document allocation, retry sizing, and compiled post-call validation.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

Fixes #159

## Changes Made

<!-- List the key changes made in this PR -->

- Add `TileBufferOverflow` with required count, allocated capacity, and segmented-system context, and use it across eager Torch and JAX cluster-tile output paths.
- Add explicit `max_tiles_per_group` controls to cluster-tile bindings and require a positive static Python integer for transformed or compiled JAX calls.
- Extend existing overflow tests and document heuristic estimation, exact eager retry sizing, worst-case bounds, and compiled count validation.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass locally (`make pytest`)
- [x] Linting passes (`make lint`)
- [x] New tests added for new functionality meets coverage expectations?

## Checklist

- [x] I have read and understand the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG.md](../CHANGELOG.md)
- [x] I have performed a self-review of my code
- [x] I have added docstrings to new functions/classes
- [x] I have updated the documentation (if applicable)

## Additional Notes

<!-- Any additional information that reviewers should know -->

None.

> [!TIP]
> This repository uses Greptile, an AI code review service, to help conduct
> pull request reviews. We encourage contributors to read and consider suggestions
> made by Greptile, but note that human maintainers will provide the necessary
> reviews for merging: Greptile's comments are **not** a qualitative judgement
> of your code, nor is it an indication that the PR will be accepted/rejected.
> We encourage the use of emoji reactions to Greptile comments, depending on
> their usefulness and accuracy.
